### PR TITLE
refactor(sandbox-daemon): replace HMAC-derived token with fixed DAEMON_AUTH_TOKEN

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,7 +141,7 @@ Required:
 - `DEEPSEEK_API_KEY`
 - `E2B_API_KEY`
 - `DATABASE_URL`
-- `DAEMON_AUTH_SECRET`
+- `DAEMON_AUTH_TOKEN`
 
 Optional:
 - `LOG_LEVEL` (default: `info`)

--- a/apps/chat-api/README.md
+++ b/apps/chat-api/README.md
@@ -132,7 +132,7 @@ When running the development server, interactive API documentation is available 
 |----------|-------------|----------|
 | `OPENAI_API_KEY` | OpenAI API key for chat functionality | Yes |
 | `E2B_API_KEY` | API key for the sandbox prototype script | Yes (for prototype) |
-| `DAEMON_AUTH_SECRET` | Server secret used to derive per-sandbox daemon auth tokens | Yes |
+| `DAEMON_AUTH_TOKEN` | Shared secret presented on every daemon `/turn` request | Yes |
 | `E2B_TEMPLATE` | E2B sandbox template for the prototype script | Yes (for prototype) |
 | `PORT` | Server port (default: 3000) | No |
 | `PROTECTED_API_PREFIX` | Path prefix used when forwarding chat entities (e.g. `/beta-api` or `/api`) | No |

--- a/apps/chat-api/src/config/env.ts
+++ b/apps/chat-api/src/config/env.ts
@@ -12,14 +12,14 @@ export const apiEnv = (() => {
 	invariant(Bun.env.DEEPSEEK_API_KEY, "DEEPSEEK_API_KEY is required");
 	invariant(Bun.env.E2B_API_KEY, "E2B_API_KEY is required");
 	invariant(Bun.env.DATABASE_URL, "DATABASE_URL is required");
-	invariant(Bun.env.DAEMON_AUTH_SECRET, "DAEMON_AUTH_SECRET is required");
+	invariant(Bun.env.DAEMON_AUTH_TOKEN, "DAEMON_AUTH_TOKEN is required");
 
 	return {
 		DATABASE_URL: Bun.env.DATABASE_URL,
 		OPENAI_API_KEY: Bun.env.OPENAI_API_KEY,
 		ANTHROPIC_API_KEY: Bun.env.ANTHROPIC_API_KEY,
 		DEEPSEEK_API_KEY: Bun.env.DEEPSEEK_API_KEY,
-		DAEMON_AUTH_SECRET: Bun.env.DAEMON_AUTH_SECRET,
+		DAEMON_AUTH_TOKEN: Bun.env.DAEMON_AUTH_TOKEN,
 		DEEPSEEK_BASE_URL: Bun.env.DEEPSEEK_BASE_URL || null,
 		DEEPSEEK_DEFAULT_MODEL:
 			Bun.env.DEEPSEEK_DEFAULT_MODEL || DEFAULT_DEEPSEEK_MODEL,

--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-manager.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-manager.ts
@@ -1,4 +1,3 @@
-import { createHmac } from "node:crypto";
 import { resolve } from "node:path";
 import { Sandbox } from "e2b";
 import { apiEnv } from "@/config/env";
@@ -79,12 +78,6 @@ async function loadSandboxBundles(): Promise<SandboxBundleSet> {
 }
 
 export class SandboxManager {
-	private getDaemonAuthToken(sandbox: Sandbox): string {
-		return createHmac("sha256", apiEnv.DAEMON_AUTH_SECRET)
-			.update(sandbox.sandboxId)
-			.digest("hex");
-	}
-
 	async getOrCreateSandbox(
 		userId: string,
 		sandboxId: string | null,
@@ -163,7 +156,7 @@ export class SandboxManager {
 
 	/**
 	 * Ensure the sandbox daemon is running and up-to-date.
-	 * Returns the daemon URL.
+	 * Returns the daemon URL and the fixed auth token clients must present.
 	 */
 	async ensureSandboxDaemon(
 		userId: string,
@@ -171,14 +164,14 @@ export class SandboxManager {
 		logger: SyncLogger,
 	): Promise<SandboxDaemonEndpoint> {
 		const daemonUrl = this.getDaemonUrl(sandbox);
-		const authToken = this.getDaemonAuthToken(sandbox);
+		const endpoint = { url: daemonUrl, authToken: apiEnv.DAEMON_AUTH_TOKEN };
 
 		const bundles = await getSandboxBundles();
 
 		try {
 			const health = await this.checkDaemonHealth(daemonUrl);
 			if (health && health.version === bundles.version) {
-				return { url: daemonUrl, authToken };
+				return endpoint;
 			}
 
 			if (health) {
@@ -187,8 +180,8 @@ export class SandboxManager {
 					currentVersion: health.version,
 					expectedVersion: bundles.version,
 				});
-				await this.restartDaemon(sandbox, logger, bundles, authToken);
-				return { url: daemonUrl, authToken };
+				await this.restartDaemon(sandbox, logger, bundles);
+				return endpoint;
 			}
 		} catch {
 			// Daemon not running, deploy it
@@ -200,8 +193,8 @@ export class SandboxManager {
 			sandboxId: sandbox.sandboxId,
 		});
 
-		await this.deploySandboxBundles(sandbox, logger, bundles, authToken);
-		return { url: daemonUrl, authToken };
+		await this.deploySandboxBundles(sandbox, logger, bundles);
+		return endpoint;
 	}
 
 	getDaemonUrl(sandbox: Sandbox): string {
@@ -231,7 +224,6 @@ export class SandboxManager {
 		sandbox: Sandbox,
 		logger: SyncLogger,
 		bundles: SandboxBundleSet,
-		authToken: string,
 	): Promise<void> {
 		await sandbox.files.write(
 			bundles.files.map(({ sandboxPath, code }) => ({
@@ -240,14 +232,13 @@ export class SandboxManager {
 			})),
 		);
 
-		await this.startDaemonProcess(sandbox, logger, bundles.version, authToken);
+		await this.startDaemonProcess(sandbox, logger, bundles.version);
 	}
 
 	private async restartDaemon(
 		sandbox: Sandbox,
 		logger: SyncLogger,
 		bundles: SandboxBundleSet,
-		authToken: string,
 	): Promise<void> {
 		// Kill whatever process owns port 8080 (process name may not match pkill pattern)
 		await sandbox.commands.run("kill $(lsof -ti :8080) 2>/dev/null || true", {
@@ -255,14 +246,13 @@ export class SandboxManager {
 		});
 
 		// Re-deploy with updated bundles
-		await this.deploySandboxBundles(sandbox, logger, bundles, authToken);
+		await this.deploySandboxBundles(sandbox, logger, bundles);
 	}
 
 	private async startDaemonProcess(
 		sandbox: Sandbox,
 		logger: SyncLogger,
 		expectedVersion: string,
-		authToken: string,
 	): Promise<void> {
 		await sandbox.commands.run(
 			`bun ${DAEMON_BUNDLE_PATH} >> /workspace/daemon.log 2>&1`,
@@ -272,7 +262,7 @@ export class SandboxManager {
 					ANTHROPIC_API_KEY: apiEnv.ANTHROPIC_API_KEY,
 					DATABASE_URL: apiEnv.DATABASE_URL as string,
 					DAEMON_VERSION: expectedVersion,
-					DAEMON_AUTH_TOKEN: authToken,
+					DAEMON_AUTH_TOKEN: apiEnv.DAEMON_AUTH_TOKEN,
 				},
 			},
 		);

--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-orchestration.test.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-orchestration.test.ts
@@ -55,7 +55,7 @@ describe("runSandboxChat", () => {
 		Bun.env.ANTHROPIC_API_KEY = "test-anthropic-key";
 		Bun.env.DEEPSEEK_API_KEY = "test-deepseek-key";
 		Bun.env.E2B_API_KEY = "test-e2b-key";
-		Bun.env.DAEMON_AUTH_SECRET = "test-daemon-auth-secret";
+		Bun.env.DAEMON_AUTH_TOKEN = "test-daemon-auth-token";
 		Bun.env.DATABASE_URL = "mysql://user:pass@localhost:3306/test";
 		({ runSandboxChat } = await import("./sandbox-orchestration"));
 		singletonModule = await import("./singleton");
@@ -71,7 +71,7 @@ describe("runSandboxChat", () => {
 			"ensureSandboxDaemon",
 		).mockResolvedValue({
 			url: "http://daemon:8080",
-			authToken: "daemon-token",
+			authToken: "test-daemon-auth-token",
 		});
 	});
 
@@ -96,7 +96,7 @@ describe("runSandboxChat", () => {
 		expect(spyForwardTurn).toHaveBeenCalledWith(
 			expect.objectContaining({
 				daemonUrl: "http://daemon:8080",
-				daemonAuthToken: "daemon-token",
+				daemonAuthToken: "test-daemon-auth-token",
 			}),
 		);
 	});

--- a/apps/chat-api/src/test-setup.ts
+++ b/apps/chat-api/src/test-setup.ts
@@ -4,7 +4,7 @@ Bun.env.OPENAI_API_KEY = Bun.env.OPENAI_API_KEY ?? "test-openai-key";
 Bun.env.ANTHROPIC_API_KEY = Bun.env.ANTHROPIC_API_KEY ?? "test-anthropic-key";
 Bun.env.DEEPSEEK_API_KEY = Bun.env.DEEPSEEK_API_KEY ?? "test-deepseek-key";
 Bun.env.E2B_API_KEY = Bun.env.E2B_API_KEY ?? "test-e2b-key";
-Bun.env.DAEMON_AUTH_SECRET =
-	Bun.env.DAEMON_AUTH_SECRET ?? "test-daemon-auth-secret";
+Bun.env.DAEMON_AUTH_TOKEN =
+	Bun.env.DAEMON_AUTH_TOKEN ?? "test-daemon-auth-token";
 Bun.env.DATABASE_URL =
 	Bun.env.DATABASE_URL ?? "postgres://test:test@localhost:5432/test";


### PR DESCRIPTION
## Summary

Walks back the per-sandbox HMAC-derived auth token from PR #100 to a single fixed `DAEMON_AUTH_TOKEN`.

### Why

The per-sandbox derivation (HMAC-SHA256 over `sandboxId` keyed by a server secret) added real machinery — an extra required env var, a private method, parameter-threading through three private methods of `SandboxManager` — for a threat model that isn't honored in practice. The only thing reading the token is the daemon process inside that one sandbox, which already receives the value directly from its own startup env. Distinguishing tokens across sandboxes adds no extra protection because there's no caller that legitimately holds tokens for multiple sandboxes simultaneously.

A fixed shared secret has the same security property (an attacker who learns the token can call `/turn`) with strictly less code.

### What changed

- `apiEnv.DAEMON_AUTH_TOKEN` (required) replaces `DAEMON_AUTH_SECRET`.
- `SandboxManager.getDaemonAuthToken` and the `createHmac` import: removed.
- `ensureSandboxDaemon` returns `{ url, authToken: apiEnv.DAEMON_AUTH_TOKEN }`.
- `deploySandboxBundles` / `restartDaemon` / `startDaemonProcess` no longer thread `authToken` as a parameter; `startDaemonProcess` reads from `apiEnv` directly at the only use site.

### What didn't change

Daemon-side `/turn` check is identical: same `x-daemon-auth-token` header, same byte-length guard before `timingSafeEqual`, same missing/wrong/non-ASCII 401 tests.

### Diff

```
6 files changed, 19 insertions(+), 29 deletions(-)
```

## Test plan

- [x] `bun test src/features/sandbox-orchestration/sandbox-proxy.test.ts src/features/sandbox-orchestration/sandbox-orchestration.test.ts` — 20/20
- [x] `bun test routes/turn.integration.test.ts child-spawn.test.ts` (sandbox-daemon) — 14/14
- [x] Full suites: chat-api 36/36, sandbox-daemon 85/85
- [x] `bun run build` (sandbox-daemon) — daemon bundle still 27 KB, **0** refs to drizzle/mysql2/SDK
- [x] `biome check --write` on touched files — no fixes applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)