### PR TITLE
build: Add env file to Docker run commands for deployments

### DIFF
--- a/.github/workflows/deploy-staging-production.yml
+++ b/.github/workflows/deploy-staging-production.yml
@@ -159,6 +159,7 @@ jobs:
             sudo docker run -d \
               --name "$CONTAINER_NAME" \
               --restart unless-stopped \
+              --env-file /etc/mymemo/chat-api.env \
               -e NODE_ENV="$NODE_ENV" \
               -p "$HOST_PORT:$CONTAINER_PORT" \
               --memory=2g \
@@ -278,6 +279,7 @@ jobs:
             sudo docker run -d \
               --name "$CONTAINER_NAME" \
               --restart unless-stopped \
+              --env-file /etc/mymemo/chat-api.env \
               -e NODE_ENV="$NODE_ENV" \
               -p "$HOST_PORT:$CONTAINER_PORT" \
               --memory=4g \

--- a/scripts/chat-api-preview-deploy.sh
+++ b/scripts/chat-api-preview-deploy.sh
@@ -40,6 +40,7 @@ fi
 echo "Starting new container: $CONTAINER"
 sudo -n docker run -d --name "$CONTAINER" \
   --restart unless-stopped \
+  --env-file /etc/mymemo/chat-api.env \
   -e NODE_ENV=production \
   -p ":${CONTAINER_PORT}" \
   --memory=1g \


### PR DESCRIPTION
This pull request updates the deployment configuration for the chat API to ensure environment variables are consistently loaded from a centralized environment file during container startup. The main change is the addition of the `--env-file /etc/mymemo/chat-api.env` flag to the relevant `docker run` commands across deployment scripts and workflows.

Deployment configuration updates:

* Added the `--env-file /etc/mymemo/chat-api.env` flag to the `docker run` commands in both staging and production jobs in `.github/workflows/deploy-staging-production.yml` to load environment variables from a shared environment file. [[1]](diffhunk://#diff-1310d2132c65d1fd303fb6e593c3d9e8a79ab77134d4181398d11fa69e9c4c8fR162) [[2]](diffhunk://#diff-1310d2132c65d1fd303fb6e593c3d9e8a79ab77134d4181398d11fa69e9c4c8fR282)
* Updated the `docker run` command in `scripts/chat-api-preview-deploy.sh` to include the same `--env-file /etc/mymemo/chat-api.env` flag for consistency across preview deployments.Updated deployment workflow and preview deploy script to include the --env-file /etc/mymemo/chat-api.env option in Docker run commands. This ensures environment variables are consistently loaded from the specified file during container startup.