### PR TITLE
chore: drop dead synced_version column from user_sandbox_runtime

### DIFF
--- a/apps/chat-api/src/db/user-runtime.ts
+++ b/apps/chat-api/src/db/user-runtime.ts
@@ -6,7 +6,6 @@ export interface UserSandboxRuntime {
 	user_id: string;
 	sandbox_id: string | null;
 	state_version: number;
-	synced_version: number;
 	last_seen_at: string;
 }
 
@@ -21,7 +20,6 @@ export async function getRuntime(
 			user_id: userSandboxRuntime.userId,
 			sandbox_id: userSandboxRuntime.sandboxId,
 			state_version: userSandboxRuntime.stateVersion,
-			synced_version: userSandboxRuntime.syncedVersion,
 			last_seen_at: userSandboxRuntime.lastSeenAt,
 		})
 		.from(userSandboxRuntime)
@@ -31,27 +29,22 @@ export async function getRuntime(
 
 /**
  * Upsert sandbox runtime fields for a user.
- * Both INSERT and UPDATE paths include all supplied fields.
  */
 export async function upsertRuntime(
 	userId: string,
-	fields: Partial<Pick<UserSandboxRuntime, "sandbox_id" | "synced_version">>,
+	fields: Partial<Pick<UserSandboxRuntime, "sandbox_id">>,
 ): Promise<void> {
 	await getDb()
 		.insert(userSandboxRuntime)
 		.values({
 			userId,
 			sandboxId: fields.sandbox_id ?? undefined,
-			syncedVersion: fields.synced_version ?? undefined,
 		})
 		.onDuplicateKeyUpdate({
 			set: {
 				lastSeenAt: sql`NOW()`,
 				...(fields.sandbox_id !== undefined && {
 					sandboxId: fields.sandbox_id,
-				}),
-				...(fields.synced_version !== undefined && {
-					syncedVersion: fields.synced_version,
 				}),
 			},
 		});

--- a/packages/db/schema.sql
+++ b/packages/db/schema.sql
@@ -16,7 +16,6 @@ CREATE TABLE IF NOT EXISTS user_sandbox_runtime (
   user_id           VARCHAR(255) NOT NULL PRIMARY KEY,
   sandbox_id        VARCHAR(255),
   state_version     BIGINT NOT NULL DEFAULT 0,
-  synced_version    BIGINT NOT NULL DEFAULT 0,
   last_seen_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 

--- a/packages/db/schema.ts
+++ b/packages/db/schema.ts
@@ -32,9 +32,6 @@ export const userSandboxRuntime = mysqlTable("user_sandbox_runtime", {
 	stateVersion: bigint("state_version", { mode: "number" })
 		.notNull()
 		.default(0),
-	syncedVersion: bigint("synced_version", { mode: "number" })
-		.notNull()
-		.default(0),
 	lastSeenAt: timestamp("last_seen_at", { mode: "string" })
 		.notNull()
 		.defaultNow(),


### PR DESCRIPTION
## Summary

- `user_sandbox_runtime.synced_version` was declared in the MySQL schema, drizzle schema, and `UserSandboxRuntime` TypeScript interface, but **nothing in the codebase ever wrote to it** — it's pure dead state.
- The sandbox daemon's `reconcile()` (apps/sandbox-daemon/reconcile.ts:57-63) uses `state_version` from MySQL to decide whether to skip work, and tracks its own "last synced version" on the sandbox's **local filesystem** via `apps/sandbox-daemon/state.ts` (`.synced-version` file under the data root), not in MySQL.
- The filesystem location is actually the correct design: `synced_version` tracks the state of a specific sandbox's physical disk. If the sandbox dies and E2B hands us a new one, the new disk is empty and we *must* do a full reconcile even if MySQL said "already synced to v42". Storing it in MySQL would produce false positives on reconnect.
- `state_version` itself stays — it's meaningful (cheap O(1) SELECT to short-circuit `getManifest()` when nothing has changed) and correctly bumped by triggers on `user_files` changes.

## Changes

- `packages/db/schema.sql` — drop `synced_version` column from `user_sandbox_runtime`
- `packages/db/schema.ts` — drop `syncedVersion` drizzle binding
- `apps/chat-api/src/db/user-runtime.ts` — drop `synced_version` from `UserSandboxRuntime` interface, from `getRuntime` select, and from `upsertRuntime`'s `fields` parameter (which no caller was using anyway; both call sites in `sandbox-manager.ts` only pass `sandbox_id`)

Net: 3 files, +1 / -12.

## Migration note

Existing staging/prod databases still have the column. After merge, run this on each environment:

```sql
ALTER TABLE user_sandbox_runtime DROP COLUMN synced_version;
```

It's a safe drop — no reader or writer touches the column, so dropping it is a no-op for runtime behavior. Leaving it in place is also fine; the drizzle schema just stops projecting it.

## Test plan

- [x] `bun test` in `apps/chat-api` — 172/172 tests pass
- [x] `bun run scripts/run-daemon-e2b-integration.ts` — all 11 E2B daemon integration tests pass end-to-end on this branch (seed + state_version bump, sandbox create, daemon deploy, reconciliation + turn, sync-skip fast path at 162ms, concurrent turn rejection, global/collection/document scopes, missing scope/doc errors, Postgres-backed sandbox_id persistence + reconnect, cleanup). Confirms the cleanup is a pure no-op at runtime.
- [ ] After merge: drop the column in staging via the ALTER above, confirm app still healthy, then do the same in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)