### PR TITLE
feat: Remove collapseFlag and memberCode from chat message endpoints

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -72,8 +72,6 @@ interface ChatMessagesEndpointOptions {
 	collectionId?: string | null;
 	summaryId?: string | null;
 	size?: number | null;
-	memberCode?: string | null;
-	collapseFlag?: string | null;
 }
 
 export const getProtectedChatMessagesEndpoint = (
@@ -87,8 +85,7 @@ export const getProtectedChatMessagesEndpoint = (
 	const path = prefix === "/" ? basePath : `${prefix}${basePath}`;
 	const url = new URL(path, origin);
 
-	const { scope, collectionId, summaryId, size, memberCode, collapseFlag } =
-		options;
+	const { scope, collectionId, summaryId, size } = options;
 
 	if (scope) {
 		url.searchParams.set("scope", scope);
@@ -106,16 +103,6 @@ export const getProtectedChatMessagesEndpoint = (
 
 	if (typeof size === "number" && Number.isFinite(size) && size > 0) {
 		url.searchParams.set("size", String(size));
-	}
-
-	const normalizedMemberCode = memberCode?.trim();
-	if (normalizedMemberCode) {
-		url.searchParams.set("memberCode", normalizedMemberCode);
-	}
-
-	const normalizedCollapseFlag = collapseFlag?.trim();
-	if (normalizedCollapseFlag) {
-		url.searchParams.set("collapseFlag", normalizedCollapseFlag);
 	}
 
 	return url.toString();
@@ -162,9 +149,7 @@ export const getProtectedFileDetailEndpoint = (
 	return new URL(path, origin).toString();
 };
 
-export const getProtectedSummariesEndpoint = (
-	ids: Array<string | number>,
-) => {
+export const getProtectedSummariesEndpoint = (ids: Array<string | number>) => {
 	const origin = getProtectedApiOrigin();
 	const prefix = getProtectedApiPrefix();
 	const basePath = `/protected/summaries`;

--- a/src/features/chat/chat.controller.ts
+++ b/src/features/chat/chat.controller.ts
@@ -45,8 +45,6 @@ export async function complete(
 				summaryId,
 				scope: summaryId ? "document" : collectionId ? "collection" : "general",
 				size: 1000,
-				// Only fetch the not collapsed messages
-				collapseFlag: "1",
 			},
 			protectedFetchOptions,
 			logger,

--- a/src/features/chat/chat.external.ts
+++ b/src/features/chat/chat.external.ts
@@ -321,7 +321,6 @@ export interface FetchProtectedChatMessagesParams {
 	collectionId?: string | null | undefined;
 	summaryId?: string | null | undefined;
 	size?: number | null | undefined;
-	collapseFlag?: string | null | undefined;
 }
 
 export async function fetchProtectedChatMessages(
@@ -330,7 +329,7 @@ export async function fetchProtectedChatMessages(
 	options: FetchOptions = {},
 	logger: ChatLogger,
 ): Promise<ProtectedChatMessage[]> {
-	const { scope, collectionId, summaryId, size, collapseFlag } = params;
+	const { scope, collectionId, summaryId, size } = params;
 	const resolvedScope = normalizeChatMessagesScope(scope);
 
 	const endpoint = getProtectedChatMessagesEndpoint(chatKey, {
@@ -338,7 +337,6 @@ export async function fetchProtectedChatMessages(
 		collectionId: collectionId ?? null,
 		summaryId: summaryId ?? null,
 		size: size ?? null,
-		collapseFlag: collapseFlag ?? null,
 	});
 
 	try {


### PR DESCRIPTION
This pull request removes the `collapseFlag` and `memberCode` parameters from the chat messages API interfaces and related logic. The changes simplify the API by eliminating unused or unnecessary parameters, streamlining both the endpoint construction and the data flow for fetching chat messages.

**API parameter and interface cleanup:**

* Removed `collapseFlag` and `memberCode` from the `ChatMessagesEndpointOptions` interface in `src/config/env.ts` and from the `FetchProtectedChatMessagesParams` interface in `src/features/chat/chat.external.ts`. [[1]](diffhunk://#diff-0628e9bc652476c15d1024481f1eaebb8f1ca780b4ac24da3b2b20651662968aL75-L76) [[2]](diffhunk://#diff-230691a4bf2720b8f46036ac4fa0cc5547a6b47d14c7725bf553e97715e564e1L324)
* Removed all logic related to adding `collapseFlag` and `memberCode` as query parameters in the `getProtectedChatMessagesEndpoint` function in `src/config/env.ts`. [[1]](diffhunk://#diff-0628e9bc652476c15d1024481f1eaebb8f1ca780b4ac24da3b2b20651662968aL90-R88) [[2]](diffhunk://#diff-0628e9bc652476c15d1024481f1eaebb8f1ca780b4ac24da3b2b20651662968aL111-L120)
* Updated the `fetchProtectedChatMessages` function in `src/features/chat/chat.external.ts` to stop passing and extracting the `collapseFlag` parameter.
* Removed the `collapseFlag` parameter from the call to `getProtectedChatMessagesEndpoint` in the `complete` function in `src/features/chat/chat.controller.ts`.

**Minor code formatting:**

* Minor formatting change in the `getProtectedSummariesEndpoint` function signature in `src/config/env.ts` (no functional impact).Eliminated the use of collapseFlag and memberCode parameters from chat message endpoint construction and related interfaces. Updated controller and external fetch logic to no longer reference or pass these parameters, simplifying the API and data flow.