### PR TITLE
feat: Remove unused fields from chatContextSchema

### DIFF
--- a/src/features/chat/chat.external.ts
+++ b/src/features/chat/chat.external.ts
@@ -39,8 +39,6 @@ const chatDataSchema = z.object({
 const chatContextSchema = z
 	.object({
 		chatKey: z.string(),
-		collectionId: z.string().optional().nullable(),
-		summaryId: z.string().optional().nullable(),
 		chatData: chatDataSchema.optional(),
 		timestamp: z.string().optional(),
 	})


### PR DESCRIPTION
This pull request makes a small change to the `chatContextSchema` definition by removing the optional `collectionId` and `summaryId` fields. This simplifies the schema and reduces unnecessary properties.Deleted the optional 'collectionId' and 'summaryId' fields from the chatContextSchema as they are no longer required.