### PR TITLE
refactor: await SSE event handlers to preserve emission order

### DIFF
--- a/apps/chat-api/src/features/chat/chat.controller.ts
+++ b/apps/chat-api/src/features/chat/chat.controller.ts
@@ -32,41 +32,36 @@ export async function complete(
 	const sendEvent = (message: EventMessage): Promise<void> =>
 		mymemoEventSender.send({ id: crypto.randomUUID(), message });
 
-	const onTextDelta = (text: string) => {
-		// Fire-and-forget on the hot path; the final `done` event in onTextEnd
-		// is awaited so the stream stays open until it flushes.
-		sendEvent({ type: "text_delta", text }).catch((err) => {
-			logger.error({
-				message: "Failed to send text_delta",
-				error: err,
-			});
-		});
+	const onTextDelta = async (text: string) => {
+		try {
+			await sendEvent({ type: "text_delta", text });
+		} catch (err) {
+			logger.error({ message: "Failed to send text_delta", error: err });
+		}
 	};
 
 	const onTextEnd = async () => {
 		await sendEvent({ type: "done" });
 	};
 
-	const onSessionId = (newSessionId: string) => {
+	const onSessionId = async (newSessionId: string) => {
 		// Skip echoing a sessionId the client already supplied.
 		if (newSessionId === sessionId) return;
-		sendEvent({ type: "session_id", sessionId: newSessionId }).catch((err) => {
-			logger.error({
-				message: "Failed to send session_id event",
-				error: err,
-			});
-		});
+		try {
+			await sendEvent({ type: "session_id", sessionId: newSessionId });
+		} catch (err) {
+			logger.error({ message: "Failed to send session_id event", error: err });
+		}
 	};
 
-	const onSandboxId = (newSandboxId: string) => {
+	const onSandboxId = async (newSandboxId: string) => {
 		// Skip echoing a sandboxId the client already supplied.
 		if (newSandboxId === sandboxId) return;
-		sendEvent({ type: "sandbox_id", sandboxId: newSandboxId }).catch((err) => {
-			logger.error({
-				message: "Failed to send sandbox_id event",
-				error: err,
-			});
-		});
+		try {
+			await sendEvent({ type: "sandbox_id", sandboxId: newSandboxId });
+		} catch (err) {
+			logger.error({ message: "Failed to send sandbox_id event", error: err });
+		}
 	};
 
 	await runSandboxChat({

--- a/apps/chat-api/src/features/chat/chat.streaming.test.ts
+++ b/apps/chat-api/src/features/chat/chat.streaming.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "bun:test";
+import { SSEStreamingApi } from "hono/streaming";
+import { HonoSSESender } from "./chat.streaming";
+
+describe("HonoSSESender", () => {
+	it("preserves wire order when send and sendPing are interleaved without awaits", async () => {
+		// Simulates the keepalive setInterval firing between two send() calls
+		// in chat.controller.ts. With current hono (4.12.12) the WritableStream
+		// queue plus microtask FIFO keep frames in invocation order even
+		// though sendPing is fire-and-forget in production. If hono ever adds
+		// async work before its writer.write() enqueue, this test will fail
+		// and HonoSSESender will need an internal serialization queue.
+		const { readable, writable } = new TransformStream<Uint8Array>();
+		const stream = new SSEStreamingApi(writable, readable);
+		const sender = new HonoSSESender(stream);
+
+		const reader = stream.responseReadable.getReader();
+		const decoder = new TextDecoder();
+		let buf = "";
+		const readAll = (async () => {
+			while (true) {
+				const { done, value } = await reader.read();
+				if (done) break;
+				buf += decoder.decode(value, { stream: true });
+			}
+		})();
+
+		const writes = [
+			sender.send({
+				id: "a",
+				message: { type: "text_delta", text: "first" },
+			}),
+			sender.sendPing(),
+			sender.send({
+				id: "b",
+				message: { type: "text_delta", text: "second" },
+			}),
+			sender.sendPing(),
+			sender.send({
+				id: "c",
+				message: { type: "text_delta", text: "third" },
+			}),
+		];
+		await Promise.all(writes);
+		await stream.close();
+		await readAll;
+
+		const events = Array.from(buf.matchAll(/event: (\S+)/g)).map((m) => m[1]);
+		expect(events).toEqual([
+			"text_delta",
+			"ping",
+			"text_delta",
+			"ping",
+			"text_delta",
+		]);
+	});
+});

--- a/apps/chat-api/src/features/chat/chat.streaming.ts
+++ b/apps/chat-api/src/features/chat/chat.streaming.ts
@@ -9,6 +9,15 @@ export interface MymemoEventSender extends Sender<MymemoEvent> {
 	sendPing(): Promise<void>;
 }
 
+// Wire order between concurrent send / sendPing calls is load-bearing on
+// hono's writeSSE doing its `writer.write()` enqueue in the first microtask
+// after the call (no async work between the sync string build and the
+// enqueue). Today (hono 4.12.12) that holds, and microtask FIFO + the
+// WritableStream's FIFO queue keep frames in invocation order even though
+// the keepalive setInterval doesn't await its sendPing. If hono ever adds
+// real async work before the enqueue in writeSSE, this class will need an
+// internal serialization queue. The `interleaved order` test in
+// chat.streaming.test.ts pins this behavior.
 export class HonoSSESender implements MymemoEventSender {
 	constructor(private stream: SSEStreamingApi) {}
 

--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-orchestration.test.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-orchestration.test.ts
@@ -33,10 +33,10 @@ function makeOptions(
 		summaryId: null,
 		sessionId: null,
 		sandboxId: null,
-		onTextDelta: () => {},
+		onTextDelta: async () => {},
 		onTextEnd: async () => {},
-		onSessionId: () => {},
-		onSandboxId: () => {},
+		onSessionId: async () => {},
+		onSandboxId: async () => {},
 		logger: silentLogger,
 		...overrides,
 	};
@@ -150,7 +150,11 @@ describe("runSandboxChat", () => {
 
 		const received: string[] = [];
 		await runSandboxChat(
-			makeOptions({ onSandboxId: (id) => received.push(id) }),
+			makeOptions({
+				onSandboxId: async (id) => {
+					received.push(id);
+				},
+			}),
 		);
 
 		expect(received).toEqual(["sbx-123"]);
@@ -162,11 +166,15 @@ describe("runSandboxChat", () => {
 			proxyModule,
 			"forwardChatTurnToSandbox",
 		).mockImplementation(async (opts) => {
-			opts.onSessionId("new-session-123");
+			await opts.onSessionId("new-session-123");
 		});
 
 		await runSandboxChat(
-			makeOptions({ onSessionId: (id) => received.push(id) }),
+			makeOptions({
+				onSessionId: async (id) => {
+					received.push(id);
+				},
+			}),
 		);
 
 		expect(received).toEqual(["new-session-123"]);

--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-orchestration.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-orchestration.ts
@@ -22,10 +22,10 @@ export interface RunSandboxChatOptions {
 	summaryId: string | null;
 	sessionId: string | null;
 	sandboxId: string | null;
-	onTextDelta: (text: string) => void;
+	onTextDelta: (text: string) => Promise<void>;
 	onTextEnd: () => Promise<void>;
-	onSessionId: (sessionId: string) => void;
-	onSandboxId: (sandboxId: string) => void;
+	onSessionId: (sessionId: string) => Promise<void>;
+	onSandboxId: (sandboxId: string) => Promise<void>;
 	logger: ChatLogger;
 }
 
@@ -60,7 +60,7 @@ export async function runSandboxChat(
 			logger,
 		);
 
-		onSandboxId(sandbox.sandboxId);
+		await onSandboxId(sandbox.sandboxId);
 
 		const daemonUrl = await sandboxManager.ensureSandboxDaemon(
 			userId,

--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-proxy.test.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-proxy.test.ts
@@ -38,9 +38,9 @@ describe("forwardChatTurnToSandbox", () => {
 				forwardChatTurnToSandbox({
 					daemonUrl: "http://localhost:8080",
 					turnRequest: makeTurnRequest(),
-					onTextDelta: () => {},
+					onTextDelta: async () => {},
 					onTextEnd: async () => {},
-					onSessionId: () => {},
+					onSessionId: async () => {},
 				}),
 			).rejects.toBeInstanceOf(ConversationBusyError);
 		} finally {
@@ -59,9 +59,9 @@ describe("forwardChatTurnToSandbox", () => {
 				forwardChatTurnToSandbox({
 					daemonUrl: "http://localhost:8080",
 					turnRequest: makeTurnRequest(),
-					onTextDelta: () => {},
+					onTextDelta: async () => {},
 					onTextEnd: async () => {},
-					onSessionId: () => {},
+					onSessionId: async () => {},
 				}),
 			).rejects.toThrow("Daemon returned 500");
 		} finally {
@@ -89,15 +89,57 @@ describe("forwardChatTurnToSandbox", () => {
 			await forwardChatTurnToSandbox({
 				daemonUrl: "http://localhost:8080",
 				turnRequest: makeTurnRequest(),
-				onTextDelta: (text) => deltas.push(text),
+				onTextDelta: async (text) => {
+					deltas.push(text);
+				},
 				onTextEnd: async () => {
 					textEndCalled = true;
 				},
-				onSessionId: () => {},
+				onSessionId: async () => {},
 			});
 
 			expect(deltas).toEqual(["hello ", "world"]);
 			expect(textEndCalled).toBe(true);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+
+	it("awaits each handler so a slow text_delta does not reorder later events", async () => {
+		// A slow first handler would let a later text_delta complete first if
+		// the proxy didn't await — the recorded order would be ["fast", "slow"].
+		const body = ndjsonBody([
+			{ type: "started", turn_id: "t1" },
+			{ type: "text_delta", text: "slow" },
+			{ type: "text_delta", text: "fast" },
+			{ type: "session_id", sessionId: "sess-1" },
+			{ type: "completed" },
+		]);
+
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = mock(() =>
+			Promise.resolve(new Response(body, { status: 200 })),
+		) as unknown as typeof fetch;
+
+		const completionOrder: string[] = [];
+
+		try {
+			await forwardChatTurnToSandbox({
+				daemonUrl: "http://localhost:8080",
+				turnRequest: makeTurnRequest(),
+				onTextDelta: async (text) => {
+					if (text === "slow") {
+						await new Promise((r) => setTimeout(r, 30));
+					}
+					completionOrder.push(text);
+				},
+				onTextEnd: async () => {},
+				onSessionId: async (id) => {
+					completionOrder.push(id);
+				},
+			});
+
+			expect(completionOrder).toEqual(["slow", "fast", "sess-1"]);
 		} finally {
 			globalThis.fetch = originalFetch;
 		}
@@ -121,9 +163,9 @@ describe("forwardChatTurnToSandbox", () => {
 			await forwardChatTurnToSandbox({
 				daemonUrl: "http://localhost:8080",
 				turnRequest: makeTurnRequest(),
-				onTextDelta: () => {},
+				onTextDelta: async () => {},
 				onTextEnd: async () => {},
-				onSessionId: (id) => {
+				onSessionId: async (id) => {
 					capturedSessionId = id;
 				},
 			});
@@ -150,9 +192,9 @@ describe("forwardChatTurnToSandbox", () => {
 				forwardChatTurnToSandbox({
 					daemonUrl: "http://localhost:8080",
 					turnRequest: makeTurnRequest(),
-					onTextDelta: () => {},
+					onTextDelta: async () => {},
 					onTextEnd: async () => {},
-					onSessionId: () => {},
+					onSessionId: async () => {},
 				}),
 			).rejects.toThrow("agent crashed");
 		} finally {
@@ -176,9 +218,9 @@ describe("forwardChatTurnToSandbox", () => {
 				forwardChatTurnToSandbox({
 					daemonUrl: "http://localhost:8080",
 					turnRequest: makeTurnRequest(),
-					onTextDelta: () => {},
+					onTextDelta: async () => {},
 					onTextEnd: async () => {},
-					onSessionId: () => {},
+					onSessionId: async () => {},
 				}),
 			).rejects.toThrow("agent error");
 		} finally {
@@ -207,9 +249,11 @@ describe("forwardChatTurnToSandbox", () => {
 			await forwardChatTurnToSandbox({
 				daemonUrl: "http://localhost:8080",
 				turnRequest: makeTurnRequest(),
-				onTextDelta: (text) => deltas.push(text),
+				onTextDelta: async (text) => {
+					deltas.push(text);
+				},
 				onTextEnd: async () => {},
-				onSessionId: () => {},
+				onSessionId: async () => {},
 			});
 
 			expect(deltas).toEqual(["ok"]);

--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-proxy.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-proxy.ts
@@ -14,9 +14,9 @@ export interface TurnRequest {
 interface ForwardOptions {
 	daemonUrl: string;
 	turnRequest: TurnRequest;
-	onTextDelta: (text: string) => void;
+	onTextDelta: (text: string) => Promise<void>;
 	onTextEnd: () => Promise<void>;
-	onSessionId: (id: string) => void;
+	onSessionId: (id: string) => Promise<void>;
 }
 
 /**
@@ -73,12 +73,12 @@ export async function forwardChatTurnToSandbox(
 						switch (parsed.type) {
 							case "text_delta":
 								if (typeof parsed.text === "string") {
-									onTextDelta(parsed.text);
+									await onTextDelta(parsed.text);
 								}
 								break;
 							case "session_id":
 								if (typeof parsed.sessionId === "string") {
-									onSessionId(parsed.sessionId);
+									await onSessionId(parsed.sessionId);
 								}
 								break;
 							case "completed":

--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-proxy.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-proxy.ts
@@ -67,36 +67,39 @@ export async function forwardChatTurnToSandbox(
 			buffer = buffer.slice(newlineIndex + 1);
 
 			if (line) {
+				let parsed: unknown;
 				try {
-					const parsed = JSON.parse(line);
-					if (typeof parsed === "object" && parsed !== null) {
-						switch (parsed.type) {
-							case "text_delta":
-								if (typeof parsed.text === "string") {
-									await onTextDelta(parsed.text);
-								}
-								break;
-							case "session_id":
-								if (typeof parsed.sessionId === "string") {
-									await onSessionId(parsed.sessionId);
-								}
-								break;
-							case "completed":
-								break;
-							case "failed":
-								agentError = parsed.message ?? "Turn failed";
-								break;
-							case "started":
-								break;
-							case "result":
-								break;
-							case "error":
-								agentError = parsed.message ?? "Unknown agent error";
-								break;
-						}
-					}
+					parsed = JSON.parse(line);
 				} catch {
 					// Non-JSON line, ignore
+					parsed = null;
+				}
+				if (typeof parsed === "object" && parsed !== null) {
+					const evt = parsed as { type?: string } & Record<string, unknown>;
+					switch (evt.type) {
+						case "text_delta":
+							if (typeof evt.text === "string") {
+								await onTextDelta(evt.text);
+							}
+							break;
+						case "session_id":
+							if (typeof evt.sessionId === "string") {
+								await onSessionId(evt.sessionId);
+							}
+							break;
+						case "completed":
+							break;
+						case "failed":
+							agentError = (evt.message as string) ?? "Turn failed";
+							break;
+						case "started":
+							break;
+						case "result":
+							break;
+						case "error":
+							agentError = (evt.message as string) ?? "Unknown agent error";
+							break;
+					}
 				}
 			}
 


### PR DESCRIPTION
## Summary

Make event callbacks (`onTextDelta`, `onSessionId`, `onSandboxId`) return `Promise<void>` and await them at every call site so the four named SSE events (`text_delta`, `session_id`, `sandbox_id`, `done`) cannot reorder on the wire.

Before, fire-and-forget invocations in `chat.controller.ts` meant two `writeSSE` calls could race; if `writeSSE` had any internal await before enqueueing, a later event's frame could land on the wire before an earlier one.

Now everything flows through a single async chain — `sandbox-proxy.ts` awaits each handler before reading the next NDJSON line, and `sandbox-orchestration.ts` awaits `onSandboxId` before starting the daemon stream. By construction, none of the named events are ever concurrent with each other.

## Non-goal: keepalive ping

`sender.sendPing()` from the 5s `setInterval` in `chat.route.ts` is still fire-and-forget and can be concurrent with named-event writes. That's accepted:
- WHATWG `WritableStreamDefaultWriter.write()` queues chunks in invocation order, so frames don't byte-interleave.
- SSE clients parse by `event:` type, so a ping landing between two text_deltas is harmless.

## Test plan

- [x] `bun test` — 81/81 pass, including a new ordering test in `sandbox-proxy.test.ts` that injects a slow first `onTextDelta` and asserts the recorded order matches emission order. Verified the test fails (`["fast", "slow"]` instead of `["slow", "fast"]`) when the awaits are removed from the proxy loop.
- [x] `bunx tsc --noEmit` — only the two pre-existing errors in `scripts/probe-agent-tools.ts` (unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)