### PR TITLE
chore: tailor .worktreeinclude to this repo's env files

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,3 +1,7 @@
+# Gitignored local files copied into new worktrees (.gitignore syntax).
+# Only files that are ALSO gitignored are copied.
+
+# dotenv (root + per-app, any depth: .env, .env.local, .env.dev-tool, ...)
 .env
+.env.*
 .env.local
-config/secrets.json


### PR DESCRIPTION
## What

`.worktreeinclude` (added in #91) still carried the docs' generic example, which didn't fully fit this repo. Tailor it:

- **Drop `config/secrets.json`** — a pure doc placeholder; it doesn't exist here and isn't gitignored, so it could never be copied.
- **Add `.env.*`** so per-app dotenv like `apps/chat-api/.env.dev-tool` is shared into new worktrees. The bare `.env` / `.env.local` patterns missed it (distinct name).
- Add header comments noting the `.gitignore`-syntax + "only-gitignored-files-are-copied" semantics.

## Why

New worktrees are fresh checkouts and lack gitignored local files (credentials). Without `.env.dev-tool` coverage, a worktree missed env this came up in practice. `node_modules` (~935 MB) is intentionally left out — `bun install` is the cleaner path than a per-worktree copy.

## Coverage check
Patterns now match the repo's actual gitignored env files: `apps/chat-api/.env`, `apps/chat-api/.env.dev-tool`, `apps/chat-api/sandbox-template/.env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)