### PR TITLE
feat: Handle files without fileName in list-collection-files

### DIFF
--- a/src/features/chat/tools/list-collection-files.ts
+++ b/src/features/chat/tools/list-collection-files.ts
@@ -86,14 +86,23 @@ export async function handleListCollectionFiles({
 	invariant(collectionName.length > 0, "Collection name is required");
 
 	const fileList = normalizedFiles
-		.map(
-			(file) => `
+		.map((file) => {
+			if (!file.fileName && file.fileLink) {
+				return `
+				<file>
+					<link>${file.fileLink}</link>
+					<id>${file.summaryId}</id>
+					<type>${file.fileType}</type>
+				</file>`;
+			}
+
+			return `
 			<file>
 				<name>${file.fileName}</name>
 				<id>${file.summaryId}</id>
 				<type>${file.fileType}</type>
-			</file>`,
-		)
+			</file>`;
+		})
 		.join("\n");
 
 	onEvent({


### PR DESCRIPTION
This pull request updates the logic for formatting file entries in the `handleListCollectionFiles` function to better handle cases where a file may not have a `fileName` but does have a `fileLink`. This ensures that files without a name are still represented correctly in the output.

**Improvements to file formatting logic:**

* Updated the mapping logic in `handleListCollectionFiles` (`src/features/chat/tools/list-collection-files.ts`) to output `<link>` instead of `<name>` for files that lack a `fileName` but have a `fileLink`, ensuring all files are represented appropriately in the output.Updated the file list mapping to support files that lack a fileName but have a fileLink, ensuring such files are correctly represented in the output XML.