### PR TITLE
refactor: split sandbox-daemon into daemon/sync/agent bundles

### DIFF
--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-manager.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-manager.ts
@@ -17,16 +17,23 @@ const DAEMON_HEALTH_CHECK_INTERVAL_MS = 500;
 // the hash of all three concatenated — any change to any one triggers a
 // daemon restart. The daemon spawns sync.js / agent.js per turn; only the
 // daemon bundle is long-running.
-const SANDBOX_BUNDLES = [
-	{
-		name: "daemon",
-		sandboxPath: "/workspace/daemon.js",
-		distFile: "daemon.js",
-	},
-	{ name: "sync", sandboxPath: "/workspace/sync.js", distFile: "sync.js" },
-	{ name: "agent", sandboxPath: "/workspace/agent.js", distFile: "agent.js" },
-] as const;
-const DAEMON_BUNDLE_PATH = SANDBOX_BUNDLES[0].sandboxPath;
+const DAEMON_BUNDLE = {
+	name: "daemon",
+	sandboxPath: "/workspace/daemon.js",
+	distFile: "daemon.js",
+} as const;
+const SYNC_BUNDLE = {
+	name: "sync",
+	sandboxPath: "/workspace/sync.js",
+	distFile: "sync.js",
+} as const;
+const AGENT_BUNDLE = {
+	name: "agent",
+	sandboxPath: "/workspace/agent.js",
+	distFile: "agent.js",
+} as const;
+const SANDBOX_BUNDLES = [DAEMON_BUNDLE, SYNC_BUNDLE, AGENT_BUNDLE] as const;
+const DAEMON_BUNDLE_PATH = DAEMON_BUNDLE.sandboxPath;
 const DIST_DIR = resolve(
 	import.meta.dirname,
 	"../../../../sandbox-daemon/dist",

--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-manager.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-manager.ts
@@ -12,34 +12,57 @@ export const WORKSPACE_ROOT = "/workspace";
 const DAEMON_PORT = 8080;
 const DAEMON_STARTUP_TIMEOUT_MS = 15_000;
 const DAEMON_HEALTH_CHECK_INTERVAL_MS = 500;
-const DAEMON_BUNDLE_PATH = "/workspace/daemon.js";
-const DAEMON_PREBUILT_PATH = resolve(
+
+// Three separate bundles deployed into the sandbox. Versioned together by
+// the hash of all three concatenated — any change to any one triggers a
+// daemon restart. The daemon spawns sync.js / agent.js per turn; only the
+// daemon bundle is long-running.
+const SANDBOX_BUNDLES = [
+	{
+		name: "daemon",
+		sandboxPath: "/workspace/daemon.js",
+		distFile: "daemon.js",
+	},
+	{ name: "sync", sandboxPath: "/workspace/sync.js", distFile: "sync.js" },
+	{ name: "agent", sandboxPath: "/workspace/agent.js", distFile: "agent.js" },
+] as const;
+const DAEMON_BUNDLE_PATH = SANDBOX_BUNDLES[0].sandboxPath;
+const DIST_DIR = resolve(
 	import.meta.dirname,
-	"../../../../sandbox-daemon/dist/index.js",
+	"../../../../sandbox-daemon/dist",
 );
 
-let bundlePromise: Promise<{ code: string; version: string }> | null = null;
+interface SandboxBundleSet {
+	files: Array<{ sandboxPath: string; code: string }>;
+	version: string;
+}
 
-function getDaemonBundle(): Promise<{ code: string; version: string }> {
-	if (!bundlePromise) bundlePromise = loadDaemonBundle();
+let bundlePromise: Promise<SandboxBundleSet> | null = null;
+
+function getSandboxBundles(): Promise<SandboxBundleSet> {
+	if (!bundlePromise) bundlePromise = loadSandboxBundles();
 	return bundlePromise;
 }
 
-async function loadDaemonBundle(): Promise<{ code: string; version: string }> {
-	let code: string;
-	try {
-		code = await Bun.file(DAEMON_PREBUILT_PATH).text();
-	} catch (err) {
-		throw new Error(
-			`Prebuilt daemon bundle missing at ${DAEMON_PREBUILT_PATH}. Run \`bun run build:daemon\` from apps/chat-api.`,
-			{ cause: err },
-		);
+async function loadSandboxBundles(): Promise<SandboxBundleSet> {
+	const files: SandboxBundleSet["files"] = [];
+	const hasher = new Bun.CryptoHasher("sha256");
+	for (const { name, sandboxPath, distFile } of SANDBOX_BUNDLES) {
+		const path = `${DIST_DIR}/${distFile}`;
+		let code: string;
+		try {
+			code = await Bun.file(path).text();
+		} catch (err) {
+			throw new Error(
+				`Prebuilt ${name} bundle missing at ${path}. Run \`bun run build:daemon\` from apps/chat-api.`,
+				{ cause: err },
+			);
+		}
+		hasher.update(code);
+		files.push({ sandboxPath, code });
 	}
-	const version = new Bun.CryptoHasher("sha256")
-		.update(code)
-		.digest("hex")
-		.slice(0, 12);
-	return { code, version };
+	const version = hasher.digest("hex").slice(0, 12);
+	return { files, version };
 }
 
 export class SandboxManager {
@@ -130,11 +153,11 @@ export class SandboxManager {
 	): Promise<string> {
 		const daemonUrl = this.getDaemonUrl(sandbox);
 
-		const bundle = await getDaemonBundle();
+		const bundles = await getSandboxBundles();
 
 		try {
 			const health = await this.checkDaemonHealth(daemonUrl);
-			if (health && health.version === bundle.version) {
+			if (health && health.version === bundles.version) {
 				return daemonUrl;
 			}
 
@@ -142,9 +165,9 @@ export class SandboxManager {
 				logger.info({
 					msg: "Daemon version mismatch, restarting",
 					currentVersion: health.version,
-					expectedVersion: bundle.version,
+					expectedVersion: bundles.version,
 				});
-				await this.restartDaemon(sandbox, logger, bundle);
+				await this.restartDaemon(sandbox, logger, bundles);
 				return daemonUrl;
 			}
 		} catch {
@@ -157,7 +180,7 @@ export class SandboxManager {
 			sandboxId: sandbox.sandboxId,
 		});
 
-		await this.deployDaemonBundle(sandbox, logger, bundle);
+		await this.deploySandboxBundles(sandbox, logger, bundles);
 		return daemonUrl;
 	}
 
@@ -184,30 +207,33 @@ export class SandboxManager {
 		}
 	}
 
-	private async deployDaemonBundle(
+	private async deploySandboxBundles(
 		sandbox: Sandbox,
 		logger: SyncLogger,
-		bundle: { code: string; version: string },
+		bundles: SandboxBundleSet,
 	): Promise<void> {
-		await sandbox.files.write([
-			{ path: DAEMON_BUNDLE_PATH, data: bundle.code },
-		]);
+		await sandbox.files.write(
+			bundles.files.map(({ sandboxPath, code }) => ({
+				path: sandboxPath,
+				data: code,
+			})),
+		);
 
-		await this.startDaemonProcess(sandbox, logger, bundle.version);
+		await this.startDaemonProcess(sandbox, logger, bundles.version);
 	}
 
 	private async restartDaemon(
 		sandbox: Sandbox,
 		logger: SyncLogger,
-		bundle: { code: string; version: string },
+		bundles: SandboxBundleSet,
 	): Promise<void> {
 		// Kill whatever process owns port 8080 (process name may not match pkill pattern)
 		await sandbox.commands.run("kill $(lsof -ti :8080) 2>/dev/null || true", {
 			timeoutMs: 5_000,
 		});
 
-		// Re-deploy with updated bundle
-		await this.deployDaemonBundle(sandbox, logger, bundle);
+		// Re-deploy with updated bundles
+		await this.deploySandboxBundles(sandbox, logger, bundles);
 	}
 
 	private async startDaemonProcess(

--- a/apps/sandbox-daemon/agent-entry.ts
+++ b/apps/sandbox-daemon/agent-entry.ts
@@ -19,6 +19,7 @@
  */
 
 import { runAgent } from "./agent";
+import type { AgentEvent } from "./ipc-protocol";
 
 interface AgentConfig {
 	userQuery: string;
@@ -27,8 +28,8 @@ interface AgentConfig {
 	sessionId?: string;
 }
 
-function emit(obj: Record<string, unknown>): void {
-	process.stdout.write(`${JSON.stringify(obj)}\n`);
+function emit(event: AgentEvent): void {
+	process.stdout.write(`${JSON.stringify(event)}\n`);
 }
 
 async function readStdin(): Promise<string> {

--- a/apps/sandbox-daemon/agent-entry.ts
+++ b/apps/sandbox-daemon/agent-entry.ts
@@ -1,0 +1,95 @@
+/**
+ * Agent command: runs a Claude Agent SDK query and streams events as NDJSON,
+ * then exits. Spawned per-turn by the daemon under a scrubbed environment
+ * (no DATABASE_URL, no daemon secrets).
+ *
+ * Stdin:   single JSON object —
+ *            { userQuery, systemPrompt, cwd, sessionId? }
+ * Stdout:  NDJSON, one event per line —
+ *            { type: "text_delta", text: "..." }
+ *            { type: "session_id", sessionId: "..." }
+ *            { type: "completed" }
+ *            { type: "failed", message: "..." }
+ * Exit:    0 on completed, 1 on failed.
+ *
+ * Required env: ANTHROPIC_API_KEY (consumed by Claude Agent SDK).
+ *
+ * No other code path inside the daemon process imports the Claude Agent
+ * SDK — this entrypoint owns it in the sandbox bundle graph.
+ */
+
+import { runAgent } from "./agent";
+
+interface AgentConfig {
+	userQuery: string;
+	systemPrompt: string;
+	cwd: string;
+	sessionId?: string;
+}
+
+function emit(obj: Record<string, unknown>): void {
+	process.stdout.write(`${JSON.stringify(obj)}\n`);
+}
+
+async function readStdin(): Promise<string> {
+	const chunks: Uint8Array[] = [];
+	for await (const chunk of process.stdin) {
+		chunks.push(chunk as Uint8Array);
+	}
+	return Buffer.concat(chunks).toString("utf8");
+}
+
+function parseConfig(raw: string): AgentConfig {
+	const parsed = JSON.parse(raw) as Partial<AgentConfig>;
+	if (
+		typeof parsed.userQuery !== "string" ||
+		typeof parsed.systemPrompt !== "string" ||
+		typeof parsed.cwd !== "string"
+	) {
+		throw new Error(
+			"agent config requires { userQuery, systemPrompt, cwd } strings",
+		);
+	}
+	return {
+		userQuery: parsed.userQuery,
+		systemPrompt: parsed.systemPrompt,
+		cwd: parsed.cwd,
+		sessionId:
+			typeof parsed.sessionId === "string" ? parsed.sessionId : undefined,
+	};
+}
+
+async function main() {
+	let config: AgentConfig;
+	try {
+		const raw = await readStdin();
+		config = parseConfig(raw);
+	} catch (err) {
+		emit({
+			type: "failed",
+			message: err instanceof Error ? err.message : String(err),
+		});
+		process.exit(1);
+	}
+
+	let failed = false;
+	await runAgent(config, {
+		onTextDelta: async (text) => {
+			emit({ type: "text_delta", text });
+		},
+		onSessionId: async (sessionId) => {
+			emit({ type: "session_id", sessionId });
+		},
+		onCompleted: async () => {
+			emit({ type: "completed" });
+		},
+		onFailed: async (message) => {
+			failed = true;
+			emit({ type: "failed", message });
+		},
+	});
+
+	process.exit(failed ? 1 : 0);
+}
+
+main();

--- a/apps/sandbox-daemon/child-spawn.ts
+++ b/apps/sandbox-daemon/child-spawn.ts
@@ -10,20 +10,35 @@
  * chat-api writes the three bundles to /workspace/{daemon,sync,agent}.js.
  */
 
+import type { AgentEvent, SyncEvent } from "./ipc-protocol";
+
+export type { AgentEvent, SyncEvent } from "./ipc-protocol";
+export type SyncResult = SyncEvent;
+
 const SYNC_BUNDLE_PATH = process.env.SANDBOX_SYNC_PATH ?? "/workspace/sync.js";
 const AGENT_BUNDLE_PATH =
 	process.env.SANDBOX_AGENT_PATH ?? "/workspace/agent.js";
 const BUN_EXECUTABLE = process.env.SANDBOX_BUN_PATH ?? "bun";
 
-export type SyncResult =
-	| { type: "synced"; changed: boolean; dataRoot: string }
-	| { type: "failed"; message: string };
-
-export type AgentEvent =
-	| { type: "text_delta"; text: string }
-	| { type: "session_id"; sessionId: string }
-	| { type: "completed" }
-	| { type: "failed"; message: string };
+function narrowAgentEvent(raw: Record<string, unknown>): AgentEvent | null {
+	switch (raw.type) {
+		case "text_delta":
+			if (typeof raw.text === "string") return { type: "text_delta", text: raw.text };
+			return null;
+		case "session_id":
+			if (typeof raw.sessionId === "string")
+				return { type: "session_id", sessionId: raw.sessionId };
+			return null;
+		case "completed":
+			return { type: "completed" };
+		case "failed":
+			if (typeof raw.message === "string")
+				return { type: "failed", message: raw.message };
+			return null;
+		default:
+			return null;
+	}
+}
 
 async function* readNdjson(
 	stream: ReadableStream<Uint8Array>,
@@ -98,20 +113,20 @@ export async function spawnSync(input: {
 	);
 
 	const stderrPromise = drainStderr(proc.stderr);
-	let terminal: SyncResult | null = null;
+	let terminal: SyncEvent | null = null;
 	for await (const event of readNdjson(proc.stdout)) {
-		if (event.type === "synced") {
+		if (
+			event.type === "synced" &&
+			typeof event.changed === "boolean" &&
+			typeof event.dataRoot === "string"
+		) {
 			terminal = {
 				type: "synced",
-				changed: event.changed === true,
-				dataRoot: typeof event.dataRoot === "string" ? event.dataRoot : "",
+				changed: event.changed,
+				dataRoot: event.dataRoot,
 			};
-		} else if (event.type === "failed") {
-			terminal = {
-				type: "failed",
-				message:
-					typeof event.message === "string" ? event.message : "sync failed",
-			};
+		} else if (event.type === "failed" && typeof event.message === "string") {
+			terminal = { type: "failed", message: event.message };
 		}
 	}
 	await stderrPromise;
@@ -156,14 +171,8 @@ export async function spawnAgent(
 
 	const stderrPromise = drainStderr(proc.stderr);
 	for await (const event of readNdjson(proc.stdout)) {
-		if (
-			event.type === "text_delta" ||
-			event.type === "session_id" ||
-			event.type === "completed" ||
-			event.type === "failed"
-		) {
-			await onEvent(event as AgentEvent);
-		}
+		const narrowed = narrowAgentEvent(event);
+		if (narrowed) await onEvent(narrowed);
 	}
 	await stderrPromise;
 	const exitCode = await proc.exited;

--- a/apps/sandbox-daemon/child-spawn.ts
+++ b/apps/sandbox-daemon/child-spawn.ts
@@ -1,0 +1,171 @@
+/**
+ * Spawn helpers for the per-turn sync.js and agent.js children. The daemon
+ * holds DATABASE_URL and ANTHROPIC_API_KEY in its env so it can forward
+ * each to the correct child, but never imports the DB driver or the Claude
+ * Agent SDK itself — those live exclusively in sync.js / agent.js.
+ *
+ * Both children speak NDJSON on stdout. We line-buffer, parse, and dispatch.
+ *
+ * Bundle paths are env-overridable for tests; in production sandboxes the
+ * chat-api writes the three bundles to /workspace/{daemon,sync,agent}.js.
+ */
+
+const SYNC_BUNDLE_PATH = process.env.SANDBOX_SYNC_PATH ?? "/workspace/sync.js";
+const AGENT_BUNDLE_PATH =
+	process.env.SANDBOX_AGENT_PATH ?? "/workspace/agent.js";
+const BUN_EXECUTABLE = process.env.SANDBOX_BUN_PATH ?? "bun";
+
+export type SyncResult =
+	| { type: "synced"; changed: boolean; dataRoot: string }
+	| { type: "failed"; message: string };
+
+export type AgentEvent =
+	| { type: "text_delta"; text: string }
+	| { type: "session_id"; sessionId: string }
+	| { type: "completed" }
+	| { type: "failed"; message: string };
+
+async function* readNdjson(
+	stream: ReadableStream<Uint8Array>,
+): AsyncGenerator<Record<string, unknown>, void, void> {
+	const reader = stream.getReader();
+	const decoder = new TextDecoder();
+	let buf = "";
+	try {
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			buf += decoder.decode(value, { stream: true });
+			let nl = buf.indexOf("\n");
+			while (nl !== -1) {
+				const line = buf.slice(0, nl).trim();
+				buf = buf.slice(nl + 1);
+				if (line) {
+					try {
+						const parsed = JSON.parse(line);
+						if (typeof parsed === "object" && parsed !== null) {
+							yield parsed as Record<string, unknown>;
+						}
+					} catch {
+						// Non-JSON line — ignore (e.g. stray stderr leaking via stdout)
+					}
+				}
+				nl = buf.indexOf("\n");
+			}
+		}
+		if (buf.trim()) {
+			try {
+				const parsed = JSON.parse(buf.trim());
+				if (typeof parsed === "object" && parsed !== null) {
+					yield parsed as Record<string, unknown>;
+				}
+			} catch {}
+		}
+	} finally {
+		reader.releaseLock();
+	}
+}
+
+async function drainStderr(stream: ReadableStream<Uint8Array>): Promise<void> {
+	const reader = stream.getReader();
+	const decoder = new TextDecoder();
+	try {
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			const text = decoder.decode(value, { stream: true });
+			if (text.trim()) process.stderr.write(text);
+		}
+	} finally {
+		reader.releaseLock();
+	}
+}
+
+export async function spawnSync(input: {
+	userId: string;
+}): Promise<SyncResult> {
+	const proc = Bun.spawn(
+		[BUN_EXECUTABLE, SYNC_BUNDLE_PATH, "--user-id", input.userId],
+		{
+			env: {
+				DATABASE_URL: process.env.DATABASE_URL ?? "",
+				PATH: process.env.PATH ?? "",
+			},
+			stdout: "pipe",
+			stderr: "pipe",
+			stdin: "ignore",
+		},
+	);
+
+	const stderrPromise = drainStderr(proc.stderr);
+	let terminal: SyncResult | null = null;
+	for await (const event of readNdjson(proc.stdout)) {
+		if (event.type === "synced") {
+			terminal = {
+				type: "synced",
+				changed: event.changed === true,
+				dataRoot: typeof event.dataRoot === "string" ? event.dataRoot : "",
+			};
+		} else if (event.type === "failed") {
+			terminal = {
+				type: "failed",
+				message:
+					typeof event.message === "string" ? event.message : "sync failed",
+			};
+		}
+	}
+	await stderrPromise;
+	const exitCode = await proc.exited;
+
+	if (terminal) return terminal;
+	return {
+		type: "failed",
+		message: `sync exited with code ${exitCode} without emitting a terminal event`,
+	};
+}
+
+export interface SpawnAgentInput {
+	userQuery: string;
+	systemPrompt: string;
+	cwd: string;
+	sessionId?: string;
+	onEvent: (event: AgentEvent) => void | Promise<void>;
+}
+
+export interface SpawnAgentResult {
+	exitCode: number;
+}
+
+export async function spawnAgent(
+	input: SpawnAgentInput,
+): Promise<SpawnAgentResult> {
+	const { onEvent, ...config } = input;
+	const proc = Bun.spawn([BUN_EXECUTABLE, AGENT_BUNDLE_PATH], {
+		env: {
+			ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY ?? "",
+			PATH: process.env.PATH ?? "",
+			CLAUDE_CODE_PATH: process.env.CLAUDE_CODE_PATH ?? "/usr/local/bin/claude",
+		},
+		stdout: "pipe",
+		stderr: "pipe",
+		stdin: "pipe",
+	});
+
+	proc.stdin.write(JSON.stringify(config));
+	await proc.stdin.end();
+
+	const stderrPromise = drainStderr(proc.stderr);
+	for await (const event of readNdjson(proc.stdout)) {
+		if (
+			event.type === "text_delta" ||
+			event.type === "session_id" ||
+			event.type === "completed" ||
+			event.type === "failed"
+		) {
+			await onEvent(event as AgentEvent);
+		}
+	}
+	await stderrPromise;
+	const exitCode = await proc.exited;
+	return { exitCode };
+}

--- a/apps/sandbox-daemon/daemon-entry.ts
+++ b/apps/sandbox-daemon/daemon-entry.ts
@@ -1,3 +1,16 @@
+/**
+ * Daemon: long-running HTTP server in the E2B sandbox. Owns /turn, request
+ * locking, and streaming. Spawns sync.js and agent.js per turn — never
+ * imports DB code (drizzle/mysql2) or the Claude Agent SDK directly, so
+ * the daemon bundle's transitive graph stays minimal.
+ *
+ * Env:
+ *   DAEMON_PORT       — HTTP port (default 8080).
+ *   DAEMON_VERSION    — surfaced by /health for the chat-api bundle check.
+ *   DATABASE_URL      — held only to forward into sync.js's env.
+ *   ANTHROPIC_API_KEY — held only to forward into agent.js's env.
+ */
+
 import { Hono } from "hono";
 import currentRoutes from "./routes/current";
 import healthRoutes from "./routes/health";
@@ -19,7 +32,6 @@ app.onError((err, c) => {
 
 process.on("uncaughtException", (err) => {
 	console.error("Uncaught exception:", err);
-	// Do not exit — keep the daemon alive for health checks and future turns
 });
 process.on("unhandledRejection", (err) => {
 	console.error("Unhandled rejection:", err);

--- a/apps/sandbox-daemon/ipc-protocol.ts
+++ b/apps/sandbox-daemon/ipc-protocol.ts
@@ -1,0 +1,19 @@
+/**
+ * Wire protocol between the daemon and its sync.js / agent.js children.
+ *
+ * The three bundles are built and deployed independently, so the only
+ * thing keeping them in sync is this types module — imported by both
+ * producers (sync-entry, agent-entry) and the consumer (child-spawn).
+ * A typo in either side becomes a TypeScript error rather than a silent
+ * IPC mismatch at runtime.
+ */
+
+export type SyncEvent =
+	| { type: "synced"; changed: boolean; dataRoot: string }
+	| { type: "failed"; message: string };
+
+export type AgentEvent =
+	| { type: "text_delta"; text: string }
+	| { type: "session_id"; sessionId: string }
+	| { type: "completed" }
+	| { type: "failed"; message: string };

--- a/apps/sandbox-daemon/materialization.test.ts
+++ b/apps/sandbox-daemon/materialization.test.ts
@@ -132,12 +132,24 @@ describe("materialization", () => {
 			const dataRoot = join(testRoot, "count-test");
 			writeCanonicalFile(
 				dataRoot,
-				{ document_id: "a", type: 0, collections: [], content: "x", checksum: "c1" },
+				{
+					document_id: "a",
+					type: 0,
+					collections: [],
+					content: "x",
+					checksum: "c1",
+				},
 				emptyCollectionNames,
 			);
 			writeCanonicalFile(
 				dataRoot,
-				{ document_id: "b", type: 3, collections: [], content: "y", checksum: "c2" },
+				{
+					document_id: "b",
+					type: 3,
+					collections: [],
+					content: "y",
+					checksum: "c2",
+				},
 				emptyCollectionNames,
 			);
 			expect(countCanonicalFiles(dataRoot)).toBe(2);
@@ -567,10 +579,7 @@ describe("materialization", () => {
 
 			await writeIndexFile(dataRoot, entries, collectionNames);
 
-			const content = readFileSync(
-				`${dataRoot}/canonical/_index.md`,
-				"utf-8",
-			);
+			const content = readFileSync(`${dataRoot}/canonical/_index.md`, "utf-8");
 			expect(content).toContain("# Collections");
 			expect(content).toContain("## Research (col-A)");
 			expect(content).toContain("## Reading (col-B)");
@@ -597,10 +606,7 @@ describe("materialization", () => {
 				new Map(),
 			);
 
-			const content = readFileSync(
-				`${dataRoot}/canonical/_index.md`,
-				"utf-8",
-			);
+			const content = readFileSync(`${dataRoot}/canonical/_index.md`, "utf-8");
 			expect(content).toContain("## Uncategorized");
 			expect(content).toContain("- doc-1 (0/doc-1.md)");
 		});
@@ -622,10 +628,7 @@ describe("materialization", () => {
 				new Map(),
 			);
 
-			const content = readFileSync(
-				`${dataRoot}/canonical/_index.md`,
-				"utf-8",
-			);
+			const content = readFileSync(`${dataRoot}/canonical/_index.md`, "utf-8");
 			expect(content).toContain("## col-unknown (col-unknown)");
 		});
 
@@ -656,10 +659,7 @@ describe("materialization", () => {
 
 			await writeIndexFile(dataRoot, entries, collectionNames);
 
-			const content = readFileSync(
-				`${dataRoot}/canonical/_index.md`,
-				"utf-8",
-			);
+			const content = readFileSync(`${dataRoot}/canonical/_index.md`, "utf-8");
 			const alphaPos = content.indexOf("## Alpha");
 			const zebraPos = content.indexOf("## Zebra");
 			expect(alphaPos).toBeGreaterThan(-1);
@@ -685,10 +685,7 @@ describe("materialization", () => {
 				new Map([["col-A", "Collection\nName"]]),
 			);
 
-			const content = readFileSync(
-				`${dataRoot}/canonical/_index.md`,
-				"utf-8",
-			);
+			const content = readFileSync(`${dataRoot}/canonical/_index.md`, "utf-8");
 			// Newlines should be replaced with spaces, not injecting extra lines
 			expect(content).toContain("- Title With Newlines");
 			expect(content).toContain("## Collection Name (col-A)");
@@ -702,10 +699,7 @@ describe("materialization", () => {
 
 			await writeIndexFile(dataRoot, [], new Map());
 
-			const content = readFileSync(
-				`${dataRoot}/canonical/_index.md`,
-				"utf-8",
-			);
+			const content = readFileSync(`${dataRoot}/canonical/_index.md`, "utf-8");
 			expect(content).toContain("# Collections");
 			expect(content).not.toContain("## Uncategorized");
 		});

--- a/apps/sandbox-daemon/materialization.ts
+++ b/apps/sandbox-daemon/materialization.ts
@@ -133,9 +133,7 @@ export function writeCanonicalFile(
 	const cite = buildCitePath(doc);
 	const lines = ["---", `title: ${JSON.stringify(title)}`, `cite: ${cite}`];
 	if (doc.collections.length > 0) {
-		const names = doc.collections.map(
-			(id) => collectionNames.get(id) ?? id,
-		);
+		const names = doc.collections.map((id) => collectionNames.get(id) ?? id);
 		lines.push(`collections: ${JSON.stringify(names)}`);
 	}
 	lines.push("---", "", doc.content, "");

--- a/apps/sandbox-daemon/package.json
+++ b/apps/sandbox-daemon/package.json
@@ -3,7 +3,7 @@
 	"version": "0.1.0",
 	"type": "module",
 	"scripts": {
-		"build": "bun build ./index.ts --target=bun --minify --outfile=dist/index.js",
+		"build": "bun build ./daemon-entry.ts --target=bun --minify --outfile=dist/daemon.js && bun build ./sync-entry.ts --target=bun --minify --outfile=dist/sync.js && bun build ./agent-entry.ts --target=bun --minify --outfile=dist/agent.js",
 		"format": "biome format --write",
 		"lint": "biome lint --write",
 		"check": "biome check --write"

--- a/apps/sandbox-daemon/reconcile.test.ts
+++ b/apps/sandbox-daemon/reconcile.test.ts
@@ -253,9 +253,7 @@ describe("reconcile", () => {
 
 		expect(result).toBe(true);
 		expect(existsSync(`${dataRoot}/canonical/0/doc-new.md`)).toBe(true);
-		expect(existsSync(`${dataRoot}/collections/col-B/0/doc-new.md`)).toBe(
-			true,
-		);
+		expect(existsSync(`${dataRoot}/collections/col-B/0/doc-new.md`)).toBe(true);
 
 		const content = readFileSync(`${dataRoot}/canonical/0/doc-new.md`, "utf-8");
 		expect(content).toContain("New document content");

--- a/apps/sandbox-daemon/routes/turn.integration.test.ts
+++ b/apps/sandbox-daemon/routes/turn.integration.test.ts
@@ -11,16 +11,31 @@ import { mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Hono } from "hono";
+import type {
+	AgentEvent,
+	SpawnAgentInput,
+	SpawnAgentResult,
+	SyncResult,
+} from "../child-spawn";
 
-// Mock the agent module before importing the route
-const mockRunAgent = mock();
-mock.module("../agent", () => ({
-	runAgent: mockRunAgent,
-}));
-
-// Mock reconcile to avoid needing a real Postgres
-mock.module("../reconcile", () => ({
-	reconcile: mock(() => Promise.resolve(false)),
+// Mock spawnSync / spawnAgent — turn route no longer runs sync/agent
+// in-process. Sync now executes inside sync.js (spawned), agent inside
+// agent.js (spawned). The test stubs both functions to control behavior.
+const mockSpawnSync = mock(
+	async (_input: { userId: string }): Promise<SyncResult> => ({
+		type: "synced",
+		changed: false,
+		dataRoot: "/tmp/data",
+	}),
+);
+const mockSpawnAgent = mock(
+	async (_input: SpawnAgentInput): Promise<SpawnAgentResult> => ({
+		exitCode: 0,
+	}),
+);
+mock.module("../child-spawn", () => ({
+	spawnSync: mockSpawnSync,
+	spawnAgent: mockSpawnAgent,
 }));
 
 // Override getDataRoot to use a temp directory
@@ -50,7 +65,13 @@ describe("POST /turn integration", () => {
 	});
 
 	beforeEach(() => {
-		mockRunAgent.mockReset();
+		mockSpawnSync.mockReset();
+		mockSpawnSync.mockImplementation(async () => ({
+			type: "synced",
+			changed: false,
+			dataRoot: "/tmp/data",
+		}));
+		mockSpawnAgent.mockReset();
 	});
 
 	afterAll(() => {
@@ -66,7 +87,6 @@ describe("POST /turn integration", () => {
 			scope_type: "global",
 			message: "hello",
 			system_prompt: "you are helpful",
-			db_connection_string: "postgresql://localhost/test",
 			...overrides,
 		};
 	}
@@ -78,19 +98,24 @@ describe("POST /turn integration", () => {
 			.map((line) => JSON.parse(line));
 	}
 
-	it("streams text_delta events from agent", async () => {
-		mockRunAgent.mockImplementation(
-			async (
-				_opts: unknown,
-				callbacks: {
-					onTextDelta: (text: string) => void;
-					onCompleted: () => void;
-				},
-			) => {
-				callbacks.onTextDelta("Hello ");
-				callbacks.onTextDelta("World");
-				callbacks.onCompleted();
-			},
+	async function emitAgent(
+		input: SpawnAgentInput,
+		events: AgentEvent[],
+		exitCode = 0,
+	): Promise<SpawnAgentResult> {
+		for (const event of events) {
+			await input.onEvent(event);
+		}
+		return { exitCode };
+	}
+
+	it("streams text_delta events forwarded from agent.js", async () => {
+		mockSpawnAgent.mockImplementation((input) =>
+			emitAgent(input, [
+				{ type: "text_delta", text: "Hello " },
+				{ type: "text_delta", text: "World" },
+				{ type: "completed" },
+			]),
 		);
 
 		const res = await app.request("/turn", {
@@ -100,8 +125,7 @@ describe("POST /turn integration", () => {
 		});
 
 		expect(res.status).toBe(200);
-		const text = await res.text();
-		const events = parseNdjson(text);
+		const events = parseNdjson(await res.text());
 
 		const types = events.map((e) => e.type);
 		expect(types).toContain("started");
@@ -114,18 +138,12 @@ describe("POST /turn integration", () => {
 		expect(deltas).toEqual(["Hello ", "World"]);
 	});
 
-	it("streams session_id event", async () => {
-		mockRunAgent.mockImplementation(
-			async (
-				_opts: unknown,
-				callbacks: {
-					onSessionId: (id: string) => void;
-					onCompleted: () => void;
-				},
-			) => {
-				callbacks.onSessionId("sess-xyz");
-				callbacks.onCompleted();
-			},
+	it("forwards session_id from agent.js", async () => {
+		mockSpawnAgent.mockImplementation((input) =>
+			emitAgent(input, [
+				{ type: "session_id", sessionId: "sess-xyz" },
+				{ type: "completed" },
+			]),
 		);
 
 		const res = await app.request("/turn", {
@@ -134,16 +152,15 @@ describe("POST /turn integration", () => {
 			body: JSON.stringify(makeTurnBody()),
 		});
 
-		const text = await res.text();
-		const events = parseNdjson(text);
+		const events = parseNdjson(await res.text());
 
 		const sessionEvent = events.find((e) => e.type === "session_id");
 		expect(sessionEvent).toBeDefined();
 		expect(sessionEvent?.sessionId).toBe("sess-xyz");
 	});
 
-	it("emits failed event when agent throws", async () => {
-		mockRunAgent.mockRejectedValue(new Error("agent exploded"));
+	it("emits failed when spawnAgent throws", async () => {
+		mockSpawnAgent.mockRejectedValue(new Error("agent exploded"));
 
 		const res = await app.request("/turn", {
 			method: "POST",
@@ -151,22 +168,15 @@ describe("POST /turn integration", () => {
 			body: JSON.stringify(makeTurnBody()),
 		});
 
-		const text = await res.text();
-		const events = parseNdjson(text);
-
-		const failedEvent = events.find((e) => e.type === "failed");
-		expect(failedEvent).toBeDefined();
-		expect(failedEvent?.message).toContain("agent exploded");
+		const events = parseNdjson(await res.text());
+		const failed = events.find((e) => e.type === "failed");
+		expect(failed).toBeDefined();
+		expect(failed?.message).toContain("agent exploded");
 	});
 
-	it("emits failed event from onFailed callback", async () => {
-		mockRunAgent.mockImplementation(
-			async (
-				_opts: unknown,
-				callbacks: { onFailed: (msg: string) => void },
-			) => {
-				callbacks.onFailed("agent ended badly");
-			},
+	it("emits failed when agent.js emits a failed event", async () => {
+		mockSpawnAgent.mockImplementation((input) =>
+			emitAgent(input, [{ type: "failed", message: "agent ended badly" }], 1),
 		);
 
 		const res = await app.request("/turn", {
@@ -175,12 +185,30 @@ describe("POST /turn integration", () => {
 			body: JSON.stringify(makeTurnBody()),
 		});
 
-		const text = await res.text();
-		const events = parseNdjson(text);
+		const events = parseNdjson(await res.text());
+		const failed = events.find((e) => e.type === "failed");
+		expect(failed).toBeDefined();
+		expect(failed?.message).toBe("agent ended badly");
+	});
 
-		const failedEvent = events.find((e) => e.type === "failed");
-		expect(failedEvent).toBeDefined();
-		expect(failedEvent?.message).toBe("agent ended badly");
+	it("emits failed when sync.js fails", async () => {
+		mockSpawnSync.mockImplementation(async () => ({
+			type: "failed",
+			message: "DB unreachable",
+		}));
+
+		const res = await app.request("/turn", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(makeTurnBody()),
+		});
+
+		const events = parseNdjson(await res.text());
+		const failed = events.find((e) => e.type === "failed");
+		expect(failed).toBeDefined();
+		expect(failed?.message).toContain("DB unreachable");
+		// Agent must not be spawned if sync failed
+		expect(mockSpawnAgent).not.toHaveBeenCalled();
 	});
 
 	it("returns 409 when a turn is already in progress", async () => {
@@ -188,14 +216,14 @@ describe("POST /turn integration", () => {
 		const agentPromise = new Promise<void>((resolve) => {
 			resolveAgent = resolve;
 		});
-		mockRunAgent.mockImplementation(async () => {
+		mockSpawnAgent.mockImplementation(async () => {
 			await agentPromise;
+			return { exitCode: 0 };
 		});
 
 		const body1 = makeTurnBody();
 		const body2 = makeTurnBody();
 
-		// Start first turn (don't await — it blocks on the agent)
 		const req1Promise = app.request("/turn", {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
@@ -205,7 +233,6 @@ describe("POST /turn integration", () => {
 		// Give the first request time to acquire the lock
 		await new Promise((r) => setTimeout(r, 100));
 
-		// Second request should get 409
 		const res2 = await app.request("/turn", {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
@@ -216,7 +243,6 @@ describe("POST /turn integration", () => {
 		const errorBody = await res2.json();
 		expect(errorBody.error).toContain("Turn already in progress");
 
-		// Clean up: resolve the agent to release the lock
 		resolveAgent();
 		await req1Promise;
 	});

--- a/apps/sandbox-daemon/routes/turn.ts
+++ b/apps/sandbox-daemon/routes/turn.ts
@@ -1,7 +1,7 @@
 import { mkdirSync } from "node:fs";
 import { Hono } from "hono";
 import { stream } from "hono/streaming";
-import { runAgent } from "../agent";
+import { spawnAgent, spawnSync } from "../child-spawn";
 import {
 	createEphemeralDocumentScope,
 	findCanonicalDoc,
@@ -9,7 +9,6 @@ import {
 	removeEphemeralDocumentScope,
 	resolveScopeCwd,
 } from "../materialization";
-import { reconcile } from "../reconcile";
 import { acquireTurn } from "../turn-lock";
 
 const app = new Hono();
@@ -68,8 +67,16 @@ app.post("/turn", async (c) => {
 			try {
 				await s.write(ndjsonLine({ type: "started", turn_id: request_id }));
 
-				// reconcile() calls ensureDataRoot internally.
-				await reconcile({ userId: user_id });
+				const syncResult = await spawnSync({ userId: user_id });
+				if (syncResult.type === "failed") {
+					await s.write(
+						ndjsonLine({
+							type: "failed",
+							message: `sync failed: ${syncResult.message}`,
+						}),
+					);
+					return;
+				}
 
 				if (scope_type === "collection" && !collection_id) {
 					await s.write(
@@ -114,37 +121,36 @@ app.post("/turn", async (c) => {
 						scope_type,
 						collection_id ?? undefined,
 					);
-					// Ensure cwd exists (e.g. empty collection with no files)
 					mkdirSync(cwd, { recursive: true });
 				}
 
 				let turnFailed = false;
-
-				await runAgent(
-					{
-						userQuery: message,
-						systemPrompt: system_prompt,
-						cwd,
-						sessionId: agent_session_id,
-					},
-					{
-						onTextDelta: async (text) => {
-							await s.write(ndjsonLine({ type: "text_delta", text }));
-						},
-						onSessionId: async (sessionId) => {
-							await s.write(ndjsonLine({ type: "session_id", sessionId }));
-						},
-						onCompleted: async () => {
-							// Session ID persistence handled by the chat-api caller
-						},
-						onFailed: async (errorMessage) => {
+				const agentResult = await spawnAgent({
+					userQuery: message,
+					systemPrompt: system_prompt,
+					cwd,
+					sessionId: agent_session_id,
+					onEvent: async (event) => {
+						if (event.type === "completed") {
+							// We emit our own `completed` below.
+							return;
+						}
+						if (event.type === "failed") {
 							turnFailed = true;
-							await s.write(
-								ndjsonLine({ type: "failed", message: errorMessage }),
-							);
-						},
+						}
+						await s.write(ndjsonLine(event));
 					},
-				);
+				});
+
+				if (agentResult.exitCode !== 0 && !turnFailed) {
+					turnFailed = true;
+					await s.write(
+						ndjsonLine({
+							type: "failed",
+							message: `agent exited with code ${agentResult.exitCode}`,
+						}),
+					);
+				}
 
 				if (!turnFailed) {
 					await s.write(ndjsonLine({ type: "completed" }));

--- a/apps/sandbox-daemon/sync-entry.ts
+++ b/apps/sandbox-daemon/sync-entry.ts
@@ -1,0 +1,63 @@
+/**
+ * Sync command: reconciles the local filesystem with the database for a
+ * single user, then exits. Spawned per-turn by the daemon.
+ *
+ * Usage:   bun sync.js --user-id <id>
+ * Stdout:  NDJSON. Exactly one terminal event per run:
+ *            { type: "synced", changed: boolean, dataRoot: "..." }
+ *            { type: "failed", message: "..." }
+ * Exit:    0 on success, 1 on failure.
+ *
+ * Required env: DATABASE_URL
+ *
+ * No other code path inside the daemon process reaches DB code — this
+ * entrypoint owns the only import of @mymemo/db / drizzle-orm in the
+ * sandbox bundle graph.
+ */
+
+import { getDataRoot } from "./materialization";
+import { reconcile } from "./reconcile";
+
+function emit(obj: Record<string, unknown>): void {
+	process.stdout.write(`${JSON.stringify(obj)}\n`);
+}
+
+function parseArgs(argv: string[]): { userId: string } {
+	const idx = argv.indexOf("--user-id");
+	if (idx === -1 || !argv[idx + 1]) {
+		throw new Error("--user-id <id> required");
+	}
+	return { userId: argv[idx + 1] as string };
+}
+
+async function main() {
+	if (!process.env.DATABASE_URL) {
+		emit({ type: "failed", message: "DATABASE_URL not set in sync env" });
+		process.exit(1);
+	}
+
+	let userId: string;
+	try {
+		({ userId } = parseArgs(process.argv.slice(2)));
+	} catch (err) {
+		emit({
+			type: "failed",
+			message: err instanceof Error ? err.message : String(err),
+		});
+		process.exit(1);
+	}
+
+	try {
+		const changed = await reconcile({ userId });
+		emit({ type: "synced", changed, dataRoot: getDataRoot(userId) });
+		process.exit(0);
+	} catch (err) {
+		emit({
+			type: "failed",
+			message: err instanceof Error ? err.message : String(err),
+		});
+		process.exit(1);
+	}
+}
+
+main();

--- a/apps/sandbox-daemon/sync-entry.ts
+++ b/apps/sandbox-daemon/sync-entry.ts
@@ -23,6 +23,27 @@ function emit(event: SyncEvent): void {
 	process.stdout.write(`${JSON.stringify(event)}\n`);
 }
 
+// Walk the .cause chain so wrapper errors (e.g. drizzle's DrizzleQueryError,
+// which sets .message to "Failed query: ..." regardless of the underlying
+// failure mode) don't hide the actual reason in the daemon log.
+function describeError(err: unknown): string {
+	const parts: string[] = [];
+	let cur: unknown = err;
+	const seen = new Set<unknown>();
+	while (cur && !seen.has(cur)) {
+		seen.add(cur);
+		if (cur instanceof Error) {
+			const code = (cur as Error & { code?: string }).code;
+			parts.push(code ? `${cur.message} [${code}]` : cur.message);
+			cur = (cur as Error & { cause?: unknown }).cause;
+		} else {
+			parts.push(String(cur));
+			break;
+		}
+	}
+	return parts.join(" <- ");
+}
+
 function parseArgs(argv: string[]): { userId: string } {
 	const idx = argv.indexOf("--user-id");
 	if (idx === -1 || !argv[idx + 1]) {
@@ -41,10 +62,7 @@ async function main() {
 	try {
 		({ userId } = parseArgs(process.argv.slice(2)));
 	} catch (err) {
-		emit({
-			type: "failed",
-			message: err instanceof Error ? err.message : String(err),
-		});
+		emit({ type: "failed", message: describeError(err) });
 		process.exit(1);
 	}
 
@@ -53,10 +71,7 @@ async function main() {
 		emit({ type: "synced", changed, dataRoot: getDataRoot(userId) });
 		process.exit(0);
 	} catch (err) {
-		emit({
-			type: "failed",
-			message: err instanceof Error ? err.message : String(err),
-		});
+		emit({ type: "failed", message: describeError(err) });
 		process.exit(1);
 	}
 }

--- a/apps/sandbox-daemon/sync-entry.ts
+++ b/apps/sandbox-daemon/sync-entry.ts
@@ -15,11 +15,12 @@
  * sandbox bundle graph.
  */
 
+import type { SyncEvent } from "./ipc-protocol";
 import { getDataRoot } from "./materialization";
 import { reconcile } from "./reconcile";
 
-function emit(obj: Record<string, unknown>): void {
-	process.stdout.write(`${JSON.stringify(obj)}\n`);
+function emit(event: SyncEvent): void {
+	process.stdout.write(`${JSON.stringify(event)}\n`);
 }
 
 function parseArgs(argv: string[]): { userId: string } {


### PR DESCRIPTION
## Summary

Replace the single `sandbox-daemon` bundle with three bundles deployed side-by-side in the E2B sandbox. Per the proposed design: **daemon is the only long-running public/control process; sync and agent are per-turn executables**.

### The three bundles

| Bundle | Lifetime | Role | Env | Size |
|---|---|---|---|---|
| `daemon.js` | long-running HTTP server | Owns `/turn`, `/health`, `/current`, request locking, streaming. Spawns the other two. | `DATABASE_URL`, `ANTHROPIC_API_KEY` (forwarded to children) | ~27 KB |
| `sync.js` | spawned per turn | DB reads + filesystem materialization. CLI: `bun sync.js --user-id <id>`. | `DATABASE_URL` only | ~1.1 MB |
| `agent.js` | spawned per turn | Claude Agent SDK execution. Reads JSON config on stdin. | `ANTHROPIC_API_KEY` only | ~0.6 MB |

Both children speak NDJSON on stdout; the daemon line-buffers, parses, and dispatches via `child-spawn.ts` (the only place `Bun.spawn` lives).

### Privilege boundary

Enforced at the **bundle graph level** — not just env. The daemon bundle contains **zero** references to `drizzle-orm`, `mysql2`, `@anthropic-ai/claude-agent-sdk`, or DB schema names (verified via grep on `dist/daemon.js`). Sync owns the only import of `@mymemo/db`; agent owns the only import of the Claude SDK. If the daemon process is ever compromised, it cannot directly query the DB or call the SDK — only spawn its children, which themselves have minimal env.

### Flow

```
daemon receives /turn
  acquire lock
  spawn sync.js --user-id ...       env: { DATABASE_URL }
    read NDJSON: { type: \"synced\" | \"failed\" }
    on failed → emit `failed` event, abort
  prepare scope (cwd resolution, ephemeral document scope)
  spawn agent.js                    env: { ANTHROPIC_API_KEY }
    pipe { userQuery, systemPrompt, cwd, sessionId? } to stdin
    forward NDJSON events to HTTP response stream
  emit `completed`
  release lock
```

### chat-api side

`sandbox-manager.ts` now loads and deploys **all three bundles**, hashing them together for the daemon version check so any change to any bundle triggers a redeploy + restart. Daemon process still receives both secrets in its env — it forwards each to the correct child via `Bun.spawn`'s `env` option.

### Out of scope (follow-up)

Bwrap-wrapping the agent spawn — this PR delivers the process split that makes that wrap a small change. Once we wrap `[\"bwrap\", ...flags..., \"bun\", \"/workspace/agent.js\"]` in `spawnAgent`, the agent runs with read-only scope-restricted FS access.

## Test plan

- [x] \`bun test\` (sandbox-daemon) — 77/77 pass, including a fully-rewritten turn integration test that mocks the new \`child-spawn\` module instead of the old in-process \`runAgent\`/\`reconcile\`.
- [x] \`bun test\` (chat-api) — 35/35 pass; sandbox-manager bundle-loading updated.
- [x] \`bunx tsc --noEmit\` (chat-api) — only the two pre-existing errors in \`scripts/probe-agent-tools.ts\` (unrelated).
- [x] \`bun run build\` (sandbox-daemon) — produces dist/{daemon,sync,agent}.js. Verified \`grep -c \"drizzle-orm|mysql2|@anthropic-ai/claude-agent-sdk|userFiles\" dist/daemon.js\` returns **0**.
- [ ] End-to-end exercise via E2B integration script after merge (touches a live sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)