### PR TITLE
feat: Add explanation field to update plan tool

### DIFF
--- a/src/features/chat/tools/update-plan.ts
+++ b/src/features/chat/tools/update-plan.ts
@@ -3,21 +3,31 @@ import { z } from "zod";
 import type { EventMessage } from "../chat.events";
 
 export const updatePlanToolInputSchema = z.object({
-	plan: z.array(
-		z.object({
-			step: z.string().describe("The step to update"),
-			status: z
-				.enum(["pending", "in_progress", "completed"])
-				.describe("The status of the step"),
-		}),
-	),
+	explanation: z
+		.string()
+		.optional()
+		.describe("The explanation for the plan update"),
+	plan: z
+		.array(
+			z.object({
+				step: z.string(),
+				status: z
+					.enum(["pending", "in_progress", "completed"])
+					.describe(
+						"The status of the step, one of pending, in_progress, completed",
+					),
+			}),
+		)
+		.describe("The list of steps to update"),
 });
 
 export type UpdatePlanToolInput = z.infer<typeof updatePlanToolInputSchema>;
 
 // the `tool` helper function ensures correct type inference:
 export const updatePlanTool = tool({
-	description: "Update the plan",
+	description: `Update the task plan.
+Provide an optional explanation and a list of plan items, each with a step and status.
+At most one step can be in_progress at a time.`,
 	inputSchema: updatePlanToolInputSchema,
 });
 
@@ -30,10 +40,10 @@ export async function handleUpdatePlan({
 }) {
 	onEvent({
 		type: "plan_update",
+		explanation: args.explanation,
 		plan: args.plan,
 	});
 	return {
-		plan: args.plan,
 		message: "Plan updated",
 	};
 }


### PR DESCRIPTION
This pull request enhances the plan update functionality by allowing an optional explanation to be included when updating a plan and clarifies the structure and documentation of the input schema. The changes also update the tool's description to provide clearer guidance on its usage.

**Schema and API enhancements:**

* Added an optional `explanation` field to the `updatePlanToolInputSchema` and included it in the `plan_update` event, allowing users to provide context for plan updates. [[1]](diffhunk://#diff-8eb496add14ca71433f5332c332f492a041223afed04bbe05336a0a699d15476L6-R30) [[2]](diffhunk://#diff-8eb496add14ca71433f5332c332f492a041223afed04bbe05336a0a699d15476R43-L36)
* Improved documentation and descriptions for the `plan` array and its items in the schema, making it clearer how to use the tool and what each field represents.
* Updated the tool's description to specify that only one step can be `in_progress` at a time and to clarify the expected input structure.Introduces an optional 'explanation' field to the updatePlanToolInputSchema and updates the tool description to clarify usage. The event handler now includes the explanation in the emitted event.