### PR TITLE
feat: Make parseContent field nullable in SummaryEvent schema

### DIFF
--- a/src/worker/events.schema.ts
+++ b/src/worker/events.schema.ts
@@ -9,7 +9,7 @@ import { z } from "zod";
  *   "id": 12345,
  *   "memberCode": "user123",
  *   "teamCode": "team456",
- *   "parseContent": "This is the parsed summary content...",
+ *   "parseContent": "This is the parsed summary content...", // nullable
  *   "action": "CREATED",
  *   "timestamp": "2025-10-01T12:30:45.123Z"
  * }
@@ -19,7 +19,7 @@ export const SummaryEventSchema = z.object({
 	id: z.number(),
 	memberCode: z.string(),
 	teamCode: z.string().nullable(),
-	parseContent: z.string(),
+	parseContent: z.string().nullable(),
 	action: z.enum(["CREATED", "UPDATED", "DELETED"]),
 	timestamp: z.iso.datetime(), // ISO 8601 format from Java's @JsonFormat
 });
@@ -37,7 +37,7 @@ export type SummaryEvent = z.infer<typeof SummaryEventSchema>;
  *     "id": 12345,
  *     "memberCode": "user123",
  *     "teamCode": "team456",
- *     "parseContent": "This is the parsed summary content...",
+ *     "parseContent": "This is the parsed summary content...", // nullable
  *     "action": "CREATED",
  *     "timestamp": "2025-10-01T12:30:45.123Z"
  *   }


### PR DESCRIPTION
This pull request updates the schema for summary events to allow the `parseContent` field to be nullable. This change ensures that events can be processed even when the parsed content is not available.

Schema updates:

* Modified the `SummaryEventSchema` in `src/worker/events.schema.ts` to set `parseContent` as a nullable string, allowing it to be `null` when necessary.
* Updated example documentation and type comments in `src/worker/events.schema.ts` to indicate that `parseContent` is now nullable. [[1]](diffhunk://#diff-f9fc787e4482f2f97f0bad4b439f308cf6ec1f065047294b2bfbb43198799a78L12-R12) [[2]](diffhunk://#diff-f9fc787e4482f2f97f0bad4b439f308cf6ec1f065047294b2bfbb43198799a78L40-R40)Updated the SummaryEvent schema to allow the parseContent field to be nullable. Adjusted documentation comments to clarify that parseContent can be null, improving flexibility for event payloads where summary content may be absent.