### PR TITLE
ci: Terraform plan/apply workflow for sandbox-sync production

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -3,6 +3,8 @@ name: Deploy Preview Environment
 on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
+    paths-ignore:
+      - "infra/terraform/**"
 
 concurrency:
   group: preview-deploy-${{ github.event.pull_request.number }}

--- a/.github/workflows/terraform-sandbox-sync.yml
+++ b/.github/workflows/terraform-sandbox-sync.yml
@@ -1,0 +1,123 @@
+name: "Terraform: Sandbox Sync"
+
+on:
+  pull_request:
+    paths:
+      - "infra/terraform/sandbox-sync/**"
+      - ".github/workflows/terraform-sandbox-sync.yml"
+  push:
+    branches: [main]
+    paths:
+      - "infra/terraform/sandbox-sync/**"
+      - ".github/workflows/terraform-sandbox-sync.yml"
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
+env:
+  AWS_REGION: us-west-2
+  TF_WORKING_DIR: infra/terraform/sandbox-sync
+  TF_STATE_BUCKET: mymemo-terraform-state
+  TF_STATE_KEY: sandbox-sync/production
+
+jobs:
+  plan:
+    name: Terraform Plan (Production)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    concurrency:
+      group: terraform-sandbox-sync-plan-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Configure AWS credentials (read-only)
+        uses: aws-actions/configure-aws-credentials@v4.3.1
+        with:
+          role-to-assume: ${{ secrets.AWS_READONLY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: "~> 1.10"
+
+      - name: Cache Terraform providers
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.TF_WORKING_DIR }}/.terraform/providers
+          key: terraform-providers-${{ hashFiles('infra/terraform/sandbox-sync/.terraform.lock.hcl') }}
+
+      - name: Terraform Init
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        run: |
+          terraform init \
+            -backend-config="bucket=${{ env.TF_STATE_BUCKET }}" \
+            -backend-config="key=${{ env.TF_STATE_KEY }}" \
+            -backend-config="region=${{ env.AWS_REGION }}"
+
+      - name: Terraform Plan
+        id: plan
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        run: terraform plan -var-file=production.tfvars -var="aws_profile=" -lock=false -no-color -out=tfplan
+        continue-on-error: true
+
+      - name: Comment plan on PR
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: terraform-sandbox-sync
+          message: |
+            ### Terraform Plan: `sandbox-sync` (production)
+
+            ```
+            ${{ steps.plan.outputs.stdout }}
+            ```
+
+            ${{ steps.plan.outcome == 'failure' && '**Plan failed.** See workflow logs for details.' || '' }}
+
+      - name: Fail if plan failed
+        if: steps.plan.outcome == 'failure'
+        run: exit 1
+
+  apply:
+    name: Terraform Apply (Production)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    concurrency:
+      group: terraform-sandbox-sync-apply
+      cancel-in-progress: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Configure AWS credentials (write)
+        uses: aws-actions/configure-aws-credentials@v4.3.1
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: "~> 1.10"
+
+      - name: Cache Terraform providers
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.TF_WORKING_DIR }}/.terraform/providers
+          key: terraform-providers-${{ hashFiles('infra/terraform/sandbox-sync/.terraform.lock.hcl') }}
+
+      - name: Terraform Init
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        run: |
+          terraform init \
+            -backend-config="bucket=${{ env.TF_STATE_BUCKET }}" \
+            -backend-config="key=${{ env.TF_STATE_KEY }}" \
+            -backend-config="region=${{ env.AWS_REGION }}"
+
+      - name: Terraform Apply
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        run: terraform apply -var-file=production.tfvars -var="aws_profile=" -auto-approve


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow to automate production SQS FIFO infrastructure deployment
- PR triggers `terraform plan` (read-only OIDC role, `-lock=false`) and posts output as sticky PR comment
- Merge to main triggers `terraform apply` (write OIDC role) with `-auto-approve`
- Per-job concurrency: PR plans run in parallel, applies serialize
- Provider caching via `actions/cache@v4` for faster init

## Test plan
- [ ] Verify this PR triggers the plan job and posts a comment with the plan output
- [ ] After merge, verify the apply job creates production SQS queues and CloudWatch alarms
- [ ] Confirm resources: `aws sqs list-queues --queue-name-prefix sandbox-sync-production --profile mymemo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)