### PR TITLE
refactor: drop slug field from user_files and daemon pipeline

### DIFF
--- a/apps/chat-api/scripts/run-daemon-e2b-integration.ts
+++ b/apps/chat-api/scripts/run-daemon-e2b-integration.ts
@@ -40,7 +40,6 @@ async function seedTestData() {
 			userId,
 			documentId: "doc-1",
 			type: 0,
-			slug: "france-capital",
 			pathKey: "col-test",
 			content:
 				"The capital of France is Paris. It is known for the Eiffel Tower.",
@@ -50,7 +49,6 @@ async function seedTestData() {
 			userId,
 			documentId: "doc-2",
 			type: 3,
-			slug: "shopping-list",
 			pathKey: "",
 			content: "Buy milk, eggs, and bread from the store.",
 			checksum: "checksum-doc-2",

--- a/apps/chat-api/src/features/sandbox-agent/sandbox-agent.prompt.ts
+++ b/apps/chat-api/src/features/sandbox-agent/sandbox-agent.prompt.ts
@@ -19,8 +19,6 @@ Documents are stored as \`.md\` files in your working directory. Each file has Y
 ---
 summaryId: 12345
 type: 0
-sourceKind: text
-title: "Document Title"
 ---
 
 Document content here...

--- a/apps/sandbox-daemon/materialization.test.ts
+++ b/apps/sandbox-daemon/materialization.test.ts
@@ -98,7 +98,7 @@ describe("materialization", () => {
 			expect(path).toBe("/data/u1/canonical/3/my-doc-id.md");
 		});
 
-		it("two docs with same slug but different IDs get distinct paths", () => {
+		it("distinct document_ids produce distinct paths", () => {
 			const path1 = buildCanonicalPath("/data/u1", {
 				type: 0,
 				document_id: "id-1",
@@ -118,7 +118,6 @@ describe("materialization", () => {
 			const doc: DocFile = {
 				document_id: "123",
 				type: 0,
-				slug: "test-doc",
 				path_key: "",
 				content: "Hello world",
 				checksum: "abc",
@@ -153,7 +152,6 @@ describe("materialization", () => {
 			const doc: DocFile = {
 				document_id: "456",
 				type: 0,
-				slug: "linked-doc",
 				path_key: "",
 				content: "content",
 				checksum: "xyz",
@@ -162,7 +160,6 @@ describe("materialization", () => {
 			writeCanonicalFile(dataRoot, doc);
 			buildCollectionSymlink(dataRoot, doc, "col-A");
 
-			// Path uses document_id, not slug
 			const linkPath = `${dataRoot}/collections/col-A/0/456.md`;
 			expect(existsSync(linkPath)).toBe(true);
 
@@ -176,8 +173,8 @@ describe("materialization", () => {
 			const dataRoot = join(testRoot, "index-test");
 
 			buildCollectionIndex(dataRoot, "col-X", [
-				{ document_id: "1", type: 0, slug: "doc-one" },
-				{ document_id: "2", type: 3, slug: "note-two" },
+				{ document_id: "1", type: 0 },
+				{ document_id: "2", type: 3 },
 			]);
 
 			const indexPath = `${dataRoot}/indexes/collections/col-X.md`;
@@ -185,11 +182,8 @@ describe("materialization", () => {
 
 			const content = readFileSync(indexPath, "utf-8");
 			expect(content).toContain("# Collection: col-X");
-			// Display name is slug, link path uses document_id
-			expect(content).toContain("[doc-one]");
-			expect(content).toContain("/1.md");
-			expect(content).toContain("[note-two]");
-			expect(content).toContain("/2.md");
+			expect(content).toContain("[1](../../collections/col-X/0/1.md)");
+			expect(content).toContain("[2](../../collections/col-X/3/2.md)");
 		});
 	});
 
@@ -228,7 +222,6 @@ describe("materialization", () => {
 			const doc: DocFile = {
 				document_id: "789",
 				type: 0,
-				slug: "eph-doc",
 				path_key: "",
 				content: "ephemeral",
 				checksum: "eph",

--- a/apps/sandbox-daemon/materialization.ts
+++ b/apps/sandbox-daemon/materialization.ts
@@ -33,7 +33,6 @@ import { ensureParentDir } from "./fs-utils";
 export interface DocFile {
 	document_id: string;
 	type: number;
-	slug: string;
 	path_key: string;
 	content: string;
 	checksum: string;
@@ -82,7 +81,6 @@ export function writeCanonicalFile(dataRoot: string, doc: DocFile): void {
 		"---",
 		`summaryId: ${doc.document_id}`,
 		`type: ${doc.type}`,
-		`title: ${JSON.stringify(doc.slug)}`,
 		"---",
 		"",
 		doc.content,
@@ -137,7 +135,7 @@ export function buildCollectionSymlink(
 export function buildCollectionIndex(
 	dataRoot: string,
 	collectionId: string,
-	docs: Array<{ document_id: string; type: number; slug: string }>,
+	docs: Array<{ document_id: string; type: number }>,
 ): void {
 	const indexPath = `${dataRoot}/indexes/collections/${sanitizePathSegment(collectionId)}.md`;
 	const lines = [
@@ -145,7 +143,7 @@ export function buildCollectionIndex(
 		"",
 		...docs.map(
 			(doc) =>
-				`- [${doc.slug}](../../collections/${sanitizePathSegment(collectionId)}/${doc.type}/${sanitizePathSegment(doc.document_id)}.md)`,
+				`- [${doc.document_id}](../../collections/${sanitizePathSegment(collectionId)}/${doc.type}/${sanitizePathSegment(doc.document_id)}.md)`,
 		),
 		"",
 	];

--- a/apps/sandbox-daemon/queries.ts
+++ b/apps/sandbox-daemon/queries.ts
@@ -14,7 +14,6 @@ export async function getManifest(
 		.select({
 			document_id: userFiles.documentId,
 			type: userFiles.type,
-			slug: userFiles.slug,
 			path_key: userFiles.pathKey,
 			checksum: userFiles.checksum,
 		})
@@ -32,7 +31,6 @@ export async function getFileContents(
 		.select({
 			document_id: userFiles.documentId,
 			type: userFiles.type,
-			slug: userFiles.slug,
 			path_key: userFiles.pathKey,
 			content: userFiles.content,
 			checksum: userFiles.checksum,

--- a/apps/sandbox-daemon/reconcile.test.ts
+++ b/apps/sandbox-daemon/reconcile.test.ts
@@ -50,7 +50,6 @@ describe("reconcile", () => {
 		const entry = {
 			document_id: "doc-1",
 			type: 0,
-			slug: "my-doc",
 			path_key: "col-A",
 			checksum: "aaa",
 		};
@@ -67,7 +66,6 @@ describe("reconcile", () => {
 		const doc: DocFile = {
 			document_id: "doc-1",
 			type: 0,
-			slug: "my-doc",
 			path_key: "col-A",
 			content: "Hello world",
 			checksum: "aaa",
@@ -75,14 +73,13 @@ describe("reconcile", () => {
 		writeCanonicalFile(dataRoot, doc);
 		buildCollectionSymlink(dataRoot, doc, "col-A");
 		buildCollectionIndex(dataRoot, "col-A", [
-			{ document_id: "doc-1", type: 0, slug: "my-doc" },
+			{ document_id: "doc-1", type: 0 },
 		]);
 
 		writeLocalManifest(dataRoot, [
 			{
 				document_id: "doc-1",
 				type: 0,
-				slug: "my-doc",
 				path_key: "col-A",
 				checksum: "aaa",
 			},
@@ -108,7 +105,6 @@ describe("reconcile", () => {
 			{
 				document_id: "doc-new",
 				type: 0,
-				slug: "new-doc",
 				path_key: "col-B",
 				checksum: "bbb",
 			},
@@ -117,7 +113,6 @@ describe("reconcile", () => {
 			{
 				document_id: "doc-new",
 				type: 0,
-				slug: "new-doc",
 				path_key: "col-B",
 				content: "New document content",
 				checksum: "bbb",
@@ -138,7 +133,6 @@ describe("reconcile", () => {
 		const oldDoc: DocFile = {
 			document_id: "doc-1",
 			type: 0,
-			slug: "my-doc",
 			path_key: "",
 			content: "old content",
 			checksum: "old",
@@ -148,7 +142,6 @@ describe("reconcile", () => {
 			{
 				document_id: "doc-1",
 				type: 0,
-				slug: "my-doc",
 				path_key: "",
 				checksum: "old",
 			},
@@ -158,7 +151,6 @@ describe("reconcile", () => {
 			{
 				document_id: "doc-1",
 				type: 0,
-				slug: "my-doc",
 				path_key: "",
 				checksum: "new",
 			},
@@ -167,7 +159,6 @@ describe("reconcile", () => {
 			{
 				document_id: "doc-1",
 				type: 0,
-				slug: "my-doc",
 				path_key: "",
 				content: "new content",
 				checksum: "new",
@@ -189,7 +180,6 @@ describe("reconcile", () => {
 			{
 				document_id: "doc-1",
 				type: 0,
-				slug: "my-doc",
 				path_key: "",
 				checksum: "new",
 			},
@@ -203,14 +193,12 @@ describe("reconcile", () => {
 			{
 				document_id: "doc-1",
 				type: 0,
-				slug: "d1",
 				path_key: "",
 				checksum: "c1",
 			},
 			{
 				document_id: "doc-2",
 				type: 3,
-				slug: "d2",
 				path_key: "col-X",
 				checksum: "c2",
 			},

--- a/apps/sandbox-daemon/reconcile.ts
+++ b/apps/sandbox-daemon/reconcile.ts
@@ -35,7 +35,6 @@ function hasEntryChanged(
 	return (
 		local.checksum !== remote.checksum ||
 		local.type !== remote.type ||
-		local.slug !== remote.slug ||
 		local.path_key !== remote.path_key
 	);
 }
@@ -83,7 +82,7 @@ export async function reconcile(input: ReconcileInput): Promise<boolean> {
 	const allCollectionIds = new Set<string>();
 	const collectionDocsIndex = new Map<
 		string,
-		Array<{ document_id: string; type: number; slug: string }>
+		Array<{ document_id: string; type: number }>
 	>();
 	const remoteCollectionIds = new Map<string, string[]>();
 
@@ -98,7 +97,6 @@ export async function reconcile(input: ReconcileInput): Promise<boolean> {
 			collectionDocsIndex.get(colId)?.push({
 				document_id: entry.document_id,
 				type: entry.type,
-				slug: entry.slug,
 			});
 		}
 	}
@@ -161,7 +159,6 @@ export async function reconcile(input: ReconcileInput): Promise<boolean> {
 		const doc: DocFile = {
 			document_id: file.document_id,
 			type: file.type,
-			slug: file.slug,
 			path_key: file.path_key,
 			content: file.content,
 			checksum: file.checksum,
@@ -190,7 +187,6 @@ export async function reconcile(input: ReconcileInput): Promise<boolean> {
 	const newManifest: LocalManifestEntry[] = remoteManifest.map((entry) => ({
 		document_id: entry.document_id,
 		type: entry.type,
-		slug: entry.slug,
 		path_key: entry.path_key,
 		checksum: entry.checksum,
 	}));

--- a/apps/sandbox-daemon/state.test.ts
+++ b/apps/sandbox-daemon/state.test.ts
@@ -29,14 +29,12 @@ describe("state", () => {
 				{
 					document_id: "doc-1",
 					type: 0,
-					slug: "my-document",
 					path_key: "col-A",
 					checksum: "abc123",
 				},
 				{
 					document_id: "doc-2",
 					type: 3,
-					slug: "my-note",
 					path_key: "",
 					checksum: "def456",
 				},

--- a/apps/sandbox-daemon/state.ts
+++ b/apps/sandbox-daemon/state.ts
@@ -8,7 +8,6 @@ import { ensureParentDir } from "./fs-utils";
 export interface LocalManifestEntry {
 	document_id: string;
 	type: number;
-	slug: string;
 	path_key: string;
 	checksum: string;
 }

--- a/packages/db/schema.sql
+++ b/packages/db/schema.sql
@@ -3,7 +3,6 @@ CREATE TABLE IF NOT EXISTS user_files (
   user_id       VARCHAR(255) NOT NULL,
   document_id   VARCHAR(255) NOT NULL,
   type          INT NOT NULL DEFAULT 0,
-  slug          TEXT NOT NULL,
   path_key      TEXT NOT NULL,
   content       MEDIUMTEXT NOT NULL,
   checksum      VARCHAR(255) NOT NULL,

--- a/packages/db/schema.ts
+++ b/packages/db/schema.ts
@@ -14,7 +14,6 @@ export const userFiles = mysqlTable(
 		userId: varchar("user_id", { length: 255 }).notNull(),
 		documentId: varchar("document_id", { length: 255 }).notNull(),
 		type: int("type").notNull().default(0),
-		slug: text("slug").notNull(),
 		pathKey: text("path_key").notNull(),
 		content: mediumtext("content").notNull(),
 		checksum: varchar("checksum", { length: 255 }).notNull(),


### PR DESCRIPTION
## Summary

`user_files` is a prototype sync source that will eventually be swapped for the real content table, which does **not** have a `slug` column. Remove `slug` from the daemon pipeline now so nothing breaks at swap time.

### Verification that slug was safe to remove

- **Agent system prompt** (`apps/chat-api/src/features/sandbox-agent/sandbox-agent.prompt.ts`) showed `title: "Document Title"` in the example frontmatter but **never instructed the agent to use it**. Citation paths are built from `summaryId` + `type` only (lines 45-49). The example also had a stale `sourceKind: text` field the daemon wasn't actually emitting — this PR updates the example to match reality.
- **Materialization** used slug in exactly two decorative places: the YAML `title:` frontmatter line in each canonical `.md`, and the link text inside the collection index file. The agent greps file content and cites by `summaryId`/`type`, so neither site is load-bearing.
- No code in `apps/chat-api/src/features/sandbox-agent/` references `slug`.

## Changes

**Schema:**
- Drop `slug` column from `user_files` (`packages/db/schema.sql`)
- Drop `slug` binding from drizzle (`packages/db/schema.ts`)

**Daemon:**
- `state.ts` — drop `slug` from `LocalManifestEntry`
- `queries.ts` — drop `slug` from `getManifest` / `getFileContents` selects
- `materialization.ts`:
  - Drop `slug` from `DocFile`
  - `writeCanonicalFile`: drop the `title:` frontmatter line. New frontmatter is just `summaryId` + `type`.
  - `buildCollectionIndex`: use `document_id` as the link label instead of slug; update the `docs` parameter type accordingly
- `reconcile.ts`:
  - `hasEntryChanged`: four-field comparison instead of five (checksum / type / path_key)
  - Drop `slug` from `collectionDocsIndex` map value type and the push that populates it
  - Drop `slug` from the `DocFile` construction passed to `writeCanonicalFile`
  - Drop `slug` from the `newManifest` mapping in the tail

**Chat-api:**
- `sandbox-agent.prompt.ts` — example frontmatter now matches what the daemon emits (`summaryId` + `type` only, no stale `sourceKind` or `title`)

**Tests:**
- `state.test.ts` / `reconcile.test.ts` / `materialization.test.ts` — drop `slug` from all fixtures
- `materialization.test.ts` — rename `"two docs with same slug but different IDs get distinct paths"` → `"distinct document_ids produce distinct paths"`, and update the `buildCollectionIndex` test's expected link labels from `[doc-one]` / `[note-two]` to `[1]` / `[2]`
- `run-daemon-e2b-integration.ts` — drop `slug` from the two `user_files` insert rows in `seedTestData`

Net: **11 files, +9 / -45**. Most of the diff is fixture cleanup.

## Test plan

- [x] `cd apps/chat-api && bun test` — **172/172 pass**
- [x] `cd apps/sandbox-daemon && bun test` — **45/45 pass**
- [x] `bun build` on the daemon entry — bundles cleanly
- [x] `bun run scripts/run-daemon-e2b-integration.ts` — **all 11 tests pass end-to-end**. Critical checks:
  - **Test 4**: the agent still answers `"Paris"` correctly to `"What is the capital of France?"`. This was the worry — removing `title:` from the frontmatter could theoretically degrade the agent's ability to find the document. It doesn't, because the answer lives in the body and the agent uses Grep on content, not titles.
  - **Test 5** (sync-skip): still short-circuits via `manifestsEqual`, measured at 210ms.
  - **Tests 7-8** (collection / document scope): collection index now uses `document_id` as the link label; still produces valid output, scope-bound queries still work.

## Migration (post-merge, staging)

The sandbox chat feature is still pre-public, so no deploy-ordering dance. Run against staging when convenient:

```sql
ALTER TABLE user_files DROP COLUMN slug;
```

Safe to run any time after the new image is deployed — the code stops selecting `slug`, so dropping the column is a no-op for runtime behavior.

Canonical files already materialized on existing E2B sandbox disks have a stale `title:` line in their frontmatter. The agent ignored it before and still does. The next reconciliation that touches any document will rewrite that file cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)