### PR TITLE
feat: clarify task_status usage and response order

### DIFF
--- a/apps/chat-api/src/features/chat/core/mymemo.ts
+++ b/apps/chat-api/src/features/chat/core/mymemo.ts
@@ -464,13 +464,10 @@ async function runTask({
 					{
 						type: "text" as const,
 						text:
-							"You haven't called any tools. If the task is completed, " +
-							"If there is any tool you need to call, like read_file, update_plan, update_citations, search_knowledge, " +
-							"you MUST call it now. If you don't call it, the task will never be completed." +
-							"If the task is completed, " +
-							"call the task_status tool with taskStatus: complete." +
-							"If the task is waiting for user input, " +
-							"call the task_status tool with taskStatus: ask_user.",
+							"You haven't called any tools. If there is any tool you need to call, like read_file, update_plan, update_citations, search_knowledge, " +
+							"you MUST call it now. If you don't call it, the task will never be completed. " +
+							"If the task is completed, respond to the user in text first, then call the task_status tool with taskStatus: complete. " +
+							"If the task is waiting for user input, ask your question in text first, then call the task_status tool with taskStatus: ask_user.",
 					},
 				],
 			});

--- a/apps/chat-api/src/features/chat/prompts/system-prompt.md
+++ b/apps/chat-api/src/features/chat/prompts/system-prompt.md
@@ -76,7 +76,7 @@ Always call `task_status` to indicate the current state of the task:
    - After asking a question in your text response
    - When offering options in your text response
    - When unsure how to proceed (explain in text first)
-	 - **Before calling `task_status("ask_user")`, you MUST send your question as text to the user.**
+   - **Before calling `task_status("ask_user")`, you MUST send your question as text to the user.**
 
 
 2. **complete**: The task is FULLY finished
@@ -233,8 +233,7 @@ Can I complete this in ONE tool call?
 3. **Cite sources** with numbered markers
 4. **Keep it simple** - no technical jargon or IDs
 5. **Stay helpful** - acknowledge limits honestly
-6. **Mark task completion** - if the task is complete, call `task_status` with `taskStatus: "complete"`
-7. **Always end with a text response** before calling `task_status("complete")`
+6. **Mark task completion** - provide a text response summarizing the outcome, then call `task_status` with `taskStatus: "complete"`
 
 ## Rule of Thumb for Planning
 

--- a/apps/chat-api/src/features/chat/prompts/system-prompt.md
+++ b/apps/chat-api/src/features/chat/prompts/system-prompt.md
@@ -73,20 +73,26 @@ For multi-step tasks, ALWAYS use the planning tool first:
 Always call `task_status` to indicate the current state of the task:
 
 1. **ask_user**: You need user input, clarification, or confirmation
-   - After asking a question
-   - When offering options
-   - When unsure how to proceed
+   - After asking a question in your text response
+   - When offering options in your text response
+   - When unsure how to proceed (explain in text first)
+	 - **Before calling `task_status("ask_user")`, you MUST send your question as text to the user.**
+
 
 2. **complete**: The task is FULLY finished
-   - User's question is completely answered
+   - User's question is completely answered in your text response
    - All requested actions are done
    - No more data to fetch
+   - **Before calling `task_status("complete")`, you MUST send a user-facing text response summarizing the outcome.**
+
+**Important:** Always provide your text response FIRST, then call `task_status` as a separate action.
 
 **Examples:**
-- Found 100 files with more available → `task_status("ask_user")` with question
-- Provided full file count → `task_status("complete")`
-- Summarized requested documents → `task_status("complete")`
-- Asking which files to analyze → `task_status("ask_user")`
+- Found 100 files with more available → Provide text: "你有100个文件，还有更多..." → Then `task_status("ask_user")` with question
+- Provided full file count → Provide text: "你有100个文件" → Then `task_status("complete")`
+- Summarized documents → Provide text with summary → Then `task_status("complete")`
+- Asking which files to analyze → Provide text with question → Then `task_status("ask_user")`
+- Tool-only responses are INVALID; users must always receive a final text answer.
 
 ### Communication Style
 
@@ -228,7 +234,7 @@ Can I complete this in ONE tool call?
 4. **Keep it simple** - no technical jargon or IDs
 5. **Stay helpful** - acknowledge limits honestly
 6. **Mark task completion** - if the task is complete, call `task_status` with `taskStatus: "complete"`
-
+7. **Always end with a text response** before calling `task_status("complete")`
 
 ## Rule of Thumb for Planning
 


### PR DESCRIPTION
This pull request updates the system prompt and task handling logic to ensure users always receive a clear, user-facing text response before any tool calls signal task completion or requests for user input. These changes improve user experience by making bot responses more informative and conversational.

**Prompt and task handling improvements:**

* Updated the instructions in `system-prompt.md` to require that a text response is always sent to the user before calling the `task_status` tool, both for completion and for requests for user input. Examples and rules were clarified to reinforce this behavior. [[1]](diffhunk://#diff-1691e05428b508bcffc8ade30cdb084d1de2228abfc3fcb52ff15fc6eca17e18L76-R95) [[2]](diffhunk://#diff-1691e05428b508bcffc8ade30cdb084d1de2228abfc3fcb52ff15fc6eca17e18L231-R237)
* Modified the message in `runTask` in `mymemo.ts` to instruct the bot to respond in text first before calling `task_status`, ensuring compliance with the new prompt guidelines.Updated mymemo.ts and system-prompt.md to require a user-facing text response before calling the task_status tool for both 'complete' and 'ask_user' states. This ensures users always receive a clear text answer prior to any tool invocation, improving communication consistency.