### PR TITLE
refactor(worker): replace console logging with pino logger in worker

### DIFF
--- a/src/worker/logger.ts
+++ b/src/worker/logger.ts
@@ -1,0 +1,5 @@
+import { pino } from "pino";
+
+export const logger = pino({
+	level: "info",
+});

--- a/src/worker/queue-worker.ts
+++ b/src/worker/queue-worker.ts
@@ -7,6 +7,7 @@ import pLimit from "p-limit";
 import invariant from "tiny-invariant";
 import { getSqsQueueUrl, getSqsRegion } from "@/config/env";
 import { SQSMessageSchema, type SummaryEvent } from "./events.schema";
+import { logger } from "./logger";
 
 const QUEUE_URL = getSqsQueueUrl();
 const REGION = getSqsRegion();
@@ -22,12 +23,15 @@ const sqs = new SQSClient({ region: REGION });
 type WorkResult = { receiptHandle: string; ok: boolean };
 
 async function handleSummaryEvent(event: SummaryEvent): Promise<void> {
-	console.log(`Processing summary ${event.action}:`, {
-		id: event.id,
-		memberCode: event.memberCode,
-		teamCode: event.teamCode,
-		action: event.action,
-	});
+	logger.info(
+		{
+			id: event.id,
+			memberCode: event.memberCode,
+			teamCode: event.teamCode,
+			action: event.action,
+		},
+		`Processing summary ${event.action}`,
+	);
 
 	switch (event.action) {
 		case "CREATED":
@@ -54,17 +58,17 @@ async function handleMessage(
 	try {
 		parsed = JSON.parse(body);
 	} catch (_err) {
-		console.error("Invalid JSON in message body:", body);
+		logger.error({ body }, "Invalid JSON in message body");
 		throw new Error("INVALID_JSON");
 	}
 
 	// Validate against schema
 	const result = SQSMessageSchema.safeParse(parsed);
 	if (!result.success) {
-		console.error("Message validation failed:", {
-			body,
-			errors: result.error.issues,
-		});
+		logger.error(
+			{ body, errors: result.error.issues },
+			"Message validation failed",
+		);
 		throw new Error("INVALID_MESSAGE_SCHEMA");
 	}
 
@@ -110,7 +114,7 @@ async function processBatch() {
 					await handleMessage(m.Body, receiptHandle);
 					return { receiptHandle, ok: true };
 				} catch (err) {
-					console.error("Message failed:", err);
+					logger.error({ receiptHandle, err }, "Message failed");
 					return { receiptHandle, ok: false };
 				}
 			}),
@@ -137,24 +141,24 @@ async function processBatch() {
 				}),
 			);
 		} catch (err) {
-			console.error("Failed to delete messages:", err);
+			logger.error({ toDelete, err }, "Failed to delete messages");
 			// Messages will be reprocessed - ensure idempotency in handlers
 		}
 	}
 }
 
 async function run({ signal }: { signal: AbortSignal }) {
-	console.log("SQS worker starting...");
+	logger.info("SQS worker starting...");
 	while (!signal.aborted) {
 		try {
 			await processBatch();
 		} catch (e) {
-			console.error("Batch error:", e);
+			logger.error({ e }, "Batch error");
 			// small backoff after unexpected errors
 			await new Promise((r) => setTimeout(r, 2000));
 		}
 	}
-	console.log("SQS worker stopped.");
+	logger.info("SQS worker stopped.");
 }
 
 export async function runWorker({ signal }: { signal: AbortSignal }) {


### PR DESCRIPTION
Introduced a new logger module using pino and replaced all console.log and console.error statements in queue-worker.ts with logger calls for improved logging consistency and structure.
This pull request refactors logging in the worker service to use a centralized logger instead of direct `console` statements. The main change is the introduction of the `pino` logger, which improves log consistency and structure across the worker codebase.

Logging improvements:

* Added a new `logger` instance using `pino` in `src/worker/logger.ts` and replaced all `console.log` and `console.error` calls in `src/worker/queue-worker.ts` with structured logging via this logger. [[1]](diffhunk://#diff-8bc4fd9ce7a32dcfb769243cb32dee382ebecc979b3e34b0408a795802ef063eR1-R5) [[2]](diffhunk://#diff-0fd32c272fa68fbe6537e25e9d5ff33a3e3a465ea79e314e760fceb0c9b903d9R10)
* Updated all logging calls in `handleSummaryEvent`, `handleMessage`, `processBatch`, and `run` functions to use `logger.info` and `logger.error`, providing more context and structured log output. [[1]](diffhunk://#diff-0fd32c272fa68fbe6537e25e9d5ff33a3e3a465ea79e314e760fceb0c9b903d9L25-R34) [[2]](diffhunk://#diff-0fd32c272fa68fbe6537e25e9d5ff33a3e3a465ea79e314e760fceb0c9b903d9L57-R71) [[3]](diffhunk://#diff-0fd32c272fa68fbe6537e25e9d5ff33a3e3a465ea79e314e760fceb0c9b903d9L113-R117) [[4]](diffhunk://#diff-0fd32c272fa68fbe6537e25e9d5ff33a3e3a465ea79e314e760fceb0c9b903d9L140-R161)