### PR TITLE
feat: Add collapseFlag to chat message fetching logic

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -73,6 +73,7 @@ interface ChatMessagesEndpointOptions {
 	summaryId?: string | null;
 	size?: number | null;
 	memberCode?: string | null;
+	collapseFlag?: string | null;
 }
 
 export const getProtectedChatMessagesEndpoint = (
@@ -86,7 +87,8 @@ export const getProtectedChatMessagesEndpoint = (
 	const path = prefix === "/" ? basePath : `${prefix}${basePath}`;
 	const url = new URL(path, origin);
 
-	const { scope, collectionId, summaryId, size, memberCode } = options;
+	const { scope, collectionId, summaryId, size, memberCode, collapseFlag } =
+		options;
 
 	if (scope) {
 		url.searchParams.set("scope", scope);
@@ -109,6 +111,11 @@ export const getProtectedChatMessagesEndpoint = (
 	const normalizedMemberCode = memberCode?.trim();
 	if (normalizedMemberCode) {
 		url.searchParams.set("memberCode", normalizedMemberCode);
+	}
+
+	const normalizedCollapseFlag = collapseFlag?.trim();
+	if (normalizedCollapseFlag) {
+		url.searchParams.set("collapseFlag", normalizedCollapseFlag);
 	}
 
 	return url.toString();

--- a/src/features/chat/chat.controller.ts
+++ b/src/features/chat/chat.controller.ts
@@ -46,6 +46,8 @@ export async function complete(
 				memberCode: config.memberCode,
 				scope: summaryId ? "document" : collectionId ? "collection" : "general",
 				size: 1000,
+				// Only fetch the not collapsed messages
+				collapseFlag: "1",
 			},
 			protectedFetchOptions,
 			logger,
@@ -122,6 +124,7 @@ export async function complete(
 				collectionId: normalizeCollectionId,
 				summaryId: normalizedSummaryId,
 				refsId: refsId,
+				// Only send the not collapsed messages
 				collapseFlag: "1",
 			};
 

--- a/src/features/chat/chat.external.ts
+++ b/src/features/chat/chat.external.ts
@@ -279,6 +279,7 @@ export interface FetchProtectedChatMessagesParams {
 	summaryId?: string | null | undefined;
 	size?: number | null | undefined;
 	memberCode?: string | null | undefined;
+	collapseFlag?: string | null | undefined;
 }
 
 export async function fetchProtectedChatMessages(
@@ -287,7 +288,8 @@ export async function fetchProtectedChatMessages(
 	options: FetchOptions = {},
 	logger: ChatLogger,
 ): Promise<ProtectedChatMessage[]> {
-	const { scope, collectionId, summaryId, size, memberCode } = params;
+	const { scope, collectionId, summaryId, size, memberCode, collapseFlag } =
+		params;
 	const resolvedScope = normalizeChatMessagesScope(scope);
 
 	const endpoint = getProtectedChatMessagesEndpoint(chatKey, {
@@ -296,6 +298,7 @@ export async function fetchProtectedChatMessages(
 		summaryId: summaryId ?? null,
 		size: size ?? null,
 		memberCode: memberCode ?? null,
+		collapseFlag: collapseFlag ?? null,
 	});
 
 	try {


### PR DESCRIPTION
This pull request adds support for a new `collapseFlag` parameter throughout the chat message fetching flow. This allows the system to filter and fetch only non-collapsed chat messages when making API requests. The change is implemented consistently across type definitions, endpoint construction, and function calls.

**Support for collapseFlag in chat message fetching:**

* Added `collapseFlag` as an optional parameter to the `ChatMessagesEndpointOptions` interface and ensured it is included in the `getProtectedChatMessagesEndpoint` URL construction logic in `src/config/env.ts`. [[1]](diffhunk://#diff-0628e9bc652476c15d1024481f1eaebb8f1ca780b4ac24da3b2b20651662968aR76) [[2]](diffhunk://#diff-0628e9bc652476c15d1024481f1eaebb8f1ca780b4ac24da3b2b20651662968aL89-R91) [[3]](diffhunk://#diff-0628e9bc652476c15d1024481f1eaebb8f1ca780b4ac24da3b2b20651662968aR116-R120)
* Updated the `FetchProtectedChatMessagesParams` interface and the `fetchProtectedChatMessages` function to accept and forward the `collapseFlag` parameter, ensuring it is passed through all relevant layers in `src/features/chat/chat.external.ts`. [[1]](diffhunk://#diff-230691a4bf2720b8f46036ac4fa0cc5547a6b47d14c7725bf553e97715e564e1R282) [[2]](diffhunk://#diff-230691a4bf2720b8f46036ac4fa0cc5547a6b47d14c7725bf553e97715e564e1L290-R292) [[3]](diffhunk://#diff-230691a4bf2720b8f46036ac4fa0cc5547a6b47d14c7725bf553e97715e564e1R301)
* Modified calls to `fetchProtectedChatMessages` in `src/features/chat/chat.controller.ts` to set `collapseFlag: "1"`, ensuring only non-collapsed messages are fetched and sent. [[1]](diffhunk://#diff-787c1546c633e120828b96d872463a7cb5e84cb123b9b8a07d96f48a6b5c3350R49-R50) [[2]](diffhunk://#diff-787c1546c633e120828b96d872463a7cb5e84cb123b9b8a07d96f48a6b5c3350R127)Introduces the collapseFlag parameter to chat message endpoint construction and usage, ensuring only non-collapsed messages are fetched and sent. Updates relevant interfaces and function calls to support this new filter.