### PR TITLE
feat: refactor event content validation in SummaryLifecycleHandler

### DIFF
--- a/apps/rag-python/src/rag_python/worker/handlers.py
+++ b/apps/rag-python/src/rag_python/worker/handlers.py
@@ -90,7 +90,7 @@ class SummaryLifecycleHandler:
             return False
 
         logger.info(
-            "Content lengths - summary=%s, original=%s",
+            "Content lengths - original=%s",
             len(original_content),
         )
 
@@ -126,7 +126,7 @@ class SummaryLifecycleHandler:
             return False
 
         logger.info(
-            "Updated content lengths - summary=%s, original=%s",
+            "Updated content lengths - original=%s",
             len(original_content),
         )
 
@@ -169,7 +169,7 @@ class SummaryLifecycleHandler:
 
     @staticmethod
     def _validate_event_content(event: SummaryEvent) -> str | None:
-        """Ensure the event contains both summary and original content."""
+        """Ensure the event contains original content."""
         original_content = event.parse_content
 
         if not original_content:


### PR DESCRIPTION
This pull request refactors the `_validate_event_content` method in `handlers.py` and updates its usage in the event handler methods to simplify content validation logic. The main change is that the method now only validates and returns the original content, removing checks and handling for summary text.

Content validation simplification:

* Refactored the `_validate_event_content` method to only validate and return `original_content`, removing summary text validation and related error logging. (`apps/rag-python/src/rag_python/worker/handlers.py`)

Event handler updates:

* Updated `_handle_created` and `_handle_updated` methods to use the new signature of `_validate_event_content`, removing summary text checks and length logging for summary text. (`apps/rag-python/src/rag_python/worker/handlers.py`) [[1]](diffhunk://#diff-8795d61540e4eee5d9291b51c715f2e5e90863b124dc83832edef86bcbc915feL88-L94) [[2]](diffhunk://#diff-8795d61540e4eee5d9291b51c715f2e5e90863b124dc83832edef86bcbc915feL125-L131)Simplifies the _validate_event_content method to only check for original content and removes summary_text validation. Updates related method calls and logging to reflect this change.