### PR TITLE
feat: Phase 2 sync foundation with repository interface pattern

### DIFF
--- a/MIGRATION_PLAN.md
+++ b/MIGRATION_PLAN.md
@@ -54,7 +54,7 @@ Treat protected/MySQL documents as the source of truth.
 
 Treat the sandbox filesystem as a materialized cache.
 
-Add a MySQL sync-state table owned by `chat-api` with fields equivalent to:
+Add a sync-state store owned by `chat-api` behind a `SyncStateRepository` interface (database engine — MySQL or Postgres — to be finalized later). Fields equivalent to:
 - `user_id`
 - `sandbox_id`
 - `summary_id`
@@ -63,7 +63,6 @@ Add a MySQL sync-state table owned by `chat-api` with fields equivalent to:
 - `content_checksum`
 - `source_updated_at`
 - `last_synced_at`
-- `last_indexed_at`
 - `sync_status`
 
 On each sync cycle, derive:
@@ -149,16 +148,34 @@ Artifacts:
 - Build: `bun run e2b:build:dev` / `bun run e2b:build:prod`
 - Run: `E2B_TEMPLATE=sandbox-template-dev bun run prototype:sandbox <input.json>`
 
-### Phase 2: Sync foundation
+### Phase 2: Sync foundation — IN PROGRESS
 
-Add a MySQL sync-state table and sync service in `chat-api`.
+Add a sync-state layer and sync service in `chat-api`.
+
+**Design decisions (2026-03-27):**
+
+- **Repository interface pattern**: Sync-state uses a `SyncStateRepository` TypeScript interface, decoupled from any specific database. The database schema (MySQL or Postgres) is finalized later when the broader refactoring settles.
+- **In-memory Map initial implementation**: Development and testing use `InMemorySyncStateRepository`. A real DB adapter is added when the schema is finalized.
+- **Composite key**: `(userId, summaryId)`. `sandboxId` is stored but not part of the key — it changes on sandbox recreation.
+- **Caller-driven source fetching**: The sync service receives `ProtectedSummary[]` from the caller. It does not fetch from the Protected Service API itself.
+- **Per-user locking**: Promise-chain pattern serializes sync operations per userId. No concurrent syncs for the same user. Distributed locking deferred to Phase 5.
+- **No chat-path integration**: Phase 2 builds sync primitives only, tested via unit tests and standalone scripts. The trigger point (on-request, background, etc.) is decided in Phase 3/4.
+- **`last_indexed_at` deferred**: Not needed for Phase 2 (no indexing step with grep/glob retrieval). Can be added in Phase 6 if vector search needs it.
 
 Implement source-to-sandbox reconciliation:
 - create/update/delete
-- checksum validation
-- sandbox manifest verification
+- checksum validation (sha256 over materialized content including frontmatter)
+- sandbox manifest verification and drift repair
 
-Define a stable on-disk file format for synced docs that includes source metadata.
+Define a stable on-disk file format for synced docs that includes source metadata (reuses Phase 1 YAML frontmatter format).
+
+Artifacts:
+- Types: `src/features/sandbox/sync-state.types.ts`
+- Repository interface: `src/features/sandbox/sync-state.repository.ts`
+- In-memory implementation: `src/features/sandbox/sync-state.repository.memory.ts`
+- Materialization: `src/features/sandbox/materialization.ts`
+- Manifest verification: `src/features/sandbox/sandbox-manifest.ts`
+- Sync service: `src/features/sandbox/sandbox-sync.service.ts`
 
 Exit criteria:
 - sandbox content can be rebuilt from source

--- a/apps/chat-api/package.json
+++ b/apps/chat-api/package.json
@@ -5,6 +5,7 @@
 		"format": "biome format --write",
 		"lint": "biome lint --write",
 		"prototype:sandbox": "bun run scripts/run-sandbox-prototype.ts",
+		"test:sync-integration": "bun run scripts/run-sync-integration.ts",
 		"e2b:build:dev": "cd sandbox-template && npx tsx build.dev.ts",
 		"e2b:build:prod": "cd sandbox-template && npx tsx build.prod.ts"
 	},

--- a/apps/chat-api/scripts/run-sync-integration.ts
+++ b/apps/chat-api/scripts/run-sync-integration.ts
@@ -1,0 +1,293 @@
+/**
+ * Phase 2 integration test: exercises the full sync lifecycle against a real E2B sandbox.
+ *
+ * Usage:
+ *   E2B_TEMPLATE=sandbox-template-dev bun run scripts/run-sync-integration.ts
+ *
+ * Requires: E2B_API_KEY and E2B_TEMPLATE environment variables.
+ *
+ * Steps:
+ *   1. Create sandbox, full sync 3 documents
+ *   2. Verify files exist on sandbox
+ *   3. Update one document, re-sync → verify update applied
+ *   4. Delete one document from source, re-sync → verify removal
+ *   5. Introduce drift (orphaned file + tampered content), verify manifest, repair
+ *   6. Rebuild sandbox from scratch
+ *   7. Cleanup
+ */
+import { Sandbox } from "e2b";
+import type { ProtectedSummary } from "../src/features/chat/api/types";
+import {
+	getDocsRoot,
+	InMemorySyncStateRepository,
+	type MaterializationConfig,
+	SandboxSyncService,
+} from "../src/features/sandbox";
+
+const now = () => Date.now();
+
+const makeSummary = (
+	id: string,
+	content: string,
+	overrides: Partial<ProtectedSummary> = {},
+): ProtectedSummary => ({
+	id,
+	type: 0,
+	content,
+	parseContent: null,
+	title: `Document ${id}`,
+	summaryTitle: null,
+	fileType: null,
+	delFlag: 0,
+	updateTime: new Date().toISOString(),
+	...overrides,
+});
+
+const assert = (condition: boolean, message: string) => {
+	if (!condition) throw new Error(`ASSERTION FAILED: ${message}`);
+};
+
+const main = async () => {
+	if (!Bun.env.E2B_API_KEY) {
+		throw new Error("E2B_API_KEY is required.");
+	}
+	const template = Bun.env.E2B_TEMPLATE?.trim();
+	if (!template) {
+		throw new Error("E2B_TEMPLATE is required.");
+	}
+
+	const userId = "integration-test-user";
+	const repository = new InMemorySyncStateRepository();
+	const logs: Array<Record<string, unknown>> = [];
+	const logger = {
+		info(obj: Record<string, unknown>) {
+			logs.push({ level: "info", ...obj });
+		},
+		error(obj: Record<string, unknown>) {
+			logs.push({ level: "error", ...obj });
+		},
+	};
+	const service = new SandboxSyncService({ repository, logger });
+	const config: MaterializationConfig = {
+		workspaceRoot: "/workspace/sandbox-prototype",
+		userId,
+	};
+	const docsRoot = getDocsRoot(config);
+
+	console.log("Creating sandbox...");
+	const t0 = now();
+	const sandbox = await Sandbox.create(template, {
+		metadata: { userId, purpose: "phase2-sync-integration" },
+	});
+	console.log(`  Sandbox created in ${now() - t0}ms: ${sandbox.sandboxId}`);
+
+	try {
+		// ── Step 1: Initial full sync ───────────────────────────────
+		console.log("\n── Step 1: Initial full sync (3 documents)");
+		const docs = [
+			makeSummary("doc-1", "Content of document one"),
+			makeSummary("doc-2", "Content of document two"),
+			makeSummary("doc-3", "Content of document three", { type: 3 }),
+		];
+
+		const t1 = now();
+		const plan1 = await service.syncUser(
+			userId,
+			sandbox.sandboxId,
+			sandbox,
+			docs,
+			config,
+		);
+		console.log(`  Synced in ${now() - t1}ms`);
+		console.log(
+			`  Creates: ${plan1.creates.length}, Updates: ${plan1.updates.length}, Deletes: ${plan1.deletes.length}, Unchanged: ${plan1.unchanged}`,
+		);
+		assert(plan1.creates.length === 3, "Expected 3 creates");
+		assert(plan1.updates.length === 0, "Expected 0 updates");
+		assert(plan1.deletes.length === 0, "Expected 0 deletes");
+
+		// ── Step 2: Verify files exist ─────────────────────────────
+		console.log("\n── Step 2: Verify files exist on sandbox");
+		const t2 = now();
+		const diff2 = await service.verifyManifest(
+			userId,
+			sandbox.sandboxId,
+			sandbox,
+			config,
+		);
+		console.log(`  Verified in ${now() - t2}ms`);
+		console.log(
+			`  Missing: ${diff2.missingInSandbox.length}, Orphaned: ${diff2.orphanedInSandbox.length}, Checksum mismatches: ${diff2.checksumMismatches.length}`,
+		);
+		assert(diff2.missingInSandbox.length === 0, "No files should be missing");
+		assert(diff2.orphanedInSandbox.length === 0, "No files should be orphaned");
+		assert(
+			diff2.checksumMismatches.length === 0,
+			"No checksum mismatches expected",
+		);
+
+		// ── Step 3: Update one document ────────────────────────────
+		console.log("\n── Step 3: Update doc-2 content, re-sync");
+		const docsUpdated = [
+			makeSummary("doc-1", "Content of document one"),
+			makeSummary("doc-2", "UPDATED content of document two"),
+			makeSummary("doc-3", "Content of document three", { type: 3 }),
+		];
+
+		const t3 = now();
+		const plan3 = await service.syncUser(
+			userId,
+			sandbox.sandboxId,
+			sandbox,
+			docsUpdated,
+			config,
+		);
+		console.log(`  Synced in ${now() - t3}ms`);
+		console.log(
+			`  Creates: ${plan3.creates.length}, Updates: ${plan3.updates.length}, Deletes: ${plan3.deletes.length}, Unchanged: ${plan3.unchanged}`,
+		);
+		assert(plan3.updates.length === 1, "Expected 1 update");
+		assert(plan3.unchanged === 2, "Expected 2 unchanged");
+
+		// Verify updated content on disk
+		const updatedContent = await sandbox.files.read(`${docsRoot}/0/doc-2.txt`);
+		assert(
+			updatedContent.includes("UPDATED content"),
+			"Updated content should be on disk",
+		);
+
+		// ── Step 4: Delete one document from source ────────────────
+		console.log("\n── Step 4: Remove doc-3 from source, re-sync");
+		const docsReduced = [
+			makeSummary("doc-1", "Content of document one"),
+			makeSummary("doc-2", "UPDATED content of document two"),
+		];
+
+		const t4 = now();
+		const plan4 = await service.syncUser(
+			userId,
+			sandbox.sandboxId,
+			sandbox,
+			docsReduced,
+			config,
+		);
+		console.log(`  Synced in ${now() - t4}ms`);
+		console.log(
+			`  Creates: ${plan4.creates.length}, Updates: ${plan4.updates.length}, Deletes: ${plan4.deletes.length}, Unchanged: ${plan4.unchanged}`,
+		);
+		assert(plan4.deletes.length === 1, "Expected 1 delete");
+		assert(plan4.unchanged === 2, "Expected 2 unchanged");
+
+		// Verify file is gone
+		const listResult = await sandbox.commands.run(
+			`find ${docsRoot} -type f -name '*.txt'`,
+			{ timeoutMs: 5_000 },
+		);
+		const remainingFiles = listResult.stdout.trim().split("\n").filter(Boolean);
+		assert(
+			remainingFiles.length === 2,
+			`Expected 2 files remaining, got ${remainingFiles.length}`,
+		);
+		assert(
+			!remainingFiles.some((f) => f.includes("doc-3")),
+			"doc-3 should be removed",
+		);
+
+		// ── Step 5: Drift detection and repair ─────────────────────
+		console.log("\n── Step 5: Introduce drift, verify, repair");
+
+		// Create an orphaned file
+		await sandbox.files.write(`${docsRoot}/0/orphan.txt`, "I should not exist");
+		// Tamper with doc-1
+		await sandbox.files.write(`${docsRoot}/0/doc-1.txt`, "tampered content");
+
+		const t5 = now();
+		const diff5 = await service.verifyManifest(
+			userId,
+			sandbox.sandboxId,
+			sandbox,
+			config,
+		);
+		console.log(`  Drift detected in ${now() - t5}ms`);
+		console.log(
+			`  Missing: ${diff5.missingInSandbox.length}, Orphaned: ${diff5.orphanedInSandbox.length}, Checksum mismatches: ${diff5.checksumMismatches.length}`,
+		);
+		assert(
+			diff5.orphanedInSandbox.length === 1,
+			"Expected 1 orphaned file (orphan.txt)",
+		);
+		assert(
+			diff5.checksumMismatches.length === 1,
+			"Expected 1 checksum mismatch (doc-1)",
+		);
+
+		// Repair
+		const t5r = now();
+		await service.repairDrift(
+			userId,
+			sandbox.sandboxId,
+			sandbox,
+			diff5,
+			docsReduced,
+			config,
+		);
+		console.log(`  Repaired in ${now() - t5r}ms`);
+
+		// Verify clean after repair
+		const diff5post = await service.verifyManifest(
+			userId,
+			sandbox.sandboxId,
+			sandbox,
+			config,
+		);
+		assert(
+			diff5post.missingInSandbox.length === 0,
+			"No files should be missing after repair",
+		);
+		assert(diff5post.orphanedInSandbox.length === 0, "No orphans after repair");
+		assert(
+			diff5post.checksumMismatches.length === 0,
+			"No mismatches after repair",
+		);
+
+		// ── Step 6: Full rebuild ───────────────────────────────────
+		console.log("\n── Step 6: Full sandbox rebuild");
+		const t6 = now();
+		const plan6 = await service.rebuildSandbox(
+			userId,
+			sandbox.sandboxId,
+			sandbox,
+			docsReduced,
+			config,
+		);
+		console.log(`  Rebuilt in ${now() - t6}ms`);
+		console.log(
+			`  Creates: ${plan6.creates.length}, Updates: ${plan6.updates.length}, Deletes: ${plan6.deletes.length}, Unchanged: ${plan6.unchanged}`,
+		);
+		assert(
+			plan6.creates.length === 2,
+			"Rebuild should create all 2 docs fresh",
+		);
+
+		const diff6 = await service.verifyManifest(
+			userId,
+			sandbox.sandboxId,
+			sandbox,
+			config,
+		);
+		assert(diff6.missingInSandbox.length === 0, "Clean after rebuild");
+		assert(diff6.orphanedInSandbox.length === 0, "Clean after rebuild");
+
+		// ── Summary ────────────────────────────────────────────────
+		const totalMs = now() - t0;
+		console.log("\n── All steps passed ──");
+		console.log(`  Total time: ${totalMs}ms`);
+		console.log(`  Sandbox: ${sandbox.sandboxId}`);
+		console.log(`  Log entries: ${logs.length}`);
+	} finally {
+		console.log("\nCleaning up sandbox...");
+		sandbox.kill().catch(() => {});
+	}
+};
+
+await main();

--- a/apps/chat-api/src/features/chat/chat.adapter.test.ts
+++ b/apps/chat-api/src/features/chat/chat.adapter.test.ts
@@ -5,10 +5,11 @@ import { adaptProtectedMessagesToModelMessages } from "./chat.adapter";
 const buildMessage = (
 	chatContent: string | null,
 	senderType: string | null | undefined,
-): ProtectedChatMessage => ({
-	chatContent,
-	senderType,
-} as ProtectedChatMessage);
+): ProtectedChatMessage =>
+	({
+		chatContent,
+		senderType,
+	}) as ProtectedChatMessage;
 
 describe("adaptProtectedMessagesToModelMessages", () => {
 	it("returns alternating messages with trimmed content", () => {

--- a/apps/chat-api/src/features/chat/chat.constants.ts
+++ b/apps/chat-api/src/features/chat/chat.constants.ts
@@ -1,3 +1,3 @@
 export const ERROR_MESSAGES = {
-  INVALID_REQUEST_BODY: "Invalid request body",
+	INVALID_REQUEST_BODY: "Invalid request body",
 } as const;

--- a/apps/chat-api/src/features/chat/lib/extract-citations-from-markdown.test.ts
+++ b/apps/chat-api/src/features/chat/lib/extract-citations-from-markdown.test.ts
@@ -15,52 +15,38 @@ describe("extractReferencesFromText", () => {
 	describe("single reference", () => {
 		it("extracts basic reference format: [c1]: 123/456", () => {
 			const result = extractReferencesFromText("[c1]: 123/456");
-			expect(result).toEqual([
-				{ id: "456", type: 123, index: 1 },
-			]);
+			expect(result).toEqual([{ id: "456", type: 123, index: 1 }]);
 		});
 
 		it("extracts reference with detail prefix: [c1]: detail/123/456", () => {
 			const result = extractReferencesFromText("[c1]: detail/123/456");
-			expect(result).toEqual([
-				{ id: "456", type: 123, index: 1 },
-			]);
+			expect(result).toEqual([{ id: "456", type: 123, index: 1 }]);
 		});
 
 		it("extracts reference with notes prefix: [c1]: notes/123/456", () => {
 			const result = extractReferencesFromText("[c1]: notes/123/456");
-			expect(result).toEqual([
-				{ id: "456", type: 123, index: 1 },
-			]);
+			expect(result).toEqual([{ id: "456", type: 123, index: 1 }]);
 		});
 
 		it("handles reference with extra whitespace", () => {
 			const result = extractReferencesFromText("[c2]:   789/101");
-			expect(result).toEqual([
-				{ id: "101", type: 789, index: 2 },
-			]);
+			expect(result).toEqual([{ id: "101", type: 789, index: 2 }]);
 		});
 
 		it("handles reference with different index values", () => {
 			const result = extractReferencesFromText("[c5]: 42/99");
-			expect(result).toEqual([
-				{ id: "99", type: 42, index: 5 },
-			]);
+			expect(result).toEqual([{ id: "99", type: 42, index: 5 }]);
 		});
 
 		it("handles reference with large numbers", () => {
 			const result = extractReferencesFromText("[c10]: 999999/888888");
-			expect(result).toEqual([
-				{ id: "888888", type: 999999, index: 10 },
-			]);
+			expect(result).toEqual([{ id: "888888", type: 999999, index: 10 }]);
 		});
 	});
 
 	describe("multiple references", () => {
 		it("extracts multiple distinct references in same text", () => {
-			const result = extractReferencesFromText(
-				"[c1]: 123/456 [c2]: 789/101"
-			);
+			const result = extractReferencesFromText("[c1]: 123/456 [c2]: 789/101");
 			expect(result).toEqual([
 				{ id: "456", type: 123, index: 1 },
 				{ id: "101", type: 789, index: 2 },
@@ -69,7 +55,7 @@ describe("extractReferencesFromText", () => {
 
 		it("extracts references with different indices", () => {
 			const result = extractReferencesFromText(
-				"[c1]: 100/200 [c3]: 300/400 [c5]: 500/600"
+				"[c1]: 100/200 [c3]: 300/400 [c5]: 500/600",
 			);
 			expect(result).toEqual([
 				{ id: "200", type: 100, index: 1 },
@@ -80,7 +66,7 @@ describe("extractReferencesFromText", () => {
 
 		it("extracts references with different types", () => {
 			const result = extractReferencesFromText(
-				"[c1]: 10/20 [c2]: 30/40 [c3]: 50/60"
+				"[c1]: 10/20 [c2]: 30/40 [c3]: 50/60",
 			);
 			expect(result).toEqual([
 				{ id: "20", type: 10, index: 1 },
@@ -91,7 +77,7 @@ describe("extractReferencesFromText", () => {
 
 		it("extracts references with different IDs", () => {
 			const result = extractReferencesFromText(
-				"[c1]: 100/200 [c2]: 100/300 [c3]: 100/400"
+				"[c1]: 100/200 [c2]: 100/300 [c3]: 100/400",
 			);
 			expect(result).toEqual([
 				{ id: "200", type: 100, index: 1 },
@@ -102,7 +88,7 @@ describe("extractReferencesFromText", () => {
 
 		it("extracts mix of detail and notes prefixes", () => {
 			const result = extractReferencesFromText(
-				"[c1]: detail/123/456 [c2]: notes/789/101"
+				"[c1]: detail/123/456 [c2]: notes/789/101",
 			);
 			expect(result).toEqual([
 				{ id: "456", type: 123, index: 1 },
@@ -114,25 +100,21 @@ describe("extractReferencesFromText", () => {
 	describe("duplicate handling", () => {
 		it("deduplicates same type/id combination appearing multiple times", () => {
 			const result = extractReferencesFromText(
-				"[c1]: 123/456 [c2]: 123/456 [c3]: 123/456"
+				"[c1]: 123/456 [c2]: 123/456 [c3]: 123/456",
 			);
-			expect(result).toEqual([
-				{ id: "456", type: 123, index: 1 },
-			]);
+			expect(result).toEqual([{ id: "456", type: 123, index: 1 }]);
 		});
 
 		it("deduplicates different indices but same type/id", () => {
 			const result = extractReferencesFromText(
-				"[c1]: 100/200 [c5]: 100/200 [c10]: 100/200"
+				"[c1]: 100/200 [c5]: 100/200 [c10]: 100/200",
 			);
-			expect(result).toEqual([
-				{ id: "200", type: 100, index: 1 },
-			]);
+			expect(result).toEqual([{ id: "200", type: 100, index: 1 }]);
 		});
 
 		it("keeps first occurrence when duplicates exist", () => {
 			const result = extractReferencesFromText(
-				"[c1]: 123/456 [c2]: 789/101 [c3]: 123/456"
+				"[c1]: 123/456 [c2]: 789/101 [c3]: 123/456",
 			);
 			expect(result).toEqual([
 				{ id: "456", type: 123, index: 1 },
@@ -142,17 +124,13 @@ describe("extractReferencesFromText", () => {
 
 		it("handles duplicates with different prefixes", () => {
 			const result = extractReferencesFromText(
-				"[c1]: 123/456 [c2]: detail/123/456 [c3]: notes/123/456"
+				"[c1]: 123/456 [c2]: detail/123/456 [c3]: notes/123/456",
 			);
-			expect(result).toEqual([
-				{ id: "456", type: 123, index: 1 },
-			]);
+			expect(result).toEqual([{ id: "456", type: 123, index: 1 }]);
 		});
 
 		it("does not deduplicate different types with same id", () => {
-			const result = extractReferencesFromText(
-				"[c1]: 100/200 [c2]: 200/200"
-			);
+			const result = extractReferencesFromText("[c1]: 100/200 [c2]: 200/200");
 			expect(result).toEqual([
 				{ id: "200", type: 100, index: 1 },
 				{ id: "200", type: 200, index: 2 },
@@ -160,9 +138,7 @@ describe("extractReferencesFromText", () => {
 		});
 
 		it("does not deduplicate same type with different ids", () => {
-			const result = extractReferencesFromText(
-				"[c1]: 100/200 [c2]: 100/300"
-			);
+			const result = extractReferencesFromText("[c1]: 100/200 [c2]: 100/300");
 			expect(result).toEqual([
 				{ id: "200", type: 100, index: 1 },
 				{ id: "300", type: 100, index: 2 },
@@ -193,21 +169,17 @@ describe("extractReferencesFromText", () => {
 
 		it("handles references with zero index", () => {
 			const result = extractReferencesFromText("[c0]: 123/456");
-			expect(result).toEqual([
-				{ id: "456", type: 123, index: 0 },
-			]);
+			expect(result).toEqual([{ id: "456", type: 123, index: 0 }]);
 		});
 
 		it("handles references with zero type", () => {
 			const result = extractReferencesFromText("[c1]: 0/456");
-			expect(result).toEqual([
-				{ id: "456", type: 0, index: 1 },
-			]);
+			expect(result).toEqual([{ id: "456", type: 0, index: 1 }]);
 		});
 
 		it("handles references at different positions in text", () => {
 			const result = extractReferencesFromText(
-				"Start [c1]: 123/456 middle [c2]: 789/101 end"
+				"Start [c1]: 123/456 middle [c2]: 789/101 end",
 			);
 			expect(result).toEqual([
 				{ id: "456", type: 123, index: 1 },
@@ -217,7 +189,7 @@ describe("extractReferencesFromText", () => {
 
 		it("handles mixed valid and invalid patterns", () => {
 			const result = extractReferencesFromText(
-				"[c1]: 123/456 invalid [c2]: 789/101 also [c3]: 111/222"
+				"[c1]: 123/456 invalid [c2]: 789/101 also [c3]: 111/222",
 			);
 			expect(result).toEqual([
 				{ id: "456", type: 123, index: 1 },
@@ -229,14 +201,12 @@ describe("extractReferencesFromText", () => {
 		it("handles very long markdown text", () => {
 			const longText = "a".repeat(1000) + "[c1]: 123/456" + "b".repeat(1000);
 			const result = extractReferencesFromText(longText);
-			expect(result).toEqual([
-				{ id: "456", type: 123, index: 1 },
-			]);
+			expect(result).toEqual([{ id: "456", type: 123, index: 1 }]);
 		});
 
 		it("handles newlines in text", () => {
 			const result = extractReferencesFromText(
-				"[c1]: 123/456\n[c2]: 789/101\n[c3]: 111/222"
+				"[c1]: 123/456\n[c2]: 789/101\n[c3]: 111/222",
 			);
 			expect(result).toEqual([
 				{ id: "456", type: 123, index: 1 },
@@ -247,7 +217,7 @@ describe("extractReferencesFromText", () => {
 
 		it("handles references with tabs and spaces", () => {
 			const result = extractReferencesFromText(
-				"[c1]:\t123/456\t[c2]:  789/101"
+				"[c1]:\t123/456\t[c2]:  789/101",
 			);
 			expect(result).toEqual([
 				{ id: "456", type: 123, index: 1 },
@@ -258,7 +228,8 @@ describe("extractReferencesFromText", () => {
 
 	describe("real-world scenarios", () => {
 		it("extracts references from markdown paragraph", () => {
-			const text = "This is a paragraph with a citation [c1]: 123/456 and another one [c2]: 789/101.";
+			const text =
+				"This is a paragraph with a citation [c1]: 123/456 and another one [c2]: 789/101.";
 			const result = extractReferencesFromText(text);
 			expect(result).toEqual([
 				{ id: "456", type: 123, index: 1 },
@@ -267,7 +238,8 @@ describe("extractReferencesFromText", () => {
 		});
 
 		it("extracts references with surrounding markdown content", () => {
-			const text = "# Header\n\nSome text with [c1]: detail/123/456 reference.\n\nMore text [c2]: notes/789/101 here.";
+			const text =
+				"# Header\n\nSome text with [c1]: detail/123/456 reference.\n\nMore text [c2]: notes/789/101 here.";
 			const result = extractReferencesFromText(text);
 			expect(result).toEqual([
 				{ id: "456", type: 123, index: 1 },
@@ -295,23 +267,21 @@ Final paragraph has [c4]: 700/800.
 		});
 
 		it("handles references with other markdown links", () => {
-			const text = "Check [this link](https://example.com) and citation [c1]: 123/456.";
+			const text =
+				"Check [this link](https://example.com) and citation [c1]: 123/456.";
 			const result = extractReferencesFromText(text);
-			expect(result).toEqual([
-				{ id: "456", type: 123, index: 1 },
-			]);
+			expect(result).toEqual([{ id: "456", type: 123, index: 1 }]);
 		});
 
 		it("handles references with code blocks nearby", () => {
 			const text = "Code: `const x = 1;` Citation: [c1]: 123/456";
 			const result = extractReferencesFromText(text);
-			expect(result).toEqual([
-				{ id: "456", type: 123, index: 1 },
-			]);
+			expect(result).toEqual([{ id: "456", type: 123, index: 1 }]);
 		});
 
 		it("handles references with markdown formatting", () => {
-			const text = "**Bold** text with [c1]: 123/456 and *italic* with [c2]: 789/101";
+			const text =
+				"**Bold** text with [c1]: 123/456 and *italic* with [c2]: 789/101";
 			const result = extractReferencesFromText(text);
 			expect(result).toEqual([
 				{ id: "456", type: 123, index: 1 },
@@ -320,7 +290,10 @@ Final paragraph has [c4]: 700/800.
 		});
 
 		it("handles many references in a single text", () => {
-			const text = Array.from({ length: 10 }, (_, i) => `[c${i + 1}]: ${i * 10}/${i * 100}`).join(" ");
+			const text = Array.from(
+				{ length: 10 },
+				(_, i) => `[c${i + 1}]: ${i * 10}/${i * 100}`,
+			).join(" ");
 			const result = extractReferencesFromText(text);
 			expect(result).toHaveLength(10);
 			expect(result[0]).toEqual({ id: "0", type: 0, index: 1 });
@@ -328,4 +301,3 @@ Final paragraph has [c4]: 700/800.
 		});
 	});
 });
-

--- a/apps/chat-api/src/features/chat/prompts/environment-context.ts
+++ b/apps/chat-api/src/features/chat/prompts/environment-context.ts
@@ -69,7 +69,6 @@ const ALL_FILES_CONTEXT_TEMPLATE = [
 	"---",
 ].join("\n");
 
-
 export function buildEnvironmentContext(
 	scope: ChatMessagesScope,
 	enableKnowledge: boolean,

--- a/apps/chat-api/src/features/chat/tools/utils.test.ts
+++ b/apps/chat-api/src/features/chat/tools/utils.test.ts
@@ -24,7 +24,7 @@ describe("escapeXml", () => {
 
 	it("escapes all special characters at once", () => {
 		expect(escapeXml('<tag attr="value">Tom & Jerry\'s</tag>')).toBe(
-			"&lt;tag attr=&quot;value&quot;&gt;Tom &amp; Jerry&apos;s&lt;/tag&gt;"
+			"&lt;tag attr=&quot;value&quot;&gt;Tom &amp; Jerry&apos;s&lt;/tag&gt;",
 		);
 	});
 
@@ -68,25 +68,25 @@ describe("xml", () => {
 	describe("automatic escaping", () => {
 		it("escapes special characters in content by default", () => {
 			expect(xml("text", "<script>alert('xss')</script>")).toBe(
-				"<text>&lt;script&gt;alert(&apos;xss&apos;)&lt;/script&gt;</text>"
+				"<text>&lt;script&gt;alert(&apos;xss&apos;)&lt;/script&gt;</text>",
 			);
 		});
 
 		it("escapes ampersands in content", () => {
 			expect(xml("company", "Tom & Jerry Inc.")).toBe(
-				"<company>Tom &amp; Jerry Inc.</company>"
+				"<company>Tom &amp; Jerry Inc.</company>",
 			);
 		});
 
 		it("can disable escaping with shouldEscape: false", () => {
 			expect(xml("text", "Tom & Jerry", { shouldEscape: false })).toBe(
-				"<text>Tom & Jerry</text>"
+				"<text>Tom & Jerry</text>",
 			);
 		});
 
 		it("can use raw option to skip escaping", () => {
 			expect(xml("html", "<b>bold</b>", { raw: true })).toBe(
-				"<html><b>bold</b></html>"
+				"<html><b>bold</b></html>",
 			);
 		});
 	});
@@ -102,7 +102,7 @@ describe("xml", () => {
 
 		it("adds multiple levels of indentation", () => {
 			expect(xml("name", "John", { indent: 3 })).toBe(
-				"\t\t\t<name>John</name>"
+				"\t\t\t<name>John</name>",
 			);
 		});
 
@@ -119,27 +119,31 @@ describe("xml", () => {
 			]);
 
 			expect(result).toBe(
-				"<person>\n\t<name>John</name>\n\t<age>30</age>\n</person>"
+				"<person>\n\t<name>John</name>\n\t<age>30</age>\n</person>",
 			);
 		});
 
 		it("handles deeply nested structures", () => {
 			const result = xml("user", [
 				xml("id", 123, { indent: 1 }),
-				xml("profile", [
-					xml("name", "John", { indent: 2 }),
-					xml("email", "john@example.com", { indent: 2 }),
-				], { indent: 1 }),
+				xml(
+					"profile",
+					[
+						xml("name", "John", { indent: 2 }),
+						xml("email", "john@example.com", { indent: 2 }),
+					],
+					{ indent: 1 },
+				),
 			]);
 
 			expect(result).toBe(
 				"<user>\n" +
-				"\t<id>123</id>\n" +
-				"\t<profile>\n" +
-				"\t\t<name>John</name>\n" +
-				"\t\t<email>john@example.com</email>\n" +
-				"\t</profile>\n" +
-				"</user>"
+					"\t<id>123</id>\n" +
+					"\t<profile>\n" +
+					"\t\t<name>John</name>\n" +
+					"\t\t<email>john@example.com</email>\n" +
+					"\t</profile>\n" +
+					"</user>",
 			);
 		});
 
@@ -148,7 +152,9 @@ describe("xml", () => {
 			const items = ["<item>A</item>", "<item>B</item>", "<item>C</item>"];
 			const result = xml("list", items);
 
-			expect(result).toBe("<list><item>A</item><item>B</item><item>C</item></list>");
+			expect(result).toBe(
+				"<list><item>A</item><item>B</item><item>C</item></list>",
+			);
 		});
 
 		it("handles mixed content in arrays", () => {
@@ -159,7 +165,7 @@ describe("xml", () => {
 			]);
 
 			expect(result).toBe(
-				"<data>\n\t<string>text</string>\n\t<number>42</number>\n\t<empty />\n</data>"
+				"<data>\n\t<string>text</string>\n\t<number>42</number>\n\t<empty />\n</data>",
 			);
 		});
 	});
@@ -172,7 +178,7 @@ describe("xml", () => {
 			]);
 
 			expect(result).toBe(
-				"<searchResults>\n\t<query>test query</query>\n\t<totalResults>5</totalResults>\n</searchResults>"
+				"<searchResults>\n\t<query>test query</query>\n\t<totalResults>5</totalResults>\n</searchResults>",
 			);
 		});
 
@@ -185,25 +191,33 @@ describe("xml", () => {
 
 			expect(result).toBe(
 				"<searchResults>\n" +
-				"\t<query>no results</query>\n" +
-				"\t<totalResults>0</totalResults>\n" +
-				"\t<message>No results found for this query.</message>\n" +
-				"</searchResults>"
+					"\t<query>no results</query>\n" +
+					"\t<totalResults>0</totalResults>\n" +
+					"\t<message>No results found for this query.</message>\n" +
+					"</searchResults>",
 			);
 		});
 
 		it("formats complex nested search results with escaping", () => {
-			const matchingChild = xml("matchingChild", [
-				xml("chunkIndex", 0, { indent: 3 }),
-				xml("score", "0.8500", { indent: 3 }),
-				xml("text", "Text with <special> & 'characters'", { indent: 3 }),
-			], { indent: 2 });
+			const matchingChild = xml(
+				"matchingChild",
+				[
+					xml("chunkIndex", 0, { indent: 3 }),
+					xml("score", "0.8500", { indent: 3 }),
+					xml("text", "Text with <special> & 'characters'", { indent: 3 }),
+				],
+				{ indent: 2 },
+			);
 
-			const chunk = xml("chunk", [
-				xml("chunkIndex", 0, { indent: 2 }),
-				xml("maxScore", "0.9200", { indent: 2 }),
-				xml("matchingChildren", [matchingChild], { indent: 2 }),
-			], { indent: 1 });
+			const chunk = xml(
+				"chunk",
+				[
+					xml("chunkIndex", 0, { indent: 2 }),
+					xml("maxScore", "0.9200", { indent: 2 }),
+					xml("matchingChildren", [matchingChild], { indent: 2 }),
+				],
+				{ indent: 1 },
+			);
 
 			const result = xml("searchResults", [
 				xml("query", "test", { indent: 1 }),
@@ -214,7 +228,7 @@ describe("xml", () => {
 			expect(result).toContain("<chunkIndex>0</chunkIndex>");
 			expect(result).toContain("<score>0.8500</score>");
 			expect(result).toContain(
-				"Text with &lt;special&gt; &amp; &apos;characters&apos;"
+				"Text with &lt;special&gt; &amp; &apos;characters&apos;",
 			);
 		});
 	});
@@ -257,22 +271,21 @@ describe("xml", () => {
 
 	describe("option combinations", () => {
 		it("combines indent and shouldEscape options", () => {
-			expect(xml("text", "Tom & Jerry", { indent: 2, shouldEscape: false })).toBe(
-				"\t\t<text>Tom & Jerry</text>"
-			);
+			expect(
+				xml("text", "Tom & Jerry", { indent: 2, shouldEscape: false }),
+			).toBe("\t\t<text>Tom & Jerry</text>");
 		});
 
 		it("combines indent and raw options", () => {
 			expect(xml("html", "<b>bold</b>", { indent: 1, raw: true })).toBe(
-				"\t<html><b>bold</b></html>"
+				"\t<html><b>bold</b></html>",
 			);
 		});
 
 		it("raw option overrides shouldEscape option", () => {
 			expect(xml("text", "<tag>", { shouldEscape: true, raw: true })).toBe(
-				"<text><tag></text>"
+				"<text><tag></text>",
 			);
 		});
 	});
 });
-

--- a/apps/chat-api/src/features/sandbox/index.ts
+++ b/apps/chat-api/src/features/sandbox/index.ts
@@ -1,0 +1,26 @@
+export {
+	computeChecksum,
+	getDocsRoot,
+	type MaterializationConfig,
+	type MaterializedFile,
+	materializeSummaries,
+	materializeSummary,
+	resolveContent,
+	resolveSourceKind,
+	sanitizePathSegment,
+} from "./materialization";
+export { diffManifest, listSandboxFiles } from "./sandbox-manifest";
+export {
+	SandboxSyncService,
+	type SandboxSyncServiceDeps,
+	type SyncLogger,
+} from "./sandbox-sync.service";
+export type { SyncStateRepository } from "./sync-state.repository";
+export { InMemorySyncStateRepository } from "./sync-state.repository.memory";
+export type {
+	ManifestDiff,
+	ReconciliationAction,
+	ReconciliationPlan,
+	SyncStateRecord,
+	SyncStatus,
+} from "./sync-state.types";

--- a/apps/chat-api/src/features/sandbox/materialization.test.ts
+++ b/apps/chat-api/src/features/sandbox/materialization.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it } from "bun:test";
+import type { ProtectedSummary } from "@/features/chat/api/types";
+import {
+	computeChecksum,
+	getDocsRoot,
+	materializeSummary,
+	resolveContent,
+	resolveSourceKind,
+	sanitizePathSegment,
+} from "./materialization";
+
+const makeConfig = (userId = "user-1") => ({
+	workspaceRoot: "/workspace/sandbox-prototype",
+	userId,
+});
+
+const makeSummary = (
+	overrides: Partial<ProtectedSummary> = {},
+): ProtectedSummary => ({
+	id: "100",
+	type: 0,
+	content: "Hello world",
+	parseContent: null,
+	title: "Test Doc",
+	summaryTitle: null,
+	fileType: null,
+	delFlag: 0,
+	updateTime: "2026-03-27T00:00:00Z",
+	...overrides,
+});
+
+describe("sanitizePathSegment", () => {
+	it("passes through alphanumeric and allowed chars", () => {
+		expect(sanitizePathSegment("hello-world_1.0")).toBe("hello-world_1.0");
+	});
+
+	it("replaces spaces and special characters with hyphens", () => {
+		expect(sanitizePathSegment("hello world!@#")).toBe("hello-world-");
+	});
+
+	it("collapses consecutive special chars into one hyphen", () => {
+		expect(sanitizePathSegment("a   b///c")).toBe("a-b-c");
+	});
+
+	it("trims whitespace before sanitizing", () => {
+		expect(sanitizePathSegment("  abc  ")).toBe("abc");
+	});
+
+	it("returns 'unknown' for empty or whitespace-only input", () => {
+		expect(sanitizePathSegment("")).toBe("unknown");
+		expect(sanitizePathSegment("   ")).toBe("unknown");
+	});
+
+	it("handles unicode characters", () => {
+		expect(sanitizePathSegment("文档-123")).toBe("--123");
+	});
+});
+
+describe("computeChecksum", () => {
+	it("returns a 64-character hex string", () => {
+		const result = computeChecksum("hello");
+		expect(result).toHaveLength(64);
+		expect(result).toMatch(/^[0-9a-f]{64}$/);
+	});
+
+	it("is deterministic", () => {
+		const a = computeChecksum("same content");
+		const b = computeChecksum("same content");
+		expect(a).toBe(b);
+	});
+
+	it("differs for different content", () => {
+		const a = computeChecksum("content A");
+		const b = computeChecksum("content B");
+		expect(a).not.toBe(b);
+	});
+
+	it("handles empty string", () => {
+		const result = computeChecksum("");
+		expect(result).toHaveLength(64);
+	});
+});
+
+describe("resolveSourceKind", () => {
+	it("returns 'parser_output' for PDF", () => {
+		expect(
+			resolveSourceKind(makeSummary({ fileType: "application/pdf" })),
+		).toBe("parser_output");
+	});
+
+	it("returns 'parser_output' for normal links", () => {
+		expect(resolveSourceKind(makeSummary({ fileType: "link/normal" }))).toBe(
+			"parser_output",
+		);
+	});
+
+	it("returns 'parser_output' for video links", () => {
+		expect(resolveSourceKind(makeSummary({ fileType: "link/video" }))).toBe(
+			"parser_output",
+		);
+	});
+
+	it("returns 'markdown' for type 3 (notes)", () => {
+		expect(resolveSourceKind(makeSummary({ type: 3 }))).toBe("markdown");
+	});
+
+	it("returns 'text' for other types", () => {
+		expect(resolveSourceKind(makeSummary({ type: 0 }))).toBe("text");
+		expect(resolveSourceKind(makeSummary({ type: 6 }))).toBe("text");
+	});
+
+	it("parser_output takes precedence over type 3 for PDFs", () => {
+		expect(
+			resolveSourceKind(makeSummary({ type: 3, fileType: "application/pdf" })),
+		).toBe("parser_output");
+	});
+});
+
+describe("resolveContent", () => {
+	it("returns content for text type", () => {
+		expect(
+			resolveContent(
+				makeSummary({ content: "raw", parseContent: "parsed", type: 0 }),
+			),
+		).toBe("raw");
+	});
+
+	it("returns parseContent for parser_output type", () => {
+		expect(
+			resolveContent(
+				makeSummary({
+					content: "raw",
+					parseContent: "parsed",
+					fileType: "application/pdf",
+				}),
+			),
+		).toBe("parsed");
+	});
+
+	it("falls back to parseContent when content is null", () => {
+		expect(
+			resolveContent(makeSummary({ content: null, parseContent: "parsed" })),
+		).toBe("parsed");
+	});
+
+	it("falls back to content when parseContent is null for PDF", () => {
+		expect(
+			resolveContent(
+				makeSummary({
+					content: "raw",
+					parseContent: null,
+					fileType: "application/pdf",
+				}),
+			),
+		).toBe("raw");
+	});
+
+	it("returns empty string when both are null", () => {
+		expect(
+			resolveContent(makeSummary({ content: null, parseContent: null })),
+		).toBe("");
+	});
+});
+
+describe("getDocsRoot", () => {
+	it("builds the correct path", () => {
+		expect(getDocsRoot(makeConfig("user-1"))).toBe(
+			"/workspace/sandbox-prototype/docs/user-1",
+		);
+	});
+
+	it("sanitizes the userId", () => {
+		expect(getDocsRoot(makeConfig("user with spaces"))).toBe(
+			"/workspace/sandbox-prototype/docs/user-with-spaces",
+		);
+	});
+});
+
+describe("materializeSummary", () => {
+	it("produces correct frontmatter format", () => {
+		const result = materializeSummary(makeSummary(), makeConfig());
+		const lines = result.content.split("\n");
+
+		expect(lines[0]).toBe("---");
+		expect(lines[1]).toBe("summaryId: 100");
+		expect(lines[2]).toBe("type: 0");
+		expect(lines[3]).toBe("sourceKind: text");
+		expect(lines[4]).toBe('title: "Test Doc"');
+		expect(lines[5]).toBe("---");
+		expect(lines[6]).toBe("");
+		expect(lines[7]).toBe("Hello world");
+		expect(lines[8]).toBe("");
+	});
+
+	it("builds correct path", () => {
+		const result = materializeSummary(makeSummary({ id: "456" }), makeConfig());
+		expect(result.path).toBe(
+			"/workspace/sandbox-prototype/docs/user-1/0/456.txt",
+		);
+		expect(result.relativePath).toBe("0/456.txt");
+	});
+
+	it("uses summaryTitle as fallback when title is null", () => {
+		const result = materializeSummary(
+			makeSummary({ title: null, summaryTitle: "Fallback Title" }),
+			makeConfig(),
+		);
+		expect(result.content).toContain('title: "Fallback Title"');
+	});
+
+	it("uses empty string when both titles are null", () => {
+		const result = materializeSummary(
+			makeSummary({ title: null, summaryTitle: null }),
+			makeConfig(),
+		);
+		expect(result.content).toContain('title: ""');
+	});
+
+	it("trims content", () => {
+		const result = materializeSummary(
+			makeSummary({ content: "  hello  \n\n" }),
+			makeConfig(),
+		);
+		// Body should be trimmed, followed by trailing newline
+		const lines = result.content.split("\n");
+		expect(lines[7]).toBe("hello");
+	});
+
+	it("defaults type to 0 when null", () => {
+		const result = materializeSummary(
+			makeSummary({ type: null }),
+			makeConfig(),
+		);
+		expect(result.type).toBe(0);
+		expect(result.content).toContain("type: 0");
+	});
+
+	it("computes a checksum", () => {
+		const result = materializeSummary(makeSummary(), makeConfig());
+		expect(result.checksum).toHaveLength(64);
+		expect(result.checksum).toMatch(/^[0-9a-f]{64}$/);
+	});
+
+	it("checksum is deterministic for same input", () => {
+		const a = materializeSummary(makeSummary(), makeConfig());
+		const b = materializeSummary(makeSummary(), makeConfig());
+		expect(a.checksum).toBe(b.checksum);
+		expect(a.content).toBe(b.content);
+	});
+
+	it("checksum changes when content changes", () => {
+		const a = materializeSummary(
+			makeSummary({ content: "version 1" }),
+			makeConfig(),
+		);
+		const b = materializeSummary(
+			makeSummary({ content: "version 2" }),
+			makeConfig(),
+		);
+		expect(a.checksum).not.toBe(b.checksum);
+	});
+
+	it("handles special characters in title via JSON.stringify", () => {
+		const result = materializeSummary(
+			makeSummary({ title: 'He said "hello"' }),
+			makeConfig(),
+		);
+		expect(result.content).toContain('title: "He said \\"hello\\""');
+	});
+});

--- a/apps/chat-api/src/features/sandbox/materialization.ts
+++ b/apps/chat-api/src/features/sandbox/materialization.ts
@@ -1,0 +1,127 @@
+import type { ProtectedSummary } from "@/features/chat/api/types";
+
+export interface MaterializedFile {
+	summaryId: string;
+	type: number;
+	/** Full sandbox path */
+	path: string;
+	/** Path relative to docs root */
+	relativePath: string;
+	/** Frontmatter + body content ready to write to disk */
+	content: string;
+	/** SHA-256 hex checksum of content */
+	checksum: string;
+}
+
+export interface MaterializationConfig {
+	/** Sandbox workspace root, e.g. "/workspace/sandbox-prototype" */
+	workspaceRoot: string;
+	userId: string;
+}
+
+/**
+ * Sanitize a value for use as a filesystem path segment.
+ * Extracted from scripts/run-sandbox-prototype.ts.
+ */
+export function sanitizePathSegment(value: string): string {
+	return value.trim().replace(/[^a-zA-Z0-9._-]+/g, "-") || "unknown";
+}
+
+/** Compute SHA-256 hex checksum of content using Bun's crypto. */
+export function computeChecksum(content: string): string {
+	const hasher = new Bun.CryptoHasher("sha256");
+	hasher.update(content);
+	return hasher.digest("hex");
+}
+
+/**
+ * Determine the source kind from a ProtectedSummary.
+ * - PDFs and links use parsed content → "parser_output"
+ * - Notes (type 3) are typically markdown → "markdown"
+ * - Everything else → "text"
+ */
+export function resolveSourceKind(
+	summary: ProtectedSummary,
+): "markdown" | "text" | "parser_output" {
+	const fileType = summary.fileType;
+
+	if (
+		fileType === "application/pdf" ||
+		fileType === "link/normal" ||
+		fileType === "link/video"
+	) {
+		return "parser_output";
+	}
+
+	if (summary.type === 3) {
+		return "markdown";
+	}
+
+	return "text";
+}
+
+/**
+ * Extract the best available text content from a ProtectedSummary.
+ * Prefers parseContent for file types that have parsed output,
+ * falls back to content, then empty string.
+ */
+export function resolveContent(summary: ProtectedSummary): string {
+	const sourceKind = resolveSourceKind(summary);
+
+	if (sourceKind === "parser_output") {
+		return summary.parseContent ?? summary.content ?? "";
+	}
+
+	return summary.content ?? summary.parseContent ?? "";
+}
+
+/** Build the docs root path for a user within the workspace. */
+export function getDocsRoot(config: MaterializationConfig): string {
+	return `${config.workspaceRoot}/docs/${sanitizePathSegment(config.userId)}`;
+}
+
+/**
+ * Materialize a single ProtectedSummary into a file with YAML frontmatter.
+ * Format matches the prototype in scripts/run-sandbox-prototype.ts.
+ */
+export function materializeSummary(
+	summary: ProtectedSummary,
+	config: MaterializationConfig,
+): MaterializedFile {
+	const summaryId = summary.id;
+	const type = summary.type ?? 0;
+	const docsRoot = getDocsRoot(config);
+	const relativePath = `${type}/${sanitizePathSegment(summaryId)}.txt`;
+	const sourceKind = resolveSourceKind(summary);
+	const title = summary.title?.trim() ?? summary.summaryTitle?.trim() ?? "";
+	const body = resolveContent(summary).trim();
+
+	const content = [
+		"---",
+		`summaryId: ${summaryId}`,
+		`type: ${type}`,
+		`sourceKind: ${sourceKind}`,
+		`title: ${JSON.stringify(title)}`,
+		"---",
+		"",
+		body,
+		"",
+	].join("\n");
+
+	return {
+		summaryId,
+		type,
+		path: `${docsRoot}/${relativePath}`,
+		relativePath,
+		content,
+		checksum: computeChecksum(content),
+	};
+}
+
+/** Batch materialization of multiple summaries. */
+export function materializeSummaries(
+	summaries: ProtectedSummary[],
+	config: MaterializationConfig,
+): MaterializedFile[] {
+	return summaries.map((summary) => materializeSummary(summary, config));
+}

--- a/apps/chat-api/src/features/sandbox/sandbox-manifest.ts
+++ b/apps/chat-api/src/features/sandbox/sandbox-manifest.ts
@@ -1,0 +1,82 @@
+import type { Sandbox } from "e2b";
+import { computeChecksum } from "./materialization";
+import type { ManifestDiff, SyncStateRecord } from "./sync-state.types";
+
+/**
+ * List all .txt files under the docs root in the sandbox.
+ * Returns paths relative to the sandbox filesystem root.
+ */
+export async function listSandboxFiles(
+	sandbox: Sandbox,
+	docsRoot: string,
+): Promise<string[]> {
+	const result = await sandbox.commands.run(
+		`find ${docsRoot} -type f -name '*.txt' 2>/dev/null`,
+		{ timeoutMs: 10_000 },
+	);
+
+	if (result.exitCode !== 0 || !result.stdout.trim()) {
+		return [];
+	}
+
+	return result.stdout
+		.trim()
+		.split("\n")
+		.filter((line) => line.length > 0);
+}
+
+/**
+ * Read a file from the sandbox and compute its SHA-256 checksum.
+ * Returns null if the file does not exist or cannot be read.
+ */
+export async function readSandboxFileChecksum(
+	sandbox: Sandbox,
+	path: string,
+): Promise<string | null> {
+	try {
+		const content = await sandbox.files.read(path);
+		return computeChecksum(content);
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Compare expected state (from sync-state records) against actual sandbox filesystem.
+ * Returns a diff describing missing files, orphaned files, and checksum mismatches.
+ */
+export async function diffManifest(
+	expectedRecords: SyncStateRecord[],
+	sandbox: Sandbox,
+	docsRoot: string,
+): Promise<ManifestDiff> {
+	const actualFiles = await listSandboxFiles(sandbox, docsRoot);
+	const actualSet = new Set(actualFiles);
+
+	const missingInSandbox: SyncStateRecord[] = [];
+	const checksumMismatches: SyncStateRecord[] = [];
+	const expectedPaths = new Set<string>();
+
+	for (const record of expectedRecords) {
+		expectedPaths.add(record.expectedPath);
+
+		if (!actualSet.has(record.expectedPath)) {
+			missingInSandbox.push(record);
+			continue;
+		}
+
+		const actualChecksum = await readSandboxFileChecksum(
+			sandbox,
+			record.expectedPath,
+		);
+		if (actualChecksum !== null && actualChecksum !== record.contentChecksum) {
+			checksumMismatches.push(record);
+		}
+	}
+
+	const orphanedInSandbox = actualFiles.filter(
+		(path) => !expectedPaths.has(path),
+	);
+
+	return { missingInSandbox, orphanedInSandbox, checksumMismatches };
+}

--- a/apps/chat-api/src/features/sandbox/sandbox-sync.service.test.ts
+++ b/apps/chat-api/src/features/sandbox/sandbox-sync.service.test.ts
@@ -1,0 +1,341 @@
+import { describe, expect, it } from "bun:test";
+import type { ProtectedSummary } from "@/features/chat/api/types";
+import type { MaterializationConfig } from "./materialization";
+import { SandboxSyncService } from "./sandbox-sync.service";
+import { InMemorySyncStateRepository } from "./sync-state.repository.memory";
+
+const config: MaterializationConfig = {
+	workspaceRoot: "/workspace/sandbox-prototype",
+	userId: "user-1",
+};
+
+const silentLogger = {
+	info(_obj: Record<string, unknown>) {},
+	error(_obj: Record<string, unknown>) {},
+};
+
+const makeSummary = (
+	overrides: Partial<ProtectedSummary> = {},
+): ProtectedSummary => ({
+	id: "100",
+	type: 0,
+	content: "Hello world",
+	parseContent: null,
+	title: "Test Doc",
+	summaryTitle: null,
+	fileType: null,
+	delFlag: 0,
+	updateTime: "2026-03-27T00:00:00Z",
+	...overrides,
+});
+
+function createService() {
+	const repository = new InMemorySyncStateRepository();
+	const service = new SandboxSyncService({
+		repository,
+		logger: silentLogger,
+	});
+	return { repository, service };
+}
+
+describe("SandboxSyncService.buildReconciliationPlan", () => {
+	it("produces creates for new summaries", async () => {
+		const { service } = createService();
+		const plan = await service.buildReconciliationPlan(
+			"user-1",
+			"sbx-1",
+			[makeSummary({ id: "1" }), makeSummary({ id: "2" })],
+			config,
+		);
+
+		expect(plan.creates).toHaveLength(2);
+		expect(plan.updates).toHaveLength(0);
+		expect(plan.deletes).toHaveLength(0);
+		expect(plan.unchanged).toBe(0);
+	});
+
+	it("produces updates when content changes", async () => {
+		const { repository, service } = createService();
+
+		// Seed existing state
+		const firstPlan = await service.buildReconciliationPlan(
+			"user-1",
+			"sbx-1",
+			[makeSummary({ id: "1", content: "version 1" })],
+			config,
+		);
+		// Simulate applying the first plan
+		for (const action of firstPlan.creates) {
+			await repository.upsert({
+				...action.record,
+				lastSyncedAt: new Date().toISOString(),
+			});
+		}
+
+		// Now change content
+		const plan = await service.buildReconciliationPlan(
+			"user-1",
+			"sbx-1",
+			[makeSummary({ id: "1", content: "version 2" })],
+			config,
+		);
+
+		expect(plan.creates).toHaveLength(0);
+		expect(plan.updates).toHaveLength(1);
+		expect(plan.updates[0].reason).toBe("content_changed");
+		expect(plan.deletes).toHaveLength(0);
+		expect(plan.unchanged).toBe(0);
+	});
+
+	it("produces noop when content is unchanged", async () => {
+		const { repository, service } = createService();
+
+		const summaries = [makeSummary({ id: "1", content: "stable" })];
+
+		const firstPlan = await service.buildReconciliationPlan(
+			"user-1",
+			"sbx-1",
+			summaries,
+			config,
+		);
+		for (const action of firstPlan.creates) {
+			await repository.upsert(action.record);
+		}
+
+		const plan = await service.buildReconciliationPlan(
+			"user-1",
+			"sbx-1",
+			summaries,
+			config,
+		);
+
+		expect(plan.creates).toHaveLength(0);
+		expect(plan.updates).toHaveLength(0);
+		expect(plan.deletes).toHaveLength(0);
+		expect(plan.unchanged).toBe(1);
+	});
+
+	it("produces deletes for removed summaries", async () => {
+		const { repository, service } = createService();
+
+		// Seed two documents
+		const firstPlan = await service.buildReconciliationPlan(
+			"user-1",
+			"sbx-1",
+			[makeSummary({ id: "1" }), makeSummary({ id: "2" })],
+			config,
+		);
+		for (const action of firstPlan.creates) {
+			await repository.upsert(action.record);
+		}
+
+		// Source now only has document 1
+		const plan = await service.buildReconciliationPlan(
+			"user-1",
+			"sbx-1",
+			[makeSummary({ id: "1" })],
+			config,
+		);
+
+		expect(plan.creates).toHaveLength(0);
+		expect(plan.deletes).toHaveLength(1);
+		expect(plan.deletes[0].record.summaryId).toBe("2");
+		expect(plan.unchanged).toBe(1);
+	});
+
+	it("produces deletes for summaries with delFlag=1", async () => {
+		const { repository, service } = createService();
+
+		const firstPlan = await service.buildReconciliationPlan(
+			"user-1",
+			"sbx-1",
+			[makeSummary({ id: "1" })],
+			config,
+		);
+		for (const action of firstPlan.creates) {
+			await repository.upsert(action.record);
+		}
+
+		// Source now has delFlag=1
+		const plan = await service.buildReconciliationPlan(
+			"user-1",
+			"sbx-1",
+			[makeSummary({ id: "1", delFlag: 1 })],
+			config,
+		);
+
+		expect(plan.creates).toHaveLength(0);
+		expect(plan.deletes).toHaveLength(1);
+		expect(plan.deletes[0].record.summaryId).toBe("1");
+	});
+
+	it("handles delFlag as string '1'", async () => {
+		const { repository, service } = createService();
+
+		const firstPlan = await service.buildReconciliationPlan(
+			"user-1",
+			"sbx-1",
+			[makeSummary({ id: "1" })],
+			config,
+		);
+		for (const action of firstPlan.creates) {
+			await repository.upsert(action.record);
+		}
+
+		const plan = await service.buildReconciliationPlan(
+			"user-1",
+			"sbx-1",
+			[makeSummary({ id: "1", delFlag: "1" })],
+			config,
+		);
+
+		expect(plan.deletes).toHaveLength(1);
+	});
+
+	it("handles mixed creates, updates, deletes, and unchanged", async () => {
+		const { repository, service } = createService();
+
+		// Seed three documents
+		const firstPlan = await service.buildReconciliationPlan(
+			"user-1",
+			"sbx-1",
+			[
+				makeSummary({ id: "keep", content: "stable" }),
+				makeSummary({ id: "change", content: "v1" }),
+				makeSummary({ id: "remove", content: "gone soon" }),
+			],
+			config,
+		);
+		for (const action of firstPlan.creates) {
+			await repository.upsert(action.record);
+		}
+
+		// Source: keep unchanged, change updated, remove gone, new added
+		const plan = await service.buildReconciliationPlan(
+			"user-1",
+			"sbx-1",
+			[
+				makeSummary({ id: "keep", content: "stable" }),
+				makeSummary({ id: "change", content: "v2" }),
+				makeSummary({ id: "new-doc", content: "brand new" }),
+			],
+			config,
+		);
+
+		expect(plan.unchanged).toBe(1);
+		expect(plan.updates).toHaveLength(1);
+		expect(plan.updates[0].record.summaryId).toBe("change");
+		expect(plan.deletes).toHaveLength(1);
+		expect(plan.deletes[0].record.summaryId).toBe("remove");
+		expect(plan.creates).toHaveLength(1);
+		expect(plan.creates[0].record.summaryId).toBe("new-doc");
+	});
+
+	it("empty source with existing records produces all deletes", async () => {
+		const { repository, service } = createService();
+
+		const firstPlan = await service.buildReconciliationPlan(
+			"user-1",
+			"sbx-1",
+			[makeSummary({ id: "1" }), makeSummary({ id: "2" })],
+			config,
+		);
+		for (const action of firstPlan.creates) {
+			await repository.upsert(action.record);
+		}
+
+		const plan = await service.buildReconciliationPlan(
+			"user-1",
+			"sbx-1",
+			[],
+			config,
+		);
+
+		expect(plan.deletes).toHaveLength(2);
+		expect(plan.creates).toHaveLength(0);
+		expect(plan.unchanged).toBe(0);
+	});
+
+	it("empty source with no existing records produces empty plan", async () => {
+		const { service } = createService();
+
+		const plan = await service.buildReconciliationPlan(
+			"user-1",
+			"sbx-1",
+			[],
+			config,
+		);
+
+		expect(plan.creates).toHaveLength(0);
+		expect(plan.updates).toHaveLength(0);
+		expect(plan.deletes).toHaveLength(0);
+		expect(plan.unchanged).toBe(0);
+	});
+
+	it("isolates users — records from other users are not affected", async () => {
+		const { repository, service } = createService();
+
+		// Seed records for user-2
+		await repository.upsert({
+			userId: "user-2",
+			sandboxId: "sbx-2",
+			summaryId: "other",
+			type: 0,
+			expectedPath: "/workspace/docs/user-2/0/other.txt",
+			contentChecksum: "xxx",
+			sourceUpdatedAt: "2026-03-27T00:00:00Z",
+			lastSyncedAt: null,
+			syncStatus: "synced",
+		});
+
+		const plan = await service.buildReconciliationPlan(
+			"user-1",
+			"sbx-1",
+			[makeSummary({ id: "1" })],
+			config,
+		);
+
+		// Should only create for user-1, not delete user-2's record
+		expect(plan.creates).toHaveLength(1);
+		expect(plan.deletes).toHaveLength(0);
+
+		// user-2's record still exists
+		const user2Records = await repository.findByUserId("user-2");
+		expect(user2Records).toHaveLength(1);
+	});
+});
+
+describe("SandboxSyncService.withLock (serialization)", () => {
+	it("serializes concurrent calls for the same user", async () => {
+		const { service } = createService();
+		const order: number[] = [];
+
+		const p1 = service.buildReconciliationPlan(
+			"user-1",
+			"sbx-1",
+			[makeSummary({ id: "1" })],
+			config,
+		);
+		const p2 = service.buildReconciliationPlan(
+			"user-1",
+			"sbx-1",
+			[makeSummary({ id: "2" })],
+			config,
+		);
+
+		const [r1, r2] = await Promise.all([
+			p1.then((r) => {
+				order.push(1);
+				return r;
+			}),
+			p2.then((r) => {
+				order.push(2);
+				return r;
+			}),
+		]);
+
+		// Both should succeed
+		expect(r1.creates).toHaveLength(1);
+		expect(r2.creates).toHaveLength(1);
+	});
+});

--- a/apps/chat-api/src/features/sandbox/sandbox-sync.service.ts
+++ b/apps/chat-api/src/features/sandbox/sandbox-sync.service.ts
@@ -1,0 +1,369 @@
+import type { Sandbox } from "e2b";
+import type { ProtectedSummary } from "@/features/chat/api/types";
+import {
+	getDocsRoot,
+	type MaterializationConfig,
+	type MaterializedFile,
+	materializeSummaries,
+} from "./materialization";
+import { diffManifest } from "./sandbox-manifest";
+import type { SyncStateRepository } from "./sync-state.repository";
+import type {
+	ManifestDiff,
+	ReconciliationPlan,
+	SyncStateRecord,
+} from "./sync-state.types";
+
+export interface SyncLogger {
+	info(obj: Record<string, unknown>): void;
+	error(obj: Record<string, unknown>): void;
+}
+
+export interface SandboxSyncServiceDeps {
+	repository: SyncStateRepository;
+	logger: SyncLogger;
+}
+
+function isDeleted(summary: ProtectedSummary): boolean {
+	return summary.delFlag === 1 || summary.delFlag === "1";
+}
+
+function nowISO(): string {
+	return new Date().toISOString();
+}
+
+export class SandboxSyncService {
+	private readonly repository: SyncStateRepository;
+	private readonly logger: SyncLogger;
+	private readonly locks = new Map<string, Promise<void>>();
+
+	constructor(deps: SandboxSyncServiceDeps) {
+		this.repository = deps.repository;
+		this.logger = deps.logger;
+	}
+
+	/**
+	 * Full reconciliation: compare source summaries against sync-state,
+	 * produce a plan, apply it to the sandbox, update sync-state.
+	 */
+	async syncUser(
+		userId: string,
+		sandboxId: string,
+		sandbox: Sandbox,
+		sourceSummaries: ProtectedSummary[],
+		config: MaterializationConfig,
+	): Promise<ReconciliationPlan> {
+		return this.withLock(userId, async () => {
+			const plan = await this.buildReconciliationPlan(
+				userId,
+				sandboxId,
+				sourceSummaries,
+				config,
+			);
+
+			this.logger.info({
+				msg: "reconciliation plan built",
+				userId,
+				sandboxId,
+				creates: plan.creates.length,
+				updates: plan.updates.length,
+				deletes: plan.deletes.length,
+				unchanged: plan.unchanged,
+			});
+
+			await this.applyPlan(userId, sandboxId, sandbox, plan);
+
+			return plan;
+		});
+	}
+
+	/**
+	 * Build a reconciliation plan without applying it.
+	 * Pure comparison: source summaries + current sync-state → plan.
+	 */
+	async buildReconciliationPlan(
+		userId: string,
+		sandboxId: string,
+		sourceSummaries: ProtectedSummary[],
+		config: MaterializationConfig,
+	): Promise<ReconciliationPlan> {
+		const existingRecords = await this.repository.findByUserId(userId);
+		const existingMap = new Map<string, SyncStateRecord>();
+		for (const record of existingRecords) {
+			existingMap.set(record.summaryId, record);
+		}
+
+		// Filter out deleted summaries — they produce delete actions
+		const activeSummaries = sourceSummaries.filter((s) => !isDeleted(s));
+		const deletedSummaryIds = new Set(
+			sourceSummaries.filter(isDeleted).map((s) => s.id),
+		);
+
+		const materialized = materializeSummaries(activeSummaries, config);
+		const materializedMap = new Map<string, MaterializedFile>();
+		for (const file of materialized) {
+			materializedMap.set(file.summaryId, file);
+		}
+
+		const plan: ReconciliationPlan = {
+			creates: [],
+			updates: [],
+			deletes: [],
+			unchanged: 0,
+		};
+
+		// Detect creates and updates
+		for (const file of materialized) {
+			const existing = existingMap.get(file.summaryId);
+			const record: SyncStateRecord = {
+				userId,
+				sandboxId,
+				summaryId: file.summaryId,
+				type: file.type,
+				expectedPath: file.path,
+				contentChecksum: file.checksum,
+				sourceUpdatedAt:
+					activeSummaries.find((s) => s.id === file.summaryId)?.updateTime ??
+					nowISO(),
+				lastSyncedAt: null,
+				syncStatus: "synced",
+			};
+
+			if (!existing) {
+				plan.creates.push({ kind: "create", record, content: file.content });
+			} else if (existing.contentChecksum !== file.checksum) {
+				plan.updates.push({
+					kind: "update",
+					record,
+					content: file.content,
+					reason: "content_changed",
+				});
+			} else {
+				plan.unchanged++;
+			}
+		}
+
+		// Detect deletes: existing records not in active source, or explicitly deleted
+		for (const existing of existingRecords) {
+			if (
+				!materializedMap.has(existing.summaryId) ||
+				deletedSummaryIds.has(existing.summaryId)
+			) {
+				plan.deletes.push({ kind: "delete", record: existing });
+			}
+		}
+
+		return plan;
+	}
+
+	/**
+	 * Apply a reconciliation plan to the sandbox filesystem and update sync-state.
+	 */
+	async applyPlan(
+		userId: string,
+		sandboxId: string,
+		sandbox: Sandbox,
+		plan: ReconciliationPlan,
+	): Promise<void> {
+		const timestamp = nowISO();
+
+		// Apply creates and updates
+		const writes = [...plan.creates, ...plan.updates];
+		for (const action of writes) {
+			try {
+				await sandbox.files.write(action.record.expectedPath, action.content);
+				await this.repository.upsert({
+					...action.record,
+					lastSyncedAt: timestamp,
+					syncStatus: "synced",
+				});
+			} catch (err) {
+				this.logger.error({
+					msg: "failed to write file to sandbox",
+					userId,
+					sandboxId,
+					path: action.record.expectedPath,
+					error: err instanceof Error ? err.message : String(err),
+				});
+				await this.repository.upsert({
+					...action.record,
+					syncStatus: "error",
+				});
+			}
+		}
+
+		// Apply deletes
+		if (plan.deletes.length > 0) {
+			const paths = plan.deletes.map((d) => d.record.expectedPath);
+			try {
+				const escapedPaths = paths.map((p) => `'${p}'`).join(" ");
+				await sandbox.commands.run(`rm -f ${escapedPaths}`, {
+					timeoutMs: 10_000,
+				});
+				await this.repository.bulkDelete(
+					userId,
+					plan.deletes.map((d) => d.record.summaryId),
+				);
+			} catch (err) {
+				this.logger.error({
+					msg: "failed to delete files from sandbox",
+					userId,
+					sandboxId,
+					paths,
+					error: err instanceof Error ? err.message : String(err),
+				});
+			}
+		}
+	}
+
+	/**
+	 * Compare sync-state expectations against actual sandbox filesystem.
+	 * Returns a drift report.
+	 */
+	async verifyManifest(
+		userId: string,
+		sandboxId: string,
+		sandbox: Sandbox,
+		config: MaterializationConfig,
+	): Promise<ManifestDiff> {
+		const records = await this.repository.findByUserAndSandbox(
+			userId,
+			sandboxId,
+		);
+		const docsRoot = getDocsRoot(config);
+		return diffManifest(records, sandbox, docsRoot);
+	}
+
+	/**
+	 * Repair drift found by verifyManifest.
+	 * Re-materializes missing/mismatched files, removes orphans.
+	 */
+	async repairDrift(
+		userId: string,
+		sandboxId: string,
+		sandbox: Sandbox,
+		diff: ManifestDiff,
+		sourceSummaries: ProtectedSummary[],
+		config: MaterializationConfig,
+	): Promise<void> {
+		return this.withLock(userId, async () => {
+			const summaryMap = new Map<string, ProtectedSummary>();
+			for (const s of sourceSummaries) {
+				summaryMap.set(s.id, s);
+			}
+			const timestamp = nowISO();
+
+			// Re-write missing and mismatched files
+			const toRepair = [...diff.missingInSandbox, ...diff.checksumMismatches];
+			for (const record of toRepair) {
+				const summary = summaryMap.get(record.summaryId);
+				if (!summary) continue;
+
+				const materialized = materializeSummaries([summary], config);
+				if (materialized.length === 0) continue;
+
+				const file = materialized[0];
+				try {
+					await sandbox.files.write(file.path, file.content);
+					await this.repository.upsert({
+						...record,
+						expectedPath: file.path,
+						contentChecksum: file.checksum,
+						lastSyncedAt: timestamp,
+						syncStatus: "synced",
+					});
+				} catch (err) {
+					this.logger.error({
+						msg: "failed to repair file",
+						userId,
+						sandboxId,
+						path: file.path,
+						error: err instanceof Error ? err.message : String(err),
+					});
+				}
+			}
+
+			// Remove orphaned files
+			if (diff.orphanedInSandbox.length > 0) {
+				const escapedPaths = diff.orphanedInSandbox
+					.map((p) => `'${p}'`)
+					.join(" ");
+				try {
+					await sandbox.commands.run(`rm -f ${escapedPaths}`, {
+						timeoutMs: 10_000,
+					});
+				} catch (err) {
+					this.logger.error({
+						msg: "failed to remove orphaned files",
+						userId,
+						sandboxId,
+						paths: diff.orphanedInSandbox,
+						error: err instanceof Error ? err.message : String(err),
+					});
+				}
+			}
+
+			this.logger.info({
+				msg: "drift repair complete",
+				userId,
+				sandboxId,
+				repairedFiles: toRepair.length,
+				removedOrphans: diff.orphanedInSandbox.length,
+			});
+		});
+	}
+
+	/**
+	 * Clear all sync-state for the user, delete all sandbox docs,
+	 * and perform a full sync from scratch.
+	 */
+	async rebuildSandbox(
+		userId: string,
+		sandboxId: string,
+		sandbox: Sandbox,
+		sourceSummaries: ProtectedSummary[],
+		config: MaterializationConfig,
+	): Promise<ReconciliationPlan> {
+		return this.withLock(userId, async () => {
+			const docsRoot = getDocsRoot(config);
+
+			// Clear existing state
+			await this.repository.deleteAllForUser(userId);
+			await sandbox.commands.run(`rm -rf ${docsRoot}`, { timeoutMs: 10_000 });
+
+			this.logger.info({
+				msg: "sandbox cleared for rebuild",
+				userId,
+				sandboxId,
+			});
+
+			// Build and apply a full sync plan (bypass lock since we already hold it)
+			const plan = await this.buildReconciliationPlan(
+				userId,
+				sandboxId,
+				sourceSummaries,
+				config,
+			);
+			await this.applyPlan(userId, sandboxId, sandbox, plan);
+
+			return plan;
+		});
+	}
+
+	/**
+	 * Serialize sync operations per userId.
+	 * New operations chain onto the previous promise for the same user.
+	 */
+	private withLock<T>(userId: string, fn: () => Promise<T>): Promise<T> {
+		const prev = this.locks.get(userId) ?? Promise.resolve();
+		const next = prev.then(() => fn());
+		this.locks.set(
+			userId,
+			next.then(
+				() => {},
+				() => {},
+			),
+		);
+		return next;
+	}
+}

--- a/apps/chat-api/src/features/sandbox/sync-state.repository.memory.test.ts
+++ b/apps/chat-api/src/features/sandbox/sync-state.repository.memory.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import { InMemorySyncStateRepository } from "./sync-state.repository.memory";
+import type { SyncStateRecord } from "./sync-state.types";
+
+const makeRecord = (
+	overrides: Partial<SyncStateRecord> = {},
+): SyncStateRecord => ({
+	userId: "user-1",
+	sandboxId: "sbx-1",
+	summaryId: "sum-1",
+	type: 0,
+	expectedPath: "/workspace/docs/user-1/0/sum-1.txt",
+	contentChecksum: "abc123",
+	sourceUpdatedAt: "2026-03-27T00:00:00Z",
+	lastSyncedAt: null,
+	syncStatus: "synced",
+	...overrides,
+});
+
+describe("InMemorySyncStateRepository", () => {
+	let repo: InMemorySyncStateRepository;
+
+	beforeEach(() => {
+		repo = new InMemorySyncStateRepository();
+	});
+
+	describe("upsert / findBySummaryId", () => {
+		it("inserts a new record", async () => {
+			const record = makeRecord();
+			await repo.upsert(record);
+			const found = await repo.findBySummaryId("user-1", "sum-1");
+			expect(found).toEqual(record);
+		});
+
+		it("overwrites an existing record", async () => {
+			await repo.upsert(makeRecord({ contentChecksum: "old" }));
+			await repo.upsert(makeRecord({ contentChecksum: "new" }));
+			const found = await repo.findBySummaryId("user-1", "sum-1");
+			expect(found?.contentChecksum).toBe("new");
+		});
+
+		it("returns null for non-existent record", async () => {
+			const found = await repo.findBySummaryId("user-1", "nope");
+			expect(found).toBeNull();
+		});
+	});
+
+	describe("delete", () => {
+		it("removes a record", async () => {
+			await repo.upsert(makeRecord());
+			await repo.delete("user-1", "sum-1");
+			const found = await repo.findBySummaryId("user-1", "sum-1");
+			expect(found).toBeNull();
+		});
+
+		it("does nothing for non-existent record", async () => {
+			await repo.delete("user-1", "nope");
+			// no throw
+		});
+	});
+
+	describe("bulkUpsert", () => {
+		it("inserts multiple records", async () => {
+			await repo.bulkUpsert([
+				makeRecord({ summaryId: "a" }),
+				makeRecord({ summaryId: "b" }),
+				makeRecord({ summaryId: "c" }),
+			]);
+			const results = await repo.findByUserId("user-1");
+			expect(results).toHaveLength(3);
+		});
+	});
+
+	describe("bulkDelete", () => {
+		it("deletes multiple records", async () => {
+			await repo.bulkUpsert([
+				makeRecord({ summaryId: "a" }),
+				makeRecord({ summaryId: "b" }),
+				makeRecord({ summaryId: "c" }),
+			]);
+			await repo.bulkDelete("user-1", ["a", "c"]);
+			const results = await repo.findByUserId("user-1");
+			expect(results).toHaveLength(1);
+			expect(results[0].summaryId).toBe("b");
+		});
+	});
+
+	describe("deleteAllForUser", () => {
+		it("deletes all records for a user", async () => {
+			await repo.bulkUpsert([
+				makeRecord({ userId: "user-1", summaryId: "a" }),
+				makeRecord({ userId: "user-1", summaryId: "b" }),
+				makeRecord({ userId: "user-2", summaryId: "c" }),
+			]);
+			await repo.deleteAllForUser("user-1");
+			expect(await repo.findByUserId("user-1")).toHaveLength(0);
+			expect(await repo.findByUserId("user-2")).toHaveLength(1);
+		});
+	});
+
+	describe("findByUserAndSandbox", () => {
+		it("filters by both userId and sandboxId", async () => {
+			await repo.bulkUpsert([
+				makeRecord({ sandboxId: "sbx-1", summaryId: "a" }),
+				makeRecord({ sandboxId: "sbx-2", summaryId: "b" }),
+				makeRecord({ sandboxId: "sbx-1", summaryId: "c" }),
+			]);
+			const results = await repo.findByUserAndSandbox("user-1", "sbx-1");
+			expect(results).toHaveLength(2);
+			expect(results.map((r) => r.summaryId).sort()).toEqual(["a", "c"]);
+		});
+	});
+
+	describe("findByUserId", () => {
+		it("returns all records for a user", async () => {
+			await repo.bulkUpsert([
+				makeRecord({ userId: "user-1", summaryId: "a" }),
+				makeRecord({ userId: "user-1", summaryId: "b" }),
+				makeRecord({ userId: "user-2", summaryId: "c" }),
+			]);
+			const results = await repo.findByUserId("user-1");
+			expect(results).toHaveLength(2);
+		});
+
+		it("returns empty array for unknown user", async () => {
+			const results = await repo.findByUserId("unknown");
+			expect(results).toHaveLength(0);
+		});
+	});
+
+	describe("findByStatus", () => {
+		it("filters by syncStatus", async () => {
+			await repo.bulkUpsert([
+				makeRecord({ summaryId: "a", syncStatus: "synced" }),
+				makeRecord({ summaryId: "b", syncStatus: "error" }),
+				makeRecord({ summaryId: "c", syncStatus: "synced" }),
+			]);
+			const synced = await repo.findByStatus("user-1", "synced");
+			expect(synced).toHaveLength(2);
+
+			const errors = await repo.findByStatus("user-1", "error");
+			expect(errors).toHaveLength(1);
+			expect(errors[0].summaryId).toBe("b");
+		});
+	});
+
+	describe("updateStatus", () => {
+		it("updates syncStatus on an existing record", async () => {
+			await repo.upsert(makeRecord({ syncStatus: "synced" }));
+			await repo.updateStatus("user-1", "sum-1", "error");
+			const found = await repo.findBySummaryId("user-1", "sum-1");
+			expect(found?.syncStatus).toBe("error");
+		});
+
+		it("updates lastSyncedAt when timestamp provided", async () => {
+			await repo.upsert(makeRecord({ lastSyncedAt: null }));
+			await repo.updateStatus(
+				"user-1",
+				"sum-1",
+				"synced",
+				"2026-03-27T12:00:00Z",
+			);
+			const found = await repo.findBySummaryId("user-1", "sum-1");
+			expect(found?.lastSyncedAt).toBe("2026-03-27T12:00:00Z");
+		});
+
+		it("does nothing for non-existent record", async () => {
+			await repo.updateStatus("user-1", "nope", "error");
+			// no throw
+		});
+	});
+});

--- a/apps/chat-api/src/features/sandbox/sync-state.repository.memory.ts
+++ b/apps/chat-api/src/features/sandbox/sync-state.repository.memory.ts
@@ -1,0 +1,96 @@
+import type { SyncStateRepository } from "./sync-state.repository";
+import type { SyncStateRecord, SyncStatus } from "./sync-state.types";
+
+export class InMemorySyncStateRepository implements SyncStateRepository {
+	private store = new Map<string, SyncStateRecord>();
+
+	private key(userId: string, summaryId: string): string {
+		return `${userId}:${summaryId}`;
+	}
+
+	async upsert(record: SyncStateRecord): Promise<void> {
+		this.store.set(this.key(record.userId, record.summaryId), record);
+	}
+
+	async bulkUpsert(records: SyncStateRecord[]): Promise<void> {
+		for (const record of records) {
+			this.store.set(this.key(record.userId, record.summaryId), record);
+		}
+	}
+
+	async delete(userId: string, summaryId: string): Promise<void> {
+		this.store.delete(this.key(userId, summaryId));
+	}
+
+	async bulkDelete(userId: string, summaryIds: string[]): Promise<void> {
+		for (const summaryId of summaryIds) {
+			this.store.delete(this.key(userId, summaryId));
+		}
+	}
+
+	async deleteAllForUser(userId: string): Promise<void> {
+		for (const [key, record] of this.store) {
+			if (record.userId === userId) {
+				this.store.delete(key);
+			}
+		}
+	}
+
+	async findByUserAndSandbox(
+		userId: string,
+		sandboxId: string,
+	): Promise<SyncStateRecord[]> {
+		const results: SyncStateRecord[] = [];
+		for (const record of this.store.values()) {
+			if (record.userId === userId && record.sandboxId === sandboxId) {
+				results.push(record);
+			}
+		}
+		return results;
+	}
+
+	async findByUserId(userId: string): Promise<SyncStateRecord[]> {
+		const results: SyncStateRecord[] = [];
+		for (const record of this.store.values()) {
+			if (record.userId === userId) {
+				results.push(record);
+			}
+		}
+		return results;
+	}
+
+	async findBySummaryId(
+		userId: string,
+		summaryId: string,
+	): Promise<SyncStateRecord | null> {
+		return this.store.get(this.key(userId, summaryId)) ?? null;
+	}
+
+	async findByStatus(
+		userId: string,
+		status: SyncStatus,
+	): Promise<SyncStateRecord[]> {
+		const results: SyncStateRecord[] = [];
+		for (const record of this.store.values()) {
+			if (record.userId === userId && record.syncStatus === status) {
+				results.push(record);
+			}
+		}
+		return results;
+	}
+
+	async updateStatus(
+		userId: string,
+		summaryId: string,
+		status: SyncStatus,
+		timestamp?: string,
+	): Promise<void> {
+		const record = this.store.get(this.key(userId, summaryId));
+		if (!record) return;
+
+		record.syncStatus = status;
+		if (timestamp) {
+			record.lastSyncedAt = timestamp;
+		}
+	}
+}

--- a/apps/chat-api/src/features/sandbox/sync-state.repository.ts
+++ b/apps/chat-api/src/features/sandbox/sync-state.repository.ts
@@ -1,0 +1,28 @@
+import type { SyncStateRecord, SyncStatus } from "./sync-state.types";
+
+export interface SyncStateRepository {
+	upsert(record: SyncStateRecord): Promise<void>;
+	bulkUpsert(records: SyncStateRecord[]): Promise<void>;
+
+	delete(userId: string, summaryId: string): Promise<void>;
+	bulkDelete(userId: string, summaryIds: string[]): Promise<void>;
+	deleteAllForUser(userId: string): Promise<void>;
+
+	findByUserAndSandbox(
+		userId: string,
+		sandboxId: string,
+	): Promise<SyncStateRecord[]>;
+	findByUserId(userId: string): Promise<SyncStateRecord[]>;
+	findBySummaryId(
+		userId: string,
+		summaryId: string,
+	): Promise<SyncStateRecord | null>;
+
+	findByStatus(userId: string, status: SyncStatus): Promise<SyncStateRecord[]>;
+	updateStatus(
+		userId: string,
+		summaryId: string,
+		status: SyncStatus,
+		timestamp?: string,
+	): Promise<void>;
+}

--- a/apps/chat-api/src/features/sandbox/sync-state.types.ts
+++ b/apps/chat-api/src/features/sandbox/sync-state.types.ts
@@ -1,0 +1,58 @@
+export type SyncStatus =
+	| "synced"
+	| "pending_create"
+	| "pending_update"
+	| "pending_delete"
+	| "error";
+
+export interface SyncStateRecord {
+	userId: string;
+	sandboxId: string;
+	summaryId: string;
+	type: number;
+	/** Full sandbox-relative path, e.g. "docs/{userId}/{type}/{sanitizedId}.txt" */
+	expectedPath: string;
+	/** SHA-256 hex of the materialized file content (frontmatter + body) */
+	contentChecksum: string;
+	/** ISO 8601 from ProtectedSummary.updateTime */
+	sourceUpdatedAt: string;
+	lastSyncedAt: string | null;
+	syncStatus: SyncStatus;
+}
+
+export type ReconciliationAction =
+	| {
+			kind: "create";
+			record: SyncStateRecord;
+			content: string;
+	  }
+	| {
+			kind: "update";
+			record: SyncStateRecord;
+			content: string;
+			reason: "content_changed" | "checksum_mismatch";
+	  }
+	| {
+			kind: "delete";
+			record: SyncStateRecord;
+	  }
+	| {
+			kind: "noop";
+			record: SyncStateRecord;
+	  };
+
+export interface ReconciliationPlan {
+	creates: Extract<ReconciliationAction, { kind: "create" }>[];
+	updates: Extract<ReconciliationAction, { kind: "update" }>[];
+	deletes: Extract<ReconciliationAction, { kind: "delete" }>[];
+	unchanged: number;
+}
+
+export interface ManifestDiff {
+	/** Expected by sync-state but not found on sandbox disk */
+	missingInSandbox: SyncStateRecord[];
+	/** Found on sandbox disk but not in sync-state */
+	orphanedInSandbox: string[];
+	/** On disk but content checksum differs from sync-state */
+	checksumMismatches: SyncStateRecord[];
+}


### PR DESCRIPTION
## Summary

- Add sync-state layer for sandbox document synchronization behind a `SyncStateRepository` interface — database choice (MySQL/Postgres) deferred until schema refactoring settles
- In-memory Map implementation for development and testing
- Reconciliation engine: detects creates, updates, deletes, and checksums mismatches from source `ProtectedSummary[]`
- Sandbox manifest verification and drift repair (missing files, orphaned files, tampered content)
- Per-user promise-chain locking to serialize concurrent sync operations
- Document materialization extracted and formalized from Phase 1 prototype
- Updated `MIGRATION_PLAN.md` with Phase 2 design decisions

New module: `apps/chat-api/src/features/sandbox/`

## Test plan

- [x] 59 unit tests passing (`bun test src/features/sandbox/`)
  - Materialization: checksum determinism, content resolution, path generation, frontmatter format, sourceKind detection
  - Repository: CRUD, bulk ops, user isolation, status queries
  - Sync service: reconciliation plans, delFlag handling (string and number), mixed operations, user isolation
- [x] E2B integration test passing (`bun run test:sync-integration`)
  - Initial full sync (3 docs) → verify files on sandbox
  - Incremental update (1 doc changed) → verify content on disk
  - Delete from source → verify file removed
  - Drift detection (orphan + tampered content) → repair → verify clean
  - Full sandbox rebuild from scratch → verify clean
  - Timings: initial sync ~4.8s, incremental ~177ms, rebuild ~595ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)