### PR TITLE
feat: Integrate hono-pino for structured logging

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,8 @@
         "ai": "^5.0.0-beta.34",
         "hono": "^4.9.7",
         "hono-openapi": "^1.0.8",
-        "pino": "^9.10.0",
+        "hono-pino": "^0.10.2",
+        "pino": "^9.12.0",
         "pino-http": "^10.5.0",
         "tiny-invariant": "^1.3.3",
         "zod": "^4.1.9",
@@ -88,6 +89,8 @@
 
     "csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
 
+    "defu": ["defu@6.1.4", "", {}, "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="],
+
     "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
 
     "fast-redact": ["fast-redact@3.5.0", "", {}, "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A=="],
@@ -98,6 +101,8 @@
 
     "hono-openapi": ["hono-openapi@1.0.8", "", { "peerDependencies": { "@hono/standard-validator": "^0.1.2", "@standard-community/standard-json": "^0.3.1", "@standard-community/standard-openapi": "^0.2.4", "@types/json-schema": "^7.0.15", "hono": "^4.8.3", "openapi-types": "^12.1.3" }, "optionalPeers": ["@hono/standard-validator", "hono"] }, "sha512-JjSdT4sNUgxQGgwO90boRLfnrVYp3ge+Y/vHqPMJrAZuaIhKekAVipoeJ8AgpTyK+ZaxPzqdcmDBA9L+Ce3X9Q=="],
 
+    "hono-pino": ["hono-pino@0.10.2", "", { "dependencies": { "defu": "^6.1.4" }, "peerDependencies": { "hono": ">=4.0.0", "pino": ">=7.1.0" } }, "sha512-h8h4jODUoWdY7n7J1GsOO5Szpf0KH0+bdh8inJVTFrud/R/cxNjKty/pEaJIYSY9+enP0dfAiY+gjXTEFkARYg=="],
+
     "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
 
     "nanoid": ["nanoid@5.1.5", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw=="],
@@ -106,7 +111,7 @@
 
     "openapi-types": ["openapi-types@12.1.3", "", {}, "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="],
 
-    "pino": ["pino@9.10.0", "", { "dependencies": { "atomic-sleep": "^1.0.0", "fast-redact": "^3.1.1", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^2.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^3.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-VOFxoNnxICtxaN8S3E73pR66c5MTFC+rwRcNRyHV/bV/c90dXvJqMfjkeRFsGBDXmlUN3LccJQPqGIufnaJePA=="],
+    "pino": ["pino@9.12.0", "", { "dependencies": { "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^2.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "slow-redact": "^0.3.0", "sonic-boom": "^4.0.1", "thread-stream": "^3.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-0Gd0OezGvqtqMwgYxpL7P0pSHHzTJ0Lx992h+mNlMtRVfNnqweWmf0JmRWk5gJzHalyd2mxTzKjhiNbGS2Ztfw=="],
 
     "pino-abstract-transport": ["pino-abstract-transport@2.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw=="],
 
@@ -123,6 +128,8 @@
     "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
 
     "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
+
+    "slow-redact": ["slow-redact@0.3.0", "", {}, "sha512-cf723wn9JeRIYP9tdtd86GuqoR5937u64Io+CYjlm2i7jvu7g0H+Cp0l0ShAf/4ZL+ISUTVT+8Qzz7RZmp9FjA=="],
 
     "sonic-boom": ["sonic-boom@4.2.0", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww=="],
 
@@ -153,5 +160,7 @@
     "ai/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0-beta.2", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-vqhtZA7R24q1XnmfmIb1fZSmHMIaJH1BVQ+0kFnNJgqWsc+V8i+yfetZ37gUc4fXATFmBuS/6O7+RPoHsZ2Fqg=="],
 
     "ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.0-beta.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0-beta.2", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.3", "zod-to-json-schema": "^3.24.1" }, "peerDependencies": { "zod": "^3.25.76 || ^4" } }, "sha512-e6WSsgM01au04/1L/v5daXHn00eKjPBQXl3jq3BfvQbQ1jo8Rls2pvrdkyVc25jBW4TV4Zm+tw+v6NAh5NPXMA=="],
+
+    "pino-http/pino": ["pino@9.10.0", "", { "dependencies": { "atomic-sleep": "^1.0.0", "fast-redact": "^3.1.1", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^2.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^3.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-VOFxoNnxICtxaN8S3E73pR66c5MTFC+rwRcNRyHV/bV/c90dXvJqMfjkeRFsGBDXmlUN3LccJQPqGIufnaJePA=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
 		"ai": "^5.0.0-beta.34",
 		"hono": "^4.9.7",
 		"hono-openapi": "^1.0.8",
-		"pino": "^9.10.0",
+		"hono-pino": "^0.10.2",
+		"pino": "^9.12.0",
 		"pino-http": "^10.5.0",
 		"tiny-invariant": "^1.3.3",
 		"zod": "^4.1.9"

--- a/src/features/chat/chat.logger.ts
+++ b/src/features/chat/chat.logger.ts
@@ -1,11 +1,14 @@
+import type { PinoLogger } from "hono-pino";
+
 export class ChatLogger {
 	constructor(
+		private logger: PinoLogger,
 		private memberCode: string,
 		private chatKey: string,
 	) {}
 
 	info(message: Record<string, unknown>) {
-		console.log({
+		this.logger.info({
 			memberCode: this.memberCode,
 			chatKey: this.chatKey,
 			...message,
@@ -13,18 +16,23 @@ export class ChatLogger {
 	}
 
 	dir(message: Record<string, unknown>) {
-		console.dir(
-			{
-				memberCode: this.memberCode,
-				chatKey: this.chatKey,
-				...message,
-			},
-			{ depth: null },
-		);
+		// console.dir(
+		// 	{
+		// 		memberCode: this.memberCode,
+		// 		chatKey: this.chatKey,
+		// 		...message,
+		// 	},
+		// 	{ depth: null },
+		// );
+		this.logger.info({
+			memberCode: this.memberCode,
+			chatKey: this.chatKey,
+			...message,
+		});
 	}
 
 	error(message: Record<string, unknown>) {
-		console.error({
+		this.logger.error({
 			memberCode: this.memberCode,
 			chatKey: this.chatKey,
 			...message,

--- a/src/features/chat/chat.route.ts
+++ b/src/features/chat/chat.route.ts
@@ -1,12 +1,13 @@
 import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import { validator as zValidator } from "hono-openapi";
+import type { PinoLogger } from "hono-pino";
 import { complete } from "./chat.controller";
 import { ChatLogger } from "./chat.logger";
 import { ChatRequest } from "./chat.schema";
 import { HonoSSESender } from "./chat.streaming";
 
-const app = new Hono();
+const app = new Hono<{ Bindings: { logger: PinoLogger } }>();
 
 app.post(
 	"/",
@@ -54,7 +55,7 @@ app.post(
 						memberCode,
 					},
 					new HonoSSESender(stream),
-					new ChatLogger(memberCode, request.chatKey),
+					new ChatLogger(c.env.logger, memberCode, request.chatKey),
 				);
 			},
 			async (error, stream) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,11 @@
 import { Hono } from "hono";
+import { requestId } from "hono/request-id";
+import { pinoLogger } from "hono-pino";
 import routes from "./routes";
 
 const app = new Hono();
+app.use(requestId());
+app.use(pinoLogger());
 
 app.get("/", (c) => {
 	return c.text("Hello Hono!");


### PR DESCRIPTION
This pull request updates the chat logging system to use structured logging with `hono-pino` instead of raw console logging, and ensures the logger is available throughout the chat feature. It also upgrades related dependencies and integrates request ID middleware for improved traceability.

**Dependency and Middleware Updates:**

* Replaces direct `pino` usage with `hono-pino` for structured logging, updates `pino` to version 9.12.0, and adds `hono-pino` as a dependency in `package.json`.
* Adds `requestId` and `pinoLogger` middleware from `hono` and `hono-pino` in `src/index.ts` to automatically generate request IDs and attach a logger to each request.

**Logger Integration in Chat Feature:**

* Updates the `ChatLogger` class in `src/features/chat/chat.logger.ts` to use the injected `PinoLogger` for all log methods (`info`, `dir`, and `error`) instead of `console`, ensuring all logs are structured and consistent.
* Modifies the `Hono` app in `src/features/chat/chat.route.ts` to include a `logger` in its bindings, making the logger accessible in route handlers.
* Passes the request-specific logger from the context (`c.env.logger`) to the `ChatLogger` instance in the chat route handler, ensuring logs are properly attributed and traceable.Replaced console logging in ChatLogger with hono-pino's PinoLogger for structured logging. Updated chat.route and index to initialize and inject the logger. Upgraded pino to 9.12.0 and added hono-pino as a dependency.