### PR TITLE
feat(sandbox-daemon): timeouts for spawnSync and spawnAgent

### DIFF
--- a/apps/sandbox-daemon/child-spawn.test.ts
+++ b/apps/sandbox-daemon/child-spawn.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Real-subprocess timeout tests for spawnSync / spawnAgent. We write tiny
+ * fixture scripts to a tmpdir and point the env-overridable paths at them,
+ * so we exercise the actual Bun.spawn + NDJSON + watchdog wiring rather
+ * than mocking it.
+ */
+
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+} from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type AgentEvent, spawnAgent, spawnSync } from "./child-spawn";
+
+let tmpDir: string;
+const fixtures: Record<string, string> = {};
+
+beforeAll(() => {
+	tmpDir = mkdtempSync(join(tmpdir(), "child-spawn-"));
+
+	// Sync that never exits.
+	fixtures.syncHang = join(tmpDir, "sync-hang.ts");
+	writeFileSync(fixtures.syncHang, `await new Promise(() => {});\n`);
+
+	// Sync that emits a synced event and exits 0.
+	fixtures.syncOk = join(tmpDir, "sync-ok.ts");
+	writeFileSync(
+		fixtures.syncOk,
+		`process.stdout.write(JSON.stringify({ type: "synced", changed: false, dataRoot: "/tmp" }) + "\\n");\nprocess.exit(0);\n`,
+	);
+
+	// Agent that consumes stdin then hangs (idle forever).
+	fixtures.agentHang = join(tmpDir, "agent-hang.ts");
+	writeFileSync(
+		fixtures.agentHang,
+		`for await (const _ of process.stdin) {}\nawait new Promise(() => {});\n`,
+	);
+
+	// Agent that emits 5 text_delta events 80ms apart, then completes.
+	// Total wall-clock ~400ms; max gap ~80ms — survives any idle threshold > 80ms.
+	fixtures.agentSlow = join(tmpDir, "agent-slow.ts");
+	writeFileSync(
+		fixtures.agentSlow,
+		`for await (const _ of process.stdin) {}\nfor (let i = 0; i < 5; i++) {\n  process.stdout.write(JSON.stringify({ type: "text_delta", text: "tick" }) + "\\n");\n  await new Promise((r) => setTimeout(r, 80));\n}\nprocess.stdout.write(JSON.stringify({ type: "completed" }) + "\\n");\nprocess.exit(0);\n`,
+	);
+});
+
+afterAll(() => {
+	rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const TIMEOUT_ENV_VARS = [
+	"SANDBOX_SYNC_PATH",
+	"SANDBOX_AGENT_PATH",
+	"SANDBOX_SYNC_TIMEOUT_MS",
+	"SANDBOX_AGENT_IDLE_TIMEOUT_MS",
+];
+
+beforeEach(() => {
+	for (const key of TIMEOUT_ENV_VARS) delete process.env[key];
+});
+afterEach(() => {
+	for (const key of TIMEOUT_ENV_VARS) delete process.env[key];
+});
+
+describe("spawnSync wall-clock timeout", () => {
+	it("returns failed when child exceeds timeout", async () => {
+		process.env.SANDBOX_SYNC_PATH = fixtures.syncHang;
+		process.env.SANDBOX_SYNC_TIMEOUT_MS = "200";
+
+		const start = Date.now();
+		const result = await spawnSync({ userId: "u1" });
+		const elapsed = Date.now() - start;
+
+		expect(result.type).toBe("failed");
+		if (result.type === "failed") {
+			expect(result.message).toContain("timed out");
+			expect(result.message).toContain("200");
+		}
+		// 200ms timeout + spawn/teardown overhead. Cap at 5s to catch hangs.
+		expect(elapsed).toBeLessThan(5_000);
+	});
+
+	it("succeeds when child finishes within timeout", async () => {
+		process.env.SANDBOX_SYNC_PATH = fixtures.syncOk;
+		process.env.SANDBOX_SYNC_TIMEOUT_MS = "10000";
+
+		const result = await spawnSync({ userId: "u1" });
+
+		expect(result.type).toBe("synced");
+		if (result.type === "synced") {
+			expect(result.dataRoot).toBe("/tmp");
+		}
+	});
+});
+
+describe("spawnAgent idle timeout", () => {
+	function makeInput(onEvent: (e: AgentEvent) => void) {
+		return {
+			userQuery: "test",
+			systemPrompt: "test",
+			cwd: "/tmp",
+			onEvent,
+		};
+	}
+
+	it("kills child and emits failed when no events arrive", async () => {
+		process.env.SANDBOX_AGENT_PATH = fixtures.agentHang;
+		process.env.SANDBOX_AGENT_IDLE_TIMEOUT_MS = "200";
+
+		const events: AgentEvent[] = [];
+		const start = Date.now();
+		await spawnAgent(makeInput((e) => events.push(e)));
+		const elapsed = Date.now() - start;
+
+		expect(elapsed).toBeLessThan(5_000);
+		const failed = events.find((e) => e.type === "failed");
+		expect(failed).toBeDefined();
+		if (failed?.type === "failed") {
+			expect(failed.message).toContain("idle timeout");
+			expect(failed.message).toContain("200");
+		}
+	});
+
+	it("does not fire while events keep arriving (timer resets)", async () => {
+		process.env.SANDBOX_AGENT_PATH = fixtures.agentSlow;
+		// 300ms idle window; child emits every 80ms — well under threshold.
+		process.env.SANDBOX_AGENT_IDLE_TIMEOUT_MS = "300";
+
+		const events: AgentEvent[] = [];
+		const result = await spawnAgent(makeInput((e) => events.push(e)));
+
+		expect(result.exitCode).toBe(0);
+		expect(events.find((e) => e.type === "failed")).toBeUndefined();
+		const deltas = events.filter((e) => e.type === "text_delta");
+		expect(deltas.length).toBe(5);
+	});
+});

--- a/apps/sandbox-daemon/child-spawn.ts
+++ b/apps/sandbox-daemon/child-spawn.ts
@@ -15,10 +15,24 @@ import type { AgentEvent, SyncEvent } from "./ipc-protocol";
 export type { AgentEvent, SyncEvent } from "./ipc-protocol";
 export type SyncResult = SyncEvent;
 
-const SYNC_BUNDLE_PATH = process.env.SANDBOX_SYNC_PATH ?? "/workspace/sync.js";
-const AGENT_BUNDLE_PATH =
+// Resolved at call time so tests can swap env vars per scenario.
+const getSyncBundlePath = () =>
+	process.env.SANDBOX_SYNC_PATH ?? "/workspace/sync.js";
+const getAgentBundlePath = () =>
 	process.env.SANDBOX_AGENT_PATH ?? "/workspace/agent.js";
-const BUN_EXECUTABLE = process.env.SANDBOX_BUN_PATH ?? "bun";
+const getBunExecutable = () => process.env.SANDBOX_BUN_PATH ?? "bun";
+
+// Sync is bounded work (DB read + filesystem write); a wall-clock cap
+// is appropriate. Agent is a streaming workload so we use an idle
+// timeout instead — reset on every event from agent.js.
+const DEFAULT_SYNC_TIMEOUT_MS = 120_000;
+const DEFAULT_AGENT_IDLE_TIMEOUT_MS = 120_000;
+const getSyncTimeoutMs = () =>
+	Number(process.env.SANDBOX_SYNC_TIMEOUT_MS ?? DEFAULT_SYNC_TIMEOUT_MS);
+const getAgentIdleTimeoutMs = () =>
+	Number(
+		process.env.SANDBOX_AGENT_IDLE_TIMEOUT_MS ?? DEFAULT_AGENT_IDLE_TIMEOUT_MS,
+	);
 
 function narrowAgentEvent(raw: Record<string, unknown>): AgentEvent | null {
 	switch (raw.type) {
@@ -99,8 +113,9 @@ async function drainStderr(stream: ReadableStream<Uint8Array>): Promise<void> {
 export async function spawnSync(input: {
 	userId: string;
 }): Promise<SyncResult> {
+	const timeoutMs = getSyncTimeoutMs();
 	const proc = Bun.spawn(
-		[BUN_EXECUTABLE, SYNC_BUNDLE_PATH, "--user-id", input.userId],
+		[getBunExecutable(), getSyncBundlePath(), "--user-id", input.userId],
 		{
 			env: {
 				DATABASE_URL: process.env.DATABASE_URL ?? "",
@@ -112,31 +127,47 @@ export async function spawnSync(input: {
 		},
 	);
 
-	const stderrPromise = drainStderr(proc.stderr);
-	let terminal: SyncEvent | null = null;
-	for await (const event of readNdjson(proc.stdout)) {
-		if (
-			event.type === "synced" &&
-			typeof event.changed === "boolean" &&
-			typeof event.dataRoot === "string"
-		) {
-			terminal = {
-				type: "synced",
-				changed: event.changed,
-				dataRoot: event.dataRoot,
-			};
-		} else if (event.type === "failed" && typeof event.message === "string") {
-			terminal = { type: "failed", message: event.message };
-		}
-	}
-	await stderrPromise;
-	const exitCode = await proc.exited;
+	let timedOut = false;
+	const timer = setTimeout(() => {
+		timedOut = true;
+		proc.kill("SIGKILL");
+	}, timeoutMs);
 
-	if (terminal) return terminal;
-	return {
-		type: "failed",
-		message: `sync exited with code ${exitCode} without emitting a terminal event`,
-	};
+	try {
+		const stderrPromise = drainStderr(proc.stderr);
+		let terminal: SyncEvent | null = null;
+		for await (const event of readNdjson(proc.stdout)) {
+			if (
+				event.type === "synced" &&
+				typeof event.changed === "boolean" &&
+				typeof event.dataRoot === "string"
+			) {
+				terminal = {
+					type: "synced",
+					changed: event.changed,
+					dataRoot: event.dataRoot,
+				};
+			} else if (event.type === "failed" && typeof event.message === "string") {
+				terminal = { type: "failed", message: event.message };
+			}
+		}
+		await stderrPromise;
+		const exitCode = await proc.exited;
+
+		if (timedOut) {
+			return {
+				type: "failed",
+				message: `sync timed out after ${timeoutMs}ms`,
+			};
+		}
+		if (terminal) return terminal;
+		return {
+			type: "failed",
+			message: `sync exited with code ${exitCode} without emitting a terminal event`,
+		};
+	} finally {
+		clearTimeout(timer);
+	}
 }
 
 export interface SpawnAgentInput {
@@ -155,7 +186,8 @@ export async function spawnAgent(
 	input: SpawnAgentInput,
 ): Promise<SpawnAgentResult> {
 	const { onEvent, ...config } = input;
-	const proc = Bun.spawn([BUN_EXECUTABLE, AGENT_BUNDLE_PATH], {
+	const idleMs = getAgentIdleTimeoutMs();
+	const proc = Bun.spawn([getBunExecutable(), getAgentBundlePath()], {
 		env: {
 			ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY ?? "",
 			PATH: process.env.PATH ?? "",
@@ -169,12 +201,35 @@ export async function spawnAgent(
 	proc.stdin.write(JSON.stringify(config));
 	await proc.stdin.end();
 
-	const stderrPromise = drainStderr(proc.stderr);
-	for await (const event of readNdjson(proc.stdout)) {
-		const narrowed = narrowAgentEvent(event);
-		if (narrowed) await onEvent(narrowed);
+	let timedOut = false;
+	let idleTimer: ReturnType<typeof setTimeout>;
+	const armIdleTimer = () => {
+		clearTimeout(idleTimer);
+		idleTimer = setTimeout(() => {
+			timedOut = true;
+			proc.kill("SIGKILL");
+		}, idleMs);
+	};
+	armIdleTimer();
+
+	try {
+		const stderrPromise = drainStderr(proc.stderr);
+		for await (const event of readNdjson(proc.stdout)) {
+			armIdleTimer();
+			const narrowed = narrowAgentEvent(event);
+			if (narrowed) await onEvent(narrowed);
+		}
+		await stderrPromise;
+		const exitCode = await proc.exited;
+
+		if (timedOut) {
+			await onEvent({
+				type: "failed",
+				message: `agent idle timeout: no events for ${idleMs}ms`,
+			});
+		}
+		return { exitCode };
+	} finally {
+		clearTimeout(idleTimer);
 	}
-	await stderrPromise;
-	const exitCode = await proc.exited;
-	return { exitCode };
 }


### PR DESCRIPTION
## Summary

- `spawnSync` gets a wall-clock timeout (default **120s**, `SANDBOX_SYNC_TIMEOUT_MS`). On timeout, SIGKILLs the child and returns `{ type: "failed", message: "sync timed out after Nms" }`.
- `spawnAgent` gets an **idle** timeout (default **120s**, `SANDBOX_AGENT_IDLE_TIMEOUT_MS`). The watchdog resets on every NDJSON event, so a long valid turn survives — only true hangs (no events arriving) trigger the kill. On timeout the agent is SIGKILLed and a synthetic `failed` event is emitted through the existing `onEvent` callback, so `routes/turn.ts`'s failure plumbing fires unchanged.
- Bundle path resolution moved from module-load constants to call-time `process.env` reads, enabling per-test fixture swapping without dynamic imports.
- Followup to the issue raised in #99 review (no timeouts on per-turn children).

## Why these defaults
- Sync is bounded work (single DB read + filesystem materialization). 120s is generous for cold starts on large users while still failing fast if the DB is unreachable.
- Agent streams responses, so wall-clock would kill legitimate long turns. An idle threshold catches the actual failure mode (SDK / API hangs) without that risk.

## Test plan

- [x] `bun test` (sandbox-daemon) — 81/81 pass (was 77; +4 in new `child-spawn.test.ts` covering sync timeout, sync success, agent idle timeout, agent surviving long runs with frequent events).
- [x] `bunx tsc --noEmit` (chat-api) — only the two pre-existing `scripts/probe-agent-tools.ts` errors.
- [x] `bun run build` (sandbox-daemon) — produces dist/{daemon,sync,agent}.js. `grep -cE "drizzle-orm|mysql2|@anthropic-ai/claude-agent-sdk" dist/daemon.js` returns **0** (privilege boundary preserved).
- [ ] End-to-end exercise via E2B integration script after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)