### PR TITLE
chore: drop redundant @anthropic-ai/claude-code install from sandbox template

### DIFF
--- a/apps/chat-api/sandbox-template/template.ts
+++ b/apps/chat-api/sandbox-template/template.ts
@@ -8,5 +8,4 @@ export const template = Template()
 	.runCmd("curl -fsSL https://bun.sh/install | bash")
 	.runCmd("ln -s /home/user/.bun/bin/bun /usr/local/bin/bun", { user: "root" })
 	.setWorkdir(WORKSPACE_ROOT)
-	.runCmd(`mkdir -p ${WORKSPACE_ROOT}/data`)
-	.npmInstall("@anthropic-ai/claude-code", { g: true });
+	.runCmd(`mkdir -p ${WORKSPACE_ROOT}/data`);


### PR DESCRIPTION
## Summary
- The Claude Agent SDK (`@anthropic-ai/claude-agent-sdk`, already a dep of `apps/sandbox-daemon`) [bundles a native Claude Code binary as an optional dependency](https://code.claude.com/docs/en/agent-sdk/overview), so the separate `npm install -g @anthropic-ai/claude-code` in the E2B template is redundant.
- Drop the `.npmInstall("@anthropic-ai/claude-code", { g: true })` step from `apps/chat-api/sandbox-template/template.ts`.

## Test plan
- [x] `bun run e2b:build:dev` succeeds (rebuilt `sandbox-template-dev` in 58s)
- [ ] Smoke-test a sandbox session end-to-end against the new template before promoting to prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)