### PR TITLE
chore(docker): switch Docker log driver to awslogs for deployments

### DIFF
--- a/.github/workflows/deploy-staging-production.yml
+++ b/.github/workflows/deploy-staging-production.yml
@@ -290,7 +290,7 @@ jobs:
               --log-driver=awslogs \
               --log-opt awslogs-region=us-west-2 \
               --log-opt awslogs-group=/apps/chat-api \
-              --log-opt awslogs-stream=ec2-{{.ID}} \
+              --log-opt awslogs-stream=ec2-$CONTAINER_NAME \
               --log-opt awslogs-create-group=true \
               "$IMAGE"
 

--- a/.github/workflows/deploy-staging-production.yml
+++ b/.github/workflows/deploy-staging-production.yml
@@ -287,9 +287,11 @@ jobs:
               --memory=4g \
               --memory-reservation=3g \
               --memory-swap=6g \
-              --log-driver json-file \
-              --log-opt max-size=10m \
-              --log-opt max-file=5 \
+              --log-driver=awslogs \
+              --log-opt awslogs-region=us-west-2 \
+              --log-opt awslogs-group=/apps/chat-api \
+              --log-opt awslogs-stream=ec2-{{.ID}} \
+              --log-opt awslogs-create-group=true \
               "$IMAGE"
 
             echo "✅ Production deployment completed on port $HOST_PORT"

--- a/scripts/chat-api-preview-deploy.sh
+++ b/scripts/chat-api-preview-deploy.sh
@@ -47,9 +47,12 @@ sudo -n docker run -d --name "$CONTAINER" \
   --memory=1g \
   --memory-reservation=512m \
   --memory-swap=2g \
-  --log-driver json-file \
-  --log-opt max-size=10m \
-  --log-opt max-file=5 \
+	--log-driver=awslogs \
+	--log-opt awslogs-region=us-west-2 \
+	--log-opt awslogs-group=/apps/chat-api-preview \
+	--log-opt awslogs-stream=ec2-{{$PR_NUMBER}} \
+	--log-opt awslogs-create-group=true \
+
   "$IMAGE" || { echo "Failed to start Docker container"; exit 1; }
 
 # Robust, deterministic port extraction

--- a/scripts/chat-api-preview-deploy.sh
+++ b/scripts/chat-api-preview-deploy.sh
@@ -50,7 +50,7 @@ sudo -n docker run -d --name "$CONTAINER" \
 	--log-driver=awslogs \
 	--log-opt awslogs-region=us-west-2 \
 	--log-opt awslogs-group=/apps/chat-api-preview \
-	--log-opt awslogs-stream=ec2-{{$PR_NUMBER}} \
+	--log-opt awslogs-stream=ec2-$BRANCH_SLUG \
 	--log-opt awslogs-create-group=true \
 
   "$IMAGE" || { echo "Failed to start Docker container"; exit 1; }

--- a/scripts/chat-api-preview-deploy.sh
+++ b/scripts/chat-api-preview-deploy.sh
@@ -52,7 +52,6 @@ sudo -n docker run -d --name "$CONTAINER" \
 	--log-opt awslogs-group=/apps/chat-api-preview \
 	--log-opt awslogs-stream=ec2-$BRANCH_SLUG \
 	--log-opt awslogs-create-group=true \
-
   "$IMAGE" || { echo "Failed to start Docker container"; exit 1; }
 
 # Robust, deterministic port extraction


### PR DESCRIPTION
This pull request updates the logging configuration for Docker containers in both the production and preview deployment workflows. The main change is switching from the default local JSON file logging to centralized logging using AWS CloudWatch Logs, which will improve log management and monitoring for both environments.

**Deployment logging improvements:**

* Changed the Docker log driver from `json-file` to `awslogs` in the production deployment workflow (`.github/workflows/deploy-staging-production.yml`). Now, container logs are sent to a specified AWS CloudWatch Logs group and stream, with automatic group creation enabled.
* Updated the preview deployment script (`scripts/chat-api-preview-deploy.sh`) to use the `awslogs` log driver, sending logs to a dedicated CloudWatch Logs group and stream for each PR, with group creation enabled.Updated both production and preview deployment scripts to use the awslogs log driver instead of json-file. This enables centralized logging to AWS CloudWatch, improving log management and monitoring for deployed containers.