### PR TITLE
docs: update architecture page (srt + egress allowlist, runtime variants)

### DIFF
--- a/docs/llm-gateway-architecture.html
+++ b/docs/llm-gateway-architecture.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<title>Architecture · llm-gateway control plane (PR #107)</title>
+<title>Architecture · gateway control planes (PR #116)</title>
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
@@ -23,7 +23,7 @@
     --red-dim:rgba(204,58,46,.10);
     --green:#0f8a59;     /* the bearer token */
     --green-dim:rgba(15,138,89,.10);
-    --amber:#a9690a;     /* caveat (DATABASE_URL still in sandbox) */
+    --amber:#a9690a;     /* the real document-API key (document-gateway) */
     --amber-dim:rgba(169,105,10,.12);
     --mono:"IBM Plex Mono",ui-monospace,monospace;
     --sans:"Archivo",system-ui,sans-serif;
@@ -199,8 +199,8 @@
 
   <div class="top">
     <div>AS-BUILT ARCHITECTURE · X-GPT/chat-api</div>
-    <a class="pr" href="https://github.com/X-GPT/chat-api/pull/107" target="_blank" rel="noopener">
-      PR <b>#107</b> · llm-gateway control plane ↗
+    <a class="pr" href="https://github.com/X-GPT/chat-api/pull/116" target="_blank" rel="noopener">
+      PR <b>#116</b> · scope-bound document-gateway ↗
     </a>
   </div>
 
@@ -211,9 +211,11 @@
       never the <span class="k">key</span>.
     </h1>
     <p class="sub rv" style="--d:.18s">
-      Provider credentials move out of the E2B sandbox into a dedicated <b>llm-gateway</b> control plane.
-      chat-api mints a short-lived bearer token per turn; the gateway is the <b>only</b> place the real
-      <code style="font-family:var(--mono);color:var(--red)">ANTHROPIC_API_KEY</code> lives.
+      Every real credential moves out of the E2B sandbox into dedicated control planes — an <b>llm-gateway</b>
+      for the model and a <b>document-gateway</b> for the user's documents. chat-api mints one short-lived,
+      <b>scope-bound</b> bearer token per turn; the gateways are the <b>only</b> places the real
+      <code style="font-family:var(--mono);color:var(--red)">ANTHROPIC_API_KEY</code> and
+      <code style="font-family:var(--mono);color:var(--amber)">MYMEMO_DOC_API_KEY</code> live.
     </p>
   </header>
 
@@ -223,7 +225,7 @@
       <div class="n">01</div>
       <div>
         <h2>Topology &amp; trust boundary</h2>
-        <p>Two zones. Credentials are color-coded: <b style="color:var(--red)">● real key</b>, <b style="color:var(--green)">● bearer token</b>, <b style="color:var(--amber)">● DB url</b>.</p>
+        <p>Two zones. Credentials are color-coded: <b style="color:var(--red)">● provider key</b>, <b style="color:var(--amber)">● document-API key</b>, <b style="color:var(--green)">● bearer token</b>.</p>
       </div>
     </div>
 
@@ -234,12 +236,17 @@
 
           <div class="node">
             <div class="nh"><span class="nm">chat-api</span><span class="badge tok">mints token</span></div>
-            <div class="role">Orchestrator. Validates identity, opens the SSE stream, creates/reuses the E2B sandbox, and signs a per-turn <code>llm_token</code>. No provider key.</div>
+            <div class="role">Orchestrator. Validates identity, opens the SSE stream, creates a <b>fresh E2B sandbox per turn</b> (torn down in a <code>finally</code>), and signs a per-turn, scope-bound <code>llm_token</code>. No provider key.</div>
           </div>
 
           <div class="node">
             <div class="nh"><span class="nm">llm-gateway</span><span class="badge key">ANTHROPIC_API_KEY</span></div>
-            <div class="role">Stateless service. Verifies the bearer token, injects the real <code>x-api-key</code>, and proxies a strict path allowlist (<code>/v1/messages</code>, <code>/v1/messages/count_tokens</code>) to Anthropic. The only key-holder.</div>
+            <div class="role">Stateless service. Verifies the bearer token, injects the real <code>x-api-key</code>, and proxies a strict path allowlist (<code>/v1/messages</code>, <code>/v1/messages/count_tokens</code>) to Anthropic. The only provider-key holder.</div>
+          </div>
+
+          <div class="node">
+            <div class="nh"><span class="nm">document-gateway</span><span class="badge db">MYMEMO_DOC_API_KEY</span></div>
+            <div class="role">Stateless service. Verifies the same token, <b>enforces its signed scope</b> (global / collection / document) server-side, pins every call to the token's <code>userId</code>, and proxies search/fetch to the MyMemo document API. The only document-key holder.</div>
           </div>
         </div>
 
@@ -247,36 +254,36 @@
           <div class="zlabel"><span class="pip"></span>E2B sandbox · untrusted</div>
 
           <div class="node">
-            <div class="nh"><span class="nm">sandbox-daemon</span><span class="badge db">DATABASE_URL</span></div>
-            <div class="role">Long-running in-sandbox server. Per turn: reconciles files (sync.js) and spawns the agent, forwarding the token into its env. No provider key.</div>
+            <div class="nh"><span class="nm">sandbox-daemon</span><span class="badge none">no secrets</span></div>
+            <div class="role">Long-running in-sandbox server. Per turn it just spawns the agent, forwarding the token + gateway URLs into its env. No provider key, no document key, no database.</div>
           </div>
 
           <div class="node">
             <div class="nh"><span class="nm">agent · claude</span><span class="badge tok">bearer token only</span></div>
-            <div class="role"><b>srt</b>-isolated (bwrap on Linux · sandbox-exec on macOS), <b>network egress allowlisted to the gateway host only</b>. Env: <code>ANTHROPIC_BASE_URL</code> + <code>ANTHROPIC_AUTH_TOKEN</code> — nothing worth stealing, nowhere to send it.</div>
+            <div class="role"><b>srt</b>-isolated (bwrap on Linux · sandbox-exec on macOS), <b>network egress allowlisted to the gateway hosts only</b>. Env: <code>ANTHROPIC_BASE_URL</code>/<code>ANTHROPIC_AUTH_TOKEN</code> + <code>MYMEMO_DOC_GATEWAY_URL</code>/<code>MYMEMO_DOC_TOKEN</code>. Reaches documents on demand via the <code>mymemo-docs</code> CLI — nothing worth stealing, nowhere to send it.</div>
           </div>
         </div>
       </div>
 
       <div class="boundary-note">
         <span class="tag">trust boundary</span>
-        <div>The agent has <b>nowhere else to reach</b> — srt's network allowlist denies every egress except the gateway host. Combined with the 10-minute, single-user <span style="color:var(--green);font-weight:600">Bearer token</span>, a prompt-injected agent has nothing worth stealing <em>and</em> nowhere to send a stolen secret.</div>
+        <div>The agent has <b>nowhere else to reach</b> — srt's network allowlist denies every egress except the two gateway hosts. Its only token is a 10-minute, single-user <span style="color:var(--green);font-weight:600">Bearer token</span> whose <b>scope is signed in</b>, so a prompt-injected agent can't widen its document access, has nothing worth stealing, <em>and</em> nowhere to send a stolen secret.</div>
       </div>
       <div class="external">
-        <span class="dot"></span>EXTERNAL &nbsp;·&nbsp; <b>api.anthropic.com</b> — reached only by llm-gateway (with the injected <span style="color:var(--red)">x-api-key</span>) &nbsp;·&nbsp; <b>Postgres</b> — read by the daemon's sync.js
+        <span class="dot"></span>EXTERNAL &nbsp;·&nbsp; <b>api.anthropic.com</b> — reached only by llm-gateway (with the injected <span style="color:var(--red)">x-api-key</span>) &nbsp;·&nbsp; <b>MyMemo document API</b> — reached only by document-gateway (with the injected <span style="color:var(--amber)">doc key</span>)
       </div>
     </div>
 
     <div class="credflow rv">
       <div class="cf k">
-        <h4>● the real key — contained</h4>
-        <p>Set on one service, used in one place, crosses one external edge.</p>
-        <div class="path"><span class="hot">llm-gateway</span> &nbsp;set x-api-key&nbsp; → &nbsp;api.anthropic.com</div>
+        <h4>● the real keys — contained</h4>
+        <p>Each lives on one service, is used in one place, and crosses one external edge.</p>
+        <div class="path"><span class="hot">llm-gateway</span> &nbsp;set x-api-key&nbsp; → &nbsp;api.anthropic.com<br/><span class="hot">document-gateway</span> &nbsp;set doc key&nbsp; → &nbsp;MyMemo doc API</div>
       </div>
       <div class="cf t">
         <h4>● the token — travels</h4>
-        <p>Minted, carried in the turn body, set as agent env, presented as Bearer, verified, discarded.</p>
-        <div class="path"><span class="hot">chat-api</span> → daemon → agent → <span class="hot">llm-gateway</span> ✓</div>
+        <p>Minted with scope, carried in the turn body, set as agent env, presented as Bearer to both gateways, verified, discarded.</p>
+        <div class="path"><span class="hot">chat-api</span> → daemon → agent → <span class="hot">llm-gateway</span> / <span class="hot">document-gateway</span> ✓</div>
       </div>
     </div>
   </section>
@@ -296,24 +303,24 @@
         <div class="d"><code>POST /api/v1/chat</code> with identity headers; chat-api opens the SSE response.</div>
       </div></div>
       <div class="step"><div class="num"></div><div class="body">
-        <div class="t">Resolve the sandbox</div>
-        <div class="d"><code>getOrCreateSandbox</code> — reconnect via the client's <code>sandboxId</code>, or create a fresh E2B sandbox; then <code>ensureSandboxDaemon</code> deploys/verifies the daemon bundle.</div>
+        <div class="t">Create the sandbox</div>
+        <div class="d"><code>createSandbox</code> — a <b>fresh E2B sandbox per turn</b> (no reconnect; killed in a <code>finally</code> when the turn ends); then <code>ensureSandboxDaemon</code> deploys/verifies the daemon bundle.</div>
       </div></div>
       <div class="step"><div class="num"></div><div class="body">
-        <div class="t">Mint the token</div>
-        <div class="d">HMAC-sign <code class="tok">{ userId, sandboxId, requestId, exp:+10m }</code> with <code>LLM_TOKEN_SECRET</code> (<code>packages/llm-token</code>).</div>
+        <div class="t">Mint the scope-bound token</div>
+        <div class="d">HMAC-sign <code class="tok">{ userId, sandboxId, requestId, scope, collectionId?, summaryId?, exp:+10m }</code> with <code>LLM_TOKEN_SECRET</code> (<code>packages/llm-token</code>). One token serves both gateways.</div>
       </div></div>
       <div class="step"><div class="num"></div><div class="body">
         <div class="t">chat-api → daemon</div>
-        <div class="d"><code>POST /turn</code> (<code>x-daemon-auth-token</code>) with the system prompt, scope, message, and <code class="tok">llm_base_url</code> + <code class="tok">llm_token</code>.</div>
-      </div></div>
-      <div class="step"><div class="num"></div><div class="body">
-        <div class="t">Reconcile files</div>
-        <div class="d">Daemon spawns <code>sync.js</code>, which diffs Postgres against the sandbox FS and materializes the user's documents for the requested scope.</div>
+        <div class="d"><code>POST /turn</code> (<code>x-daemon-auth-token</code>) with the system prompt, scope, message, <code class="tok">llm_base_url</code>, <code class="tok">doc_gateway_url</code>, and <code class="tok">llm_token</code>.</div>
       </div></div>
       <div class="step"><div class="num"></div><div class="body">
         <div class="t">Spawn the agent (srt)</div>
-        <div class="d">Daemon spawns <code>bun agent.js</code> under <a href="https://github.com/anthropic-experimental/sandbox-runtime" target="_blank" rel="noopener">srt</a> (bwrap on Linux · sandbox-exec on macOS) — filesystem allowlist for the scope cwd, network allowlist for the gateway host only. Env: <code class="tok">ANTHROPIC_BASE_URL</code> + <code class="tok">ANTHROPIC_AUTH_TOKEN</code>, <b>no</b> <code class="key">ANTHROPIC_API_KEY</code>.</div>
+        <div class="d">Daemon spawns <code>bun agent.js</code> under <a href="https://github.com/anthropic-experimental/sandbox-runtime" target="_blank" rel="noopener">srt</a> (bwrap on Linux · sandbox-exec on macOS) — filesystem allowlist for the workspace cwd, network allowlist for the gateway hosts only. Env: <code class="tok">ANTHROPIC_BASE_URL</code>/<code class="tok">ANTHROPIC_AUTH_TOKEN</code> + <code class="tok">MYMEMO_DOC_GATEWAY_URL</code>/<code class="tok">MYMEMO_DOC_TOKEN</code>, <b>no</b> <code class="key">ANTHROPIC_API_KEY</code>, <b>no</b> <code class="key">MYMEMO_DOC_API_KEY</code>.</div>
+      </div></div>
+      <div class="step"><div class="num"></div><div class="body">
+        <div class="t">agent → document-gateway (on demand)</div>
+        <div class="d">When it needs documents the agent runs <code>mymemo-docs search</code>/<code>fetch</code> (a CLI on its <code>PATH</code>) → <code>document-gateway</code> verifies the token, <b>enforces the signed scope</b>, and proxies to the MyMemo doc API with the real <code class="key">doc key</code>. Nothing is materialized to the sandbox FS.</div>
       </div></div>
       <div class="step"><div class="num"></div><div class="body">
         <div class="t">claude → llm-gateway</div>
@@ -336,11 +343,11 @@
       </div>
     </div>
     <div class="life rv">
-      <div class="ls"><div class="stage">mint</div><div class="who">chat-api</div><div class="what">HMAC-SHA256 over claims; 10-min TTL.</div><div class="arrow">→</div></div>
-      <div class="ls"><div class="stage">carry</div><div class="who">/turn body</div><div class="what">As <code style="font-family:var(--mono);font-size:11px">llm_token</code> + <code style="font-family:var(--mono);font-size:11px">llm_base_url</code>.</div><div class="arrow">→</div></div>
-      <div class="ls"><div class="stage">inject env</div><div class="who">daemon</div><div class="what">Set on the agent as <code style="font-family:var(--mono);font-size:11px">ANTHROPIC_AUTH_TOKEN</code>.</div><div class="arrow">→</div></div>
-      <div class="ls"><div class="stage">present</div><div class="who">claude</div><div class="what"><code style="font-family:var(--mono);font-size:11px">Authorization: Bearer</code>.</div><div class="arrow">→</div></div>
-      <div class="ls"><div class="stage">verify</div><div class="who">llm-gateway</div><div class="what">Sig + expiry + payload shape → swap for the real key.</div></div>
+      <div class="ls"><div class="stage">mint</div><div class="who">chat-api</div><div class="what">HMAC-SHA256 over claims incl. <b>scope</b>; 10-min TTL.</div><div class="arrow">→</div></div>
+      <div class="ls"><div class="stage">carry</div><div class="who">/turn body</div><div class="what">As <code style="font-family:var(--mono);font-size:11px">llm_token</code> + <code style="font-family:var(--mono);font-size:11px">llm_base_url</code> + <code style="font-family:var(--mono);font-size:11px">doc_gateway_url</code>.</div><div class="arrow">→</div></div>
+      <div class="ls"><div class="stage">inject env</div><div class="who">daemon</div><div class="what">Set on the agent as <code style="font-family:var(--mono);font-size:11px">ANTHROPIC_AUTH_TOKEN</code> + <code style="font-family:var(--mono);font-size:11px">MYMEMO_DOC_TOKEN</code>.</div><div class="arrow">→</div></div>
+      <div class="ls"><div class="stage">present</div><div class="who">claude</div><div class="what"><code style="font-family:var(--mono);font-size:11px">Authorization: Bearer</code> to either gateway.</div><div class="arrow">→</div></div>
+      <div class="ls"><div class="stage">verify</div><div class="who">gateways</div><div class="what">Sig + expiry + shape → swap for the real key; document-gateway also enforces the scope.</div></div>
     </div>
   </section>
 
@@ -355,28 +362,35 @@
     </div>
     <table class="mtx rv">
       <thead>
-        <tr><th>Component</th><th>ANTHROPIC_API_KEY</th><th>LLM_TOKEN_SECRET</th><th>DATABASE_URL</th><th>Talks to</th></tr>
+        <tr><th>Component</th><th>ANTHROPIC_API_KEY</th><th>MYMEMO_DOC_API_KEY</th><th>LLM_TOKEN_SECRET</th><th>Talks to</th></tr>
       </thead>
       <tbody>
         <tr>
           <td class="comp">chat-api</td>
           <td class="c no">✕</td>
+          <td class="c no">✕</td>
           <td class="c yes">✓ <span class="sm">mint</span></td>
-          <td class="c yes">✓</td>
           <td>→ E2B daemon</td>
         </tr>
         <tr>
           <td class="comp">llm-gateway</td>
           <td class="c only">✓ only here</td>
-          <td class="c yes">✓ <span class="sm">verify</span></td>
           <td class="c no">✕</td>
+          <td class="c yes">✓ <span class="sm">verify</span></td>
           <td>← sandboxes · → anthropic</td>
+        </tr>
+        <tr>
+          <td class="comp">document-gateway</td>
+          <td class="c no">✕</td>
+          <td class="c only">✓ only here</td>
+          <td class="c yes">✓ <span class="sm">verify + enforce scope</span></td>
+          <td>← sandboxes · → MyMemo doc API</td>
         </tr>
         <tr>
           <td class="comp">sandbox-daemon</td>
           <td class="c no">✕</td>
           <td class="c no">✕</td>
-          <td class="c cav">✓ <span class="sm">sync (see #105/#104 backlog)</span></td>
+          <td class="c no">✕</td>
           <td>← chat-api</td>
         </tr>
         <tr>
@@ -384,7 +398,7 @@
           <td class="c no">✕</td>
           <td class="c no">✕</td>
           <td class="c no">✕</td>
-          <td>→ llm-gateway only <span class="sm">(srt egress allowlist)</span></td>
+          <td>→ llm-gateway + document-gateway only <span class="sm">(srt egress allowlist)</span></td>
         </tr>
       </tbody>
     </table>
@@ -400,14 +414,15 @@
       </div>
     </div>
     <div class="tree rv">
-<span class="b">daemon.js</span> <span class="c"># long-running Hono server · port 8080 · holds no provider key</span>
-├─ spawn <span class="b">bun sync.js</span>       <span class="c"># per-turn: reconcile Postgres → sandbox FS, then exits</span>
+<span class="b">daemon.js</span> <span class="c"># long-running Hono server · port 8080 · holds no secrets</span>
 └─ spawn <span class="b">srt …</span>             <span class="c"># per-turn: filesystem allowlist + network allowlist + ns</span>
-   └─ <span class="b">bun agent.js</span>          <span class="g"># env: ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN (no key)</span>
+   └─ <span class="b">bun agent.js</span>          <span class="g"># env: ANTHROPIC_* + MYMEMO_DOC_* (tokens only, no keys)</span>
       └─ <span class="b">claude</span>             <span class="c"># Agent SDK · </span><span class="g">Authorization: Bearer</span>
          ├─ Bash / Grep / Read   <span class="c"># tool subprocesses</span>
-         ├─ <span class="g">✓ llm-gateway</span>        <span class="c"># the only host srt allows outbound</span>
-         └─ <span class="r">✗ everywhere else</span>     <span class="c"># api.anthropic.com, public internet — denied</span>
+         ├─ <span class="a">mymemo-docs</span>          <span class="c"># CLI on PATH · search/fetch via document-gateway</span>
+         ├─ <span class="g">✓ llm-gateway</span>        <span class="c"># model calls — allowed outbound</span>
+         ├─ <span class="g">✓ document-gateway</span>   <span class="c"># document calls — allowed outbound</span>
+         └─ <span class="r">✗ everywhere else</span>     <span class="c"># anthropic, MyMemo doc API, public internet — denied</span>
     </div>
   </section>
 
@@ -417,28 +432,28 @@
       <div class="n">06</div>
       <div>
         <h2>Runtime variants</h2>
-        <p>Same architecture, three deployment shapes — only the sandbox runtime and the gateway's locality change.</p>
+        <p>Same architecture, three deployment shapes — only the sandbox runtime and the gateways' locality change.</p>
       </div>
     </div>
     <table class="mtx rv">
       <thead>
-        <tr><th>Environment</th><th>Sandbox runtime</th><th>llm-gateway</th><th>Agent isolation</th></tr>
+        <tr><th>Environment</th><th>Sandbox runtime</th><th>gateways (llm + doc)</th><th>Agent isolation</th></tr>
       </thead>
       <tbody>
         <tr>
           <td class="comp">production</td>
           <td>real E2B · Firecracker microVM</td>
-          <td>separate service · public ALB</td>
+          <td>separate services · public HTTPS</td>
           <td>srt (bwrap) + egress allowlist</td>
         </tr>
         <tr>
           <td class="comp">E2B integration test</td>
           <td>real E2B</td>
-          <td>sibling process inside the sandbox · loopback</td>
+          <td>sibling processes inside the sandbox · loopback</td>
           <td>srt (bwrap) + egress allowlist</td>
         </tr>
         <tr>
-          <td class="comp">local dev · agent + gateway</td>
+          <td class="comp">local dev · agent + gateways</td>
           <td>none — bun on host</td>
           <td>bun on host · localhost</td>
           <td>(skipped — no sandbox runtime)</td>
@@ -446,13 +461,13 @@
       </tbody>
     </table>
     <p style="margin-top:14px;font-size:13.5px;color:var(--ink-soft);max-width:680px">
-      The same code path runs in all three — the toggle is <code style="font-family:var(--mono);background:var(--paper-2);border:1px solid var(--line);border-radius:3px;padding:1px 5px">LLM_GATEWAY_PUBLIC_URL</code> (loopback vs. public URL) plus the choice of sandbox provider. chat-api always mints the token; the gateway always verifies it.
+      The same code path runs in all three — the toggle is <code style="font-family:var(--mono);background:var(--paper-2);border:1px solid var(--line);border-radius:3px;padding:1px 5px">LLM_GATEWAY_PUBLIC_URL</code> + <code style="font-family:var(--mono);background:var(--paper-2);border:1px solid var(--line);border-radius:3px;padding:1px 5px">DOCUMENT_GATEWAY_PUBLIC_URL</code> (loopback vs. public URL) plus the choice of sandbox provider. chat-api always mints the token; the gateways always verify it.
     </p>
   </section>
 
   <footer>
-    AS-BUILT ARCHITECTURE OF PR #107 · GENERATED FROM THE llm-gateway CONTROL-PLANE CHANGE<br/>
-    PR — <a href="https://github.com/X-GPT/chat-api/pull/107" target="_blank" rel="noopener">github.com/X-GPT/chat-api/pull/107</a><br/>
+    AS-BUILT ARCHITECTURE OF PR #116 · SCOPE-BOUND DOCUMENT-GATEWAY (BUILDS ON THE #107 llm-gateway CONTROL PLANE)<br/>
+    PR — <a href="https://github.com/X-GPT/chat-api/pull/116" target="_blank" rel="noopener">github.com/X-GPT/chat-api/pull/116</a><br/>
     FOLLOW-UPS —
     <a href="https://github.com/X-GPT/chat-api/issues/103" target="_blank" rel="noopener">#103</a>
     <a href="https://github.com/X-GPT/chat-api/issues/104" target="_blank" rel="noopener">#104</a>
@@ -467,7 +482,7 @@
     <a href="https://github.com/X-GPT/chat-api/issues/114" target="_blank" rel="noopener">#114</a>
     <br/>NOTE — agent isolation migrates from raw <code style="font-family:var(--mono)">bwrap</code> to <a href="https://github.com/anthropic-experimental/sandbox-runtime" target="_blank" rel="noopener">srt</a> alongside #103 (adds the egress allowlist). SDK pinned at <code style="font-family:var(--mono)">@anthropic-ai/claude-agent-sdk@0.2.97</code>.
     <div class="pills">
-      <span>apps/chat-api</span><span>apps/llm-gateway</span><span>apps/sandbox-daemon</span><span>packages/llm-token</span><span>packages/db</span>
+      <span>apps/chat-api</span><span>apps/llm-gateway</span><span>apps/document-gateway</span><span>apps/sandbox-daemon</span><span>packages/llm-token</span>
     </div>
   </footer>
 

--- a/docs/llm-gateway-architecture.html
+++ b/docs/llm-gateway-architecture.html
@@ -239,7 +239,7 @@
 
           <div class="node">
             <div class="nh"><span class="nm">llm-gateway</span><span class="badge key">ANTHROPIC_API_KEY</span></div>
-            <div class="role">New stateless service. Verifies the bearer token, injects the real <code>x-api-key</code>, and transparently proxies to Anthropic. The only key-holder.</div>
+            <div class="role">Stateless service. Verifies the bearer token, injects the real <code>x-api-key</code>, and proxies a strict path allowlist (<code>/v1/messages</code>, <code>/v1/messages/count_tokens</code>) to Anthropic. The only key-holder.</div>
           </div>
         </div>
 
@@ -253,14 +253,14 @@
 
           <div class="node">
             <div class="nh"><span class="nm">agent · claude</span><span class="badge tok">bearer token only</span></div>
-            <div class="role">bwrap-isolated. Runs with <code>ANTHROPIC_BASE_URL</code> + <code>ANTHROPIC_AUTH_TOKEN</code> — nothing worth stealing.</div>
+            <div class="role"><b>srt</b>-isolated (bwrap on Linux · sandbox-exec on macOS), <b>network egress allowlisted to the gateway host only</b>. Env: <code>ANTHROPIC_BASE_URL</code> + <code>ANTHROPIC_AUTH_TOKEN</code> — nothing worth stealing, nowhere to send it.</div>
           </div>
         </div>
       </div>
 
       <div class="boundary-note">
         <span class="tag">trust boundary</span>
-        <div>The single inbound edge from the sandbox is <b>agent → llm-gateway</b>, carrying <b>only</b> a 10-minute, single-user <span style="color:var(--green);font-weight:600">Bearer token</span>. A prompt-injected agent has no provider key to exfiltrate.</div>
+        <div>The agent has <b>nowhere else to reach</b> — srt's network allowlist denies every egress except the gateway host. Combined with the 10-minute, single-user <span style="color:var(--green);font-weight:600">Bearer token</span>, a prompt-injected agent has nothing worth stealing <em>and</em> nowhere to send a stolen secret.</div>
       </div>
       <div class="external">
         <span class="dot"></span>EXTERNAL &nbsp;·&nbsp; <b>api.anthropic.com</b> — reached only by llm-gateway (with the injected <span style="color:var(--red)">x-api-key</span>) &nbsp;·&nbsp; <b>Postgres</b> — read by the daemon's sync.js
@@ -312,8 +312,8 @@
         <div class="d">Daemon spawns <code>sync.js</code>, which diffs Postgres against the sandbox FS and materializes the user's documents for the requested scope.</div>
       </div></div>
       <div class="step"><div class="num"></div><div class="body">
-        <div class="t">Spawn the agent (bwrap)</div>
-        <div class="d">Daemon spawns <code>bun agent.js</code> under bubblewrap with env <code class="tok">ANTHROPIC_BASE_URL</code> + <code class="tok">ANTHROPIC_AUTH_TOKEN</code> — and <b>no</b> <code class="key">ANTHROPIC_API_KEY</code>.</div>
+        <div class="t">Spawn the agent (srt)</div>
+        <div class="d">Daemon spawns <code>bun agent.js</code> under <a href="https://github.com/anthropic-experimental/sandbox-runtime" target="_blank" rel="noopener">srt</a> (bwrap on Linux · sandbox-exec on macOS) — filesystem allowlist for the scope cwd, network allowlist for the gateway host only. Env: <code class="tok">ANTHROPIC_BASE_URL</code> + <code class="tok">ANTHROPIC_AUTH_TOKEN</code>, <b>no</b> <code class="key">ANTHROPIC_API_KEY</code>.</div>
       </div></div>
       <div class="step"><div class="num"></div><div class="body">
         <div class="t">claude → llm-gateway</div>
@@ -384,7 +384,7 @@
           <td class="c no">✕</td>
           <td class="c no">✕</td>
           <td class="c no">✕</td>
-          <td>→ llm-gateway only</td>
+          <td>→ llm-gateway only <span class="sm">(srt egress allowlist)</span></td>
         </tr>
       </tbody>
     </table>
@@ -401,22 +401,71 @@
     </div>
     <div class="tree rv">
 <span class="b">daemon.js</span> <span class="c"># long-running Hono server · port 8080 · holds no provider key</span>
-├─ spawn <span class="b">bun sync.js</span>      <span class="c"># per-turn: reconcile Postgres → sandbox FS, then exits</span>
-└─ spawn <span class="b">bwrap …</span>           <span class="c"># per-turn child: ro-bind /, tmpfs /workspace, unshare ns</span>
+├─ spawn <span class="b">bun sync.js</span>       <span class="c"># per-turn: reconcile Postgres → sandbox FS, then exits</span>
+└─ spawn <span class="b">srt …</span>             <span class="c"># per-turn: filesystem allowlist + network allowlist + ns</span>
    └─ <span class="b">bun agent.js</span>          <span class="g"># env: ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN (no key)</span>
-      └─ <span class="b">claude</span>             <span class="c"># Agent SDK → </span><span class="g">Authorization: Bearer</span><span class="c"> → llm-gateway</span>
-         ├─ Bash / Grep / Read  <span class="c"># tool subprocesses</span>
-         └─ <span class="r">✗ api.anthropic.com</span>  <span class="c"># unreachable directly — only via the gateway</span>
+      └─ <span class="b">claude</span>             <span class="c"># Agent SDK · </span><span class="g">Authorization: Bearer</span>
+         ├─ Bash / Grep / Read   <span class="c"># tool subprocesses</span>
+         ├─ <span class="g">✓ llm-gateway</span>        <span class="c"># the only host srt allows outbound</span>
+         └─ <span class="r">✗ everywhere else</span>     <span class="c"># api.anthropic.com, public internet — denied</span>
     </div>
+  </section>
+
+  <!-- 06 RUNTIME VARIANTS -->
+  <section>
+    <div class="sh rv">
+      <div class="n">06</div>
+      <div>
+        <h2>Runtime variants</h2>
+        <p>Same architecture, three deployment shapes — only the sandbox runtime and the gateway's locality change.</p>
+      </div>
+    </div>
+    <table class="mtx rv">
+      <thead>
+        <tr><th>Environment</th><th>Sandbox runtime</th><th>llm-gateway</th><th>Agent isolation</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="comp">production</td>
+          <td>real E2B · Firecracker microVM</td>
+          <td>separate service · public ALB</td>
+          <td>srt (bwrap) + egress allowlist</td>
+        </tr>
+        <tr>
+          <td class="comp">E2B integration test</td>
+          <td>real E2B</td>
+          <td>sibling process inside the sandbox · loopback</td>
+          <td>srt (bwrap) + egress allowlist</td>
+        </tr>
+        <tr>
+          <td class="comp">local dev · agent + gateway</td>
+          <td>none — bun on host</td>
+          <td>bun on host · localhost</td>
+          <td>(skipped — no sandbox runtime)</td>
+        </tr>
+      </tbody>
+    </table>
+    <p style="margin-top:14px;font-size:13.5px;color:var(--ink-soft);max-width:680px">
+      The same code path runs in all three — the toggle is <code style="font-family:var(--mono);background:var(--paper-2);border:1px solid var(--line);border-radius:3px;padding:1px 5px">LLM_GATEWAY_PUBLIC_URL</code> (loopback vs. public URL) plus the choice of sandbox provider. chat-api always mints the token; the gateway always verifies it.
+    </p>
   </section>
 
   <footer>
     AS-BUILT ARCHITECTURE OF PR #107 · GENERATED FROM THE llm-gateway CONTROL-PLANE CHANGE<br/>
     PR — <a href="https://github.com/X-GPT/chat-api/pull/107" target="_blank" rel="noopener">github.com/X-GPT/chat-api/pull/107</a><br/>
-    FOLLOW-UPS — <a href="https://github.com/X-GPT/chat-api/issues/103" target="_blank" rel="noopener">#103</a>
+    FOLLOW-UPS —
+    <a href="https://github.com/X-GPT/chat-api/issues/103" target="_blank" rel="noopener">#103</a>
     <a href="https://github.com/X-GPT/chat-api/issues/104" target="_blank" rel="noopener">#104</a>
     <a href="https://github.com/X-GPT/chat-api/issues/105" target="_blank" rel="noopener">#105</a>
     <a href="https://github.com/X-GPT/chat-api/issues/106" target="_blank" rel="noopener">#106</a>
+    <a href="https://github.com/X-GPT/chat-api/issues/108" target="_blank" rel="noopener">#108</a>
+    <a href="https://github.com/X-GPT/chat-api/issues/109" target="_blank" rel="noopener">#109</a>
+    <a href="https://github.com/X-GPT/chat-api/issues/110" target="_blank" rel="noopener">#110</a>
+    <a href="https://github.com/X-GPT/chat-api/issues/111" target="_blank" rel="noopener">#111</a>
+    <a href="https://github.com/X-GPT/chat-api/issues/112" target="_blank" rel="noopener">#112</a>
+    <a href="https://github.com/X-GPT/chat-api/issues/113" target="_blank" rel="noopener">#113</a>
+    <a href="https://github.com/X-GPT/chat-api/issues/114" target="_blank" rel="noopener">#114</a>
+    <br/>NOTE — agent isolation migrates from raw <code style="font-family:var(--mono)">bwrap</code> to <a href="https://github.com/anthropic-experimental/sandbox-runtime" target="_blank" rel="noopener">srt</a> alongside #103 (adds the egress allowlist). SDK pinned at <code style="font-family:var(--mono)">@anthropic-ai/claude-agent-sdk@0.2.97</code>.
     <div class="pills">
       <span>apps/chat-api</span><span>apps/llm-gateway</span><span>apps/sandbox-daemon</span><span>packages/llm-token</span><span>packages/db</span>
     </div>


### PR DESCRIPTION
## Summary
Updates `docs/llm-gateway-architecture.html` to reflect the architectural decisions made after PR #107 merged. Doc-only — no code changes.

## What's reflected
- **Agent isolation: `srt` instead of raw `bwrap`** — `bwrap` on Linux, `sandbox-exec` on macOS via [`@anthropic-ai/sandbox-runtime`](https://github.com/anthropic-experimental/sandbox-runtime). Includes the **network egress allowlist** (gateway host only), so a prompt-injected agent has *nothing worth stealing AND nowhere to send a stolen secret*. Trust-boundary note tightened to reflect both halves.
- **Gateway path scoping** — note the strict allowlist (`/v1/messages`, `/v1/messages/count_tokens`) added in the post-PR hardening; everything else 404s even with a valid token.
- **§06 Runtime variants** (new) — production / E2B integration test / local-dev-on-host as one table. Same code, three deployments, toggled by `LLM_GATEWAY_PUBLIC_URL` + sandbox provider choice.
- **Process tree** updated: `srt` replaces `bwrap`; egress visualized as `✓ llm-gateway / ✗ everywhere else`.
- **Footer** — follow-ups extended (#103–#106, #108–#114); srt migration recorded as folding into #103; SDK pinned to `@anthropic-ai/claude-agent-sdk@0.2.97`.

Renders standalone (single HTML file with embedded CSS/JS, Google Fonts CDN — same as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
