### PR TITLE
feat: Add chat message history fetching and adaptation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "hono-openapi": "^1.0.8",
         "pino": "^9.10.0",
         "pino-http": "^10.5.0",
+        "tiny-invariant": "^1.3.3",
         "zod": "^4.1.9",
       },
       "devDependencies": {
@@ -122,6 +123,8 @@
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
     "thread-stream": ["thread-stream@3.1.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A=="],
+
+    "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 
     "undici-types": ["undici-types@7.12.0", "", {}, "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ=="],
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 		"hono-openapi": "^1.0.8",
 		"pino": "^9.10.0",
 		"pino-http": "^10.5.0",
+		"tiny-invariant": "^1.3.3",
 		"zod": "^4.1.9"
 	},
 	"devDependencies": {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -17,7 +17,9 @@ export const getProtectedApiOrigin = () => {
 
 export const getProtectedApiPrefix = () => {
 	const rawPrefix =
-		Bun.env.PROTECTED_API_PREFIX ?? Bun.env.API_PREFIX ?? DEFAULT_PROTECTED_API_PREFIX;
+		Bun.env.PROTECTED_API_PREFIX ??
+		Bun.env.API_PREFIX ??
+		DEFAULT_PROTECTED_API_PREFIX;
 	return sanitizePrefix(rawPrefix);
 };
 
@@ -58,7 +60,8 @@ export const getProtectedChatContextEndpoint = (
 export const getProtectedChatIdEndpoint = () => {
 	const origin = getProtectedApiOrigin();
 	const prefix = getProtectedApiPrefix();
-	const path = prefix === "/" ? "/protected/chat/id" : `${prefix}/protected/chat/id`;
+	const path =
+		prefix === "/" ? "/protected/chat/id" : `${prefix}/protected/chat/id`;
 	return new URL(path, origin).toString();
 };
 
@@ -79,7 +82,7 @@ export const getProtectedChatMessagesEndpoint = (
 	const origin = getProtectedApiOrigin();
 	const prefix = getProtectedApiPrefix();
 	const encodedChatKey = encodeURIComponent(chatKey);
-	const basePath = `/protected/chat/chats/${encodedChatKey}/messages`;
+	const basePath = `/protected/chats/${encodedChatKey}/messages`;
 	const path = prefix === "/" ? basePath : `${prefix}${basePath}`;
 	const url = new URL(path, origin);
 

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -61,3 +61,52 @@ export const getProtectedChatIdEndpoint = () => {
 	const path = prefix === "/" ? "/protected/chat/id" : `${prefix}/protected/chat/id`;
 	return new URL(path, origin).toString();
 };
+
+export type ChatMessagesScope = "general" | "collection" | "document";
+
+interface ChatMessagesEndpointOptions {
+	scope?: ChatMessagesScope | null;
+	collectionId?: string | null;
+	summaryId?: string | null;
+	size?: number | null;
+	memberCode?: string | null;
+}
+
+export const getProtectedChatMessagesEndpoint = (
+	chatKey: string,
+	options: ChatMessagesEndpointOptions = {},
+) => {
+	const origin = getProtectedApiOrigin();
+	const prefix = getProtectedApiPrefix();
+	const encodedChatKey = encodeURIComponent(chatKey);
+	const basePath = `/protected/chat/chats/${encodedChatKey}/messages`;
+	const path = prefix === "/" ? basePath : `${prefix}${basePath}`;
+	const url = new URL(path, origin);
+
+	const { scope, collectionId, summaryId, size, memberCode } = options;
+
+	if (scope) {
+		url.searchParams.set("scope", scope);
+	}
+
+	const normalizedCollectionId = collectionId?.trim();
+	if (normalizedCollectionId) {
+		url.searchParams.set("collectionId", normalizedCollectionId);
+	}
+
+	const normalizedSummaryId = summaryId?.trim();
+	if (normalizedSummaryId) {
+		url.searchParams.set("summaryId", normalizedSummaryId);
+	}
+
+	if (typeof size === "number" && Number.isFinite(size) && size > 0) {
+		url.searchParams.set("size", String(size));
+	}
+
+	const normalizedMemberCode = memberCode?.trim();
+	if (normalizedMemberCode) {
+		url.searchParams.set("memberCode", normalizedMemberCode);
+	}
+
+	return url.toString();
+};

--- a/src/features/chat/chat.adapter.test.ts
+++ b/src/features/chat/chat.adapter.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "bun:test";
+import { adaptProtectedMessagesToModelMessages } from "./chat.adapter";
+import type { ProtectedChatMessage } from "./chat.external";
+
+const buildMessage = (
+	chatContent: string | null,
+	senderType: string | null | undefined,
+): ProtectedChatMessage => ({
+	chatContent,
+	senderType,
+} as ProtectedChatMessage);
+
+describe("adaptProtectedMessagesToModelMessages", () => {
+	it("returns alternating messages with trimmed content", () => {
+		const history: ProtectedChatMessage[] = [
+			buildMessage(" Hello ", "User"),
+			buildMessage("  ", "assistant"),
+			buildMessage(null, "user"),
+			buildMessage("Thanks for reaching out", "assistant"),
+		];
+
+		const result = adaptProtectedMessagesToModelMessages(history);
+
+		expect(result).toEqual([
+			{
+				role: "user",
+				content: [{ type: "text", text: "Hello" }],
+			},
+			{
+				role: "assistant",
+				content: [{ type: "text", text: "Thanks for reaching out" }],
+			},
+		]);
+	});
+
+	it("drops earlier history after consecutive messages from the same role", () => {
+		const history: ProtectedChatMessage[] = [
+			buildMessage("First user", "user"),
+			buildMessage("Assistant one", "assistant"),
+			buildMessage("Assistant two", "assistant"),
+			buildMessage("Latest user", "user"),
+		];
+
+		const result = adaptProtectedMessagesToModelMessages(history);
+
+		expect(result).toEqual([
+			{
+				role: "user",
+				content: [{ type: "text", text: "Latest user" }],
+			},
+		]);
+	});
+
+	it("returns an empty array when trailing assistant replies have no matching user", () => {
+		const history: ProtectedChatMessage[] = [
+			buildMessage("Assistant only", "assistant"),
+		];
+
+		const result = adaptProtectedMessagesToModelMessages(history);
+
+		expect(result).toEqual([]);
+	});
+});

--- a/src/features/chat/chat.adapter.ts
+++ b/src/features/chat/chat.adapter.ts
@@ -1,0 +1,48 @@
+import type { ModelMessage } from "ai";
+import type { ProtectedChatMessage } from "./chat.external";
+
+const USER_SENDER_TYPE = "user";
+
+const TEXT_TYPE = "text";
+
+function getRoleFromSenderType(senderType: string | null | undefined): "user" | "assistant" {
+	if (!senderType) {
+		return "assistant";
+	}
+
+	const normalized = senderType.trim().toLowerCase();
+	if (normalized === USER_SENDER_TYPE) {
+		return "user";
+	}
+
+	return "assistant";
+}
+
+function isNonEmptyContent(value: string | null | undefined): value is string {
+	return Boolean(value && value.trim().length > 0);
+}
+
+export function adaptProtectedMessagesToModelMessages(
+	messages: ProtectedChatMessage[],
+): ModelMessage[] {
+	return messages
+		.filter((message) => isNonEmptyContent(message.chatContent))
+		.map((message) => {
+			const role = getRoleFromSenderType(message.senderType);
+			const content = [
+				{ type: TEXT_TYPE as const, text: message.chatContent! },
+			] as const;
+
+			if (role === "user") {
+				return {
+					role,
+					content,
+				} as ModelMessage;
+			}
+
+			return {
+				role,
+				content,
+			} as ModelMessage;
+		});
+}

--- a/src/features/chat/chat.adapter.ts
+++ b/src/features/chat/chat.adapter.ts
@@ -1,11 +1,14 @@
 import type { ModelMessage } from "ai";
+import invariant from "tiny-invariant";
 import type { ProtectedChatMessage } from "./chat.external";
 
 const USER_SENDER_TYPE = "user";
 
 const TEXT_TYPE = "text";
 
-function getRoleFromSenderType(senderType: string | null | undefined): "user" | "assistant" {
+function getRoleFromSenderType(
+	senderType: string | null | undefined,
+): "user" | "assistant" {
 	if (!senderType) {
 		return "assistant";
 	}
@@ -28,20 +31,22 @@ export function adaptProtectedMessagesToModelMessages(
 	return messages
 		.filter((message) => isNonEmptyContent(message.chatContent))
 		.map((message) => {
+			invariant(
+				message.chatContent,
+				"chatContent is required for convert ImChatVO to ModelMessage",
+			);
 			const role = getRoleFromSenderType(message.senderType);
-			const content = [
-				{ type: TEXT_TYPE as const, text: message.chatContent! },
-			] as const;
+			const content = [{ type: TEXT_TYPE, text: message.chatContent }];
 
 			if (role === "user") {
 				return {
-					role,
+					role: "user" as const,
 					content,
 				} as ModelMessage;
 			}
 
 			return {
-				role,
+				role: "assistant" as const,
 				content,
 			} as ModelMessage;
 		});

--- a/src/features/chat/chat.adapter.ts
+++ b/src/features/chat/chat.adapter.ts
@@ -3,12 +3,18 @@ import invariant from "tiny-invariant";
 import type { ProtectedChatMessage } from "./chat.external";
 
 const USER_SENDER_TYPE = "user";
-
 const TEXT_TYPE = "text";
+
+type SupportedRole = "user" | "assistant";
+
+interface AdapterMessage {
+	role: SupportedRole;
+	text: string;
+}
 
 function getRoleFromSenderType(
 	senderType: string | null | undefined,
-): "user" | "assistant" {
+): SupportedRole {
 	if (!senderType) {
 		return "assistant";
 	}
@@ -25,29 +31,57 @@ function isNonEmptyContent(value: string | null | undefined): value is string {
 	return Boolean(value && value.trim().length > 0);
 }
 
+function enforceAlternatingRoles(messages: AdapterMessage[]): AdapterMessage[] {
+	const validated: AdapterMessage[] = [];
+	let previousRole: SupportedRole | null = null;
+
+	for (let index = messages.length - 1; index >= 0; index -= 1) {
+		const message = messages[index];
+		invariant(message, "message is guaranteed to be non-null");
+
+		if (previousRole === null) {
+			validated.push(message);
+			previousRole = message.role;
+			continue;
+		}
+
+		if (message.role === previousRole) {
+			break;
+		}
+
+		validated.push(message);
+		previousRole = message.role;
+	}
+
+	// if the last message is 'assistant', remove it
+	if (validated[validated.length - 1]?.role === "assistant") {
+		validated.pop();
+	}
+
+	return validated.reverse();
+}
+
+function toModelMessage(message: AdapterMessage): ModelMessage {
+	return {
+		role: message.role,
+		content: [{ type: TEXT_TYPE, text: message.text }],
+	};
+}
+
 export function adaptProtectedMessagesToModelMessages(
 	messages: ProtectedChatMessage[],
 ): ModelMessage[] {
-	return messages
+	const adapterMessages = messages
 		.filter((message) => isNonEmptyContent(message.chatContent))
 		.map((message) => {
-			invariant(
-				message.chatContent,
-				"chatContent is required for convert ImChatVO to ModelMessage",
-			);
-			const role = getRoleFromSenderType(message.senderType);
-			const content = [{ type: TEXT_TYPE, text: message.chatContent }];
-
-			if (role === "user") {
-				return {
-					role: "user" as const,
-					content,
-				} as ModelMessage;
-			}
-
+			invariant(message.chatContent, "chatContent is required");
 			return {
-				role: "assistant" as const,
-				content,
-			} as ModelMessage;
+				role: getRoleFromSenderType(message.senderType),
+				text: message.chatContent.trim(),
+			} satisfies AdapterMessage;
 		});
+
+	const alternatingMessages = enforceAlternatingRoles(adapterMessages);
+
+	return alternatingMessages.map((message) => toModelMessage(message));
 }

--- a/src/features/chat/chat.controller.ts
+++ b/src/features/chat/chat.controller.ts
@@ -1,9 +1,12 @@
 import { openai } from "@ai-sdk/openai";
+import type { ModelMessage } from "ai";
 import { streamText } from "ai";
+import { adaptProtectedMessagesToModelMessages } from "./chat.adapter";
 import type { ChatEntity } from "./chat.events";
 import {
 	fetchProtectedChatContext,
 	fetchProtectedChatId,
+	fetchProtectedChatMessages,
 	sendChatEntityToProtectedService,
 } from "./chat.external";
 import type { ChatLogger } from "./chat.logger";
@@ -12,26 +15,36 @@ import type { MymemoEventSender } from "./chat.streaming";
 
 export async function complete(
 	{ chatContent, chatKey, chatType, collectionId, summaryId }: ChatRequest,
+	memberCode: string,
 	mymemoEventSender: MymemoEventSender,
 	logger: ChatLogger,
 ) {
-	const chatId = await fetchProtectedChatId({}, logger);
+	const [chatId, chatContext, chatHistory] = await Promise.all([
+		fetchProtectedChatId({}, logger),
+		fetchProtectedChatContext(chatKey, collectionId, summaryId, {}, logger),
+		fetchProtectedChatMessages(
+			chatKey,
+			{
+				collectionId,
+				summaryId,
+				memberCode,
+			},
+			{},
+			logger,
+		),
+	]);
 
-	const chatContext = await fetchProtectedChatContext(
-		chatKey,
-		collectionId,
-		summaryId,
-		{},
-		logger,
-	);
 	const contextChatData = chatContext.chatData;
-	const resolvedMemberCode = contextChatData?.memberCode ?? "";
+	const resolvedMemberCode = contextChatData?.memberCode ?? memberCode ?? "";
 	const resolvedMemberName = contextChatData?.nickName ?? "";
 	const resolvedPartnerCode = contextChatData?.partnerCode ?? "";
 	const resolvedPartnerName = contextChatData?.partnerName ?? "";
 	const resolvedSenderCode = contextChatData?.teamCode ?? "";
 
-	const messages = [
+	const historyMessages = adaptProtectedMessagesToModelMessages(chatHistory);
+
+	const messages: ModelMessage[] = [
+		...historyMessages,
 		{
 			role: "user" as const,
 			content: [{ type: "text" as const, text: chatContent }],

--- a/src/features/chat/chat.controller.ts
+++ b/src/features/chat/chat.controller.ts
@@ -42,6 +42,8 @@ export async function complete(
 	const resolvedSenderCode = contextChatData?.teamCode ?? "";
 
 	const historyMessages = adaptProtectedMessagesToModelMessages(chatHistory);
+	// TODO: remove this
+	console.debug("historyMessages", historyMessages);
 
 	const messages: ModelMessage[] = [
 		...historyMessages,

--- a/src/features/chat/chat.controller.ts
+++ b/src/features/chat/chat.controller.ts
@@ -43,7 +43,11 @@ export async function complete(
 
 	const historyMessages = adaptProtectedMessagesToModelMessages(chatHistory);
 	// TODO: remove this
-	console.debug("historyMessages", historyMessages);
+	const historyMessagesLength = historyMessages.length;
+	console.debug(
+		"historyMessages",
+		JSON.stringify(historyMessages.slice(historyMessagesLength - 10), null, 2),
+	);
 
 	const messages: ModelMessage[] = [
 		...historyMessages,

--- a/src/features/chat/chat.route.ts
+++ b/src/features/chat/chat.route.ts
@@ -41,6 +41,7 @@ app.post(
 						collectionId: request.collectionId,
 						summaryId: request.summaryId,
 					},
+					memberCode,
 					new HonoSSESender(stream),
 					new ChatLogger(memberCode, request.chatKey),
 				);


### PR DESCRIPTION
This pull request introduces support for fetching and adapting chat message history from a protected API, enabling the chat system to use previous messages as context for completions. The changes include new endpoint utilities, schema definitions, message adaptation logic, and integration into the chat controller, along with comprehensive tests.

**Chat Message History Fetching and Adaptation:**

* Added the `fetchProtectedChatMessages` function in `chat.external.ts` to retrieve chat history from the protected API, including schema validation and error handling. [[1]](diffhunk://#diff-230691a4bf2720b8f46036ac4fa0cc5547a6b47d14c7725bf553e97715e564e1R54-R84) [[2]](diffhunk://#diff-230691a4bf2720b8f46036ac4fa0cc5547a6b47d14c7725bf553e97715e564e1R202-R300)
* Defined the `ProtectedChatMessage` type and related Zod schemas for chat message validation.
* Introduced `getProtectedChatMessagesEndpoint` in `env.ts` to generate the correct endpoint URL for fetching chat messages, supporting filtering by scope, collection, summary, size, and member code.

**Message Adaptation Logic:**

* Implemented `adaptProtectedMessagesToModelMessages` in `chat.adapter.ts` to convert protected chat messages to the format expected by the AI model, ensuring alternating user/assistant roles and trimming empty or invalid content.
* Added comprehensive tests for the message adaptation logic in `chat.adapter.test.ts`.

**Controller and Route Integration:**

* Updated `chat.controller.ts` to fetch chat history, adapt it, and include it in the messages sent to the AI model for completion, ensuring proper context is used. [[1]](diffhunk://#diff-787c1546c633e120828b96d872463a7cb5e84cb123b9b8a07d96f48a6b5c3350R2-R9) [[2]](diffhunk://#diff-787c1546c633e120828b96d872463a7cb5e84cb123b9b8a07d96f48a6b5c3350R18-R53)
* Modified the chat route to pass `memberCode` to the controller for consistent context.

**Dependency Management:**

* Added the `tiny-invariant` package to enforce runtime invariants in the adapter logic.

**Environment Utilities:**

* Improved environment variable handling and endpoint generation for chat message APIs in `env.ts`. [[1]](diffhunk://#diff-0628e9bc652476c15d1024481f1eaebb8f1ca780b4ac24da3b2b20651662968aL20-R22) [[2]](diffhunk://#diff-0628e9bc652476c15d1024481f1eaebb8f1ca780b4ac24da3b2b20651662968aL61-R115)

These changes collectively enhance the chat system's ability to provide context-aware completions by leveraging chat history from the protected service.This pull request introduces support for fetching and utilizing chat message history from a protected service in the chat feature. The main changes add a new endpoint for retrieving chat messages, adapt the returned messages to the model's format, and update the chat completion logic to include chat history in the conversation context. This should improve the context-awareness of chat completions and support more advanced chat flows.

**Protected chat messages support:**

* Added a new endpoint generator `getProtectedChatMessagesEndpoint` in `env.ts` to construct URLs for fetching chat messages, with support for filtering by scope, collection, summary, size, and member code.
* Implemented `fetchProtectedChatMessages` in `chat.external.ts` to call the protected API, validate and normalize responses, and handle errors robustly. Also defined related types and schemas for chat message data and scope normalization. [[1]](diffhunk://#diff-230691a4bf2720b8f46036ac4fa0cc5547a6b47d14c7725bf553e97715e564e1R54-R84) [[2]](diffhunk://#diff-230691a4bf2720b8f46036ac4fa0cc5547a6b47d14c7725bf553e97715e564e1R202-R300)

**Chat message adaptation and integration:**

* Added `adaptProtectedMessagesToModelMessages` in `chat.adapter.ts` to convert protected chat messages into the format required by the chat model, filtering out empty content and mapping sender roles.
* Updated the chat completion controller (`chat.controller.ts`) to fetch chat history in parallel with other context, adapt it to model messages, and include it in the prompt for chat completions. [[1]](diffhunk://#diff-787c1546c633e120828b96d872463a7cb5e84cb123b9b8a07d96f48a6b5c3350R2-R9) [[2]](diffhunk://#diff-787c1546c633e120828b96d872463a7cb5e84cb123b9b8a07d96f48a6b5c3350R18-R47)

**Wiring and API changes:**

* Updated the chat route to pass `memberCode` to the new chat completion logic to ensure correct context and permissions.Introduces fetching of chat message history from the protected service and adapts it to the model message format. Adds endpoint and schema for chat messages in env and external modules, a new adapter for message transformation, and updates the chat controller and route to include message history in completions.