### PR TITLE
feat: Add enableKnowledge flag to chat context and tool selection

### DIFF
--- a/src/features/chat/chat.controller.ts
+++ b/src/features/chat/chat.controller.ts
@@ -61,6 +61,7 @@ export async function complete(
 	const resolvedPartnerName = contextChatData?.partnerName ?? null;
 	const resolvedSenderCode = contextChatData?.partnerCode ?? null;
 	const resolvedModelType = contextChatData?.modelType ?? "gpt-4o";
+	const resolvedEnableKnowledge = contextChatData?.enableKnowledge ?? 1;
 
 	const historyMessages = adaptProtectedMessagesToModelMessages(chatHistory);
 
@@ -79,6 +80,7 @@ export async function complete(
 		summaryId: normalizedSummaryId,
 		modelId: resolvedModelType,
 		partnerCode: resolvedPartnerCode ?? "",
+		enableKnowledge: resolvedEnableKnowledge === 1,
 	};
 
 	let conversationHistory: ConversationHistory = {

--- a/src/features/chat/core/config.ts
+++ b/src/features/chat/core/config.ts
@@ -7,6 +7,6 @@ export type Config = {
 	collectionId: string | null;
 	summaryId: string | null;
 	partnerCode: string;
-
+	enableKnowledge: boolean;
 	modelId: string;
 };

--- a/src/features/chat/core/mymemo.ts
+++ b/src/features/chat/core/mymemo.ts
@@ -1,5 +1,4 @@
 import { type LanguageModel, type ModelMessage, streamText } from "ai";
-import invariant from "tiny-invariant";
 import type { ChatMessagesScope } from "@/config/env";
 import type { EventMessage } from "../chat.events";
 import {
@@ -59,6 +58,7 @@ function buildSession({
 		summaryId: config.summaryId,
 		collectionId: config.collectionId,
 		partnerCode: config.partnerCode,
+		enableKnowledge: config.enableKnowledge,
 		logger,
 	};
 
@@ -91,6 +91,7 @@ export type TurnContext = {
 	summaryId: string | null;
 	collectionId: string | null;
 	partnerCode: string;
+	enableKnowledge: boolean;
 	logger: ChatLogger;
 };
 
@@ -115,6 +116,7 @@ async function runTurn(
 		environmentContext: turnContext.environmentContext,
 		messages: turnInput,
 		scope: turnContext.scope,
+		enableKnowledge: turnContext.enableKnowledge,
 		tools,
 	});
 

--- a/src/features/chat/prompts/prompts.ts
+++ b/src/features/chat/prompts/prompts.ts
@@ -23,15 +23,17 @@ export function buildPrompt({
 	environmentContext,
 	tools,
 	scope,
+	enableKnowledge,
 	messages,
 }: {
 	systemPrompt: string;
 	environmentContext: string | null;
 	tools: ReturnType<typeof getTools>;
 	scope: ChatMessagesScope;
+	enableKnowledge: boolean;
 	messages: ModelMessage[];
 }) {
-	const allowedTools = getAllowedTools(scope);
+	const allowedTools = getAllowedTools(scope, enableKnowledge);
 
 	return {
 		system: `${systemPrompt}\n\n${environmentContext ?? ""}`,

--- a/src/features/chat/tools/tools.ts
+++ b/src/features/chat/tools/tools.ts
@@ -11,7 +11,10 @@ export function getTools() {
 	};
 }
 
-export function getAllowedTools(scope: ChatMessagesScope) {
+export function getAllowedTools(
+	scope: ChatMessagesScope,
+	enableKnowledge: boolean,
+) {
 	switch (scope) {
 		case "collection":
 			return [
@@ -21,7 +24,15 @@ export function getAllowedTools(scope: ChatMessagesScope) {
 			];
 		case "document":
 			return ["update_plan" as const, "read_file" as const];
+		case "general":
+			return enableKnowledge
+				? [
+						"update_plan" as const,
+						"read_file" as const,
+						"list_collection_files" as const,
+					]
+				: ["update_plan" as const];
 		default:
-			return ["update_plan" as const, "read_file" as const];
+			return ["update_plan" as const];
 	}
 }


### PR DESCRIPTION
This pull request introduces support for an `enableKnowledge` flag throughout the chat feature, allowing for dynamic control of tool availability based on this setting. The main focus is on propagating this flag through the chat session configuration and using it to determine which tools are accessible in different chat scopes.

Feature: Knowledge Enablement

* Added an `enableKnowledge` boolean property to the chat configuration (`Config` type) and ensured it is passed through all relevant layers, including the controller, session, and turn context. [[1]](diffhunk://#diff-787c1546c633e120828b96d872463a7cb5e84cb123b9b8a07d96f48a6b5c3350R64) [[2]](diffhunk://#diff-787c1546c633e120828b96d872463a7cb5e84cb123b9b8a07d96f48a6b5c3350R83) [[3]](diffhunk://#diff-e86893737fcadc890a8f61242e644befbf894a4b5e51e9cff5da7e4e59515f3fL10-R10) [[4]](diffhunk://#diff-7c2ef494e77cb130e56c10a42ea4adb91c215c9112311f9ad1cc43cc46c4c282R61) [[5]](diffhunk://#diff-7c2ef494e77cb130e56c10a42ea4adb91c215c9112311f9ad1cc43cc46c4c282R94) [[6]](diffhunk://#diff-7c2ef494e77cb130e56c10a42ea4adb91c215c9112311f9ad1cc43cc46c4c282R119)
* Updated the prompt building logic to accept the `enableKnowledge` flag and forward it to the tool selection logic.

Tool Selection Logic

* Modified the `getAllowedTools` function to use the `enableKnowledge` flag: when enabled in the "general" scope, additional tools (`read_file`, `list_collection_files`) become available; otherwise, only `update_plan` is allowed. Adjusted the default case for stricter tool access. [[1]](diffhunk://#diff-c5dbc0691a1b809aebf1b7557a6a3a00f526829b5d4b4c6b09083b525d14095cL14-R17) [[2]](diffhunk://#diff-c5dbc0691a1b809aebf1b7557a6a3a00f526829b5d4b4c6b09083b525d14095cR27-R36)Introduces an enableKnowledge boolean flag to the chat context, configuration, and prompt building logic. Tool selection in getAllowedTools now respects this flag, allowing additional tools in 'general' scope when enabled. This change enables more granular control over tool availability based on chat context.