### PR TITLE
feat: Remove memberCode from chat message fetching

### DIFF
--- a/src/features/chat/chat.controller.ts
+++ b/src/features/chat/chat.controller.ts
@@ -43,7 +43,6 @@ export async function complete(
 			{
 				collectionId,
 				summaryId,
-				memberCode: config.memberCode,
 				scope: summaryId ? "document" : collectionId ? "collection" : "general",
 				size: 1000,
 				// Only fetch the not collapsed messages

--- a/src/features/chat/chat.external.ts
+++ b/src/features/chat/chat.external.ts
@@ -321,7 +321,6 @@ export interface FetchProtectedChatMessagesParams {
 	collectionId?: string | null | undefined;
 	summaryId?: string | null | undefined;
 	size?: number | null | undefined;
-	memberCode?: string | null | undefined;
 	collapseFlag?: string | null | undefined;
 }
 
@@ -331,8 +330,7 @@ export async function fetchProtectedChatMessages(
 	options: FetchOptions = {},
 	logger: ChatLogger,
 ): Promise<ProtectedChatMessage[]> {
-	const { scope, collectionId, summaryId, size, memberCode, collapseFlag } =
-		params;
+	const { scope, collectionId, summaryId, size, collapseFlag } = params;
 	const resolvedScope = normalizeChatMessagesScope(scope);
 
 	const endpoint = getProtectedChatMessagesEndpoint(chatKey, {
@@ -340,7 +338,6 @@ export async function fetchProtectedChatMessages(
 		collectionId: collectionId ?? null,
 		summaryId: summaryId ?? null,
 		size: size ?? null,
-		memberCode: memberCode ?? null,
 		collapseFlag: collapseFlag ?? null,
 	});
 
@@ -381,7 +378,6 @@ export async function fetchProtectedChatMessages(
 				collectionId,
 				summaryId,
 				size,
-				memberCode,
 				rawBody,
 			});
 			throw new Error(`Failed to fetch chat messages: ${body.msg}`);
@@ -398,7 +394,6 @@ export async function fetchProtectedChatMessages(
 				collectionId,
 				summaryId,
 				size,
-				memberCode,
 			});
 			throw error;
 		}
@@ -411,7 +406,6 @@ export async function fetchProtectedChatMessages(
 			collectionId,
 			summaryId,
 			size,
-			memberCode,
 		});
 		throw new Error(String(error));
 	}


### PR DESCRIPTION
This pull request removes the unused `memberCode` parameter from the chat message fetching logic, simplifying the codebase and the related interfaces. The changes affect both the interface definitions and the internal handling of parameters in the chat feature.

**Chat message fetching simplification:**

* Removed the `memberCode` property from the `FetchProtectedChatMessagesParams` interface and all related function parameters and API calls in `chat.external.ts`. [[1]](diffhunk://#diff-230691a4bf2720b8f46036ac4fa0cc5547a6b47d14c7725bf553e97715e564e1L324) [[2]](diffhunk://#diff-230691a4bf2720b8f46036ac4fa0cc5547a6b47d14c7725bf553e97715e564e1L334-L343) [[3]](diffhunk://#diff-230691a4bf2720b8f46036ac4fa0cc5547a6b47d14c7725bf553e97715e564e1L384) [[4]](diffhunk://#diff-230691a4bf2720b8f46036ac4fa0cc5547a6b47d14c7725bf553e97715e564e1L401) [[5]](diffhunk://#diff-230691a4bf2720b8f46036ac4fa0cc5547a6b47d14c7725bf553e97715e564e1L414)
* Removed the use of `memberCode` when calling the chat message fetch function in `chat.controller.ts`.Eliminated the memberCode parameter from FetchProtectedChatMessagesParams and related function calls in chat.controller.ts and chat.external.ts, simplifying the API and data flow for fetching protected chat messages.