### PR TITLE
fix: Add scope parameter to chat completion request

### DIFF
--- a/src/features/chat/chat.controller.ts
+++ b/src/features/chat/chat.controller.ts
@@ -29,6 +29,7 @@ export async function complete(
 				summaryId,
 				memberCode,
 				size: 1000,
+				scope: summaryId ? "document" : collectionId ? "collection" : "general",
 			},
 			{},
 			logger,


### PR DESCRIPTION
This pull request introduces a small but important change to the `complete` function in `src/features/chat/chat.controller.ts`. The change adds a `scope` property to the query parameters, dynamically setting its value based on whether `summaryId` or `collectionId` is present. This helps clarify the context in which the function operates.Introduces a 'scope' parameter to the chat completion function, setting its value based on the presence of summaryId or collectionId. This helps specify the context for the completion operation.