### PR TITLE
refactor: stream text deltas, drop chat_entity event and client-supplied ids

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,12 +96,16 @@ docker-compose up    # Local development
 ### Request Flow
 
 1. `POST /api/v1/chat` with:
-   - **JSON body** (`ChatBodyRequest`): chat payload — `chatContent`, `chatKey`, `chatType`, optional `collectionId`/`summaryId`/client-supplied `chatId`/`refsId`/`sessionId`
+   - **JSON body** (`ChatBodyRequest`): chat payload — `chatContent`, optional `collectionId`/`summaryId`/`sessionId`
    - **Identity headers** (`InternalIdentity`): `X-Member-Code` (required), `X-Partner-Code` (required), `X-Team-Code`, `X-Member-Name`, `X-Partner-Name` (all optional)
 2. SSE stream initiated in `chat.route.ts` after body validation (`.strict()`, rejects extra keys) and identity-header validation (401 on missing/invalid)
 3. `chat.controller.ts::complete()` orchestrates the merged request — no upstream API calls
 4. `runSandboxChat` is the sole agent path: forwards the turn to a per-user E2B sandbox daemon. The optional `sessionId` from the request body is passed through as the daemon's `agent_session_id`; when omitted, the daemon allocates a new session.
-5. Events emitted via SSE: `chat_entity` (streaming chat content), `session_id` (daemon-assigned conversation session — clients must persist and echo back to resume), `error`
+5. Events emitted via SSE:
+   - `text_delta` — `{ text }` payload, one event per streamed token chunk; the client concatenates these to build the full response
+   - `done` — `{}` payload, marks end-of-stream after the final `text_delta`
+   - `session_id` — `{ sessionId }`, daemon-assigned conversation session; clients must persist and echo back to resume
+   - `error` — `{ message }`, surfaced on agent or transport failure
 
 ### Trust Boundary
 

--- a/apps/chat-api/src/features/chat/chat.controller.ts
+++ b/apps/chat-api/src/features/chat/chat.controller.ts
@@ -1,6 +1,6 @@
 import type { ChatMessagesScope } from "@/config/env";
 import { runSandboxChat } from "@/features/sandbox-orchestration";
-import type { ChatEntity, EventMessage } from "./chat.events";
+import type { EventMessage } from "./chat.events";
 import type { ChatLogger } from "./chat.logger";
 import type { ChatRequest } from "./chat.schema";
 import type { MymemoEventSender } from "./chat.streaming";
@@ -10,25 +10,11 @@ export async function complete(
 	mymemoEventSender: MymemoEventSender,
 	logger: ChatLogger,
 ) {
-	const {
-		chatContent,
-		chatKey,
-		chatType,
-		collectionId,
-		summaryId,
-		sessionId,
-		memberCode,
-		memberName,
-		teamCode,
-		partnerCode,
-		partnerName,
-	} = request;
+	const { chatContent, collectionId, summaryId, sessionId, memberCode } =
+		request;
 
 	const normalizedCollectionId = collectionId?.trim() ?? null;
 	const normalizedSummaryId = summaryId?.trim() ?? null;
-
-	const chatId = request.chatId ?? crypto.randomUUID();
-	const refsId = request.refsId ?? crypto.randomUUID();
 
 	let scope: ChatMessagesScope = "general";
 	if (normalizedSummaryId) {
@@ -37,51 +23,22 @@ export async function complete(
 		scope = "collection";
 	}
 
-	let accumulatedContent = "";
-
-	const buildChatEntity = (readFlag: "0" | "1"): ChatEntity => ({
-		id: chatId,
-		chatKey,
-		readFlag,
-		delFlag: "0",
-		teamCode: teamCode ?? null,
-		memberCode,
-		memberName: memberName ?? null,
-		partnerCode,
-		partnerName: partnerName ?? null,
-		chatType,
-		senderType: "AI",
-		senderCode: partnerCode,
-		chatContent: accumulatedContent,
-		followup: "",
-		endFlag: 1,
-		collectionId: normalizedCollectionId,
-		summaryId: normalizedSummaryId,
-		refsId,
-		collapseFlag: "1",
-		refsContent: null,
-	});
-
 	const sendEvent = (message: EventMessage): Promise<void> =>
 		mymemoEventSender.send({ id: crypto.randomUUID(), message });
 
-	const sendChatEntity = (readFlag: "0" | "1"): Promise<void> =>
-		sendEvent({ type: "chat_entity", ...buildChatEntity(readFlag) });
-
 	const onTextDelta = (text: string) => {
-		accumulatedContent += text;
-		// Fire-and-forget on the hot path; the final entity in onTextEnd is
-		// awaited so the stream stays open until it flushes.
-		sendChatEntity("1").catch((err) => {
+		// Fire-and-forget on the hot path; the final `done` event in onTextEnd
+		// is awaited so the stream stays open until it flushes.
+		sendEvent({ type: "text_delta", text }).catch((err) => {
 			logger.error({
-				message: "Failed to send chat_entity delta",
+				message: "Failed to send text_delta",
 				error: err,
 			});
 		});
 	};
 
 	const onTextEnd = async () => {
-		await sendChatEntity("0");
+		await sendEvent({ type: "done" });
 	};
 
 	const onSessionId = (newSessionId: string) => {

--- a/apps/chat-api/src/features/chat/chat.events.ts
+++ b/apps/chat-api/src/features/chat/chat.events.ts
@@ -3,7 +3,11 @@ export interface MymemoEvent {
 	message: EventMessage;
 }
 
-export type EventMessage = ErrorEvent | ChatEntityEvent | SessionIdEvent;
+export type EventMessage =
+	| ErrorEvent
+	| TextDeltaEvent
+	| DoneEvent
+	| SessionIdEvent;
 
 export interface ErrorEvent {
 	type: "error";
@@ -15,28 +19,11 @@ export interface SessionIdEvent {
 	sessionId: string;
 }
 
-export interface ChatEntityEvent {
-	type: "chat_entity";
-	chatContent: string;
-	chatKey: string;
-	chatType: string;
-	delFlag: string;
-	followup: string;
-	id: string;
-	memberCode: string | null;
-	memberName: string | null;
-	partnerCode: string | null;
-	partnerName: string | null;
-	readFlag: string;
-	senderCode: string | null;
-	senderType: string;
-	summaryId: string | null;
-	endFlag: number;
-	collectionId: string | null;
-	teamCode: string | null;
-	refsId: string | null;
-	refsContent: string | null;
-	collapseFlag: string;
+export interface TextDeltaEvent {
+	type: "text_delta";
+	text: string;
 }
 
-export type ChatEntity = Omit<ChatEntityEvent, "type">;
+export interface DoneEvent {
+	type: "done";
+}

--- a/apps/chat-api/src/features/chat/chat.logger.ts
+++ b/apps/chat-api/src/features/chat/chat.logger.ts
@@ -4,13 +4,11 @@ export class ChatLogger {
 	constructor(
 		private logger: PinoLogger,
 		private memberCode: string,
-		private chatKey: string,
 	) {}
 
 	info(message: Record<string, unknown>) {
 		this.logger.info({
 			memberCode: this.memberCode,
-			chatKey: this.chatKey,
 			...message,
 		});
 	}
@@ -18,7 +16,6 @@ export class ChatLogger {
 	warn(message: Record<string, unknown>) {
 		this.logger.warn({
 			memberCode: this.memberCode,
-			chatKey: this.chatKey,
 			...message,
 		});
 	}
@@ -26,7 +23,6 @@ export class ChatLogger {
 	error(message: Record<string, unknown>) {
 		this.logger.error({
 			memberCode: this.memberCode,
-			chatKey: this.chatKey,
 			...message,
 		});
 	}

--- a/apps/chat-api/src/features/chat/chat.route.ts
+++ b/apps/chat-api/src/features/chat/chat.route.ts
@@ -76,7 +76,7 @@ app.post(
 					await complete(
 						request,
 						sender,
-						new ChatLogger(c.var.logger, request.memberCode, request.chatKey),
+						new ChatLogger(c.var.logger, request.memberCode),
 					);
 				} catch (err) {
 					if (err instanceof ConversationBusyError) {

--- a/apps/chat-api/src/features/chat/chat.schema.ts
+++ b/apps/chat-api/src/features/chat/chat.schema.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 
 const MAX_IDENTIFIER_LENGTH = 256;
-const MAX_CHAT_TYPE_LENGTH = 64;
 const MAX_MESSAGE_LENGTH = 50_000;
 
 export const MAX_REQUEST_BODY_BYTES = 10 * 1024 * 1024;
@@ -14,13 +13,8 @@ export const MAX_REQUEST_BODY_BYTES = 10 * 1024 * 1024;
 export const ChatBodyRequest = z
 	.object({
 		chatContent: z.string().min(1).max(MAX_MESSAGE_LENGTH),
-		chatKey: z.string().min(1).max(MAX_IDENTIFIER_LENGTH),
-		chatType: z.string().min(1).max(MAX_CHAT_TYPE_LENGTH),
 		collectionId: z.string().max(MAX_IDENTIFIER_LENGTH).nullish(),
 		summaryId: z.string().max(MAX_IDENTIFIER_LENGTH).nullish(),
-
-		chatId: z.string().uuid().optional(),
-		refsId: z.string().uuid().optional(),
 
 		// Daemon-managed conversation session. When omitted, the daemon
 		// allocates a new session; when present, the daemon resumes that


### PR DESCRIPTION
## Summary

- Replace the `chat_entity` SSE event (full content snapshot resent on every token, ~20 fields of identity/routing metadata) with minimal `text_delta { text }` events plus a final `done` event. Clients now concatenate deltas themselves.
- Drop `chatKey`, `chatType`, `chatId`, `refsId` from `ChatBodyRequest`; drop `chatKey` from `ChatLogger`. Clients track their own correlation ids.
- Net: 26 insertions, 88 deletions.

## Event shape

```
event: text_delta
data: {"text":"Hello"}

event: text_delta
data: {" world"}

event: done
data: {}
```

`session_id` and `error` events are unchanged.

## Test plan

- [x] `bun run lint` clean
- [x] `bun test` — 77/77 pass
- [ ] Verify client streaming consumer concatenates deltas correctly and observes `done`
- [ ] Confirm no downstream caller still posts `chatKey`/`chatType`/`chatId`/`refsId` in the request body (would now be rejected by `.strict()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)