### PR TITLE
chore: add .worktreeinclude for sharing dotenv files into worktrees

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,3 @@
+.env
+.env.local
+config/secrets.json


### PR DESCRIPTION
## Summary
- Adds `.worktreeinclude` listing `.env`, `.env.local`, and `config/secrets.json` so Claude Code copies these gitignored files into new worktrees.

## Test plan
- [ ] Create a new worktree and confirm dotenv files are populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)