### PR TITLE
feat(sandbox): route agent LLM calls through an llm-gateway control plane

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,8 +70,11 @@ Source: [forrestchang/andrej-karpathy-skills](https://github.com/forrestchang/an
 
 ## Project Overview
 
-MyMemo Monorepo containing the chat-api application:
-- **chat-api** (TypeScript/Bun) - AI chat service at `apps/chat-api/`
+MyMemo Monorepo (Bun workspaces) containing:
+- **chat-api** (`apps/chat-api/`) - AI chat service; orchestrates per-user E2B sandboxes
+- **sandbox-daemon** (`apps/sandbox-daemon/`) - in-sandbox HTTP daemon; bundled and shipped into E2B
+- **llm-gateway** (`apps/llm-gateway/`) - control plane; the only service holding the real `ANTHROPIC_API_KEY`. Verifies the per-turn bearer token and proxies to Anthropic
+- **@mymemo/db** (`packages/db/`), **@mymemo/llm-token** (`packages/llm-token/`) - shared packages
 
 ## Commands
 
@@ -100,7 +103,7 @@ docker-compose up    # Local development
    - **Identity headers** (`InternalIdentity`): `X-Member-Code` (required), `X-Partner-Code` (required), `X-Team-Code`, `X-Member-Name`, `X-Partner-Name` (all optional)
 2. SSE stream initiated in `chat.route.ts` after body validation (`.strict()`, rejects extra keys) and identity-header validation (401 on missing/invalid)
 3. `chat.controller.ts::complete()` orchestrates the merged request — no upstream API calls
-4. `runSandboxChat` is the sole agent path: forwards the turn to a per-user E2B sandbox daemon. The optional `sessionId` from the request body is passed through as the daemon's `agent_session_id`; when omitted, the daemon allocates a new session. The optional `sandboxId` is used to reconnect to an existing E2B sandbox; when omitted (or reconnection fails), a new sandbox is created.
+4. `runSandboxChat` is the sole agent path: forwards the turn to a per-user E2B sandbox daemon. The optional `sessionId` from the request body is passed through as the daemon's `agent_session_id`; when omitted, the daemon allocates a new session. The optional `sandboxId` is used to reconnect to an existing E2B sandbox; when omitted (or reconnection fails), a new sandbox is created. chat-api also mints a short-lived `@mymemo/llm-token` bound to `{userId, sandboxId, requestId}` and sends it (with `LLM_GATEWAY_PUBLIC_URL`) in the turn body. The daemon sets these as `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` on the agent process, so **the sandbox never holds a provider key** — all LLM calls route through `llm-gateway`, which validates the token and injects the real `ANTHROPIC_API_KEY`.
 5. Events emitted via SSE:
    - `text_delta` — `{ text }` payload, one event per streamed token chunk; the client concatenates these to build the full response
    - `done` — `{}` payload, marks end-of-stream after the final `text_delta`
@@ -112,14 +115,18 @@ docker-compose up    # Local development
 
 Identity arrives via `X-*` headers, **not** the JSON body. chat-api does not authenticate users itself; the internal caller (gateway / BFF) is responsible for authenticating the user and forwarding their identity. The body schema uses `.strict()` so any attempt to pass identity in the body is rejected with a 400. This service must therefore only be reachable from trusted internal callers; do not expose `POST /api/v1/chat` directly to untrusted networks.
 
+The sandboxed agent is treated as untrusted (it runs prompt-injectable, Bash-capable code). It holds no provider key — only a short-lived, single-user, signed bearer token. The single inbound edge from a sandbox is **sandbox → llm-gateway**; `llm-gateway` holds `ANTHROPIC_API_KEY` + `LLM_TOKEN_SECRET` and should only be reachable from sandboxes (and only reach `api.anthropic.com` outbound). chat-api and llm-gateway share `LLM_TOKEN_SECRET` (chat-api mints, gateway verifies); the daemon never sees it.
+
 ### Key Modules
 
 | Path | Purpose |
 |------|---------|
 | `src/features/chat/chat.controller.ts` | Reads context from request body, hands the turn to the sandbox |
-| `src/features/sandbox-orchestration/` | `runSandboxChat`, sandbox manager, daemon proxy |
+| `src/features/sandbox-orchestration/` | `runSandboxChat`, sandbox manager, daemon proxy; mints the per-turn LLM token |
 | `src/features/sandbox-agent/` | Sandbox-side agent system prompt builder |
 | `src/config/env.ts` | Environment validation |
+| `apps/llm-gateway/src/index.ts` | Control-plane proxy: verifies token, injects `ANTHROPIC_API_KEY`, forwards to Anthropic |
+| `packages/llm-token/index.ts` | `mintLlmToken` / `verifyLlmToken` (shared, HMAC-signed) |
 
 ### Chat Scopes
 
@@ -135,17 +142,26 @@ Identity arrives via `X-*` headers, **not** the JSON body. chat-api does not aut
 
 ## Environment Variables
 
+### chat-api
+
 Required:
-- `OPENAI_API_KEY`
-- `ANTHROPIC_API_KEY`
-- `DEEPSEEK_API_KEY`
 - `E2B_API_KEY`
 - `DATABASE_URL`
 - `DAEMON_AUTH_TOKEN`
+- `LLM_TOKEN_SECRET` — HMAC secret for minting per-turn LLM tokens (shared with llm-gateway)
+- `LLM_GATEWAY_PUBLIC_URL` — gateway base URL the sandbox agent uses; **must be reachable from inside the E2B sandbox**
 
 Optional:
 - `LOG_LEVEL` (default: `info`)
 - `PORT` (default: 3000)
 - `E2B_TEMPLATE` (default: `sandbox-template-dev`)
-- `DEEPSEEK_BASE_URL`
-- `DEEPSEEK_DEFAULT_MODEL` (default: `deepseek-v4-flash`)
+
+### llm-gateway
+
+Required:
+- `ANTHROPIC_API_KEY` — the real provider key; lives **only** in this service
+- `LLM_TOKEN_SECRET` — must match chat-api's
+
+Optional:
+- `UPSTREAM_BASE_URL` (default: `https://api.anthropic.com`)
+- `PORT` (default: 8081)

--- a/apps/chat-api/Dockerfile
+++ b/apps/chat-api/Dockerfile
@@ -9,12 +9,14 @@ COPY package.json bun.lock /temp/dev/
 COPY apps/chat-api/package.json /temp/dev/apps/chat-api/
 COPY apps/sandbox-daemon/package.json /temp/dev/apps/sandbox-daemon/
 COPY packages/db/package.json /temp/dev/packages/db/
+COPY packages/llm-token/package.json /temp/dev/packages/llm-token/
 RUN cd /temp/dev && bun install --frozen-lockfile
 
 COPY package.json bun.lock /temp/prod/
 COPY apps/chat-api/package.json /temp/prod/apps/chat-api/
 COPY apps/sandbox-daemon/package.json /temp/prod/apps/sandbox-daemon/
 COPY packages/db/package.json /temp/prod/packages/db/
+COPY packages/llm-token/package.json /temp/prod/packages/llm-token/
 RUN cd /temp/prod && bun install --frozen-lockfile --production
 
 # Copy source, prebuild daemon bundle, and run tests
@@ -23,6 +25,7 @@ COPY --from=install /temp/dev/node_modules node_modules
 COPY apps/chat-api/ apps/chat-api/
 COPY apps/sandbox-daemon/ apps/sandbox-daemon/
 COPY packages/db/ packages/db/
+COPY packages/llm-token/ packages/llm-token/
 COPY package.json .
 
 WORKDIR /usr/src/app/apps/chat-api
@@ -38,6 +41,7 @@ COPY --from=prerelease /usr/src/app/apps/chat-api/package.json apps/chat-api/
 COPY --from=prerelease /usr/src/app/apps/chat-api/tsconfig.json apps/chat-api/
 COPY --from=prerelease /usr/src/app/apps/sandbox-daemon/dist apps/sandbox-daemon/dist
 COPY --from=prerelease /usr/src/app/packages/db packages/db
+COPY --from=prerelease /usr/src/app/packages/llm-token packages/llm-token
 COPY --from=prerelease /usr/src/app/package.json .
 
 WORKDIR /usr/src/app/apps/chat-api

--- a/apps/chat-api/package.json
+++ b/apps/chat-api/package.json
@@ -7,6 +7,7 @@
 		"lint": "biome lint --write",
 		"check": "biome check --write",
 		"prototype:sandbox": "bun run scripts/run-sandbox-prototype.ts",
+		"smoke:gateway": "bun run scripts/smoke-gateway.ts",
 		"e2b:build:dev": "cd sandbox-template && bun run build.dev.ts",
 		"e2b:build:prod": "cd sandbox-template && bun run build.prod.ts"
 	},

--- a/apps/chat-api/package.json
+++ b/apps/chat-api/package.json
@@ -11,14 +11,10 @@
 		"e2b:build:prod": "cd sandbox-template && bun run build.prod.ts"
 	},
 	"dependencies": {
-		"@ai-sdk/anthropic": "^3.0.12",
-		"@ai-sdk/deepseek": "^2.0.29",
-		"@ai-sdk/google": "^3.0.7",
-		"@ai-sdk/openai": "^3.0.9",
 		"@hono/standard-validator": "^0.1.5",
 		"@mymemo/db": "workspace:*",
+		"@mymemo/llm-token": "workspace:*",
 		"@scalar/hono-api-reference": "^0.9.22",
-		"ai": "^6.0.33",
 		"drizzle-orm": "^0.44.1",
 		"e2b": "^2.14.0",
 		"hono": "^4.10.1",

--- a/apps/chat-api/scripts/smoke-gateway.ts
+++ b/apps/chat-api/scripts/smoke-gateway.ts
@@ -197,22 +197,19 @@ async function run(): Promise<number> {
 			"  · skipped (claude not on PATH; set CLAUDE_CODE_PATH to run)",
 		);
 	} else {
+		// Inherit the full env (PATH, HOME, and any proxy/CA/SHELL vars the CLI
+		// needs in CI) but scrub the provider key, so this leg proves the keyless
+		// Bearer contract without breaking behind a proxy or custom CA. The minted
+		// token overrides any ANTHROPIC_AUTH_TOKEN already in the env.
+		const childEnv: Record<string, string | undefined> = {
+			...process.env,
+			ANTHROPIC_BASE_URL: BASE,
+			ANTHROPIC_AUTH_TOKEN: mint(),
+		};
+		delete childEnv.ANTHROPIC_API_KEY;
 		const proc = Bun.spawn(
 			[claudeBin, "-p", "Reply with the single word: pong"],
-			{
-				// Scrubbed env: mirror the production agent, which holds NO provider
-				// key — only the gateway base URL + bearer token. Spreading
-				// process.env here would leak ANTHROPIC_API_KEY and let the binary
-				// bypass the gateway, invalidating the contract this leg proves.
-				env: {
-					PATH: process.env.PATH ?? "",
-					HOME: process.env.HOME ?? "",
-					ANTHROPIC_BASE_URL: BASE,
-					ANTHROPIC_AUTH_TOKEN: mint(),
-				},
-				stdout: "pipe",
-				stderr: "pipe",
-			},
+			{ env: childEnv, stdout: "pipe", stderr: "pipe" },
 		);
 		const out = (await new Response(proc.stdout).text()).trim();
 		const err = (await new Response(proc.stderr).text()).trim();

--- a/apps/chat-api/scripts/smoke-gateway.ts
+++ b/apps/chat-api/scripts/smoke-gateway.ts
@@ -1,0 +1,234 @@
+#!/usr/bin/env bun
+/**
+ * Smoke test for the LLM-gateway credential path — no E2B, no sandbox required.
+ *
+ * Boots apps/llm-gateway locally and verifies the legs that no unit test covers,
+ * against the REAL Anthropic API:
+ *
+ *   Layer A — gateway ⇄ Anthropic
+ *     • a valid minted token → /v1/messages streams a real completion
+ *     • garbage / expired / missing token → 401 (auth actually gates)
+ *
+ *   Layer B — claude binary → gateway   (the contract #106 is about)
+ *     • the real `claude` binary, pointed at the gateway via ANTHROPIC_BASE_URL
+ *       + ANTHROPIC_AUTH_TOKEN, completes a prompt — proving it sends the token
+ *       as `Authorization: Bearer`. Skipped if `claude` isn't on PATH.
+ *
+ * Usage (from apps/chat-api):
+ *   ANTHROPIC_API_KEY=sk-ant-… bun run scripts/smoke-gateway.ts
+ *   ANTHROPIC_API_KEY=sk-ant-… bun run scripts/smoke-gateway.ts --port 8099 --model claude-sonnet-4-6 --no-binary
+ *
+ * Makes a few small, real (paid) Anthropic calls. Exits non-zero on any failure.
+ */
+
+import { mintLlmToken } from "@mymemo/llm-token";
+
+const flags = new Set(Bun.argv.slice(2));
+function argValue(flag: string, fallback: string): string {
+	const i = Bun.argv.indexOf(flag);
+	const v = i !== -1 ? Bun.argv[i + 1] : undefined;
+	return v ?? fallback;
+}
+
+const PORT = Number(argValue("--port", "8099"));
+const MODEL = argValue("--model", "claude-sonnet-4-6");
+const RUN_BINARY = !flags.has("--no-binary");
+const SECRET = Bun.env.LLM_TOKEN_SECRET || `smoke-${crypto.randomUUID()}`;
+const BASE = `http://localhost:${PORT}`;
+const GATEWAY_ENTRY = `${import.meta.dir}/../../llm-gateway/src/index.ts`;
+
+const apiKey = Bun.env.ANTHROPIC_API_KEY;
+if (!apiKey) {
+	console.error(
+		"✗ ANTHROPIC_API_KEY is required — a real key; this script makes live calls.",
+	);
+	process.exit(2);
+}
+
+let failures = 0;
+function check(name: string, ok: boolean, detail = ""): void {
+	console.log(`  ${ok ? "✓" : "✗"} ${name}${detail ? ` — ${detail}` : ""}`);
+	if (!ok) failures++;
+}
+
+function mint(ttlMs?: number): string {
+	return mintLlmToken(
+		{ userId: "smoke", sandboxId: "smoke-sbx", requestId: crypto.randomUUID() },
+		SECRET,
+		ttlMs,
+	);
+}
+
+async function waitForHealth(timeoutMs = 10_000): Promise<boolean> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		try {
+			const r = await fetch(`${BASE}/health`, {
+				signal: AbortSignal.timeout(1000),
+			});
+			if (r.ok) return true;
+		} catch {
+			// not up yet
+		}
+		await Bun.sleep(150);
+	}
+	return false;
+}
+
+function postMessages(token: string): Promise<Response> {
+	return fetch(`${BASE}/v1/messages`, {
+		method: "POST",
+		headers: {
+			authorization: `Bearer ${token}`,
+			"anthropic-version": "2023-06-01",
+			"content-type": "application/json",
+		},
+		body: JSON.stringify({
+			model: MODEL,
+			max_tokens: 16,
+			stream: true,
+			messages: [{ role: "user", content: "Reply with the single word: pong" }],
+		}),
+	});
+}
+
+/** Drain an Anthropic SSE stream and concatenate the text deltas. */
+async function readSseText(res: Response): Promise<string> {
+	if (!res.body) return "";
+	const reader = res.body.getReader();
+	const decoder = new TextDecoder();
+	let buf = "";
+	let text = "";
+	while (true) {
+		const { done, value } = await reader.read();
+		if (done) break;
+		buf += decoder.decode(value, { stream: true });
+		let nl = buf.indexOf("\n");
+		while (nl !== -1) {
+			const line = buf.slice(0, nl).trim();
+			buf = buf.slice(nl + 1);
+			if (line.startsWith("data:")) {
+				try {
+					const evt = JSON.parse(line.slice(5).trim());
+					if (evt?.delta?.text) text += evt.delta.text;
+				} catch {
+					// non-JSON keepalive/comment line
+				}
+			}
+			nl = buf.indexOf("\n");
+		}
+	}
+	return text;
+}
+
+// ── boot the gateway as a subprocess (its real deployable entrypoint) ──
+const gateway = Bun.spawn(["bun", "run", GATEWAY_ENTRY], {
+	env: {
+		...process.env,
+		ANTHROPIC_API_KEY: apiKey,
+		LLM_TOKEN_SECRET: SECRET,
+		GATEWAY_PORT: String(PORT),
+	},
+	stdout: "pipe",
+	stderr: "pipe",
+});
+
+let gwLog = "";
+async function drain(stream: ReadableStream<Uint8Array>): Promise<void> {
+	const reader = stream.getReader();
+	const decoder = new TextDecoder();
+	while (true) {
+		const { done, value } = await reader.read();
+		if (done) break;
+		gwLog += decoder.decode(value, { stream: true });
+	}
+}
+drain(gateway.stdout);
+drain(gateway.stderr);
+
+async function run(): Promise<number> {
+	console.log(`\n▶ booting llm-gateway on :${PORT} …`);
+	if (!(await waitForHealth())) {
+		console.error(
+			`✗ gateway did not become healthy.\n--- gateway logs ---\n${gwLog}`,
+		);
+		return 1;
+	}
+	console.log("  ✓ /health ok");
+
+	console.log("\nLayer A — gateway ⇄ Anthropic");
+	const good = await postMessages(mint());
+	const text = good.ok ? await readSseText(good) : "";
+	check(
+		"valid token streams a completion",
+		good.ok && text.trim().length > 0,
+		good.ok ? `"${text.trim().slice(0, 40)}"` : `status ${good.status}`,
+	);
+
+	const bad = await postMessages("not-a-real-token");
+	check("garbage token → 401", bad.status === 401, `status ${bad.status}`);
+	await bad.body?.cancel();
+
+	const expired = await postMessages(mint(-1));
+	check(
+		"expired token → 401",
+		expired.status === 401,
+		`status ${expired.status}`,
+	);
+	await expired.body?.cancel();
+
+	const noauth = await fetch(`${BASE}/v1/messages`, {
+		method: "POST",
+		body: "{}",
+	});
+	check("missing token → 401", noauth.status === 401, `status ${noauth.status}`);
+	await noauth.body?.cancel();
+
+	console.log("\nLayer B — claude binary → gateway (Authorization: Bearer)");
+	const claudeBin = Bun.env.CLAUDE_CODE_PATH || Bun.which("claude");
+	if (!RUN_BINARY) {
+		console.log("  · skipped (--no-binary)");
+	} else if (!claudeBin) {
+		console.log("  · skipped (claude not on PATH; set CLAUDE_CODE_PATH to run)");
+	} else {
+		const proc = Bun.spawn(
+			[claudeBin, "-p", "Reply with the single word: pong"],
+			{
+				env: {
+					...process.env,
+					ANTHROPIC_BASE_URL: BASE,
+					ANTHROPIC_AUTH_TOKEN: mint(),
+				},
+				stdout: "pipe",
+				stderr: "pipe",
+			},
+		);
+		const out = (await new Response(proc.stdout).text()).trim();
+		const err = (await new Response(proc.stderr).text()).trim();
+		const code = await proc.exited;
+		check(
+			"claude completes a prompt through the gateway",
+			code === 0 && out.length > 0,
+			code === 0
+				? `"${out.slice(0, 40)}"`
+				: `exit ${code}${err ? `: ${err.slice(0, 140)}` : ""}`,
+		);
+	}
+
+	return failures;
+}
+
+let exitCode = 1;
+try {
+	exitCode = await run();
+} catch (err) {
+	console.error("✗ smoke errored:", err instanceof Error ? err.message : err);
+	exitCode = 1;
+} finally {
+	gateway.kill();
+}
+
+console.log(
+	`\n${exitCode === 0 ? "✓ smoke passed" : `✗ smoke failed (${failures} check${failures === 1 ? "" : "s"})`}`,
+);
+process.exit(exitCode === 0 ? 0 : 1);

--- a/apps/chat-api/scripts/smoke-gateway.ts
+++ b/apps/chat-api/scripts/smoke-gateway.ts
@@ -181,7 +181,11 @@ async function run(): Promise<number> {
 		method: "POST",
 		body: "{}",
 	});
-	check("missing token → 401", noauth.status === 401, `status ${noauth.status}`);
+	check(
+		"missing token → 401",
+		noauth.status === 401,
+		`status ${noauth.status}`,
+	);
 	await noauth.body?.cancel();
 
 	console.log("\nLayer B — claude binary → gateway (Authorization: Bearer)");
@@ -189,13 +193,20 @@ async function run(): Promise<number> {
 	if (!RUN_BINARY) {
 		console.log("  · skipped (--no-binary)");
 	} else if (!claudeBin) {
-		console.log("  · skipped (claude not on PATH; set CLAUDE_CODE_PATH to run)");
+		console.log(
+			"  · skipped (claude not on PATH; set CLAUDE_CODE_PATH to run)",
+		);
 	} else {
 		const proc = Bun.spawn(
 			[claudeBin, "-p", "Reply with the single word: pong"],
 			{
+				// Scrubbed env: mirror the production agent, which holds NO provider
+				// key — only the gateway base URL + bearer token. Spreading
+				// process.env here would leak ANTHROPIC_API_KEY and let the binary
+				// bypass the gateway, invalidating the contract this leg proves.
 				env: {
-					...process.env,
+					PATH: process.env.PATH ?? "",
+					HOME: process.env.HOME ?? "",
 					ANTHROPIC_BASE_URL: BASE,
 					ANTHROPIC_AUTH_TOKEN: mint(),
 				},

--- a/apps/chat-api/src/config/env.ts
+++ b/apps/chat-api/src/config/env.ts
@@ -1,28 +1,30 @@
 import invariant from "tiny-invariant";
 
-const DEFAULT_DEEPSEEK_MODEL = "deepseek-v4-flash";
-
 /**
  * Environment variables for the API server
  * All variables are validated at module load time
  */
 export const apiEnv = (() => {
-	invariant(Bun.env.OPENAI_API_KEY, "OPENAI_API_KEY is required");
-	invariant(Bun.env.ANTHROPIC_API_KEY, "ANTHROPIC_API_KEY is required");
-	invariant(Bun.env.DEEPSEEK_API_KEY, "DEEPSEEK_API_KEY is required");
 	invariant(Bun.env.E2B_API_KEY, "E2B_API_KEY is required");
 	invariant(Bun.env.DATABASE_URL, "DATABASE_URL is required");
 	invariant(Bun.env.DAEMON_AUTH_TOKEN, "DAEMON_AUTH_TOKEN is required");
+	invariant(Bun.env.LLM_TOKEN_SECRET, "LLM_TOKEN_SECRET is required");
+	invariant(
+		Bun.env.LLM_GATEWAY_PUBLIC_URL,
+		"LLM_GATEWAY_PUBLIC_URL is required",
+	);
 
 	return {
 		DATABASE_URL: Bun.env.DATABASE_URL,
-		OPENAI_API_KEY: Bun.env.OPENAI_API_KEY,
-		ANTHROPIC_API_KEY: Bun.env.ANTHROPIC_API_KEY,
-		DEEPSEEK_API_KEY: Bun.env.DEEPSEEK_API_KEY,
 		DAEMON_AUTH_TOKEN: Bun.env.DAEMON_AUTH_TOKEN,
-		DEEPSEEK_BASE_URL: Bun.env.DEEPSEEK_BASE_URL || null,
-		DEEPSEEK_DEFAULT_MODEL:
-			Bun.env.DEEPSEEK_DEFAULT_MODEL || DEFAULT_DEEPSEEK_MODEL,
+		// HMAC secret for the session tokens minted into each sandbox turn. Shared
+		// only with llm-gateway, which verifies them.
+		LLM_TOKEN_SECRET: Bun.env.LLM_TOKEN_SECRET,
+		// Base URL the sandboxed agent points the Claude binary at
+		// (ANTHROPIC_BASE_URL). Must be reachable from inside the E2B sandbox.
+		// Trailing slash stripped so the binary's `${base}/v1/messages` never
+		// produces a double slash the gateway would have to normalize.
+		LLM_GATEWAY_PUBLIC_URL: Bun.env.LLM_GATEWAY_PUBLIC_URL.replace(/\/+$/, ""),
 		LOG_LEVEL: Bun.env.LOG_LEVEL || "info",
 		E2B_TEMPLATE: Bun.env.E2B_TEMPLATE || "sandbox-template-dev",
 	} as const;

--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-manager.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-manager.ts
@@ -259,7 +259,6 @@ export class SandboxManager {
 			{
 				background: true,
 				envs: {
-					ANTHROPIC_API_KEY: apiEnv.ANTHROPIC_API_KEY,
 					DATABASE_URL: apiEnv.DATABASE_URL as string,
 					DAEMON_VERSION: expectedVersion,
 					DAEMON_AUTH_TOKEN: apiEnv.DAEMON_AUTH_TOKEN,

--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-orchestration.test.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-orchestration.test.ts
@@ -7,6 +7,7 @@ import {
 	mock,
 	spyOn,
 } from "bun:test";
+import { verifyLlmToken } from "@mymemo/llm-token";
 import { createMockSandbox } from "./test-helpers";
 
 type RunSandboxChatOptions =
@@ -51,12 +52,11 @@ describe("runSandboxChat", () => {
 	let spyForwardTurn: ReturnType<typeof spyOn>;
 
 	beforeEach(async () => {
-		Bun.env.OPENAI_API_KEY = "test-openai-key";
-		Bun.env.ANTHROPIC_API_KEY = "test-anthropic-key";
-		Bun.env.DEEPSEEK_API_KEY = "test-deepseek-key";
 		Bun.env.E2B_API_KEY = "test-e2b-key";
 		Bun.env.DAEMON_AUTH_TOKEN = "test-daemon-auth-token";
 		Bun.env.DATABASE_URL = "mysql://user:pass@localhost:3306/test";
+		Bun.env.LLM_TOKEN_SECRET = "test-llm-token-secret";
+		Bun.env.LLM_GATEWAY_PUBLIC_URL = "https://gateway.test";
 		({ runSandboxChat } = await import("./sandbox-orchestration"));
 		singletonModule = await import("./singleton");
 		proxyModule = await import("./sandbox-proxy");
@@ -99,6 +99,24 @@ describe("runSandboxChat", () => {
 				daemonAuthToken: "test-daemon-auth-token",
 			}),
 		);
+	});
+
+	it("mints a verifiable llm token bound to the user and sandbox, plus the gateway url", async () => {
+		spyForwardTurn = spyOn(
+			proxyModule,
+			"forwardChatTurnToSandbox",
+		).mockImplementation(async (opts) => {
+			expect(opts.turnRequest.llm_base_url).toBe("https://gateway.test");
+			const verified = verifyLlmToken(
+				opts.turnRequest.llm_token,
+				"test-llm-token-secret",
+			);
+			expect(verified?.userId).toBe("user-1");
+			expect(verified?.sandboxId).toBe("sbx-123");
+			expect(verified?.requestId).toBe(opts.turnRequest.request_id);
+		});
+
+		await runSandboxChat(makeOptions());
 	});
 
 	it("forwards request sessionId as agent_session_id", async () => {

--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-orchestration.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-orchestration.ts
@@ -1,4 +1,5 @@
-import type { ChatMessagesScope } from "@/config/env";
+import { mintLlmToken } from "@mymemo/llm-token";
+import { apiEnv, type ChatMessagesScope } from "@/config/env";
 import type { ChatLogger } from "@/features/chat/chat.logger";
 import { buildSandboxAgentPrompt } from "@/features/sandbox-agent";
 import { SandboxCreationError } from "./errors";
@@ -80,8 +81,9 @@ export async function runSandboxChat(
 			conversationContext: null,
 		});
 
+		const requestId = crypto.randomUUID();
 		const turnRequest: TurnRequest = {
-			request_id: crypto.randomUUID(),
+			request_id: requestId,
 			user_id: userId,
 			scope_type: toSandboxScope(scope),
 			collection_id: collectionId ?? undefined,
@@ -89,6 +91,11 @@ export async function runSandboxChat(
 			message: query,
 			agent_session_id: sessionId ?? undefined,
 			system_prompt: systemPrompt,
+			llm_base_url: apiEnv.LLM_GATEWAY_PUBLIC_URL,
+			llm_token: mintLlmToken(
+				{ userId, sandboxId: sandbox.sandboxId, requestId },
+				apiEnv.LLM_TOKEN_SECRET,
+			),
 		};
 
 		await forwardChatTurnToSandbox({

--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-proxy.test.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-proxy.test.ts
@@ -1,9 +1,5 @@
 import { afterEach, describe, expect, it, mock } from "bun:test";
 
-Bun.env.OPENAI_API_KEY = Bun.env.OPENAI_API_KEY ?? "test-openai-key";
-Bun.env.ANTHROPIC_API_KEY = Bun.env.ANTHROPIC_API_KEY ?? "test-anthropic-key";
-Bun.env.DEEPSEEK_API_KEY = Bun.env.DEEPSEEK_API_KEY ?? "test-deepseek-key";
-
 import { ConversationBusyError } from "./errors";
 import { forwardChatTurnToSandbox, type TurnRequest } from "./sandbox-proxy";
 
@@ -14,6 +10,8 @@ function makeTurnRequest(overrides: Partial<TurnRequest> = {}): TurnRequest {
 		scope_type: "global",
 		message: "hello",
 		system_prompt: "you are helpful",
+		llm_base_url: "https://gateway.test",
+		llm_token: "test-token",
 		...overrides,
 	};
 }

--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-proxy.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-proxy.ts
@@ -9,6 +9,10 @@ export interface TurnRequest {
 	message: string;
 	agent_session_id?: string;
 	system_prompt: string;
+	/** LLM gateway base URL the sandbox agent points the Claude binary at. */
+	llm_base_url: string;
+	/** Short-lived bearer token the agent presents to the gateway. */
+	llm_token: string;
 }
 
 interface ForwardOptions {

--- a/apps/chat-api/src/test-setup.ts
+++ b/apps/chat-api/src/test-setup.ts
@@ -1,10 +1,10 @@
 // Set required env vars before any module evaluation.
 // This runs as a Bun test preload so env.ts IIFE won't crash.
-Bun.env.OPENAI_API_KEY = Bun.env.OPENAI_API_KEY ?? "test-openai-key";
-Bun.env.ANTHROPIC_API_KEY = Bun.env.ANTHROPIC_API_KEY ?? "test-anthropic-key";
-Bun.env.DEEPSEEK_API_KEY = Bun.env.DEEPSEEK_API_KEY ?? "test-deepseek-key";
 Bun.env.E2B_API_KEY = Bun.env.E2B_API_KEY ?? "test-e2b-key";
 Bun.env.DAEMON_AUTH_TOKEN =
 	Bun.env.DAEMON_AUTH_TOKEN ?? "test-daemon-auth-token";
 Bun.env.DATABASE_URL =
 	Bun.env.DATABASE_URL ?? "postgres://test:test@localhost:5432/test";
+Bun.env.LLM_TOKEN_SECRET = Bun.env.LLM_TOKEN_SECRET ?? "test-llm-token-secret";
+Bun.env.LLM_GATEWAY_PUBLIC_URL =
+	Bun.env.LLM_GATEWAY_PUBLIC_URL ?? "https://gateway.test";

--- a/apps/llm-gateway/Dockerfile
+++ b/apps/llm-gateway/Dockerfile
@@ -1,0 +1,24 @@
+FROM oven/bun:1 AS base
+WORKDIR /usr/src/app
+
+# Install dependencies — need all referenced workspace package.json files for
+# lockfile resolution.
+FROM base AS install
+RUN mkdir -p /temp/prod
+COPY package.json bun.lock /temp/prod/
+COPY apps/llm-gateway/package.json /temp/prod/apps/llm-gateway/
+COPY packages/llm-token/package.json /temp/prod/packages/llm-token/
+RUN cd /temp/prod && bun install --frozen-lockfile --production
+
+# Final release image
+FROM base AS release
+COPY --from=install /temp/prod/node_modules node_modules
+COPY apps/llm-gateway/src apps/llm-gateway/src
+COPY apps/llm-gateway/package.json apps/llm-gateway/tsconfig.json apps/llm-gateway/
+COPY packages/llm-token packages/llm-token
+COPY package.json .
+
+WORKDIR /usr/src/app/apps/llm-gateway
+USER bun
+EXPOSE 8081/tcp
+ENTRYPOINT [ "bun", "run", "src/index.ts" ]

--- a/apps/llm-gateway/Dockerfile
+++ b/apps/llm-gateway/Dockerfile
@@ -6,7 +6,12 @@ WORKDIR /usr/src/app
 FROM base AS install
 RUN mkdir -p /temp/prod
 COPY package.json bun.lock /temp/prod/
+# The root lockfile describes every workspace member, so --frozen-lockfile needs
+# each member's package.json present (only package.json — no source).
 COPY apps/llm-gateway/package.json /temp/prod/apps/llm-gateway/
+COPY apps/chat-api/package.json /temp/prod/apps/chat-api/
+COPY apps/sandbox-daemon/package.json /temp/prod/apps/sandbox-daemon/
+COPY packages/db/package.json /temp/prod/packages/db/
 COPY packages/llm-token/package.json /temp/prod/packages/llm-token/
 RUN cd /temp/prod && bun install --frozen-lockfile --production
 

--- a/apps/llm-gateway/biome.json
+++ b/apps/llm-gateway/biome.json
@@ -1,0 +1,4 @@
+{
+	"root": false,
+	"extends": "//"
+}

--- a/apps/llm-gateway/package.json
+++ b/apps/llm-gateway/package.json
@@ -1,0 +1,19 @@
+{
+	"name": "llm-gateway",
+	"version": "0.1.0",
+	"type": "module",
+	"scripts": {
+		"dev": "bun run --hot src/index.ts",
+		"format": "biome format --write",
+		"lint": "biome lint --write",
+		"check": "biome check --write"
+	},
+	"dependencies": {
+		"@mymemo/llm-token": "workspace:*",
+		"hono": "^4.10.1",
+		"tiny-invariant": "^1.3.3"
+	},
+	"devDependencies": {
+		"@types/bun": "^1.3.11"
+	}
+}

--- a/apps/llm-gateway/src/env.ts
+++ b/apps/llm-gateway/src/env.ts
@@ -1,0 +1,33 @@
+import invariant from "tiny-invariant";
+
+function parsePort(value: string | undefined, fallback: number): number {
+	if (!value) return fallback;
+	const n = Number(value);
+	invariant(
+		Number.isInteger(n) && n > 0 && n < 65536,
+		`GATEWAY_PORT must be an integer in 1..65535, got: ${value}`,
+	);
+	return n;
+}
+
+/**
+ * Environment for the LLM gateway. This is the only service that holds the real
+ * provider key — keep its surface tiny. Validated at module load.
+ *
+ * Uses a dedicated GATEWAY_PORT rather than the generic PORT so it never
+ * collides with another service's PORT when both read the same injected env.
+ */
+export const gwEnv = (() => {
+	invariant(Bun.env.ANTHROPIC_API_KEY, "ANTHROPIC_API_KEY is required");
+	invariant(Bun.env.LLM_TOKEN_SECRET, "LLM_TOKEN_SECRET is required");
+
+	return {
+		ANTHROPIC_API_KEY: Bun.env.ANTHROPIC_API_KEY,
+		LLM_TOKEN_SECRET: Bun.env.LLM_TOKEN_SECRET,
+		// Trailing slash stripped so `${base}${path}` never yields a double slash.
+		UPSTREAM_BASE_URL: (
+			Bun.env.UPSTREAM_BASE_URL || "https://api.anthropic.com"
+		).replace(/\/+$/, ""),
+		GATEWAY_PORT: parsePort(Bun.env.GATEWAY_PORT, 8081),
+	} as const;
+})();

--- a/apps/llm-gateway/src/index.test.ts
+++ b/apps/llm-gateway/src/index.test.ts
@@ -21,6 +21,11 @@ let fetchSpy: ReturnType<typeof spyOn> | undefined;
 afterEach(() => fetchSpy?.mockRestore());
 
 describe("llm-gateway", () => {
+	it("answers GET and HEAD /health without a token", async () => {
+		expect((await app.request("/health")).status).toBe(200);
+		expect((await app.request("/health", { method: "HEAD" })).status).toBe(200);
+	});
+
 	it("rejects requests with no bearer token", async () => {
 		const res = await app.request("/v1/messages", { method: "POST" });
 		expect(res.status).toBe(401);

--- a/apps/llm-gateway/src/index.test.ts
+++ b/apps/llm-gateway/src/index.test.ts
@@ -80,6 +80,23 @@ describe("llm-gateway", () => {
 		expect(fetchSpy).not.toHaveBeenCalled();
 	});
 
+	it("normalizes a trailing slash and still proxies /v1/messages", async () => {
+		fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response("{}", { status: 200 }),
+		);
+		const res = await app.request("/v1/messages/", {
+			method: "POST",
+			headers: {
+				authorization: `Bearer ${validToken()}`,
+				"content-type": "application/json",
+			},
+			body: "{}",
+		});
+		expect(res.status).toBe(200);
+		const [url] = fetchSpy.mock.calls[0] as [string, RequestInit];
+		expect(url).toBe("https://api.anthropic.com/v1/messages");
+	});
+
 	it("normalizes a double-slash path and still proxies /v1/messages", async () => {
 		fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
 			new Response("{}", { status: 200 }),

--- a/apps/llm-gateway/src/index.test.ts
+++ b/apps/llm-gateway/src/index.test.ts
@@ -61,4 +61,34 @@ describe("llm-gateway", () => {
 		expect(sent.get("anthropic-version")).toBe("2023-06-01");
 		expect(sent.has("authorization")).toBe(false);
 	});
+
+	it("404s a non-messages path even with a valid token (no upstream call)", async () => {
+		fetchSpy = spyOn(globalThis, "fetch").mockRejectedValue(
+			new Error("should not forward"),
+		);
+		const res = await app.request("/v1/files", {
+			method: "POST",
+			headers: { authorization: `Bearer ${validToken()}` },
+			body: "{}",
+		});
+		expect(res.status).toBe(404);
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	it("normalizes a double-slash path and still proxies /v1/messages", async () => {
+		fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response("{}", { status: 200 }),
+		);
+		const res = await app.request("//v1/messages", {
+			method: "POST",
+			headers: {
+				authorization: `Bearer ${validToken()}`,
+				"content-type": "application/json",
+			},
+			body: "{}",
+		});
+		expect(res.status).toBe(200);
+		const [url] = fetchSpy.mock.calls[0] as [string, RequestInit];
+		expect(url).toBe("https://api.anthropic.com/v1/messages");
+	});
 });

--- a/apps/llm-gateway/src/index.test.ts
+++ b/apps/llm-gateway/src/index.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeAll, describe, expect, it, spyOn } from "bun:test";
+import { mintLlmToken } from "@mymemo/llm-token";
+
+const SECRET = "test-secret";
+Bun.env.ANTHROPIC_API_KEY = "test-anthropic-key";
+Bun.env.LLM_TOKEN_SECRET = SECRET;
+
+// env.ts validates at module load, so import after env is set.
+let app: typeof import("./index").app;
+beforeAll(async () => {
+	({ app } = await import("./index"));
+});
+
+const validToken = () =>
+	mintLlmToken(
+		{ userId: "u1", sandboxId: "sbx-1", requestId: "req-1" },
+		SECRET,
+	);
+
+let fetchSpy: ReturnType<typeof spyOn> | undefined;
+afterEach(() => fetchSpy?.mockRestore());
+
+describe("llm-gateway", () => {
+	it("rejects requests with no bearer token", async () => {
+		const res = await app.request("/v1/messages", { method: "POST" });
+		expect(res.status).toBe(401);
+	});
+
+	it("rejects an invalid bearer token", async () => {
+		const res = await app.request("/v1/messages", {
+			method: "POST",
+			headers: { authorization: "Bearer not-a-real-token" },
+		});
+		expect(res.status).toBe(401);
+	});
+
+	it("injects x-api-key and forwards anthropic headers for a valid token", async () => {
+		fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response('{"ok":true}', {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			}),
+		);
+
+		const res = await app.request("/v1/messages", {
+			method: "POST",
+			headers: {
+				authorization: `Bearer ${validToken()}`,
+				"anthropic-version": "2023-06-01",
+				"content-type": "application/json",
+			},
+			body: JSON.stringify({ model: "claude-sonnet-4-6", messages: [] }),
+		});
+
+		expect(res.status).toBe(200);
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+		const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+		expect(url).toBe("https://api.anthropic.com/v1/messages");
+		const sent = new Headers(init.headers);
+		expect(sent.get("x-api-key")).toBe("test-anthropic-key");
+		expect(sent.get("anthropic-version")).toBe("2023-06-01");
+		expect(sent.has("authorization")).toBe(false);
+	});
+});

--- a/apps/llm-gateway/src/index.ts
+++ b/apps/llm-gateway/src/index.ts
@@ -43,7 +43,9 @@ const RESPONSE_DROP_HEADERS = new Set([
 
 export const app = new Hono();
 
-app.get("/health", (c) => c.json({ status: "ok" }));
+// GET and HEAD so load-balancer / k8s probes (which often use HEAD) don't fall
+// through to the token-gated proxy and 401.
+app.on(["GET", "HEAD"], "/health", (c) => c.json({ status: "ok" }));
 
 // Token-gated proxy for the messages endpoints. Catch-all so a trailing-slash
 // base URL (`…//v1/messages`) still routes here and gets normalized below.

--- a/apps/llm-gateway/src/index.ts
+++ b/apps/llm-gateway/src/index.ts
@@ -72,10 +72,12 @@ async function proxyToAnthropic(c: Context) {
 		);
 	}
 
-	// Collapse duplicate slashes (a trailing-slash base URL yields `//v1/messages`)
-	// before the scope check and forwarding.
+	// Normalize the path before the scope check / forwarding: collapse duplicate
+	// slashes (a trailing-slash base URL yields `//v1/messages`) and drop a single
+	// trailing slash (`/v1/messages/` → `/v1/messages`) so exact-match still holds.
 	const url = new URL(c.req.url);
-	const path = url.pathname.replace(/\/{2,}/g, "/");
+	let path = url.pathname.replace(/\/{2,}/g, "/");
+	if (path.length > 1 && path.endsWith("/")) path = path.slice(0, -1);
 	if (!ALLOWED_PATHS.has(path)) {
 		return c.json(
 			{

--- a/apps/llm-gateway/src/index.ts
+++ b/apps/llm-gateway/src/index.ts
@@ -1,0 +1,124 @@
+import { verifyLlmToken } from "@mymemo/llm-token";
+import { type Context, Hono } from "hono";
+import { gwEnv } from "./env";
+
+/**
+ * LLM gateway — the control plane for sandboxed agents.
+ *
+ * Sandboxed agents point the Claude binary at this service via ANTHROPIC_BASE_URL
+ * and authenticate with a short-lived ANTHROPIC_AUTH_TOKEN (Bearer). The agent
+ * therefore holds no provider key: we validate the token, inject the real
+ * `x-api-key`, and stream the upstream response straight back.
+ *
+ * The gateway is a transparent, token-gated reverse proxy: it forwards whatever
+ * path/method/headers the client sends (so SDK features and any Anthropic
+ * endpoint keep working) and only rewrites auth. Everything except /health is
+ * proxied.
+ */
+
+// Client request headers we must NOT forward upstream: authorization is replaced
+// by x-api-key; host/content-length/connection are recomputed by fetch (the body
+// is re-streamed with chunked encoding).
+const REQUEST_DROP_HEADERS = new Set([
+	"authorization",
+	"host",
+	"content-length",
+	"connection",
+]);
+
+// Response headers fetch already decoded for us; forwarding them would mislead
+// the client into decompressing again or mismatching the streamed length.
+const RESPONSE_DROP_HEADERS = new Set([
+	"content-encoding",
+	"content-length",
+	"transfer-encoding",
+	"connection",
+]);
+
+export const app = new Hono();
+
+app.get("/health", (c) => c.json({ status: "ok" }));
+
+// Token-gated transparent proxy for everything else.
+app.all("*", proxyToAnthropic);
+
+function bearerToken(c: Context): string {
+	const auth = c.req.header("authorization")?.trim() ?? "";
+	const match = /^Bearer\s+(.+)$/i.exec(auth);
+	return match?.[1] ?? "";
+}
+
+async function proxyToAnthropic(c: Context) {
+	const claims = verifyLlmToken(bearerToken(c), gwEnv.LLM_TOKEN_SECRET);
+	if (!claims) {
+		return c.json(
+			{
+				type: "error",
+				error: {
+					type: "authentication_error",
+					message: "invalid or expired session token",
+				},
+			},
+			401,
+		);
+	}
+
+	// Cost-cap / metering hook: claims.userId identifies the end user, and
+	// X-Claude-Code-Session-Id aggregates a session without parsing the body.
+
+	const headers = new Headers();
+	c.req.raw.headers.forEach((value, name) => {
+		if (!REQUEST_DROP_HEADERS.has(name.toLowerCase())) headers.set(name, value);
+	});
+	headers.set("x-api-key", gwEnv.ANTHROPIC_API_KEY);
+
+	const url = new URL(c.req.url);
+	// Collapse duplicate slashes (a trailing-slash base URL yields `//v1/messages`)
+	// and preserve the query string.
+	const path = url.pathname.replace(/\/{2,}/g, "/");
+	const target = `${gwEnv.UPSTREAM_BASE_URL}${path}${url.search}`;
+
+	const method = c.req.method;
+	const hasBody = method !== "GET" && method !== "HEAD";
+	const init: RequestInit & { duplex?: "half" } = { method, headers };
+	if (hasBody) {
+		init.body = c.req.raw.body;
+		// `duplex` is required to stream a request body in undici/Bun but is
+		// missing from the RequestInit lib type.
+		init.duplex = "half";
+	}
+
+	let upstream: Response;
+	try {
+		upstream = await fetch(target, init);
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		return c.json(
+			{
+				type: "error",
+				error: {
+					type: "api_error",
+					message: `upstream request failed: ${message}`,
+				},
+			},
+			502,
+		);
+	}
+
+	const responseHeaders = new Headers();
+	upstream.headers.forEach((value, name) => {
+		if (!RESPONSE_DROP_HEADERS.has(name.toLowerCase())) {
+			responseHeaders.set(name, value);
+		}
+	});
+
+	return new Response(upstream.body, {
+		status: upstream.status,
+		headers: responseHeaders,
+	});
+}
+
+export default {
+	port: gwEnv.GATEWAY_PORT,
+	fetch: app.fetch,
+};

--- a/apps/llm-gateway/src/index.ts
+++ b/apps/llm-gateway/src/index.ts
@@ -7,24 +7,30 @@ import { gwEnv } from "./env";
  *
  * Sandboxed agents point the Claude binary at this service via ANTHROPIC_BASE_URL
  * and authenticate with a short-lived ANTHROPIC_AUTH_TOKEN (Bearer). The agent
- * therefore holds no provider key: we validate the token, inject the real
- * `x-api-key`, and stream the upstream response straight back.
+ * holds no provider key: we validate the token, inject the real `x-api-key`, and
+ * stream the upstream response straight back.
  *
- * The gateway is a transparent, token-gated reverse proxy: it forwards whatever
- * path/method/headers the client sends (so SDK features and any Anthropic
- * endpoint keep working) and only rewrites auth. Everything except /health is
- * proxied.
+ * Scope is intentionally narrow: only the Anthropic Messages endpoints are
+ * proxied, and only an allowlist of request headers is forwarded. A leaked token
+ * therefore cannot reach files/batches/admin endpoints with the org key, and no
+ * arbitrary client headers (cookies, x-forwarded-*, accept-encoding) leak
+ * upstream.
  */
 
-// Client request headers we must NOT forward upstream: authorization is replaced
-// by x-api-key; host/content-length/connection are recomputed by fetch (the body
-// is re-streamed with chunked encoding).
-const REQUEST_DROP_HEADERS = new Set([
-	"authorization",
-	"host",
-	"content-length",
-	"connection",
-]);
+// Paths the gateway will proxy (after slash-normalization). Everything else 404s
+// even with a valid token.
+const ALLOWED_PATHS = new Set(["/v1/messages", "/v1/messages/count_tokens"]);
+
+// The only request headers forwarded upstream. Authorization is replaced by
+// x-api-key; everything else (host, content-length, accept-encoding, cookie, …)
+// is dropped so fetch controls compression and nothing leaks to Anthropic.
+const FORWARD_REQUEST_HEADERS = [
+	"anthropic-version",
+	"anthropic-beta",
+	"content-type",
+	"accept",
+	"x-claude-code-session-id",
+];
 
 // Response headers fetch already decoded for us; forwarding them would mislead
 // the client into decompressing again or mismatching the streamed length.
@@ -39,7 +45,8 @@ export const app = new Hono();
 
 app.get("/health", (c) => c.json({ status: "ok" }));
 
-// Token-gated transparent proxy for everything else.
+// Token-gated proxy for the messages endpoints. Catch-all so a trailing-slash
+// base URL (`…//v1/messages`) still routes here and gets normalized below.
 app.all("*", proxyToAnthropic);
 
 function bearerToken(c: Context): string {
@@ -63,21 +70,34 @@ async function proxyToAnthropic(c: Context) {
 		);
 	}
 
+	// Collapse duplicate slashes (a trailing-slash base URL yields `//v1/messages`)
+	// before the scope check and forwarding.
+	const url = new URL(c.req.url);
+	const path = url.pathname.replace(/\/{2,}/g, "/");
+	if (!ALLOWED_PATHS.has(path)) {
+		return c.json(
+			{
+				type: "error",
+				error: {
+					type: "not_found_error",
+					message: `unsupported path: ${path}`,
+				},
+			},
+			404,
+		);
+	}
+
 	// Cost-cap / metering hook: claims.userId identifies the end user, and
-	// X-Claude-Code-Session-Id aggregates a session without parsing the body.
+	// x-claude-code-session-id aggregates a session without parsing the body.
 
 	const headers = new Headers();
-	c.req.raw.headers.forEach((value, name) => {
-		if (!REQUEST_DROP_HEADERS.has(name.toLowerCase())) headers.set(name, value);
-	});
+	for (const name of FORWARD_REQUEST_HEADERS) {
+		const value = c.req.header(name);
+		if (value) headers.set(name, value);
+	}
 	headers.set("x-api-key", gwEnv.ANTHROPIC_API_KEY);
 
-	const url = new URL(c.req.url);
-	// Collapse duplicate slashes (a trailing-slash base URL yields `//v1/messages`)
-	// and preserve the query string.
-	const path = url.pathname.replace(/\/{2,}/g, "/");
 	const target = `${gwEnv.UPSTREAM_BASE_URL}${path}${url.search}`;
-
 	const method = c.req.method;
 	const hasBody = method !== "GET" && method !== "HEAD";
 	const init: RequestInit & { duplex?: "half" } = { method, headers };

--- a/apps/llm-gateway/tsconfig.json
+++ b/apps/llm-gateway/tsconfig.json
@@ -1,0 +1,22 @@
+{
+	"compilerOptions": {
+		"lib": ["ESNext"],
+		"target": "ESNext",
+		"module": "Preserve",
+		"moduleDetection": "force",
+		"moduleResolution": "bundler",
+		"allowImportingTsExtensions": true,
+		"verbatimModuleSyntax": true,
+		"noEmit": true,
+
+		"strict": true,
+		"skipLibCheck": true,
+		"noFallthroughCasesInSwitch": true,
+		"noUncheckedIndexedAccess": true,
+		"noImplicitOverride": true,
+
+		"paths": {
+			"@/*": ["./src/*"]
+		}
+	}
+}

--- a/apps/sandbox-daemon/agent-entry.ts
+++ b/apps/sandbox-daemon/agent-entry.ts
@@ -12,7 +12,9 @@
  *            { type: "failed", message: "..." }
  * Exit:    0 on completed, 1 on failed.
  *
- * Required env: ANTHROPIC_API_KEY (consumed by Claude Agent SDK).
+ * Required env: ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN — the Claude binary
+ * calls the LLM gateway (which holds the real provider key) with the bearer
+ * token. No provider key is present in this process.
  *
  * No other code path inside the daemon process imports the Claude Agent
  * SDK — this entrypoint owns it in the sandbox bundle graph.

--- a/apps/sandbox-daemon/child-spawn.test.ts
+++ b/apps/sandbox-daemon/child-spawn.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from "bun:test";
-import { buildAgentSpawnArgv } from "./child-spawn";
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildAgentSpawnArgv, spawnAgent } from "./child-spawn";
 
 describe("buildAgentSpawnArgv", () => {
 	it("wraps bun /workspace/agent.js with bwrap and the agreed flags", () => {
@@ -9,11 +11,7 @@ describe("buildAgentSpawnArgv", () => {
 
 		const dashDash = argv.indexOf("--");
 		expect(dashDash).toBeGreaterThan(0);
-		expect(argv.slice(dashDash)).toEqual([
-			"--",
-			"bun",
-			"/workspace/agent.js",
-		]);
+		expect(argv.slice(dashDash)).toEqual(["--", "bun", "/workspace/agent.js"]);
 
 		const flags = argv.slice(1, dashDash);
 		// FS layout
@@ -25,7 +23,7 @@ describe("buildAgentSpawnArgv", () => {
 		expect(flags).toContain("--proc");
 		expect(flags).toContain("--dev");
 		// Namespaces — note `--unshare-net` is intentionally absent so the
-		// agent can reach api.anthropic.com.
+		// agent can reach the LLM gateway over HTTPS.
 		expect(flags).toContain("--unshare-user");
 		expect(flags).toContain("--unshare-pid");
 		expect(flags).toContain("--unshare-uts");
@@ -116,5 +114,62 @@ describe("buildAgentSpawnArgv", () => {
 			process.env.SANDBOX_BUN_PATH = original.bun;
 			process.env.SANDBOX_AGENT_PATH = original.agent;
 		}
+	});
+});
+
+describe("spawnAgent agent environment", () => {
+	let spawnSpy: ReturnType<typeof spyOn> | undefined;
+	let originalHome: string | undefined;
+
+	afterEach(() => {
+		spawnSpy?.mockRestore();
+		if (originalHome === undefined) delete Bun.env.HOME;
+		else Bun.env.HOME = originalHome;
+	});
+
+	function fakeProc() {
+		return {
+			stdin: { write: () => {}, end: () => Promise.resolve() },
+			stdout: new ReadableStream<Uint8Array>({
+				start(controller) {
+					controller.close();
+				},
+			}),
+			stderr: new ReadableStream<Uint8Array>({
+				start(controller) {
+					controller.close();
+				},
+			}),
+			exited: Promise.resolve(0),
+		};
+	}
+
+	it("passes the gateway base url + bearer token and never a provider key", async () => {
+		// Keep ensureClaudeProjectsDir's mkdir inside a temp HOME.
+		originalHome = Bun.env.HOME;
+		Bun.env.HOME = join(tmpdir(), `spawn-agent-${Date.now()}`);
+
+		spawnSpy = spyOn(Bun, "spawn").mockReturnValue(
+			fakeProc() as unknown as ReturnType<typeof Bun.spawn>,
+		);
+
+		await spawnAgent({
+			userQuery: "q",
+			systemPrompt: "s",
+			cwd: "/workspace/data/u1/canonical",
+			llmBaseUrl: "https://gateway.example",
+			llmToken: "tok-123",
+			onEvent: async () => {},
+		});
+
+		const call = spawnSpy.mock.calls[0] as [
+			string[],
+			{ env: Record<string, string> },
+		];
+		const env = call[1].env;
+		expect(env.ANTHROPIC_BASE_URL).toBe("https://gateway.example");
+		expect(env.ANTHROPIC_AUTH_TOKEN).toBe("tok-123");
+		// The whole point of the gateway: no provider key reaches the agent.
+		expect("ANTHROPIC_API_KEY" in env).toBe(false);
 	});
 });

--- a/apps/sandbox-daemon/child-spawn.ts
+++ b/apps/sandbox-daemon/child-spawn.ts
@@ -1,8 +1,9 @@
 /**
  * Spawn helpers for the per-turn sync.js and agent.js children. The daemon
- * holds DATABASE_URL and ANTHROPIC_API_KEY in its env so it can forward
- * each to the correct child, but never imports the DB driver or the Claude
- * Agent SDK itself — those live exclusively in sync.js / agent.js.
+ * holds DATABASE_URL in its env so it can forward it to sync.js, but never
+ * imports the DB driver or the Claude Agent SDK itself — those live exclusively
+ * in sync.js / agent.js. The agent's LLM credentials are not provider keys: it
+ * gets a gateway base URL + short-lived bearer token, supplied per turn.
  *
  * Both children speak NDJSON on stdout. We line-buffer, parse, and dispatch.
  *
@@ -82,8 +83,8 @@ function getClaudeProjectsDir(): string {
  *
  * Namespaces:
  *   - --unshare-user, --unshare-pid, --unshare-uts, --unshare-ipc.
- *   - Inherited network — the Claude SDK calls api.anthropic.com over
- *     HTTPS, so we cannot --unshare-net.
+ *   - Inherited network — the Claude SDK calls the LLM gateway over HTTPS,
+ *     so we cannot --unshare-net.
  *
  * Lifetime:
  *   - --die-with-parent so a daemon crash takes bwrap + the agent with it.
@@ -137,7 +138,8 @@ function ensureClaudeProjectsDir(): void {
 function narrowAgentEvent(raw: Record<string, unknown>): AgentEvent | null {
 	switch (raw.type) {
 		case "text_delta":
-			if (typeof raw.text === "string") return { type: "text_delta", text: raw.text };
+			if (typeof raw.text === "string")
+				return { type: "text_delta", text: raw.text };
 			return null;
 		case "session_id":
 			if (typeof raw.sessionId === "string")
@@ -258,6 +260,10 @@ export interface SpawnAgentInput {
 	systemPrompt: string;
 	cwd: string;
 	sessionId?: string;
+	/** LLM gateway base URL — set as ANTHROPIC_BASE_URL for the Claude binary. */
+	llmBaseUrl: string;
+	/** Short-lived bearer token — set as ANTHROPIC_AUTH_TOKEN. */
+	llmToken: string;
 	onEvent: (event: AgentEvent) => void | Promise<void>;
 }
 
@@ -268,11 +274,14 @@ export interface SpawnAgentResult {
 export async function spawnAgent(
 	input: SpawnAgentInput,
 ): Promise<SpawnAgentResult> {
-	const { onEvent, ...config } = input;
+	const { onEvent, llmBaseUrl, llmToken, ...config } = input;
 	ensureClaudeProjectsDir();
 	const proc = Bun.spawn(buildAgentSpawnArgv(config.cwd), {
 		env: {
-			ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY ?? "",
+			// The agent holds no provider key — it talks to the LLM gateway, which
+			// injects the real key. ANTHROPIC_AUTH_TOKEN is sent as a Bearer header.
+			ANTHROPIC_BASE_URL: llmBaseUrl,
+			ANTHROPIC_AUTH_TOKEN: llmToken,
 			PATH: process.env.PATH ?? "",
 			CLAUDE_CODE_PATH: process.env.CLAUDE_CODE_PATH ?? "/usr/local/bin/claude",
 		},

--- a/apps/sandbox-daemon/daemon-entry.ts
+++ b/apps/sandbox-daemon/daemon-entry.ts
@@ -9,7 +9,9 @@
  *   DAEMON_VERSION    — surfaced by /health for the chat-api bundle check.
  *   DAEMON_AUTH_TOKEN — required bearer secret for /turn.
  *   DATABASE_URL      — held only to forward into sync.js's env.
- *   ANTHROPIC_API_KEY — held only to forward into agent.js's env.
+ *
+ * The daemon holds no provider key: the agent's LLM gateway URL and bearer
+ * token arrive per turn in the /turn body and are forwarded into agent.js's env.
  */
 
 import { Hono } from "hono";

--- a/apps/sandbox-daemon/package.json
+++ b/apps/sandbox-daemon/package.json
@@ -10,7 +10,7 @@
 	},
 	"dependencies": {
 		"hono": "^4.10.1",
-		"@anthropic-ai/claude-agent-sdk": "latest",
+		"@anthropic-ai/claude-agent-sdk": "0.2.97",
 		"@mymemo/db": "workspace:*",
 		"drizzle-orm": "^0.44.1",
 		"mysql2": "^3.14.1"

--- a/apps/sandbox-daemon/routes/turn.integration.test.ts
+++ b/apps/sandbox-daemon/routes/turn.integration.test.ts
@@ -88,6 +88,8 @@ describe("POST /turn integration", () => {
 			scope_type: "global",
 			message: "hello",
 			system_prompt: "you are helpful",
+			llm_base_url: "https://gateway.test",
+			llm_token: "test-token",
 			...overrides,
 		};
 	}
@@ -189,6 +191,26 @@ describe("POST /turn integration", () => {
 			.filter((e) => e.type === "text_delta")
 			.map((e) => e.text);
 		expect(deltas).toEqual(["Hello ", "World"]);
+	});
+
+	it("forwards llm_base_url and llm_token from the body to spawnAgent", async () => {
+		let captured: SpawnAgentInput | undefined;
+		mockSpawnAgent.mockImplementation((input) => {
+			captured = input;
+			return emitAgent(input, [{ type: "completed" }]);
+		});
+
+		const res = await app.request("/turn", {
+			method: "POST",
+			headers: turnHeaders(),
+			body: JSON.stringify(makeTurnBody()),
+		});
+		// Drain the stream so the turn completes and releases the lock before we
+		// assert (and before the next test runs).
+		await res.text();
+
+		expect(captured?.llmBaseUrl).toBe("https://gateway.test");
+		expect(captured?.llmToken).toBe("test-token");
 	});
 
 	it("forwards session_id from agent.js", async () => {

--- a/apps/sandbox-daemon/routes/turn.ts
+++ b/apps/sandbox-daemon/routes/turn.ts
@@ -35,6 +35,8 @@ interface TurnRequest {
 	message: string;
 	agent_session_id?: string;
 	system_prompt: string;
+	llm_base_url: string;
+	llm_token: string;
 }
 
 function ndjsonLine(obj: Record<string, unknown>): string {
@@ -56,7 +58,9 @@ app.post("/turn", async (c) => {
 		!body.request_id ||
 		!body.user_id ||
 		!body.message ||
-		!body.system_prompt
+		!body.system_prompt ||
+		!body.llm_base_url ||
+		!body.llm_token
 	) {
 		return c.json({ error: "Missing required fields" }, 400);
 	}
@@ -70,6 +74,8 @@ app.post("/turn", async (c) => {
 		message,
 		agent_session_id,
 		system_prompt,
+		llm_base_url,
+		llm_token,
 	} = body;
 
 	const lock = acquireTurn(request_id);
@@ -151,6 +157,8 @@ app.post("/turn", async (c) => {
 					systemPrompt: system_prompt,
 					cwd,
 					sessionId: agent_session_id,
+					llmBaseUrl: llm_base_url,
+					llmToken: llm_token,
 					onEvent: async (event) => {
 						if (event.type === "completed") {
 							// We emit our own `completed` below.

--- a/bun.lock
+++ b/bun.lock
@@ -56,7 +56,7 @@
       "name": "sandbox-daemon",
       "version": "0.1.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "latest",
+        "@anthropic-ai/claude-agent-sdk": "0.2.97",
         "@mymemo/db": "workspace:*",
         "drizzle-orm": "^0.44.1",
         "hono": "^4.10.1",

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "chat-api",
@@ -15,14 +14,10 @@
     "apps/chat-api": {
       "name": "chat-api",
       "dependencies": {
-        "@ai-sdk/anthropic": "^3.0.12",
-        "@ai-sdk/deepseek": "^2.0.29",
-        "@ai-sdk/google": "^3.0.7",
-        "@ai-sdk/openai": "^3.0.9",
         "@hono/standard-validator": "^0.1.5",
         "@mymemo/db": "workspace:*",
+        "@mymemo/llm-token": "workspace:*",
         "@scalar/hono-api-reference": "^0.9.22",
-        "ai": "^6.0.33",
         "drizzle-orm": "^0.44.1",
         "e2b": "^2.14.0",
         "hono": "^4.10.1",
@@ -43,6 +38,18 @@
         "@types/json-bigint": "^1.0.4",
         "@types/tar": "^7.0.87",
         "drizzle-kit": "^0.31.1",
+      },
+    },
+    "apps/llm-gateway": {
+      "name": "llm-gateway",
+      "version": "0.1.0",
+      "dependencies": {
+        "@mymemo/llm-token": "workspace:*",
+        "hono": "^4.10.1",
+        "tiny-invariant": "^1.3.3",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.3.11",
       },
     },
     "apps/sandbox-daemon": {
@@ -67,22 +74,12 @@
         "drizzle-kit": "^0.31.1",
       },
     },
+    "packages/llm-token": {
+      "name": "@mymemo/llm-token",
+      "version": "0.1.0",
+    },
   },
   "packages": {
-    "@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.68", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-BAd+fmgYoJMmGw0/uV+jRlXX60PyGxelA6Clp4cK/NI0dsyv9jOOwzQmKNaz2nwb+Jz7HqI7I70KK4XtU5EcXQ=="],
-
-    "@ai-sdk/deepseek": ["@ai-sdk/deepseek@2.0.29", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-cn4+xV0menm/4JKEDElnVGiUilHvi6AD4ZK/sY7DXP/Wb7Yb3Vr86NyYM6mGBE/Shk3mWHoHbzggVnF5x0uMEA=="],
-
-    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.94", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-uDDwLZhCkvC89crVS3S90D5L7AcVN8WriGuYVNYgVAaVcvy3Mthy3R9ICfzG75BObhz6pm2FWnhxDfNRK+t69Q=="],
-
-    "@ai-sdk/google": ["@ai-sdk/google@3.0.61", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-jEKU1Mjcy5CoicejdJQIzM0ntYwyXR8vtYgAZYriKaOuLAiAhiiU538++fGU3CC9HJH/mL1OfsCwMM3gFiCNsw=="],
-
-    "@ai-sdk/openai": ["@ai-sdk/openai@3.0.52", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-4Rr8NCGmfWTz6DCUvixn9UmyZcMatiHn0zWoMzI3JCUe9R1P/vsPOpCBALKoSzVYOjyJnhtnVIbfUKujcS39uw=="],
-
-    "@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
-
-    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.23", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg=="],
-
     "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.97", "", { "dependencies": { "@anthropic-ai/sdk": "^0.80.0", "@modelcontextprotocol/sdk": "^1.27.1" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-754teaU0nfrn9BC0YWzPjSbJj253GfPUtuUnkrde7LGsaKtFSjEEuQJq5skJvpozqcn+B8frrtWVPkvFdnupTw=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.80.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-WeXLn7zNVk3yjeshn+xZHvld6AoFUOR3Sep6pSoHho5YbSi6HwcirqgPA5ccFuW8QTVJAAU7N8uQQC6Wa9TG+g=="],
@@ -215,6 +212,8 @@
 
     "@mymemo/db": ["@mymemo/db@workspace:packages/db"],
 
+    "@mymemo/llm-token": ["@mymemo/llm-token@workspace:packages/llm-token"],
+
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
     "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
@@ -243,11 +242,7 @@
 
     "@types/tar": ["@types/tar@7.0.87", "", { "dependencies": { "tar": "*" } }, "sha512-3IxNBV8LeY5oi2ZFpvAhOtW1+mHswkzM7BuisVrwJgPv67GBO2rkLPQlEKtzfHuLdhDDczhkCZeT+RuizMay4A=="],
 
-    "@vercel/oidc": ["@vercel/oidc@3.1.0", "", {}, "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w=="],
-
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
-
-    "ai": ["ai@6.0.154", "", { "dependencies": { "@ai-sdk/gateway": "3.0.94", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-HfKJKCTJsDZxqrIUDSVnBQ7DpQlx5WI4ExqtLd7Bl70epLmvkpc/HYMzU1hP9W+g9VEAcvZo4fbMqc3v5D+9gQ=="],
 
     "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
@@ -399,13 +394,13 @@
 
     "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
 
-    "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
-
     "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
+    "llm-gateway": ["llm-gateway@workspace:apps/llm-gateway"],
 
     "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
@@ -587,6 +582,8 @@
 
     "chat-api/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
+    "llm-gateway/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+
     "tsx/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.18.20", "", { "os": "android", "cpu": "arm" }, "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw=="],
@@ -650,6 +647,8 @@
     "chat-api/@biomejs/biome/@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.2.4", "", { "os": "win32", "cpu": "x64" }, "sha512-3Y4V4zVRarVh/B/eSHczR4LYoSVyv3Dfuvm3cWs5w/HScccS0+Wt/lHOcDTRYeHjQmMYVC3rIRWqyN2EI52+zg=="],
 
     "chat-api/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+
+    "llm-gateway/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
     "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,6 +8,25 @@ services:
       - 3000:3000
     env_file:
       - ./apps/chat-api/.env
+    depends_on:
+      - llm-gateway
+    restart: always
+    networks:
+      - mymemo-network
+
+  # Control plane: the only service holding the real provider key. Sandboxed
+  # agents reach it via ANTHROPIC_BASE_URL with a short-lived bearer token.
+  # Note: LLM_GATEWAY_PUBLIC_URL (set for chat-api) must resolve to an address
+  # reachable from inside the E2B sandbox, not just this compose network.
+  llm-gateway:
+    container_name: llm-gateway
+    build:
+      context: .
+      dockerfile: apps/llm-gateway/Dockerfile
+    ports:
+      - 8081:8081
+    env_file:
+      - ./apps/llm-gateway/.env
     restart: always
     networks:
       - mymemo-network

--- a/docs/llm-gateway-architecture.html
+++ b/docs/llm-gateway-architecture.html
@@ -1,0 +1,437 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Architecture · llm-gateway control plane (PR #107)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+<style>
+  :root{
+    --paper:#f1eee6;
+    --paper-2:#e9e5da;
+    --card:#fbfaf6;
+    --ink:#16181d;
+    --ink-soft:#3b3e45;
+    --muted:#74777f;
+    --line:rgba(20,22,28,.14);
+    --line-2:rgba(20,22,28,.30);
+    --blue:#1f4fd0;      /* structure / control plane */
+    --blue-dim:rgba(31,79,208,.10);
+    --red:#cc3a2e;       /* the real provider key */
+    --red-dim:rgba(204,58,46,.10);
+    --green:#0f8a59;     /* the bearer token */
+    --green-dim:rgba(15,138,89,.10);
+    --amber:#a9690a;     /* caveat (DATABASE_URL still in sandbox) */
+    --amber-dim:rgba(169,105,10,.12);
+    --mono:"IBM Plex Mono",ui-monospace,monospace;
+    --sans:"Archivo",system-ui,sans-serif;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{
+    background:var(--paper);
+    color:var(--ink);
+    font-family:var(--sans);
+    line-height:1.6;
+    -webkit-font-smoothing:antialiased;
+    position:relative;
+    overflow-x:hidden;
+  }
+  /* dotted blueprint grid + paper grain */
+  body::before{
+    content:"";position:fixed;inset:0;z-index:0;pointer-events:none;opacity:.5;
+    background-image:radial-gradient(var(--line) 1px,transparent 1.4px);
+    background-size:24px 24px;
+    -webkit-mask-image:linear-gradient(180deg,#000,transparent 60%);
+            mask-image:linear-gradient(180deg,#000,transparent 60%);
+  }
+
+  .wrap{position:relative;z-index:1;max-width:1080px;margin:0 auto;padding:0 26px}
+
+  /* ── top bar ── */
+  .top{display:flex;justify-content:space-between;align-items:center;gap:16px;
+    padding:20px 0;border-bottom:1px solid var(--line-2);
+    font-family:var(--mono);font-size:11.5px;letter-spacing:.14em;text-transform:uppercase;color:var(--muted)}
+  .top .pr{display:inline-flex;align-items:center;gap:8px;color:var(--ink);text-decoration:none;
+    border:1px solid var(--line-2);border-radius:2px;padding:7px 12px;background:var(--card);transition:.2s}
+  .top .pr:hover{border-color:var(--blue);color:var(--blue)}
+  .top .pr b{color:var(--blue)}
+
+  /* ── hero ── */
+  .hero{padding:64px 0 30px}
+  .eyebrow{font-family:var(--mono);font-size:12px;letter-spacing:.22em;text-transform:uppercase;color:var(--blue);
+    display:flex;align-items:center;gap:12px;margin-bottom:22px}
+  .eyebrow::before{content:"";width:40px;height:2px;background:var(--blue)}
+  h1{font-weight:800;font-size:clamp(34px,6vw,66px);line-height:1.0;letter-spacing:-.025em}
+  h1 .k{color:var(--red)} h1 .t{color:var(--green)}
+  .sub{max-width:680px;margin-top:22px;font-size:18px;color:var(--ink-soft)}
+  .sub b{color:var(--ink);font-weight:700}
+
+  /* ── section scaffold ── */
+  section{padding:46px 0;border-top:1px solid var(--line)}
+  .sh{display:flex;gap:14px;align-items:baseline;margin-bottom:26px}
+  .sh .n{font-family:var(--mono);font-size:12px;color:var(--blue);letter-spacing:.1em;padding-top:5px}
+  .sh h2{font-weight:700;font-size:clamp(22px,3.4vw,30px);letter-spacing:-.01em}
+  .sh p{color:var(--muted);font-size:15px;margin-top:6px;max-width:640px}
+
+  /* ── zone board ── */
+  .board{position:relative;border:1px solid var(--line-2);border-radius:8px;overflow:hidden;background:var(--card)}
+  .zones{display:grid;grid-template-columns:1fr 1fr}
+  .zone{padding:22px 20px 24px}
+  .zone.trusted{border-right:2px dashed var(--line-2)}
+  .zone.sandbox{
+    background:
+      repeating-linear-gradient(135deg,transparent,transparent 9px,rgba(20,22,28,.025) 9px,rgba(20,22,28,.025) 10px),
+      var(--paper-2);
+  }
+  .zlabel{font-family:var(--mono);font-size:11px;letter-spacing:.16em;text-transform:uppercase;
+    display:flex;align-items:center;gap:8px;margin-bottom:16px}
+  .zone.trusted .zlabel{color:var(--blue)}
+  .zone.sandbox .zlabel{color:var(--amber)}
+  .zlabel .pip{width:8px;height:8px;border-radius:50%}
+  .zone.trusted .pip{background:var(--blue)}
+  .zone.sandbox .pip{background:var(--amber)}
+
+  .node{border:1px solid var(--line-2);border-radius:6px;background:var(--card);padding:14px 15px;margin-bottom:12px;
+    transition:transform .2s,box-shadow .2s}
+  .node:last-child{margin-bottom:0}
+  .node:hover{transform:translateY(-2px);box-shadow:0 6px 22px -14px rgba(20,22,28,.5)}
+  .node .nh{display:flex;align-items:center;justify-content:space-between;gap:10px}
+  .node .nm{font-family:var(--mono);font-weight:600;font-size:14px}
+  .node .role{font-size:13px;color:var(--ink-soft);margin-top:5px}
+  .badge{font-family:var(--mono);font-size:10px;letter-spacing:.04em;padding:3px 8px;border-radius:99px;white-space:nowrap;font-weight:500}
+  .badge.key{color:var(--red);background:var(--red-dim);border:1px solid rgba(204,58,46,.4)}
+  .badge.tok{color:var(--green);background:var(--green-dim);border:1px solid rgba(15,138,89,.4)}
+  .badge.db{color:var(--amber);background:var(--amber-dim);border:1px solid rgba(169,105,10,.4)}
+  .badge.none{color:var(--muted);background:rgba(20,22,28,.04);border:1px solid var(--line)}
+  .node code{font-family:var(--mono);font-size:11.5px;color:var(--blue)}
+
+  /* boundary callout */
+  .boundary-note{display:flex;gap:12px;align-items:center;border-top:1px dashed var(--line-2);
+    background:var(--green-dim);padding:13px 20px;font-size:13.5px;color:var(--ink-soft)}
+  .boundary-note .tag{font-family:var(--mono);font-size:10.5px;letter-spacing:.12em;text-transform:uppercase;color:var(--green);
+    border:1px solid var(--green);border-radius:99px;padding:3px 9px;white-space:nowrap}
+  .boundary-note b{color:var(--ink)}
+  .external{display:flex;align-items:center;gap:12px;border-top:1px solid var(--line-2);
+    padding:13px 20px;font-family:var(--mono);font-size:12.5px;color:var(--muted);background:var(--paper-2)}
+  .external .dot{width:8px;height:8px;border-radius:50%;background:var(--ink-soft)}
+  .external b{color:var(--ink);font-weight:600}
+
+  /* ── credential flow strip ── */
+  .credflow{display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-top:8px}
+  .cf{border:1px solid var(--line-2);border-radius:6px;padding:18px;background:var(--card)}
+  .cf.k{border-left:4px solid var(--red)} .cf.t{border-left:4px solid var(--green)}
+  .cf h4{font-family:var(--mono);font-size:12px;letter-spacing:.06em;text-transform:uppercase;margin-bottom:8px}
+  .cf.k h4{color:var(--red)} .cf.t h4{color:var(--green)}
+  .cf p{font-size:14px;color:var(--ink-soft)}
+  .cf .path{font-family:var(--mono);font-size:12px;color:var(--muted);margin-top:10px;line-height:1.7}
+  .cf .path .hot{color:var(--ink);font-weight:600}
+
+  /* ── numbered flow ── */
+  .flow{display:flex;flex-direction:column;gap:0;counter-reset:step}
+  .step{display:grid;grid-template-columns:42px 1fr;gap:18px;padding:15px 0;border-bottom:1px dashed var(--line)}
+  .step:last-child{border-bottom:0}
+  .step .num{counter-increment:step;font-family:var(--mono);font-weight:600;font-size:13px;color:var(--blue);
+    width:34px;height:34px;border:1px solid var(--blue);border-radius:50%;display:grid;place-items:center}
+  .step .num::before{content:counter(step,decimal-leading-zero)}
+  .step .body{align-self:center}
+  .step .t{font-weight:600;font-size:15.5px}
+  .step .d{font-size:14px;color:var(--ink-soft);margin-top:3px}
+  .step .d code,.step .t code{font-family:var(--mono);font-size:.85em;background:var(--paper-2);
+    border:1px solid var(--line);border-radius:3px;padding:1px 5px}
+  .step .d code.tok{color:var(--green)} .step .d code.key{color:var(--red)}
+
+  /* ── token lifecycle ── */
+  .life{display:grid;grid-template-columns:repeat(5,1fr);gap:0;border:1px solid var(--line-2);border-radius:6px;overflow:hidden;background:var(--card)}
+  .ls{padding:16px 14px;border-right:1px solid var(--line);position:relative}
+  .ls:last-child{border-right:0}
+  .ls .stage{font-family:var(--mono);font-size:10px;letter-spacing:.1em;text-transform:uppercase;color:var(--blue);margin-bottom:8px}
+  .ls .who{font-weight:700;font-size:14px}
+  .ls .what{font-size:12.5px;color:var(--ink-soft);margin-top:5px;line-height:1.5}
+  .ls .arrow{position:absolute;right:-7px;top:50%;transform:translateY(-50%);z-index:2;color:var(--blue);font-size:14px;background:var(--paper);padding:2px 0}
+
+  /* ── matrix ── */
+  .mtx{width:100%;border-collapse:collapse;font-size:13.5px;border:1px solid var(--line-2);background:var(--card);border-radius:6px;overflow:hidden}
+  .mtx th,.mtx td{padding:11px 13px;text-align:left;border-bottom:1px solid var(--line)}
+  .mtx thead th{font-family:var(--mono);font-size:10.5px;letter-spacing:.08em;text-transform:uppercase;color:var(--muted);background:var(--paper-2)}
+  .mtx tbody tr:last-child td{border-bottom:0}
+  .mtx td.c{font-family:var(--mono);font-weight:600}
+  .mtx .comp{font-family:var(--mono);font-weight:600;font-size:13px}
+  .yes{color:var(--green)} .no{color:var(--muted)} .only{color:var(--red)} .cav{color:var(--amber)}
+  .mtx td .sm{display:block;font-size:11px;color:var(--muted);font-family:var(--sans);font-weight:400}
+
+  /* ── process tree ── */
+  .tree{font-family:var(--mono);font-size:13.5px;background:var(--ink);color:#dfe3ea;border-radius:8px;padding:22px 22px;line-height:1.95;overflow-x:auto}
+  .tree .c{color:#7e8696}
+  .tree .b{color:#7fa8ff}
+  .tree .g{color:#5fd9a0}
+  .tree .r{color:#ff7d6e}
+  .tree .a{color:#f3c06b}
+
+  /* ── footer ── */
+  footer{border-top:1px solid var(--line-2);padding:34px 0 64px;margin-top:18px;
+    font-family:var(--mono);font-size:12px;color:var(--muted);letter-spacing:.04em;line-height:1.9}
+  footer a{color:var(--ink-soft);text-decoration:none;border-bottom:1px solid var(--line-2)}
+  footer a:hover{color:var(--blue)}
+  .pills{display:flex;flex-wrap:wrap;gap:7px;margin-top:14px}
+  .pills span{font-size:11px;color:var(--ink-soft);border:1px solid var(--line);border-radius:3px;padding:4px 9px;background:var(--card)}
+
+  /* reveal */
+  .rv{opacity:0;transform:translateY(16px);transition:opacity .6s cubic-bezier(.2,.7,.2,1),transform .6s cubic-bezier(.2,.7,.2,1)}
+  .rv.in{opacity:1;transform:none}
+  .hero .rv{transition-delay:var(--d,0s)}
+
+  @media(max-width:780px){
+    .zones{grid-template-columns:1fr}
+    .zone.trusted{border-right:0;border-bottom:2px dashed var(--line-2)}
+    .credflow{grid-template-columns:1fr}
+    .life{grid-template-columns:1fr}
+    .ls{border-right:0;border-bottom:1px solid var(--line)}
+    .ls .arrow{display:none}
+    .mtx{display:block;overflow-x:auto;white-space:nowrap}
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <div class="top">
+    <div>AS-BUILT ARCHITECTURE · X-GPT/chat-api</div>
+    <a class="pr" href="https://github.com/X-GPT/chat-api/pull/107" target="_blank" rel="noopener">
+      PR <b>#107</b> · llm-gateway control plane ↗
+    </a>
+  </div>
+
+  <header class="hero">
+    <div class="eyebrow rv" style="--d:0s">What this PR builds</div>
+    <h1 class="rv" style="--d:.07s">
+      The agent holds a <span class="t">token</span>,<br/>
+      never the <span class="k">key</span>.
+    </h1>
+    <p class="sub rv" style="--d:.18s">
+      Provider credentials move out of the E2B sandbox into a dedicated <b>llm-gateway</b> control plane.
+      chat-api mints a short-lived bearer token per turn; the gateway is the <b>only</b> place the real
+      <code style="font-family:var(--mono);color:var(--red)">ANTHROPIC_API_KEY</code> lives.
+    </p>
+  </header>
+
+  <!-- 01 TOPOLOGY -->
+  <section>
+    <div class="sh rv">
+      <div class="n">01</div>
+      <div>
+        <h2>Topology &amp; trust boundary</h2>
+        <p>Two zones. Credentials are color-coded: <b style="color:var(--red)">● real key</b>, <b style="color:var(--green)">● bearer token</b>, <b style="color:var(--amber)">● DB url</b>.</p>
+      </div>
+    </div>
+
+    <div class="board rv">
+      <div class="zones">
+        <div class="zone trusted">
+          <div class="zlabel"><span class="pip"></span>Trusted infrastructure · your servers</div>
+
+          <div class="node">
+            <div class="nh"><span class="nm">chat-api</span><span class="badge tok">mints token</span></div>
+            <div class="role">Orchestrator. Validates identity, opens the SSE stream, creates/reuses the E2B sandbox, and signs a per-turn <code>llm_token</code>. No provider key.</div>
+          </div>
+
+          <div class="node">
+            <div class="nh"><span class="nm">llm-gateway</span><span class="badge key">ANTHROPIC_API_KEY</span></div>
+            <div class="role">New stateless service. Verifies the bearer token, injects the real <code>x-api-key</code>, and transparently proxies to Anthropic. The only key-holder.</div>
+          </div>
+        </div>
+
+        <div class="zone sandbox">
+          <div class="zlabel"><span class="pip"></span>E2B sandbox · untrusted</div>
+
+          <div class="node">
+            <div class="nh"><span class="nm">sandbox-daemon</span><span class="badge db">DATABASE_URL</span></div>
+            <div class="role">Long-running in-sandbox server. Per turn: reconciles files (sync.js) and spawns the agent, forwarding the token into its env. No provider key.</div>
+          </div>
+
+          <div class="node">
+            <div class="nh"><span class="nm">agent · claude</span><span class="badge tok">bearer token only</span></div>
+            <div class="role">bwrap-isolated. Runs with <code>ANTHROPIC_BASE_URL</code> + <code>ANTHROPIC_AUTH_TOKEN</code> — nothing worth stealing.</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="boundary-note">
+        <span class="tag">trust boundary</span>
+        <div>The single inbound edge from the sandbox is <b>agent → llm-gateway</b>, carrying <b>only</b> a 10-minute, single-user <span style="color:var(--green);font-weight:600">Bearer token</span>. A prompt-injected agent has no provider key to exfiltrate.</div>
+      </div>
+      <div class="external">
+        <span class="dot"></span>EXTERNAL &nbsp;·&nbsp; <b>api.anthropic.com</b> — reached only by llm-gateway (with the injected <span style="color:var(--red)">x-api-key</span>) &nbsp;·&nbsp; <b>Postgres</b> — read by the daemon's sync.js
+      </div>
+    </div>
+
+    <div class="credflow rv">
+      <div class="cf k">
+        <h4>● the real key — contained</h4>
+        <p>Set on one service, used in one place, crosses one external edge.</p>
+        <div class="path"><span class="hot">llm-gateway</span> &nbsp;set x-api-key&nbsp; → &nbsp;api.anthropic.com</div>
+      </div>
+      <div class="cf t">
+        <h4>● the token — travels</h4>
+        <p>Minted, carried in the turn body, set as agent env, presented as Bearer, verified, discarded.</p>
+        <div class="path"><span class="hot">chat-api</span> → daemon → agent → <span class="hot">llm-gateway</span> ✓</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 02 TURN FLOW -->
+  <section>
+    <div class="sh rv">
+      <div class="n">02</div>
+      <div>
+        <h2>One turn, end to end</h2>
+        <p>From <code style="font-family:var(--mono);font-size:13px">POST /api/v1/chat</code> to a streamed answer.</p>
+      </div>
+    </div>
+    <div class="flow rv">
+      <div class="step"><div class="num"></div><div class="body">
+        <div class="t">Client → chat-api</div>
+        <div class="d"><code>POST /api/v1/chat</code> with identity headers; chat-api opens the SSE response.</div>
+      </div></div>
+      <div class="step"><div class="num"></div><div class="body">
+        <div class="t">Resolve the sandbox</div>
+        <div class="d"><code>getOrCreateSandbox</code> — reconnect via the client's <code>sandboxId</code>, or create a fresh E2B sandbox; then <code>ensureSandboxDaemon</code> deploys/verifies the daemon bundle.</div>
+      </div></div>
+      <div class="step"><div class="num"></div><div class="body">
+        <div class="t">Mint the token</div>
+        <div class="d">HMAC-sign <code class="tok">{ userId, sandboxId, requestId, exp:+10m }</code> with <code>LLM_TOKEN_SECRET</code> (<code>packages/llm-token</code>).</div>
+      </div></div>
+      <div class="step"><div class="num"></div><div class="body">
+        <div class="t">chat-api → daemon</div>
+        <div class="d"><code>POST /turn</code> (<code>x-daemon-auth-token</code>) with the system prompt, scope, message, and <code class="tok">llm_base_url</code> + <code class="tok">llm_token</code>.</div>
+      </div></div>
+      <div class="step"><div class="num"></div><div class="body">
+        <div class="t">Reconcile files</div>
+        <div class="d">Daemon spawns <code>sync.js</code>, which diffs Postgres against the sandbox FS and materializes the user's documents for the requested scope.</div>
+      </div></div>
+      <div class="step"><div class="num"></div><div class="body">
+        <div class="t">Spawn the agent (bwrap)</div>
+        <div class="d">Daemon spawns <code>bun agent.js</code> under bubblewrap with env <code class="tok">ANTHROPIC_BASE_URL</code> + <code class="tok">ANTHROPIC_AUTH_TOKEN</code> — and <b>no</b> <code class="key">ANTHROPIC_API_KEY</code>.</div>
+      </div></div>
+      <div class="step"><div class="num"></div><div class="body">
+        <div class="t">claude → llm-gateway</div>
+        <div class="d">The binary calls <code>${ANTHROPIC_BASE_URL}/v1/messages</code> with <code class="tok">Authorization: Bearer</code>. The gateway verifies (signature + expiry + shape), injects <code class="key">x-api-key</code>, and proxies to Anthropic.</div>
+      </div></div>
+      <div class="step"><div class="num"></div><div class="body">
+        <div class="t">Stream back</div>
+        <div class="d">Anthropic's SSE streams through the gateway untouched → agent emits NDJSON (<code>text_delta</code>, <code>session_id</code>) → daemon forwards → chat-api relays as SSE to the client.</div>
+      </div></div>
+    </div>
+  </section>
+
+  <!-- 03 TOKEN LIFECYCLE -->
+  <section>
+    <div class="sh rv">
+      <div class="n">03</div>
+      <div>
+        <h2>Token lifecycle</h2>
+        <p>Stateless &amp; signed — no database lookup, so the gateway scales horizontally.</p>
+      </div>
+    </div>
+    <div class="life rv">
+      <div class="ls"><div class="stage">mint</div><div class="who">chat-api</div><div class="what">HMAC-SHA256 over claims; 10-min TTL.</div><div class="arrow">→</div></div>
+      <div class="ls"><div class="stage">carry</div><div class="who">/turn body</div><div class="what">As <code style="font-family:var(--mono);font-size:11px">llm_token</code> + <code style="font-family:var(--mono);font-size:11px">llm_base_url</code>.</div><div class="arrow">→</div></div>
+      <div class="ls"><div class="stage">inject env</div><div class="who">daemon</div><div class="what">Set on the agent as <code style="font-family:var(--mono);font-size:11px">ANTHROPIC_AUTH_TOKEN</code>.</div><div class="arrow">→</div></div>
+      <div class="ls"><div class="stage">present</div><div class="who">claude</div><div class="what"><code style="font-family:var(--mono);font-size:11px">Authorization: Bearer</code>.</div><div class="arrow">→</div></div>
+      <div class="ls"><div class="stage">verify</div><div class="who">llm-gateway</div><div class="what">Sig + expiry + payload shape → swap for the real key.</div></div>
+    </div>
+  </section>
+
+  <!-- 04 SECRET MATRIX -->
+  <section>
+    <div class="sh rv">
+      <div class="n">04</div>
+      <div>
+        <h2>Who holds what</h2>
+        <p>The point of the change in one table.</p>
+      </div>
+    </div>
+    <table class="mtx rv">
+      <thead>
+        <tr><th>Component</th><th>ANTHROPIC_API_KEY</th><th>LLM_TOKEN_SECRET</th><th>DATABASE_URL</th><th>Talks to</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="comp">chat-api</td>
+          <td class="c no">✕</td>
+          <td class="c yes">✓ <span class="sm">mint</span></td>
+          <td class="c yes">✓</td>
+          <td>→ E2B daemon</td>
+        </tr>
+        <tr>
+          <td class="comp">llm-gateway</td>
+          <td class="c only">✓ only here</td>
+          <td class="c yes">✓ <span class="sm">verify</span></td>
+          <td class="c no">✕</td>
+          <td>← sandboxes · → anthropic</td>
+        </tr>
+        <tr>
+          <td class="comp">sandbox-daemon</td>
+          <td class="c no">✕</td>
+          <td class="c no">✕</td>
+          <td class="c cav">✓ <span class="sm">sync (see #105/#104 backlog)</span></td>
+          <td>← chat-api</td>
+        </tr>
+        <tr>
+          <td class="comp">agent · claude</td>
+          <td class="c no">✕</td>
+          <td class="c no">✕</td>
+          <td class="c no">✕</td>
+          <td>→ llm-gateway only</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <!-- 05 PROCESS TREE -->
+  <section>
+    <div class="sh rv">
+      <div class="n">05</div>
+      <div>
+        <h2>Inside the sandbox</h2>
+        <p>The daemon spawns a fresh, isolated process per turn — the agent is a grandchild of the daemon.</p>
+      </div>
+    </div>
+    <div class="tree rv">
+<span class="b">daemon.js</span> <span class="c"># long-running Hono server · port 8080 · holds no provider key</span>
+├─ spawn <span class="b">bun sync.js</span>      <span class="c"># per-turn: reconcile Postgres → sandbox FS, then exits</span>
+└─ spawn <span class="b">bwrap …</span>           <span class="c"># per-turn child: ro-bind /, tmpfs /workspace, unshare ns</span>
+   └─ <span class="b">bun agent.js</span>          <span class="g"># env: ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN (no key)</span>
+      └─ <span class="b">claude</span>             <span class="c"># Agent SDK → </span><span class="g">Authorization: Bearer</span><span class="c"> → llm-gateway</span>
+         ├─ Bash / Grep / Read  <span class="c"># tool subprocesses</span>
+         └─ <span class="r">✗ api.anthropic.com</span>  <span class="c"># unreachable directly — only via the gateway</span>
+    </div>
+  </section>
+
+  <footer>
+    AS-BUILT ARCHITECTURE OF PR #107 · GENERATED FROM THE llm-gateway CONTROL-PLANE CHANGE<br/>
+    PR — <a href="https://github.com/X-GPT/chat-api/pull/107" target="_blank" rel="noopener">github.com/X-GPT/chat-api/pull/107</a><br/>
+    FOLLOW-UPS — <a href="https://github.com/X-GPT/chat-api/issues/103" target="_blank" rel="noopener">#103</a>
+    <a href="https://github.com/X-GPT/chat-api/issues/104" target="_blank" rel="noopener">#104</a>
+    <a href="https://github.com/X-GPT/chat-api/issues/105" target="_blank" rel="noopener">#105</a>
+    <a href="https://github.com/X-GPT/chat-api/issues/106" target="_blank" rel="noopener">#106</a>
+    <div class="pills">
+      <span>apps/chat-api</span><span>apps/llm-gateway</span><span>apps/sandbox-daemon</span><span>packages/llm-token</span><span>packages/db</span>
+    </div>
+  </footer>
+
+</div>
+
+<script>
+  const obs = new IntersectionObserver((es)=>{
+    for(const e of es){ if(e.isIntersecting){ e.target.classList.add('in'); obs.unobserve(e.target);} }
+  },{threshold:.1, rootMargin:"0px 0px -6% 0px"});
+  document.querySelectorAll('.rv').forEach(el=>{
+    if(el.closest('.hero')) requestAnimationFrame(()=>el.classList.add('in'));
+    else obs.observe(el);
+  });
+</script>
+</body>
+</html>

--- a/packages/llm-token/index.test.ts
+++ b/packages/llm-token/index.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "bun:test";
+import { createHmac } from "node:crypto";
+import { type LlmTokenClaims, mintLlmToken, verifyLlmToken } from "./index";
+
+const SECRET = "test-secret";
+const claims: Omit<LlmTokenClaims, "exp"> = {
+	userId: "u1",
+	sandboxId: "sbx-1",
+	requestId: "req-1",
+};
+
+// Craft a token with a VALID signature over an arbitrary payload, to prove that
+// a correct signature alone is not accepted without well-formed claims.
+function signedToken(payload: unknown): string {
+	const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+	const sig = createHmac("sha256", SECRET).update(body).digest("base64url");
+	return `${body}.${sig}`;
+}
+
+describe("llm-token", () => {
+	it("round-trips a freshly minted token", () => {
+		const token = mintLlmToken(claims, SECRET);
+		const verified = verifyLlmToken(token, SECRET);
+		expect(verified).toMatchObject(claims);
+		expect(verified?.exp).toBeGreaterThan(Date.now());
+	});
+
+	it("rejects a token signed with a different secret", () => {
+		const token = mintLlmToken(claims, SECRET);
+		expect(verifyLlmToken(token, "other-secret")).toBeNull();
+	});
+
+	it("rejects a tampered payload", () => {
+		const token = mintLlmToken(claims, SECRET);
+		const [, sig] = token.split(".");
+		const forged = `${Buffer.from(
+			JSON.stringify({ ...claims, userId: "attacker", exp: Date.now() + 1000 }),
+		).toString("base64url")}.${sig}`;
+		expect(verifyLlmToken(forged, SECRET)).toBeNull();
+	});
+
+	it("rejects an expired token", () => {
+		const token = mintLlmToken(claims, SECRET, -1);
+		expect(verifyLlmToken(token, SECRET)).toBeNull();
+	});
+
+	it("rejects malformed tokens", () => {
+		expect(verifyLlmToken("", SECRET)).toBeNull();
+		expect(verifyLlmToken("nodot", SECRET)).toBeNull();
+		expect(verifyLlmToken(".sig", SECRET)).toBeNull();
+	});
+
+	it("rejects a validly-signed payload that is not an object", () => {
+		// `(12345).exp` is undefined → `undefined < Date.now()` is false, which
+		// would "never expire" without the shape guard.
+		expect(verifyLlmToken(signedToken(12345), SECRET)).toBeNull();
+		expect(verifyLlmToken(signedToken("hello"), SECRET)).toBeNull();
+		expect(verifyLlmToken(signedToken(null), SECRET)).toBeNull();
+		expect(verifyLlmToken(signedToken([1, 2, 3]), SECRET)).toBeNull();
+	});
+
+	it("rejects a validly-signed object with a missing or non-numeric exp", () => {
+		expect(
+			verifyLlmToken(
+				signedToken({ userId: "u", sandboxId: "s", requestId: "r" }),
+				SECRET,
+			),
+		).toBeNull();
+		expect(
+			verifyLlmToken(
+				signedToken({
+					userId: "u",
+					sandboxId: "s",
+					requestId: "r",
+					exp: "soon",
+				}),
+				SECRET,
+			),
+		).toBeNull();
+	});
+
+	it("rejects a validly-signed object missing claim fields", () => {
+		expect(
+			verifyLlmToken(signedToken({ exp: Date.now() + 1000 }), SECRET),
+		).toBeNull();
+	});
+});

--- a/packages/llm-token/index.test.ts
+++ b/packages/llm-token/index.test.ts
@@ -84,4 +84,14 @@ describe("llm-token", () => {
 			verifyLlmToken(signedToken({ exp: Date.now() + 1000 }), SECRET),
 		).toBeNull();
 	});
+
+	it("rejects a validly-signed payload whose exp is non-finite (Infinity)", () => {
+		// JSON.stringify(Infinity) === "null", so craft raw JSON: 1e999 → Infinity,
+		// which `Infinity < Date.now()` would treat as never-expiring.
+		const body = Buffer.from(
+			'{"userId":"u","sandboxId":"s","requestId":"r","exp":1e999}',
+		).toString("base64url");
+		const sig = createHmac("sha256", SECRET).update(body).digest("base64url");
+		expect(verifyLlmToken(`${body}.${sig}`, SECRET)).toBeNull();
+	});
 });

--- a/packages/llm-token/index.ts
+++ b/packages/llm-token/index.ts
@@ -33,7 +33,9 @@ function isLlmTokenClaims(value: unknown): value is LlmTokenClaims {
 		typeof c.userId === "string" &&
 		typeof c.sandboxId === "string" &&
 		typeof c.requestId === "string" &&
-		typeof c.exp === "number"
+		// Number.isFinite (not `typeof === "number"`) so a signed `{"exp":1e999}`
+		// → Infinity is rejected instead of being treated as never-expiring.
+		Number.isFinite(c.exp)
 	);
 }
 

--- a/packages/llm-token/index.ts
+++ b/packages/llm-token/index.ts
@@ -1,0 +1,79 @@
+/**
+ * Stateless session token for the LLM control plane.
+ *
+ * chat-api mints a short-lived token per turn; llm-gateway verifies it before
+ * proxying to Anthropic with the real key. The token is a signed, self-describing
+ * blob — no database lookup — so the gateway can stay stateless and horizontally
+ * scalable. The signing secret is passed in by the caller (read from each app's
+ * env) so this package has no dependency on a particular env shape.
+ *
+ * Wire format: `<base64url(payload)>.<base64url(hmac-sha256)>`.
+ */
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+export interface LlmTokenClaims {
+	userId: string;
+	sandboxId: string;
+	requestId: string;
+	/** Expiry as ms since epoch. */
+	exp: number;
+}
+
+const DEFAULT_TTL_MS = 10 * 60_000;
+
+function sign(body: string, secret: string): string {
+	return createHmac("sha256", secret).update(body).digest("base64url");
+}
+
+function isLlmTokenClaims(value: unknown): value is LlmTokenClaims {
+	if (typeof value !== "object" || value === null) return false;
+	const c = value as Record<string, unknown>;
+	return (
+		typeof c.userId === "string" &&
+		typeof c.sandboxId === "string" &&
+		typeof c.requestId === "string" &&
+		typeof c.exp === "number"
+	);
+}
+
+export function mintLlmToken(
+	claims: Omit<LlmTokenClaims, "exp">,
+	secret: string,
+	ttlMs: number = DEFAULT_TTL_MS,
+): string {
+	const payload: LlmTokenClaims = { ...claims, exp: Date.now() + ttlMs };
+	const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+	return `${body}.${sign(body, secret)}`;
+}
+
+export function verifyLlmToken(
+	token: string,
+	secret: string,
+): LlmTokenClaims | null {
+	const dot = token.indexOf(".");
+	if (dot < 1) return null;
+
+	const body = token.slice(0, dot);
+	const presented = Buffer.from(token.slice(dot + 1));
+	const expected = Buffer.from(sign(body, secret));
+	if (
+		presented.length !== expected.length ||
+		!timingSafeEqual(presented, expected)
+	) {
+		return null;
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(Buffer.from(body, "base64url").toString());
+	} catch {
+		return null;
+	}
+	// A valid signature only proves the secret-holder produced the payload; it
+	// does not guarantee shape. Reject anything that isn't well-formed claims so
+	// callers never see a non-object or a missing/non-numeric exp (which would
+	// make `exp < Date.now()` falsy and silently "never expire").
+	if (!isLlmTokenClaims(parsed)) return null;
+	return parsed.exp < Date.now() ? null : parsed;
+}

--- a/packages/llm-token/package.json
+++ b/packages/llm-token/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "@mymemo/llm-token",
+	"version": "0.1.0",
+	"type": "module",
+	"exports": {
+		".": "./index.ts"
+	}
+}


### PR DESCRIPTION
## Summary
Moves provider credentials out of the E2B sandbox. The sandboxed agent is treated as untrusted; it no longer holds `ANTHROPIC_API_KEY`. Instead:

- **chat-api** mints a short-lived, HMAC-signed bearer token per turn (bound to `{userId, sandboxId, requestId}`) and sends `llm_base_url` + `llm_token` in the `/turn` body.
- **sandbox-daemon** sets these as `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` on the agent process — the daemon holds no provider key.
- **llm-gateway** (new, stateless service) verifies the token, injects the real `x-api-key`, and proxies to Anthropic.

Net effect: the real key lives in exactly one small service, and a compromised/prompt-injected agent has nothing worth stealing beyond a 10-minute, single-user token.

```
chat-api (mint) ──llm_token──► daemon ──ANTHROPIC_AUTH_TOKEN──► claude
                                                                  │ Authorization: Bearer
                                                                  ▼
                                            llm-gateway (verify → inject x-api-key) ──► api.anthropic.com
```

## What's included
- `packages/llm-token` — shared mint/verify (HMAC; payload-shape validated so a signed-but-malformed payload can't bypass expiry).
- `apps/llm-gateway` — token-gated transparent proxy; Anthropic-shaped error on upstream transport failure; trimmed/case-insensitive Bearer parse; validated `GATEWAY_PORT`; base-URL trailing-slash normalization.
- chat-api: token minting + turn-body fields; **dropped `ANTHROPIC_API_KEY`** and the unused OpenAI/DeepSeek/ai-sdk deps.
- sandbox-daemon: forwards the token into the agent env.
- Tests pinning the `mint → forward → agent-env → verify` seams, including an assertion that **no provider key reaches the agent**.
- `AGENTS.md`, `Dockerfile`, `compose.yaml` updated.

## Tests
`llm-token 8/8 · llm-gateway 3/3 · sandbox-daemon 87/87 · chat-api 37/37`; gateway typechecks clean; biome clean on changed source.

## Deploy prerequisite
`LLM_GATEWAY_PUBLIC_URL` (chat-api) must resolve to an address **reachable from inside the E2B sandbox**, and `ANTHROPIC_API_KEY` + `LLM_TOKEN_SECRET` must be set on `llm-gateway` (the latter shared with chat-api). `ANTHROPIC_API_KEY` is no longer needed by chat-api or the daemon.

## Deferred follow-ups
- #103 — rework the E2B integration + probe scripts (currently broken under the new arch; in-sandbox gateway decided)
- #104 — decide token TTL vs. claim-binding enforcement
- #105 — prevent the bearer token leaking into `daemon.log`
- #106 — pin the claude → gateway `Authorization: Bearer` contract end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)
