### PR TITLE
refactor: replace state_version counter with manifest-diff reconciliation

### DIFF
--- a/apps/chat-api/scripts/run-daemon-e2b-integration.ts
+++ b/apps/chat-api/scripts/run-daemon-e2b-integration.ts
@@ -35,7 +35,6 @@ const db = getDb();
 async function seedTestData() {
 	console.log("=== Seeding test data ===");
 
-	// Insert test files
 	await db.insert(userFiles).values([
 		{
 			userId,
@@ -58,22 +57,12 @@ async function seedTestData() {
 		},
 	]);
 
-	// Verify state_version was bumped by the trigger
-	const rows = await db
-		.select({ stateVersion: userSandboxRuntime.stateVersion })
-		.from(userSandboxRuntime)
-		.where(eq(userSandboxRuntime.userId, userId));
-	const stateVersion = rows[0]?.stateVersion ?? 0;
-	console.log(`✓ Seeded 2 documents, state_version=${stateVersion}`);
-	assert.ok(stateVersion >= 2, "state_version should be >= 2 after 2 inserts");
-
-	return stateVersion;
+	console.log("✓ Seeded 2 documents");
 }
 
 async function cleanupTestData() {
-	// Delete files first — the DELETE trigger upserts into user_sandbox_runtime
-	await db.delete(userFiles).where(eq(userFiles.userId, userId));
 	await Promise.all([
+		db.delete(userFiles).where(eq(userFiles.userId, userId)),
 		db.delete(userSandboxRuntime).where(eq(userSandboxRuntime.userId, userId)),
 		db
 			.delete(userSandboxSessions)

--- a/apps/chat-api/src/db/user-runtime.ts
+++ b/apps/chat-api/src/db/user-runtime.ts
@@ -5,7 +5,6 @@ import { getDb } from "./client";
 export interface UserSandboxRuntime {
 	user_id: string;
 	sandbox_id: string | null;
-	state_version: number;
 	last_seen_at: string;
 }
 
@@ -19,7 +18,6 @@ export async function getRuntime(
 		.select({
 			user_id: userSandboxRuntime.userId,
 			sandbox_id: userSandboxRuntime.sandboxId,
-			state_version: userSandboxRuntime.stateVersion,
 			last_seen_at: userSandboxRuntime.lastSeenAt,
 		})
 		.from(userSandboxRuntime)

--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-orchestration.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-orchestration.ts
@@ -44,9 +44,9 @@ export async function runSandboxChat(
 		logger,
 	} = options;
 
-	// Note: user_files table is populated by an external service.
-	// The daemon's reconcile() reads from user_files and checks
-	// state_version directly from Postgres to sync documents.
+	// Note: user_files is populated by an external service. The daemon's
+	// reconcile() diffs user_files against its local .sync-manifest.json
+	// on each turn to sync documents into the sandbox filesystem.
 
 	const attempt = async () => {
 		// 1. Get sandbox

--- a/apps/sandbox-daemon/queries.ts
+++ b/apps/sandbox-daemon/queries.ts
@@ -1,4 +1,4 @@
-import { userFiles, userSandboxRuntime } from "@mymemo/db";
+import { userFiles } from "@mymemo/db";
 import { and, eq, inArray } from "drizzle-orm";
 import { getDb } from "./db";
 
@@ -12,14 +12,6 @@ export interface ManifestRow {
 
 export interface FileContentRow extends ManifestRow {
 	content: string;
-}
-
-export async function getStateVersion(userId: string): Promise<number> {
-	const rows = await getDb()
-		.select({ state_version: userSandboxRuntime.stateVersion })
-		.from(userSandboxRuntime)
-		.where(eq(userSandboxRuntime.userId, userId));
-	return rows[0]?.state_version ?? 0;
 }
 
 export async function getManifest(userId: string): Promise<ManifestRow[]> {

--- a/apps/sandbox-daemon/queries.ts
+++ b/apps/sandbox-daemon/queries.ts
@@ -1,20 +1,15 @@
 import { userFiles } from "@mymemo/db";
 import { and, eq, inArray } from "drizzle-orm";
 import { getDb } from "./db";
+import type { LocalManifestEntry } from "./state";
 
-export interface ManifestRow {
-	document_id: string;
-	type: number;
-	slug: string;
-	path_key: string;
-	checksum: string;
-}
-
-export interface FileContentRow extends ManifestRow {
+export interface FileContentRow extends LocalManifestEntry {
 	content: string;
 }
 
-export async function getManifest(userId: string): Promise<ManifestRow[]> {
+export async function getManifest(
+	userId: string,
+): Promise<LocalManifestEntry[]> {
 	return getDb()
 		.select({
 			document_id: userFiles.documentId,

--- a/apps/sandbox-daemon/reconcile.test.ts
+++ b/apps/sandbox-daemon/reconcile.test.ts
@@ -134,6 +134,68 @@ describe("reconcile", () => {
 		expect(content).toContain("New document content");
 	});
 
+	it("updates canonical file when remote checksum changes", async () => {
+		const oldDoc: DocFile = {
+			document_id: "doc-1",
+			type: 0,
+			slug: "my-doc",
+			path_key: "",
+			content: "old content",
+			checksum: "old",
+		};
+		writeCanonicalFile(dataRoot, oldDoc);
+		writeLocalManifest(dataRoot, [
+			{
+				document_id: "doc-1",
+				type: 0,
+				slug: "my-doc",
+				path_key: "",
+				checksum: "old",
+			},
+		]);
+
+		mockGetManifest.mockResolvedValueOnce([
+			{
+				document_id: "doc-1",
+				type: 0,
+				slug: "my-doc",
+				path_key: "",
+				checksum: "new",
+			},
+		]);
+		mockGetFileContents.mockResolvedValueOnce([
+			{
+				document_id: "doc-1",
+				type: 0,
+				slug: "my-doc",
+				path_key: "",
+				content: "new content",
+				checksum: "new",
+			},
+		]);
+
+		const result = await reconcile({ userId: "user-1" });
+
+		expect(result).toBe(true);
+		expect(mockGetFileContents).toHaveBeenCalledTimes(1);
+
+		const onDisk = readFileSync(
+			`${dataRoot}/canonical/0/doc-1.md`,
+			"utf-8",
+		);
+		expect(onDisk).toContain("new content");
+
+		expect(readLocalManifest(dataRoot)).toEqual([
+			{
+				document_id: "doc-1",
+				type: 0,
+				slug: "my-doc",
+				path_key: "",
+				checksum: "new",
+			},
+		]);
+	});
+
 	it("rewrites local manifest after sync", async () => {
 		writeLocalManifest(dataRoot, []);
 

--- a/apps/sandbox-daemon/reconcile.test.ts
+++ b/apps/sandbox-daemon/reconcile.test.ts
@@ -5,12 +5,10 @@ import { join } from "node:path";
 
 const testRoot = join(tmpdir(), `reconcile-test-${Date.now()}`);
 
-const mockGetStateVersion = mock();
 const mockGetManifest = mock();
 const mockGetFileContents = mock();
 
 mock.module("./queries", () => ({
-	getStateVersion: mockGetStateVersion,
 	getManifest: mockGetManifest,
 	getFileContents: mockGetFileContents,
 }));
@@ -31,17 +29,12 @@ import {
 	writeCanonicalFile,
 } from "./materialization";
 import { reconcile } from "./reconcile";
-import {
-	readSyncedVersion,
-	writeLocalManifest,
-	writeSyncedVersion,
-} from "./state";
+import { readLocalManifest, writeLocalManifest } from "./state";
 
 describe("reconcile", () => {
 	const dataRoot = join(testRoot, "data");
 
 	beforeEach(() => {
-		mockGetStateVersion.mockReset();
 		mockGetManifest.mockReset();
 		mockGetFileContents.mockReset();
 		rmSync(dataRoot, { recursive: true, force: true });
@@ -53,20 +46,24 @@ describe("reconcile", () => {
 		mock.restore();
 	});
 
-	it("skips sync when local version >= DB version", async () => {
-		writeSyncedVersion(dataRoot, 5);
-
-		mockGetStateVersion.mockResolvedValueOnce(5);
+	it("skips sync when local manifest equals remote manifest", async () => {
+		const entry = {
+			document_id: "doc-1",
+			type: 0,
+			slug: "my-doc",
+			path_key: "col-A",
+			checksum: "aaa",
+		};
+		writeLocalManifest(dataRoot, [entry]);
+		mockGetManifest.mockResolvedValueOnce([entry]);
 
 		const result = await reconcile({ userId: "user-1" });
 
 		expect(result).toBe(false);
-		expect(mockGetManifest).not.toHaveBeenCalled();
+		expect(mockGetFileContents).not.toHaveBeenCalled();
 	});
 
 	it("removes collection symlinks and rebuilds indexes on delete", async () => {
-		writeSyncedVersion(dataRoot, 0);
-
 		const doc: DocFile = {
 			document_id: "doc-1",
 			type: 0,
@@ -94,7 +91,6 @@ describe("reconcile", () => {
 		expect(existsSync(`${dataRoot}/canonical/0/doc-1.md`)).toBe(true);
 		expect(existsSync(`${dataRoot}/collections/col-A/0/doc-1.md`)).toBe(true);
 
-		mockGetStateVersion.mockResolvedValueOnce(1);
 		mockGetManifest.mockResolvedValueOnce([]);
 		mockGetFileContents.mockResolvedValueOnce([]);
 
@@ -106,10 +102,8 @@ describe("reconcile", () => {
 	});
 
 	it("creates canonical files and collection symlinks for new docs", async () => {
-		writeSyncedVersion(dataRoot, 0);
 		writeLocalManifest(dataRoot, []);
 
-		mockGetStateVersion.mockResolvedValueOnce(1);
 		mockGetManifest.mockResolvedValueOnce([
 			{
 				document_id: "doc-new",
@@ -140,16 +134,32 @@ describe("reconcile", () => {
 		expect(content).toContain("New document content");
 	});
 
-	it("updates synced version after sync", async () => {
-		writeSyncedVersion(dataRoot, 0);
+	it("rewrites local manifest after sync", async () => {
 		writeLocalManifest(dataRoot, []);
 
-		mockGetStateVersion.mockResolvedValueOnce(42);
-		mockGetManifest.mockResolvedValueOnce([]);
-		mockGetFileContents.mockResolvedValueOnce([]);
+		const remote = [
+			{
+				document_id: "doc-1",
+				type: 0,
+				slug: "d1",
+				path_key: "",
+				checksum: "c1",
+			},
+			{
+				document_id: "doc-2",
+				type: 3,
+				slug: "d2",
+				path_key: "col-X",
+				checksum: "c2",
+			},
+		];
+		mockGetManifest.mockResolvedValueOnce(remote);
+		mockGetFileContents.mockResolvedValueOnce(
+			remote.map((r) => ({ ...r, content: `content of ${r.document_id}` })),
+		);
 
 		await reconcile({ userId: "user-1" });
 
-		expect(readSyncedVersion(dataRoot)).toBe(42);
+		expect(readLocalManifest(dataRoot)).toEqual(remote);
 	});
 });

--- a/apps/sandbox-daemon/reconcile.ts
+++ b/apps/sandbox-daemon/reconcile.ts
@@ -12,15 +12,12 @@ import {
 import {
 	getFileContents,
 	getManifest,
-	getStateVersion,
 	type ManifestRow,
 } from "./queries";
 import {
 	type LocalManifestEntry,
 	readLocalManifest,
-	readSyncedVersion,
 	writeLocalManifest,
-	writeSyncedVersion,
 } from "./state";
 
 interface ReconcileInput {
@@ -47,6 +44,27 @@ function hasEntryChanged(
 	);
 }
 
+function manifestsEqual(
+	local: LocalManifestEntry[],
+	remote: ManifestRow[],
+): boolean {
+	if (local.length !== remote.length) return false;
+	for (let i = 0; i < local.length; i++) {
+		const l = local[i]!;
+		const r = remote[i]!;
+		if (
+			l.document_id !== r.document_id ||
+			l.type !== r.type ||
+			l.slug !== r.slug ||
+			l.path_key !== r.path_key ||
+			l.checksum !== r.checksum
+		) {
+			return false;
+		}
+	}
+	return true;
+}
+
 /**
  * Reconcile the local filesystem state with the database.
  * Returns true if sync was performed, false if skipped.
@@ -54,17 +72,14 @@ function hasEntryChanged(
 export async function reconcile(input: ReconcileInput): Promise<boolean> {
 	const { userId } = input;
 	const dataRoot = getDataRoot(userId);
-	const localVersion = readSyncedVersion(dataRoot);
 
-	const currentVersion = await getStateVersion(userId);
+	const remoteManifest = await getManifest(userId);
+	const localManifest = readLocalManifest(dataRoot);
 
-	if (localVersion >= currentVersion) {
+	if (manifestsEqual(localManifest, remoteManifest)) {
 		return false;
 	}
 
-	const remoteManifest = await getManifest(userId);
-
-	const localManifest = readLocalManifest(dataRoot);
 	const localMap = new Map(
 		localManifest.map((entry) => [entry.document_id, entry]),
 	);
@@ -189,7 +204,6 @@ export async function reconcile(input: ReconcileInput): Promise<boolean> {
 	}));
 
 	writeLocalManifest(dataRoot, newManifest);
-	writeSyncedVersion(dataRoot, currentVersion);
 
 	return true;
 }

--- a/apps/sandbox-daemon/reconcile.ts
+++ b/apps/sandbox-daemon/reconcile.ts
@@ -9,11 +9,7 @@ import {
 	removeCollectionIndex,
 	writeCanonicalFile,
 } from "./materialization";
-import {
-	getFileContents,
-	getManifest,
-	type ManifestRow,
-} from "./queries";
+import { getFileContents, getManifest } from "./queries";
 import {
 	type LocalManifestEntry,
 	readLocalManifest,
@@ -34,7 +30,7 @@ function parseCollectionIds(pathKey: string): string[] {
 
 function hasEntryChanged(
 	local: LocalManifestEntry,
-	remote: ManifestRow,
+	remote: LocalManifestEntry,
 ): boolean {
 	return (
 		local.checksum !== remote.checksum ||
@@ -46,19 +42,13 @@ function hasEntryChanged(
 
 function manifestsEqual(
 	local: LocalManifestEntry[],
-	remote: ManifestRow[],
+	remote: LocalManifestEntry[],
 ): boolean {
 	if (local.length !== remote.length) return false;
 	for (let i = 0; i < local.length; i++) {
 		const l = local[i]!;
 		const r = remote[i]!;
-		if (
-			l.document_id !== r.document_id ||
-			l.type !== r.type ||
-			l.slug !== r.slug ||
-			l.path_key !== r.path_key ||
-			l.checksum !== r.checksum
-		) {
+		if (l.document_id !== r.document_id || hasEntryChanged(l, r)) {
 			return false;
 		}
 	}

--- a/apps/sandbox-daemon/reconcile.ts
+++ b/apps/sandbox-daemon/reconcile.ts
@@ -40,6 +40,8 @@ function hasEntryChanged(
 	);
 }
 
+// Assumes both sides are ordered by document_id. Enforced by
+// getManifest()'s ORDER BY and by writeLocalManifest at the tail of reconcile().
 function manifestsEqual(
 	local: LocalManifestEntry[],
 	remote: LocalManifestEntry[],

--- a/apps/sandbox-daemon/state.test.ts
+++ b/apps/sandbox-daemon/state.test.ts
@@ -5,9 +5,7 @@ import { join } from "node:path";
 import {
 	type LocalManifestEntry,
 	readLocalManifest,
-	readSyncedVersion,
 	writeLocalManifest,
-	writeSyncedVersion,
 } from "./state";
 
 describe("state", () => {
@@ -56,31 +54,6 @@ describe("state", () => {
 
 			const result = readLocalManifest(dataRoot);
 			expect(result).toEqual([]);
-		});
-	});
-
-	describe("synced version", () => {
-		it("returns 0 when no version file exists", () => {
-			const result = readSyncedVersion(join(testRoot, "no-version"));
-			expect(result).toBe(0);
-		});
-
-		it("round-trips version number", () => {
-			const dataRoot = join(testRoot, "version-roundtrip");
-			mkdirSync(dataRoot, { recursive: true });
-
-			writeSyncedVersion(dataRoot, 42);
-			const result = readSyncedVersion(dataRoot);
-			expect(result).toBe(42);
-		});
-
-		it("returns 0 for invalid version content", () => {
-			const dataRoot = join(testRoot, "version-invalid");
-			mkdirSync(dataRoot, { recursive: true });
-			Bun.write(join(dataRoot, ".synced-version"), "not-a-number");
-
-			const result = readSyncedVersion(dataRoot);
-			expect(result).toBe(0);
 		});
 	});
 });

--- a/apps/sandbox-daemon/state.ts
+++ b/apps/sandbox-daemon/state.ts
@@ -14,7 +14,6 @@ export interface LocalManifestEntry {
 }
 
 const MANIFEST_FILENAME = ".sync-manifest.json";
-const VERSION_FILENAME = ".synced-version";
 
 export function readLocalManifest(dataRoot: string): LocalManifestEntry[] {
 	const manifestPath = `${dataRoot}/${MANIFEST_FILENAME}`;
@@ -34,21 +33,4 @@ export function writeLocalManifest(
 	const manifestPath = `${dataRoot}/${MANIFEST_FILENAME}`;
 	ensureParentDir(manifestPath);
 	writeFileSync(manifestPath, JSON.stringify(entries), "utf-8");
-}
-
-export function readSyncedVersion(dataRoot: string): number {
-	const versionPath = `${dataRoot}/${VERSION_FILENAME}`;
-	try {
-		const raw = readFileSync(versionPath, "utf-8").trim();
-		const parsed = Number.parseInt(raw, 10);
-		return Number.isNaN(parsed) ? 0 : parsed;
-	} catch {
-		return 0;
-	}
-}
-
-export function writeSyncedVersion(dataRoot: string, version: number): void {
-	const versionPath = `${dataRoot}/${VERSION_FILENAME}`;
-	ensureParentDir(versionPath);
-	writeFileSync(versionPath, String(version), "utf-8");
 }

--- a/packages/db/schema.sql
+++ b/packages/db/schema.sql
@@ -15,7 +15,6 @@ CREATE TABLE IF NOT EXISTS user_files (
 CREATE TABLE IF NOT EXISTS user_sandbox_runtime (
   user_id           VARCHAR(255) NOT NULL PRIMARY KEY,
   sandbox_id        VARCHAR(255),
-  state_version     BIGINT NOT NULL DEFAULT 0,
   last_seen_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
@@ -27,39 +26,3 @@ CREATE TABLE IF NOT EXISTS user_sandbox_sessions (
   updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (user_id, chat_key)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
--- Triggers: auto-increment state_version on user_files changes
-DELIMITER //
-
-DROP TRIGGER IF EXISTS user_files_after_insert //
-DROP TRIGGER IF EXISTS user_files_after_update //
-DROP TRIGGER IF EXISTS user_files_after_delete //
-
-CREATE TRIGGER user_files_after_insert
-AFTER INSERT ON user_files
-FOR EACH ROW
-BEGIN
-  INSERT INTO user_sandbox_runtime (user_id, state_version)
-  VALUES (NEW.user_id, 1)
-  ON DUPLICATE KEY UPDATE state_version = state_version + 1;
-END //
-
-CREATE TRIGGER user_files_after_update
-AFTER UPDATE ON user_files
-FOR EACH ROW
-BEGIN
-  INSERT INTO user_sandbox_runtime (user_id, state_version)
-  VALUES (NEW.user_id, 1)
-  ON DUPLICATE KEY UPDATE state_version = state_version + 1;
-END //
-
-CREATE TRIGGER user_files_after_delete
-AFTER DELETE ON user_files
-FOR EACH ROW
-BEGIN
-  INSERT INTO user_sandbox_runtime (user_id, state_version)
-  VALUES (OLD.user_id, 1)
-  ON DUPLICATE KEY UPDATE state_version = state_version + 1;
-END //
-
-DELIMITER ;

--- a/packages/db/schema.ts
+++ b/packages/db/schema.ts
@@ -1,5 +1,4 @@
 import {
-	bigint,
 	int,
 	mediumtext,
 	mysqlTable,
@@ -29,9 +28,6 @@ export const userFiles = mysqlTable(
 export const userSandboxRuntime = mysqlTable("user_sandbox_runtime", {
 	userId: varchar("user_id", { length: 255 }).notNull().primaryKey(),
 	sandboxId: varchar("sandbox_id", { length: 255 }),
-	stateVersion: bigint("state_version", { mode: "number" })
-		.notNull()
-		.default(0),
 	lastSeenAt: timestamp("last_seen_at", { mode: "string" })
 		.notNull()
 		.defaultNow(),


### PR DESCRIPTION
## Summary

The sandbox daemon's `reconcile()` used a `state_version` counter in MySQL (auto-bumped by three triggers on `user_files`) plus a `.synced-version` marker on the sandbox local disk to decide whether to skip reconciliation. State lived in three places, triggers encoded hidden coupling between `user_files` and `user_sandbox_runtime`, and every `user_files` write paid a second write to `user_sandbox_runtime`.

The counter only existed as an O(1) "nothing changed" signal. The same signal is available for free by comparing the remote manifest (one metadata-only SELECT we'd fetch anyway on the full-reconcile path) to the local `.sync-manifest.json` cache. Moving the fetch one step earlier and comparing to the cache gives the same fast-path behavior with:

- **one source of truth** (`user_files`)
- **zero triggers**
- **no hidden on-disk version marker**
- **self-healing on sandbox recreation** — a fresh sandbox's local manifest is `[]`, so the first remote manifest fetch forces a full reconcile
- **debuggable** by `ls` / `cat` — no hidden MySQL counter, no hidden `.synced-version` file

Cost: every turn pays one N-row metadata SELECT instead of a 1-row SELECT. For typical users the manifest is a few KB — noise next to daemon startup and Anthropic API latency.

## What changed

**Schema:**
- Dropped `state_version` column and three `user_files_after_*` triggers from `packages/db/schema.sql`
- Dropped `stateVersion` binding from `packages/db/schema.ts`

**Daemon:**
- Deleted `getStateVersion` from `apps/sandbox-daemon/queries.ts`
- Deleted `readSyncedVersion` / `writeSyncedVersion` / `VERSION_FILENAME` from `apps/sandbox-daemon/state.ts` and the corresponding tests
- `apps/sandbox-daemon/reconcile.ts`: replaced the version-based fast path with a new `manifestsEqual()` helper that does a length check + pairwise field comparison on `document_id / type / slug / path_key / checksum`. Valid without re-sorting because `getManifest` already orders by `document_id` (`queries.ts:36`) and `writeLocalManifest` preserves that order.

**Chat-api:**
- Dropped `state_version` from `UserSandboxRuntime` interface and `getRuntime` select in `apps/chat-api/src/db/user-runtime.ts`
- Fixed a stale comment in `apps/chat-api/src/features/sandbox-orchestration/sandbox-orchestration.ts` that referenced `state_version`
- Removed the `state_version >= 2` assertion from `seedTestData` in `apps/chat-api/scripts/run-daemon-e2b-integration.ts`

**Tests:**
- Rewrote 4 tests in `apps/sandbox-daemon/reconcile.test.ts` to use manifest-based mocks instead of `writeSyncedVersion` + `mockGetStateVersion`. Added a new `"rewrites local manifest after sync"` test to cover the post-reconcile manifest persistence.

Net: 10 files, +64 / -147.

## What stays exactly the same

- The canonical/collections/indexes filesystem layout in `apps/sandbox-daemon/materialization.ts`
- The diff-and-apply logic in `reconcile.ts` (creates/updates/deletes detection, symlink rebuilds, scope roots)
- `sandbox-manager.ts`, `upsertRuntime`, the agent prompt, and the daemon's HTTP API
- Observable latency of the sync-skip fast path (see test plan)

## Test plan

- [x] `cd apps/chat-api && bun test` — **172/172 pass**
- [x] `cd apps/sandbox-daemon && bun test` — **44/44 pass**
- [x] `bun build` on the daemon entry — bundles cleanly, no unresolved imports
- [x] `bun run scripts/run-daemon-e2b-integration.ts` — **all 11 E2B daemon integration tests pass end-to-end**:
  - Test 4 (full reconcile): first turn materializes `doc-1.md`, `doc-2.md`, and `indexes/collections/col-test.md` on the sandbox disk — same layout as before
  - **Test 5 (sync skip via `manifestsEqual`): second turn completed in 169ms** — same ballpark as the old state_version fast path (162-207ms), confirming the new mechanism is comparably fast
  - Tests 6-11 (concurrent-turn rejection, collection/document scopes, missing scope/doc errors, sandbox_id persistence + reconnect) all green

## Migration (post-merge, staging only)

The sandbox chat feature is not yet public, so no deploy-ordering dance. Run against staging when convenient:

```sql
DROP TRIGGER IF EXISTS user_files_after_insert;
DROP TRIGGER IF EXISTS user_files_after_update;
DROP TRIGGER IF EXISTS user_files_after_delete;
ALTER TABLE user_sandbox_runtime DROP COLUMN state_version;
```

Any stale `.synced-version` files inside existing E2B sandboxes are silently ignored by the new daemon code — no sandbox-side cleanup needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)