### PR TITLE
feat: persist sandbox ID in Postgres for direct reconnection

### DIFF
--- a/apps/chat-api/scripts/run-daemon-e2b-integration.ts
+++ b/apps/chat-api/scripts/run-daemon-e2b-integration.ts
@@ -14,6 +14,7 @@ import { Pool } from "pg";
 import type { Sandbox } from "e2b";
 import type { SyncLogger } from "@/features/sandbox";
 import { apiEnv } from "@/config/env";
+import { getRuntime } from "@/db/user-runtime";
 import {
 	SandboxManager,
 	WORKSPACE_ROOT,
@@ -456,6 +457,30 @@ async function testMissingDocument() {
 	console.log("✓ Missing document correctly rejected");
 }
 
+async function testSandboxIdPersistence() {
+	console.log("\n=== Test 11: Sandbox ID Persistence in Postgres ===");
+
+	const runtime = await getRuntime(userId);
+	const persistedId = runtime?.sandbox_id;
+	assert.ok(persistedId, "sandbox_id should be persisted in Postgres");
+	assert.equal(
+		persistedId,
+		sandbox.sandboxId,
+		"Persisted sandbox_id should match the active sandbox",
+	);
+	console.log(`✓ sandbox_id persisted: ${persistedId}`);
+
+	// A fresh SandboxManager (no in-memory state) should reconnect via Postgres
+	const freshManager = new SandboxManager();
+	const reconnected = await freshManager.getOrCreateSandbox(userId, logger);
+	assert.equal(
+		reconnected.sandboxId,
+		sandbox.sandboxId,
+		"Fresh manager should reconnect to the same sandbox via Postgres lookup",
+	);
+	console.log("✓ Fresh SandboxManager reconnected via Postgres (no Sandbox.list)");
+}
+
 async function cleanup() {
 	console.log("\n=== Cleanup ===");
 	try {
@@ -487,6 +512,7 @@ async function main() {
 		await testDocumentScope();
 		await testMissingScopeId();
 		await testMissingDocument();
+		await testSandboxIdPersistence();
 		console.log("\n✓ All E2B daemon integration tests passed");
 	} catch (err) {
 		console.error("\n✗ Test failed:", err);

--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-manager.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-manager.ts
@@ -3,6 +3,7 @@ import { join, relative, resolve } from "node:path";
 import { Sandbox } from "e2b";
 import { apiEnv } from "@/config/env";
 import { clearUserSessions } from "@/db/user-sessions";
+import { getRuntime, upsertRuntime } from "@/db/user-runtime";
 import type { SyncLogger } from "@/features/sandbox";
 import { SandboxCreationError } from "./errors";
 
@@ -72,9 +73,6 @@ function collectDaemonFiles(dir: string, base = dir): string[] {
 }
 
 export class SandboxManager {
-	// Cache sandboxId per user to avoid Sandbox.list() API call on every request.
-	// Invalidated on connect failure or killSandbox.
-	private sandboxIdCache = new Map<string, string>();
 	// Dedup concurrent getOrCreateSandbox calls for the same user.
 	private inFlight = new Map<string, Promise<Sandbox>>();
 
@@ -96,41 +94,21 @@ export class SandboxManager {
 		userId: string,
 		logger: SyncLogger,
 	): Promise<Sandbox> {
-		const cachedId = this.sandboxIdCache.get(userId);
-		if (cachedId) {
-			try {
-				return await Sandbox.connect(cachedId);
-			} catch {
-				this.sandboxIdCache.delete(userId);
-			}
-		}
-
-		const paginator = Sandbox.list({
-			query: {
-				metadata: { userId },
-				state: ["running", "paused"],
-			},
-			limit: 1,
-		});
-
-		const existing = await paginator.nextItems();
-		const info = existing[0];
-		if (info) {
+		const runtime = await getRuntime(userId);
+		if (runtime?.sandbox_id) {
 			logger.info({
-				msg: "Reconnecting to existing sandbox",
+				msg: "Reconnecting to sandbox from Postgres",
 				userId,
-				sandboxId: info.sandboxId,
+				sandboxId: runtime.sandbox_id,
 			});
 
 			try {
-				this.sandboxIdCache.set(userId, info.sandboxId);
-				return await Sandbox.connect(info.sandboxId);
+				return await Sandbox.connect(runtime.sandbox_id);
 			} catch (err) {
-				this.sandboxIdCache.delete(userId);
 				logger.error({
-					msg: "Failed to reconnect, creating new sandbox",
+					msg: "Failed to reconnect from Postgres, creating new sandbox",
 					userId,
-					sandboxId: info.sandboxId,
+					sandboxId: runtime.sandbox_id,
 					error: err instanceof Error ? err.message : String(err),
 				});
 			}
@@ -143,9 +121,10 @@ export class SandboxManager {
 				metadata: { userId },
 			});
 
-			this.sandboxIdCache.set(userId, sandbox.sandboxId);
-			// Clear stale sessions from any previous sandbox
-			await clearUserSessions(userId).catch(() => {});
+			await Promise.all([
+				upsertRuntime(userId, { sandbox_id: sandbox.sandboxId }),
+				clearUserSessions(userId).catch(() => {}),
+			]);
 			logger.info({
 				msg: "Sandbox created",
 				userId,
@@ -165,9 +144,10 @@ export class SandboxManager {
 		sandbox: Sandbox,
 		logger: SyncLogger,
 	): Promise<void> {
-		this.sandboxIdCache.delete(userId);
-		// Old sessions are invalid after sandbox destruction
-		await clearUserSessions(userId).catch(() => {});
+		await Promise.all([
+			upsertRuntime(userId, { sandbox_id: null }).catch(() => {}),
+			clearUserSessions(userId).catch(() => {}),
+		]);
 		try {
 			await sandbox.kill();
 			logger.info({
@@ -183,10 +163,6 @@ export class SandboxManager {
 				error: err instanceof Error ? err.message : String(err),
 			});
 		}
-	}
-
-	getCachedSandboxId(userId: string): string | undefined {
-		return this.sandboxIdCache.get(userId);
 	}
 
 	/**

--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-manager.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-manager.ts
@@ -144,17 +144,8 @@ export class SandboxManager {
 		sandbox: Sandbox,
 		logger: SyncLogger,
 	): Promise<void> {
-		await Promise.all([
-			upsertRuntime(userId, { sandbox_id: null }).catch(() => {}),
-			clearUserSessions(userId).catch(() => {}),
-		]);
 		try {
 			await sandbox.kill();
-			logger.info({
-				msg: "Sandbox killed",
-				userId,
-				sandboxId: sandbox.sandboxId,
-			});
 		} catch (err) {
 			logger.error({
 				msg: "Failed to kill sandbox",
@@ -162,7 +153,18 @@ export class SandboxManager {
 				sandboxId: sandbox.sandboxId,
 				error: err instanceof Error ? err.message : String(err),
 			});
+			return;
 		}
+
+		await Promise.all([
+			upsertRuntime(userId, { sandbox_id: null }).catch(() => {}),
+			clearUserSessions(userId).catch(() => {}),
+		]);
+		logger.info({
+			msg: "Sandbox killed",
+			userId,
+			sandboxId: sandbox.sandboxId,
+		});
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Replace in-memory `sandboxIdCache` and `Sandbox.list()` API call with Postgres-backed lookup via `getRuntime()`/`upsertRuntime()`
- Persist `sandbox_id` after `Sandbox.create()` and clear it on `killSandbox()`, surviving server restarts without extra E2B API calls
- Add integration test (Test 11) verifying persistence and reconnection from a fresh `SandboxManager`

## Test plan
- [x] Unit tests pass (172/172)
- [x] E2B integration test passes (11/11), including new Test 11 for sandbox_id persistence
- [ ] Verify reconnection works after API server restart in staging

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)