### PR TITLE
feat: new prompt for citation

### DIFF
--- a/apps/chat-api/src/features/chat/prompts/system-prompt.md
+++ b/apps/chat-api/src/features/chat/prompts/system-prompt.md
@@ -112,7 +112,7 @@ Always call `task_status` to indicate the current state of the task:
   ```
   * `<type>` = numeric type identifier from the tool result
   * `<fileId>` = ID returned by the tooling
-  Do not include a section heading like “References”
+  * Do not include a section heading like “References”
   * Example:
     ```
     [c1]: 0/12345


### PR DESCRIPTION
This pull request updates the system prompt for the MyMemo Document Assistant to clarify task handling, citation formatting, and internal ID usage. The changes streamline instructions for single-step and multi-step tasks, introduce a more precise markdown citation style, and reinforce privacy best practices around internal IDs.

**Task Handling and Planning:**
* Clear distinction between single-step and multi-step tasks, with explicit rules for when to use planning tools and examples for each case.

**Citation Formatting and Workflow:**
* New markdown reference style for citations: use inline markers `[N][cN]` and append citation definitions at the end, omitting headings and only including markers used in the message. Citation workflow is clarified, including incremental updates and finalization.
* Citations are now explicitly decoupled from tool calls, and renumbering of markers is prohibited once emitted.

**Internal ID and Metadata Privacy:**
* Instructions updated to prohibit exposing internal IDs or metadata in the answer body, emphasizing privacy best practices. [[1]](diffhunk://#diff-1691e05428b508bcffc8ade30cdb084d1de2228abfc3fcb52ff15fc6eca17e18L65-L83) [[2]](diffhunk://#diff-1691e05428b508bcffc8ade30cdb084d1de2228abfc3fcb52ff15fc6eca17e18L191-R202)

**Task Status Protocol:**
* Task status management is now presented in a tabular format for clarity, with explicit descriptions for `ask_user` and `complete` statuses.

**General Prompt Simplification:**
* The overall prompt language is streamlined for clarity, focusing on essential capabilities and removing redundant instructions.