### PR TITLE
feat(document-gateway): read the KB Postgres directly (FTS-only)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,9 +170,10 @@ Optional:
 ### document-gateway
 
 Required:
-- `MYMEMO_DOC_API_URL` — base URL of the real MyMemo document API
-- `MYMEMO_DOC_API_KEY` — the real document-API credential; lives **only** in this service
+- `DATABASE_URL` — read-only connection to the MyMemo KB Postgres; the credential lives **only** in this service
 - `LLM_TOKEN_SECRET` — must match chat-api's
 
 Optional:
+- `DB_PASSWORD` — spliced into `DATABASE_URL` when it is passwordless (the form the platform injects)
+- `DB_SSL` (default: on; set `disable` for a local non-TLS Postgres)
 - `DOCUMENT_GATEWAY_PORT` (default: 8082)

--- a/apps/chat-api/src/features/sandbox-agent/sandbox-agent.prompt.test.ts
+++ b/apps/chat-api/src/features/sandbox-agent/sandbox-agent.prompt.test.ts
@@ -15,7 +15,8 @@ describe("buildSandboxAgentPrompt", () => {
 		});
 
 		expect(prompt).toContain("[[N]][cN]");
-		expect(prompt).toContain("[c1]: detail/");
+		expect(prompt).toContain("passageId");
+		expect(prompt).toContain("[c1]: p_abc123");
 	});
 
 	it("instructs use of the mymemo-docs CLI", () => {
@@ -50,7 +51,7 @@ describe("buildSandboxAgentPrompt", () => {
 	});
 
 	describe("collection scope", () => {
-		it("injects the collectionId into the search instruction", () => {
+		it("explains search is auto-restricted to the collection", () => {
 			const prompt = buildSandboxAgentPrompt({
 				...baseOptions,
 				scope: "collection",
@@ -58,12 +59,12 @@ describe("buildSandboxAgentPrompt", () => {
 			});
 
 			expect(prompt).toContain("single collection");
-			expect(prompt).toContain("--collection col-123");
+			expect(prompt).toContain("automatically restricted");
 		});
 	});
 
 	describe("document scope", () => {
-		it("injects the summaryId as the documentId to fetch", () => {
+		it("explains search is auto-restricted to the document", () => {
 			const prompt = buildSandboxAgentPrompt({
 				...baseOptions,
 				scope: "document",
@@ -71,7 +72,7 @@ describe("buildSandboxAgentPrompt", () => {
 			});
 
 			expect(prompt).toContain("single specific document");
-			expect(prompt).toContain("mymemo-docs fetch doc-456");
+			expect(prompt).toContain("automatically restricted");
 		});
 	});
 

--- a/apps/chat-api/src/features/sandbox-agent/sandbox-agent.prompt.ts
+++ b/apps/chat-api/src/features/sandbox-agent/sandbox-agent.prompt.ts
@@ -28,10 +28,10 @@ You do NOT have the user's documents on your local filesystem. You access them w
   * **N** starts from **1** and increments in order of appearance
   * Example: \`The robots are autonomous [[1]][c1].\`
 * After the final answer, append only citation definitions at the very end of the message in plain text (no code fences). Example (each line exactly as shown, with no leading dash):
-[c1]: <path>
-[c2]: <path>
-* **Path format**: Use the value from the \`cite:\` line that \`mymemo-docs fetch\` prints for each document.
-  * Example: if \`mymemo-docs fetch\` prints \`cite: detail/0/12345\`, emit \`[c1]: detail/0/12345\`
+[c1]: <passageId>
+[c2]: <passageId>
+* **Path format**: Use the \`passageId\` from the \`mymemo-docs search\` result the fact came from.
+  * Example: for a search hit \`{"passageId":"p_abc123",...}\`, emit \`[c1]: p_abc123\`
 * Do not include a section heading like "References"
 * Do not wrap the citation list in code blocks
 * **Emit references only for markers used in the message**
@@ -61,7 +61,7 @@ const GENERAL_SCOPE_CONTEXT = `
 
 ### Scope
 
-The user's question is not restricted to a particular collection. Use \`mymemo-docs search\` (without \`--collection\`) to find relevant documents across all of the user's documents.
+The user's question is not restricted to a particular collection. Use \`mymemo-docs search\` to find relevant documents across all of the user's documents.
 
 **CRITICAL RULES:**
 - You MUST use \`mymemo-docs search\` and \`mymemo-docs fetch\` to find and read documents before answering.
@@ -70,30 +70,30 @@ The user's question is not restricted to a particular collection. Use \`mymemo-d
 
 ---`;
 
-function buildCollectionScopeContext(collectionId: string): string {
+function buildCollectionScopeContext(): string {
 	return `
 ---
 
 ### Scope
 
-You are answering within a single collection. Pass \`--collection ${collectionId}\` to \`mymemo-docs search\` so results are restricted to that collection.
+You are answering within a single collection. Search is **automatically restricted** to that collection by the gateway — just run \`mymemo-docs search "<query>"\` normally.
 
 **CRITICAL RULES:**
-- You must answer ONLY using documents from this collection.
-- You MUST run \`mymemo-docs search "<query>" --collection ${collectionId}\` and \`mymemo-docs fetch\` before answering.
+- You must answer ONLY using documents from this collection (the gateway enforces this).
+- You MUST run \`mymemo-docs search\` and \`mymemo-docs fetch\` before answering.
 - If the collection's documents do not contain the answer, explicitly state: "I cannot find this information in the provided collection."
 - DO NOT respond that information is missing until you have searched and fetched documents.
 
 ---`;
 }
 
-function buildDocumentScopeContext(summaryId: string): string {
+function buildDocumentScopeContext(): string {
 	return `
 ---
 
 ### Scope
 
-You are answering questions about a single specific document. Run \`mymemo-docs fetch ${summaryId}\`, then answer based on its content.
+You are answering questions about a single specific document. Search is **automatically restricted** to that document — run \`mymemo-docs search "<query>"\` to find the relevant passages, then \`mymemo-docs fetch <documentId>\` (the documentId from a search result) to read the full content.
 
 **CRITICAL RULES:**
 - Answer ONLY using the content of this specific document.
@@ -111,9 +111,9 @@ export function buildSandboxAgentPrompt(
 	let scopeContext: string;
 
 	if (scope === "document" && summaryId) {
-		scopeContext = buildDocumentScopeContext(summaryId);
+		scopeContext = buildDocumentScopeContext();
 	} else if (scope === "collection" && collectionId) {
-		scopeContext = buildCollectionScopeContext(collectionId);
+		scopeContext = buildCollectionScopeContext();
 	} else {
 		scopeContext = GENERAL_SCOPE_CONTEXT;
 	}

--- a/apps/document-gateway/src/db.ts
+++ b/apps/document-gateway/src/db.ts
@@ -1,0 +1,28 @@
+import { SQL } from "bun";
+import { gwEnv } from "./env";
+
+/**
+ * Minimal data-access seam. Parameterized SQL only — every caller passes a
+ * positional-param query, so query logic can be unit-tested with a fake Db and
+ * never needs a live Postgres.
+ */
+export interface Db {
+	query<T = Record<string, unknown>>(
+		text: string,
+		params?: unknown[],
+	): Promise<T[]>;
+}
+
+let singleton: Db | undefined;
+
+/** The real Db, backed by Bun's built-in Postgres client (lazy, pooled). */
+export function getDb(): Db {
+	if (singleton) return singleton;
+	// TLS is carried in the URL (sslmode); read-only gateway → a small pool.
+	const sql = new SQL({ url: gwEnv.DATABASE_URL, max: 8 });
+	singleton = {
+		query: <T>(text: string, params: unknown[] = []) =>
+			sql.unsafe(text, params) as Promise<T[]>,
+	};
+	return singleton;
+}

--- a/apps/document-gateway/src/env.ts
+++ b/apps/document-gateway/src/env.ts
@@ -11,26 +11,47 @@ function parsePort(value: string | undefined, fallback: number): number {
 }
 
 /**
- * Environment for the document gateway. This is the only service that holds the
- * real MyMemo document-API credential — keep its surface tiny. Validated at
- * module load.
+ * If DATABASE_URL is passwordless (e.g. `postgresql://user@host/db`, the form the
+ * platform injects) and DB_PASSWORD is set, splice the password into the URL.
+ */
+function withPassword(url: string, password: string | undefined): string {
+	if (!password) return url;
+	const m = /^([a-z]+:\/\/)([^@/]+)@(.*)$/i.exec(url);
+	if (!m) return url;
+	const [, scheme, userinfo, rest] = m;
+	if (!scheme || !userinfo || rest === undefined) return url;
+	if (userinfo.includes(":")) return url; // already has a password
+	return `${scheme}${userinfo}:${encodeURIComponent(password)}@${rest}`;
+}
+
+/** Append `sslmode=require` unless TLS is disabled or the URL already sets it. */
+function withSsl(url: string, enabled: boolean): string {
+	if (!enabled || /[?&]sslmode=/.test(url)) return url;
+	return `${url}${url.includes("?") ? "&" : "?"}sslmode=require`;
+}
+
+/**
+ * Environment for the document gateway — the trusted control plane that reads
+ * the MyMemo knowledge base directly. This is the only service here that holds
+ * the database credential; keep its surface tiny. Validated at module load.
  *
  * Uses a dedicated DOCUMENT_GATEWAY_PORT (not the generic PORT) so it never
  * collides with another co-located service reading the same injected env.
  */
 export const gwEnv = (() => {
 	invariant(Bun.env.LLM_TOKEN_SECRET, "LLM_TOKEN_SECRET is required");
-	invariant(Bun.env.MYMEMO_DOC_API_URL, "MYMEMO_DOC_API_URL is required");
-	invariant(Bun.env.MYMEMO_DOC_API_KEY, "MYMEMO_DOC_API_KEY is required");
+	invariant(Bun.env.DATABASE_URL, "DATABASE_URL is required");
 
 	return {
 		// Shared with chat-api (which mints the per-turn token) so we can verify it.
 		LLM_TOKEN_SECRET: Bun.env.LLM_TOKEN_SECRET,
-		// Base URL of the real MyMemo document API. Trailing slash stripped so
-		// `${base}${path}` never yields a double slash.
-		MYMEMO_DOC_API_URL: Bun.env.MYMEMO_DOC_API_URL.replace(/\/+$/, ""),
-		// The real document-API credential — lives ONLY in this service.
-		MYMEMO_DOC_API_KEY: Bun.env.MYMEMO_DOC_API_KEY,
+		// Read-only connection to the KB Postgres (the same RDS the platform uses).
+		// DB_PASSWORD is spliced in when DATABASE_URL is passwordless; TLS is on by
+		// default (set DB_SSL=disable for a local non-TLS Postgres).
+		DATABASE_URL: withSsl(
+			withPassword(Bun.env.DATABASE_URL, Bun.env.DB_PASSWORD),
+			Bun.env.DB_SSL !== "disable",
+		),
 		DOCUMENT_GATEWAY_PORT: parsePort(Bun.env.DOCUMENT_GATEWAY_PORT, 8082),
 	} as const;
 })();

--- a/apps/document-gateway/src/index.integration.test.ts
+++ b/apps/document-gateway/src/index.integration.test.ts
@@ -1,0 +1,151 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { mintLlmToken } from "@mymemo/llm-token";
+
+/**
+ * Integration test: exercises the REAL Bun.sql wiring + SQL against a throwaway
+ * Postgres (the unit tests use a fake Db). Gated on DOC_GATEWAY_IT so the normal
+ * suite skips it. Run:
+ *   docker run -d --name pg -e POSTGRES_PASSWORD=test -e POSTGRES_DB=kbtest \
+ *     -p 55432:5432 postgres:16
+ *   DOC_GATEWAY_IT=1 DB_SSL=disable \
+ *   DATABASE_URL=postgresql://postgres:test@127.0.0.1:55432/kbtest \
+ *   bun test apps/document-gateway/src/index.integration.test.ts
+ */
+
+const RUN = !!Bun.env.DOC_GATEWAY_IT;
+const SECRET = "test-secret";
+
+const WS = "member-ws-1"; // workspace_id = member_code (= token userId)
+const DOC = "doc-uuid-1";
+const PASSAGE = "passage-uuid-1";
+const SUMMARY_ID = "12345"; // platform_knowledge.id = content_asset.compat_int_id
+const COLLECTION = "col-compat-str"; // content_collection.compat_str_id
+const COLLECTION_INT = "98765"; // content_collection.compat_int_id
+const LONG = "Full content about machine learning. ".repeat(2000); // >50k chars
+
+let app: typeof import("./index").app;
+
+function tok(extra: Record<string, unknown> = {}): string {
+	return mintLlmToken(
+		{ userId: WS, sandboxId: "s", requestId: "r", ...extra },
+		SECRET,
+	);
+}
+function hdr(t: string): Record<string, string> {
+	return { authorization: `Bearer ${t}`, "content-type": "application/json" };
+}
+function post(path: string, t: string, body: unknown) {
+	return app.request(path, { method: "POST", headers: hdr(t), body: JSON.stringify(body) });
+}
+
+beforeAll(async () => {
+	if (!RUN) return;
+	Bun.env.LLM_TOKEN_SECRET = SECRET;
+	({ app } = await import("./index"));
+	const { getDb } = await import("./db");
+	const db = getDb();
+
+	await db.query(
+		"drop table if exists passage_collection, passage, document, content_asset, content_collection, workspace cascade",
+	);
+	await db.query("create table workspace (id text primary key)");
+	await db.query(
+		"create table document (id text primary key, workspace_id text, title text, canonical_markdown text, status text)",
+	);
+	await db.query(
+		"create table passage (id text primary key, document_id text, workspace_id text, passage_text text, search_tsv tsvector, status text)",
+	);
+	await db.query(
+		"create table content_asset (compat_int_id bigint, member_code text, kb_document_id text)",
+	);
+	await db.query(
+		"create table content_collection (compat_int_id bigint, compat_str_id text, member_code text)",
+	);
+	await db.query(
+		"create table passage_collection (passage_id text, collection_id text)",
+	);
+
+	await db.query("insert into workspace (id) values ($1)", [WS]);
+	await db.query(
+		"insert into document (id, workspace_id, title, canonical_markdown, status) values ($1,$2,$3,$4,'active')",
+		[DOC, WS, "ML Intro", LONG],
+	);
+	await db.query(
+		"insert into passage (id, document_id, workspace_id, passage_text, search_tsv, status) values ($1,$2,$3,$4, to_tsvector('simple',$4), 'active')",
+		[PASSAGE, DOC, WS, "machine learning is a subset of artificial intelligence"],
+	);
+	await db.query(
+		"insert into content_asset (compat_int_id, member_code, kb_document_id) values ($1,$2,$3)",
+		[SUMMARY_ID, WS, DOC],
+	);
+	await db.query(
+		"insert into content_collection (compat_int_id, compat_str_id, member_code) values ($1,$2,$3)",
+		[COLLECTION_INT, COLLECTION, WS],
+	);
+	// passage_collection.collection_id mirrors content_collection.compat_int_id::text
+	await db.query(
+		"insert into passage_collection (passage_id, collection_id) values ($1,$2)",
+		[PASSAGE, COLLECTION_INT],
+	);
+});
+
+describe.skipIf(!RUN)("document-gateway integration (real Postgres)", () => {
+	it("global search returns the FTS hit", async () => {
+		const res = await post("/v1/documents/search", tok({ scope: "global" }), {
+			query: "machine",
+		});
+		expect(res.status).toBe(200);
+		const { documents } = (await res.json()) as {
+			documents: { passageId: string; documentId: string; title: string }[];
+		};
+		expect(documents).toHaveLength(1);
+		expect(documents[0]).toMatchObject({
+			passageId: PASSAGE,
+			documentId: DOC,
+			title: "ML Intro",
+		});
+	});
+
+	it("global search misses on a non-matching term", async () => {
+		const res = await post("/v1/documents/search", tok({ scope: "global" }), {
+			query: "quantumzzz",
+		});
+		expect(((await res.json()) as { documents: unknown[] }).documents).toHaveLength(0);
+	});
+
+	it("fetch returns content clipped to 50k", async () => {
+		const res = await post("/v1/documents/fetch", tok({ scope: "global" }), {
+			documentId: DOC,
+		});
+		expect(res.status).toBe(200);
+		const doc = (await res.json()) as { content: string; title: string };
+		expect(doc.title).toBe("ML Intro");
+		expect(doc.content.length).toBe(50000);
+	});
+
+	it("document scope resolves summaryId and restricts to it (exercises ::bigint + ANY)", async () => {
+		const t = tok({ scope: "document", summaryId: SUMMARY_ID });
+		const res = await post("/v1/documents/search", t, { query: "machine" });
+		expect(((await res.json()) as { documents: unknown[] }).documents).toHaveLength(1);
+		// fetch in scope ok; out of scope forbidden
+		expect((await post("/v1/documents/fetch", t, { documentId: DOC })).status).toBe(200);
+		expect((await post("/v1/documents/fetch", t, { documentId: "other" })).status).toBe(403);
+	});
+
+	it("collection scope restricts to the collection's documents", async () => {
+		const t = tok({ scope: "collection", collectionId: COLLECTION });
+		const res = await post("/v1/documents/search", t, { query: "machine" });
+		expect(((await res.json()) as { documents: unknown[] }).documents).toHaveLength(1);
+		expect((await post("/v1/documents/fetch", t, { documentId: DOC })).status).toBe(200);
+	});
+
+	it("a different workspace sees nothing (the workspace pin)", async () => {
+		const t = mintLlmToken(
+			{ userId: "other-member", sandboxId: "s", requestId: "r", scope: "global" },
+			SECRET,
+		);
+		const res = await post("/v1/documents/search", t, { query: "machine" });
+		expect(((await res.json()) as { documents: unknown[] }).documents).toHaveLength(0);
+		expect((await post("/v1/documents/fetch", t, { documentId: DOC })).status).toBe(404);
+	});
+});

--- a/apps/document-gateway/src/index.test.ts
+++ b/apps/document-gateway/src/index.test.ts
@@ -139,7 +139,7 @@ describe("document-gateway (FTS / Postgres)", () => {
 			headers: headers(token({ scope: "collection", collectionId: "col-1" })),
 			body: JSON.stringify({ query: "x" }),
 		});
-		expect(callOf("resolveColl")?.params).toEqual(["col-1", "u1", "u1"]);
+		expect(callOf("resolveColl")?.params).toEqual(["col-1", "u1"]);
 		expect(callOf("search")?.params[2]).toEqual(["d1", "d2"]);
 	});
 

--- a/apps/document-gateway/src/index.test.ts
+++ b/apps/document-gateway/src/index.test.ts
@@ -93,9 +93,9 @@ describe("document-gateway (FTS / Postgres)", () => {
 			],
 		});
 		const search = callOf("search");
-		expect(search?.params[0]).toBe("u1"); // workspace_id
-		expect(search?.params[1]).toBe("hello world");
-		expect(search?.params[2]).toBeNull(); // no document filter in global scope
+		// global scope: no document filter — params are [workspace, query, limit].
+		expect(search?.params).toEqual(["u1", "hello world", 8]);
+		expect(search?.text).not.toContain("p.document_id IN");
 	});
 
 	it("document search resolves summaryId and restricts to that document", async () => {
@@ -113,7 +113,8 @@ describe("document-gateway (FTS / Postgres)", () => {
 			body: JSON.stringify({ query: "x" }),
 		});
 		expect(callOf("resolveDoc")?.params).toEqual(["42", "u1"]);
-		expect(callOf("search")?.params[2]).toEqual(["kb-doc-9"]);
+		expect(callOf("search")?.text).toContain("p.document_id IN");
+		expect(callOf("search")?.params).toContain("kb-doc-9");
 	});
 
 	it("document search with an unknown summaryId returns empty, no search", async () => {
@@ -165,7 +166,9 @@ describe("document-gateway (FTS / Postgres)", () => {
 			body: JSON.stringify({ query: "x" }),
 		});
 		expect(callOf("resolveColl")?.params).toEqual(["col-1", "u1"]);
-		expect(callOf("search")?.params[2]).toEqual(["d1", "d2"]);
+		expect(callOf("search")?.params).toEqual(
+			expect.arrayContaining(["d1", "d2"]),
+		);
 	});
 
 	it("collection search with an empty collection returns empty, no search", async () => {

--- a/apps/document-gateway/src/index.test.ts
+++ b/apps/document-gateway/src/index.test.ts
@@ -153,33 +153,31 @@ describe("document-gateway (FTS / Postgres)", () => {
 		expect(callOf("fetch")?.text).toContain("left(canonical_markdown, 50000)");
 	});
 
-	it("collection search restricts to the collection's documents", async () => {
-		responder = (t) => {
-			if (kind(t) === "resolveColl")
-				return [{ document_id: "d1" }, { document_id: "d2" }];
-			if (kind(t) === "search") return [];
-			return [];
-		};
-		await app.request("/v1/documents/search", {
+	it("collection search joins the collection in one query (no pre-resolve)", async () => {
+		responder = (t) =>
+			kind(t) === "search"
+				? [{ passage_id: "p", document_id: "d1", title: "", snippet: "" }]
+				: [];
+		const res = await app.request("/v1/documents/search", {
 			method: "POST",
 			headers: headers(token({ scope: "collection", collectionId: "col-1" })),
 			body: JSON.stringify({ query: "x" }),
 		});
-		expect(callOf("resolveColl")?.params).toEqual(["col-1", "u1"]);
-		expect(callOf("search")?.params).toEqual(
-			expect.arrayContaining(["d1", "d2"]),
-		);
+		expect(res.status).toBe(200);
+		// No separate roster query; the search joins passage_collection directly.
+		expect(callOf("search")?.text).toContain("passage_collection");
+		expect(callOf("search")?.params).toContain("col-1");
 	});
 
-	it("collection search with an empty collection returns empty, no search", async () => {
-		responder = () => [];
+	it("collection search returns empty when nothing matches (search still runs)", async () => {
+		responder = () => []; // join yields no rows
 		const res = await app.request("/v1/documents/search", {
 			method: "POST",
 			headers: headers(token({ scope: "collection", collectionId: "col-x" })),
 			body: JSON.stringify({ query: "x" }),
 		});
 		expect(await res.json()).toEqual({ documents: [] });
-		expect(callOf("search")).toBeUndefined();
+		expect(callOf("search")).toBeDefined();
 	});
 
 	it("global fetch returns the document pinned to the workspace", async () => {
@@ -228,9 +226,8 @@ describe("document-gateway (FTS / Postgres)", () => {
 		expect(res.status).toBe(200);
 	});
 
-	it("collection-scope fetch rejects a document outside the collection", async () => {
-		responder = (t) =>
-			kind(t) === "resolveColl" ? [{ document_id: "d1" }] : [];
+	it("collection-scope fetch rejects a document not in the collection (no fetch)", async () => {
+		responder = () => []; // documentInCollection: no membership row
 		const res = await app.request("/v1/documents/fetch", {
 			method: "POST",
 			headers: headers(token({ scope: "collection", collectionId: "col-1" })),
@@ -238,6 +235,21 @@ describe("document-gateway (FTS / Postgres)", () => {
 		});
 		expect(res.status).toBe(403);
 		expect(callOf("fetch")).toBeUndefined();
+	});
+
+	it("collection-scope fetch allows a document in the collection", async () => {
+		responder = (t) => {
+			if (kind(t) === "resolveColl") return [{ one: 1 }]; // membership found
+			if (kind(t) === "fetch")
+				return [{ document_id: "d1", title: "T", content: "c" }];
+			return [];
+		};
+		const res = await app.request("/v1/documents/fetch", {
+			method: "POST",
+			headers: headers(token({ scope: "collection", collectionId: "col-1" })),
+			body: JSON.stringify({ documentId: "d1" }),
+		});
+		expect(res.status).toBe(200);
 	});
 
 	it("returns 404 when the document is missing / not in the workspace", async () => {
@@ -248,5 +260,74 @@ describe("document-gateway (FTS / Postgres)", () => {
 			body: JSON.stringify({ documentId: "nope" }),
 		});
 		expect(res.status).toBe(404);
+	});
+
+	// --- fail-closed on empty identity/scope ids ---
+	it("rejects collection scope with no collectionId (fail closed, no DB)", async () => {
+		const res = await app.request("/v1/documents/search", {
+			method: "POST",
+			headers: headers(token({ scope: "collection" })),
+			body: JSON.stringify({ query: "x" }),
+		});
+		expect(res.status).toBe(403);
+		expect(calls).toHaveLength(0);
+	});
+
+	it("rejects document scope with no summaryId (fail closed, no DB)", async () => {
+		const res = await app.request("/v1/documents/search", {
+			method: "POST",
+			headers: headers(token({ scope: "document" })),
+			body: JSON.stringify({ query: "x" }),
+		});
+		expect(res.status).toBe(403);
+		expect(calls).toHaveLength(0);
+	});
+
+	it("rejects a token with an empty userId (fail closed, no DB)", async () => {
+		const res = await app.request("/v1/documents/search", {
+			method: "POST",
+			headers: headers(token({ userId: "", scope: "global" })),
+			body: JSON.stringify({ query: "x" }),
+		});
+		expect(res.status).toBe(403);
+		expect(calls).toHaveLength(0);
+	});
+
+	// --- DB errors map to 502 (not 500 / not 404) ---
+	it("maps a search DB error to 502", async () => {
+		responder = () => {
+			throw new Error("db down");
+		};
+		const res = await app.request("/v1/documents/search", {
+			method: "POST",
+			headers: headers(token({ scope: "global" })),
+			body: JSON.stringify({ query: "x" }),
+		});
+		expect(res.status).toBe(502);
+	});
+
+	it("maps a scope-resolution DB error to 502 (not unhandled 500)", async () => {
+		responder = (t) => {
+			if (kind(t) === "resolveDoc") throw new Error("db down");
+			return [];
+		};
+		const res = await app.request("/v1/documents/search", {
+			method: "POST",
+			headers: headers(token({ scope: "document", summaryId: "42" })),
+			body: JSON.stringify({ query: "x" }),
+		});
+		expect(res.status).toBe(502);
+	});
+
+	it("maps a fetch DB error to 502 (not 404)", async () => {
+		responder = () => {
+			throw new Error("db down");
+		};
+		const res = await app.request("/v1/documents/fetch", {
+			method: "POST",
+			headers: headers(token({ scope: "global" })),
+			body: JSON.stringify({ documentId: "d1" }),
+		});
+		expect(res.status).toBe(502);
 	});
 });

--- a/apps/document-gateway/src/index.test.ts
+++ b/apps/document-gateway/src/index.test.ts
@@ -1,16 +1,16 @@
-import { afterEach, beforeAll, describe, expect, it, spyOn } from "bun:test";
+import { afterEach, beforeAll, describe, expect, it } from "bun:test";
 import { type LlmTokenClaims, mintLlmToken } from "@mymemo/llm-token";
+import type { Db } from "./db";
 
 const SECRET = "test-secret";
-const DOC_API = "https://docs.test";
 
 let app: typeof import("./index").app;
+let setDbForTests: typeof import("./index").setDbForTests;
 
 beforeAll(async () => {
 	Bun.env.LLM_TOKEN_SECRET = SECRET;
-	Bun.env.MYMEMO_DOC_API_URL = DOC_API;
-	Bun.env.MYMEMO_DOC_API_KEY = "real-doc-key";
-	({ app } = await import("./index"));
+	Bun.env.DATABASE_URL = "postgres://test@localhost/test";
+	({ app, setDbForTests } = await import("./index"));
 });
 
 function token(extra: Partial<Omit<LlmTokenClaims, "exp">> = {}): string {
@@ -24,29 +24,39 @@ function headers(t: string): Record<string, string> {
 	return { authorization: `Bearer ${t}`, "content-type": "application/json" };
 }
 
-let fetchSpy: ReturnType<typeof spyOn> | undefined;
-function mockUpstream(body: unknown, status = 200) {
-	const calls: string[] = [];
-	fetchSpy = spyOn(globalThis, "fetch").mockImplementation((async (
-		url: string | URL | Request,
-	) => {
-		calls.push(String(url));
-		return new Response(JSON.stringify(body), {
-			status,
-			headers: { "content-type": "application/json" },
-		});
-	}) as unknown as typeof fetch);
-	return calls;
+// Fake Db: records every query and replies via a per-test responder keyed off
+// the SQL. Lets us assert the exact scope filters without a live Postgres.
+interface Call {
+	text: string;
+	params: unknown[];
 }
+let calls: Call[] = [];
+let responder: (text: string, params: unknown[]) => unknown[];
 
+const fakeDb: Db = {
+	async query<T>(text: string, params: unknown[] = []): Promise<T[]> {
+		calls.push({ text, params });
+		return responder(text, params) as T[];
+	},
+};
+
+function kind(text: string): "search" | "resolveDoc" | "resolveColl" | "fetch" {
+	if (text.includes("ts_rank_cd")) return "search";
+	if (text.includes("FROM content_asset")) return "resolveDoc";
+	if (text.includes("content_collection")) return "resolveColl";
+	return "fetch";
+}
+const callOf = (k: ReturnType<typeof kind>) =>
+	calls.find((c) => kind(c.text) === k);
+
+beforeAll(() => setDbForTests(fakeDb));
 afterEach(() => {
-	fetchSpy?.mockRestore();
-	fetchSpy = undefined;
+	calls = [];
+	responder = () => [];
 });
 
-describe("document-gateway", () => {
-	it("rejects requests without a valid token", async () => {
-		const calls = mockUpstream({});
+describe("document-gateway (FTS / Postgres)", () => {
+	it("rejects requests without a valid token (no DB touched)", async () => {
 		const res = await app.request("/v1/documents/search", {
 			method: "POST",
 			headers: { "content-type": "application/json" },
@@ -56,106 +66,159 @@ describe("document-gateway", () => {
 		expect(calls).toHaveLength(0);
 	});
 
-	it("global search pins the upstream call to the token userId", async () => {
-		const calls = mockUpstream({ documents: [{ documentId: "d1" }] });
+	it("rejects search when the token has no scope (fail closed)", async () => {
+		const res = await app.request("/v1/documents/search", {
+			method: "POST",
+			headers: headers(token()),
+			body: JSON.stringify({ query: "x" }),
+		});
+		expect(res.status).toBe(403);
+		expect(calls).toHaveLength(0);
+	});
+
+	it("global search pins workspace_id to the token userId and no doc filter", async () => {
+		responder = (t) =>
+			kind(t) === "search"
+				? [{ passage_id: "p1", document_id: "d1", title: "T", snippet: "S" }]
+				: [];
 		const res = await app.request("/v1/documents/search", {
 			method: "POST",
 			headers: headers(token({ scope: "global" })),
 			body: JSON.stringify({ query: "hello world" }),
 		});
 		expect(res.status).toBe(200);
-		expect(await res.json()).toEqual({ documents: [{ documentId: "d1" }] });
-		expect(calls[0]).toContain("/users/u1/documents");
-		expect(calls[0]).toContain("q=hello+world");
+		expect(await res.json()).toEqual({
+			documents: [
+				{ passageId: "p1", documentId: "d1", title: "T", snippet: "S" },
+			],
+		});
+		const search = callOf("search");
+		expect(search?.params[0]).toBe("u1"); // workspace_id
+		expect(search?.params[1]).toBe("hello world");
+		expect(search?.params[2]).toBeNull(); // no document filter in global scope
 	});
 
-	it("collection search forces the token collectionId, ignoring the body", async () => {
-		const calls = mockUpstream({ documents: [] });
+	it("document search resolves summaryId and restricts to that document", async () => {
+		responder = (t) => {
+			if (kind(t) === "resolveDoc") return [{ kb_document_id: "kb-doc-9" }];
+			if (kind(t) === "search")
+				return [
+					{ passage_id: "p", document_id: "kb-doc-9", title: "", snippet: "" },
+				];
+			return [];
+		};
 		await app.request("/v1/documents/search", {
 			method: "POST",
-			headers: headers(token({ scope: "collection", collectionId: "col-1" })),
-			body: JSON.stringify({ query: "x", collectionId: "col-evil" }),
+			headers: headers(token({ scope: "document", summaryId: "42" })),
+			body: JSON.stringify({ query: "x" }),
 		});
-		expect(calls[0]).toContain("collection=col-1");
-		expect(calls[0]).not.toContain("col-evil");
+		expect(callOf("resolveDoc")?.params).toEqual(["42", "u1"]);
+		expect(callOf("search")?.params[2]).toEqual(["kb-doc-9"]);
 	});
 
-	it("document-scope search is disabled and never hits upstream", async () => {
-		const calls = mockUpstream({ documents: [{ documentId: "leak" }] });
+	it("document search with an unknown summaryId returns empty, no search", async () => {
+		responder = () => []; // resolveDoc finds nothing
 		const res = await app.request("/v1/documents/search", {
 			method: "POST",
-			headers: headers(token({ scope: "document", summaryId: "d-1" })),
+			headers: headers(token({ scope: "document", summaryId: "999" })),
 			body: JSON.stringify({ query: "x" }),
 		});
 		expect(await res.json()).toEqual({ documents: [] });
-		expect(calls).toHaveLength(0);
+		expect(callOf("search")).toBeUndefined();
 	});
 
-	it("document-scope fetch rejects an out-of-scope documentId", async () => {
-		const calls = mockUpstream({ documentId: "d-other" });
+	it("collection search restricts to the collection's documents", async () => {
+		responder = (t) => {
+			if (kind(t) === "resolveColl")
+				return [{ document_id: "d1" }, { document_id: "d2" }];
+			if (kind(t) === "search") return [];
+			return [];
+		};
+		await app.request("/v1/documents/search", {
+			method: "POST",
+			headers: headers(token({ scope: "collection", collectionId: "col-1" })),
+			body: JSON.stringify({ query: "x" }),
+		});
+		expect(callOf("resolveColl")?.params).toEqual(["col-1", "u1", "u1"]);
+		expect(callOf("search")?.params[2]).toEqual(["d1", "d2"]);
+	});
+
+	it("collection search with an empty collection returns empty, no search", async () => {
+		responder = () => [];
+		const res = await app.request("/v1/documents/search", {
+			method: "POST",
+			headers: headers(token({ scope: "collection", collectionId: "col-x" })),
+			body: JSON.stringify({ query: "x" }),
+		});
+		expect(await res.json()).toEqual({ documents: [] });
+		expect(callOf("search")).toBeUndefined();
+	});
+
+	it("global fetch returns the document pinned to the workspace", async () => {
+		responder = (t) =>
+			kind(t) === "fetch"
+				? [{ document_id: "d1", title: "T", content: "body" }]
+				: [];
 		const res = await app.request("/v1/documents/fetch", {
 			method: "POST",
-			headers: headers(token({ scope: "document", summaryId: "d-allowed" })),
-			body: JSON.stringify({ documentId: "d-other" }),
+			headers: headers(token({ scope: "global" })),
+			body: JSON.stringify({ documentId: "d1" }),
+		});
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({
+			documentId: "d1",
+			title: "T",
+			content: "body",
+		});
+		expect(callOf("fetch")?.params).toEqual(["d1", "u1"]);
+	});
+
+	it("document-scope fetch rejects an out-of-scope documentId (no fetch)", async () => {
+		responder = (t) =>
+			kind(t) === "resolveDoc" ? [{ kb_document_id: "kb-doc-9" }] : [];
+		const res = await app.request("/v1/documents/fetch", {
+			method: "POST",
+			headers: headers(token({ scope: "document", summaryId: "42" })),
+			body: JSON.stringify({ documentId: "kb-doc-other" }),
 		});
 		expect(res.status).toBe(403);
-		expect(calls).toHaveLength(0);
+		expect(callOf("fetch")).toBeUndefined();
 	});
 
 	it("document-scope fetch allows the in-scope documentId", async () => {
-		mockUpstream({
-			documentId: "d-allowed",
-			content: "hi",
-			cite: "detail/0/1",
-		});
+		responder = (t) => {
+			if (kind(t) === "resolveDoc") return [{ kb_document_id: "kb-doc-9" }];
+			if (kind(t) === "fetch")
+				return [{ document_id: "kb-doc-9", title: "T", content: "c" }];
+			return [];
+		};
 		const res = await app.request("/v1/documents/fetch", {
 			method: "POST",
-			headers: headers(token({ scope: "document", summaryId: "d-allowed" })),
-			body: JSON.stringify({ documentId: "d-allowed" }),
+			headers: headers(token({ scope: "document", summaryId: "42" })),
+			body: JSON.stringify({ documentId: "kb-doc-9" }),
 		});
 		expect(res.status).toBe(200);
-		expect(((await res.json()) as { cite?: string }).cite).toBe("detail/0/1");
 	});
 
 	it("collection-scope fetch rejects a document outside the collection", async () => {
-		mockUpstream({ documentId: "d1", collections: ["col-2"] });
+		responder = (t) =>
+			kind(t) === "resolveColl" ? [{ document_id: "d1" }] : [];
 		const res = await app.request("/v1/documents/fetch", {
 			method: "POST",
 			headers: headers(token({ scope: "collection", collectionId: "col-1" })),
-			body: JSON.stringify({ documentId: "d1" }),
+			body: JSON.stringify({ documentId: "d2" }),
 		});
 		expect(res.status).toBe(403);
+		expect(callOf("fetch")).toBeUndefined();
 	});
 
-	it("rejects search when the token has no scope (fail closed)", async () => {
-		const calls = mockUpstream({ documents: [{ documentId: "leak" }] });
-		const res = await app.request("/v1/documents/search", {
-			method: "POST",
-			headers: headers(token()),
-			body: JSON.stringify({ query: "x" }),
-		});
-		expect(res.status).toBe(403);
-		expect(calls).toHaveLength(0);
-	});
-
-	it("rejects fetch when the token has no scope (fail closed)", async () => {
-		const calls = mockUpstream({ documentId: "any" });
+	it("returns 404 when the document is missing / not in the workspace", async () => {
+		responder = () => []; // fetch finds nothing
 		const res = await app.request("/v1/documents/fetch", {
 			method: "POST",
-			headers: headers(token()),
-			body: JSON.stringify({ documentId: "any" }),
+			headers: headers(token({ scope: "global" })),
+			body: JSON.stringify({ documentId: "nope" }),
 		});
-		expect(res.status).toBe(403);
-		expect(calls).toHaveLength(0);
-	});
-
-	it("collection-scope fetch allows a document in the collection", async () => {
-		mockUpstream({ documentId: "d1", collections: ["col-1", "col-9"] });
-		const res = await app.request("/v1/documents/fetch", {
-			method: "POST",
-			headers: headers(token({ scope: "collection", collectionId: "col-1" })),
-			body: JSON.stringify({ documentId: "d1" }),
-		});
-		expect(res.status).toBe(200);
+		expect(res.status).toBe(404);
 	});
 });

--- a/apps/document-gateway/src/index.test.ts
+++ b/apps/document-gateway/src/index.test.ts
@@ -127,6 +127,31 @@ describe("document-gateway (FTS / Postgres)", () => {
 		expect(callOf("search")).toBeUndefined();
 	});
 
+	it("document search with a non-numeric summaryId fails closed (no DB)", async () => {
+		const res = await app.request("/v1/documents/search", {
+			method: "POST",
+			headers: headers(token({ scope: "document", summaryId: "not-a-number" })),
+			body: JSON.stringify({ query: "x" }),
+		});
+		expect(await res.json()).toEqual({ documents: [] });
+		// The numeric guard returns before the $1::bigint query runs.
+		expect(callOf("resolveDoc")).toBeUndefined();
+		expect(callOf("search")).toBeUndefined();
+	});
+
+	it("fetch clips document content to 50k chars", async () => {
+		responder = (t) =>
+			kind(t) === "fetch"
+				? [{ document_id: "d1", title: "T", content: "body" }]
+				: [];
+		await app.request("/v1/documents/fetch", {
+			method: "POST",
+			headers: headers(token({ scope: "global" })),
+			body: JSON.stringify({ documentId: "d1" }),
+		});
+		expect(callOf("fetch")?.text).toContain("left(canonical_markdown, 50000)");
+	});
+
 	it("collection search restricts to the collection's documents", async () => {
 		responder = (t) => {
 			if (kind(t) === "resolveColl")

--- a/apps/document-gateway/src/index.ts
+++ b/apps/document-gateway/src/index.ts
@@ -86,7 +86,6 @@ app.post("/v1/documents/search", async (c) => {
 		documentIds = await resolveCollectionDocumentIds(db(), {
 			collectionId: claims.collectionId ?? "",
 			workspaceId,
-			memberCode: claims.userId,
 		});
 		if (documentIds.length === 0) return c.json({ documents: [] });
 	}
@@ -126,7 +125,6 @@ app.post("/v1/documents/fetch", async (c) => {
 		const allowed = await resolveCollectionDocumentIds(db(), {
 			collectionId: claims.collectionId ?? "",
 			workspaceId,
-			memberCode: claims.userId,
 		});
 		if (!allowed.includes(body.documentId)) {
 			return forbidden(c, "document not in collection");

--- a/apps/document-gateway/src/index.ts
+++ b/apps/document-gateway/src/index.ts
@@ -1,27 +1,38 @@
 import { type LlmTokenClaims, verifyLlmToken } from "@mymemo/llm-token";
 import { type Context, Hono } from "hono";
+import { type Db, getDb } from "./db";
 import { gwEnv } from "./env";
+import {
+	fetchDocument,
+	resolveCollectionDocumentIds,
+	resolveDocumentId,
+	searchPassages,
+} from "./queries";
 
 /**
  * Document gateway — the trusted control plane for sandboxed-agent document
- * access.
+ * access. It reads the MyMemo knowledge base (Postgres) directly and ENFORCES
+ * the turn's signed scope server-side, so a prompt-injected agent cannot widen
+ * it. Search is FTS-only (lexical `search_tsv`); no dense/vector or rerank.
  *
- * The sandboxed agent calls this service (via the `mymemo-docs` CLI) with a
- * short-lived per-turn Bearer token. The agent holds no document-API
- * credential: we verify the token, ENFORCE the turn's scope server-side, then
- * call the real MyMemo document API with the real key (always pinned to the
- * token's userId — never a client-supplied id).
- *
- * Scope is signed into the token, so a prompt-injected agent cannot widen it:
- *   - global     → search/fetch any of the user's own documents
- *   - collection → search forced to collectionId; fetch must be in collectionId
- *   - document   → search disabled; fetch must equal summaryId
- *
- * TODO(doc-api-contract, #117): the upstream endpoints + request/response shapes
- * below are ASSUMED. Confirm them against the real MyMemo document API and adjust.
+ * The user's workspace is their member_code (= token userId); scope narrows it:
+ *   - global     → search/fetch any document in the workspace
+ *   - collection → restricted to documents in the turn's collection
+ *   - document   → restricted to the single document (summaryId)
  */
 
 export const app = new Hono();
+
+const SEARCH_LIMIT = 8;
+
+// Test seam: inject a fake Db so query logic is exercised without a live RDS.
+let testDb: Db | null = null;
+export function setDbForTests(d: Db | null): void {
+	testDb = d;
+}
+function db(): Db {
+	return testDb ?? getDb();
+}
 
 app.on(["GET", "HEAD"], "/health", (c) => c.json({ status: "ok" }));
 
@@ -50,56 +61,44 @@ function isKnownScope(
 	return scope === "global" || scope === "collection" || scope === "document";
 }
 
-/** GET the upstream MyMemo document API, authenticated with the real key. */
-async function docApiGet(path: string, qs: URLSearchParams): Promise<Response> {
-	const query = qs.toString();
-	const url = `${gwEnv.MYMEMO_DOC_API_URL}${path}${query ? `?${query}` : ""}`;
-	return fetch(url, {
-		headers: { authorization: `Bearer ${gwEnv.MYMEMO_DOC_API_KEY}` },
-	});
-}
-
-interface FetchedDocument {
-	documentId: string;
-	title?: string;
-	content?: string;
-	cite?: string;
-	collections?: string[];
-}
-
 app.post("/v1/documents/search", async (c) => {
 	const claims = bearerClaims(c);
 	if (!claims) return unauthorized(c);
 	if (!isKnownScope(claims.scope)) return forbidden(c, "unknown scope");
 
 	const body = await c.req
-		.json<{ query?: string; collectionId?: string }>()
-		.catch(() => ({}) as { query?: string; collectionId?: string });
+		.json<{ query?: string }>()
+		.catch(() => ({}) as { query?: string });
 	if (!body.query) return c.json({ error: "query is required" }, 400);
 
-	// Server-side scope enforcement — never trust the agent's collectionId.
+	const workspaceId = claims.userId;
+
+	// Server-side scope enforcement — narrow the searchable documents.
+	let documentIds: string[] | null = null;
 	if (claims.scope === "document") {
-		// In document scope there is nothing to search; the agent must fetch the
-		// one in-scope document directly.
-		return c.json({ documents: [] });
-	}
-	const qs = new URLSearchParams({ q: body.query });
-	if (claims.scope === "collection") {
-		qs.set("collection", claims.collectionId ?? "");
-	} else if (body.collectionId) {
-		// global scope: an optional narrowing within the user's own documents.
-		qs.set("collection", body.collectionId);
+		const docId = await resolveDocumentId(db(), {
+			summaryId: claims.summaryId ?? "",
+			memberCode: claims.userId,
+		});
+		if (!docId) return c.json({ documents: [] });
+		documentIds = [docId];
+	} else if (claims.scope === "collection") {
+		documentIds = await resolveCollectionDocumentIds(db(), {
+			collectionId: claims.collectionId ?? "",
+			workspaceId,
+			memberCode: claims.userId,
+		});
+		if (documentIds.length === 0) return c.json({ documents: [] });
 	}
 
-	// Upstream call is pinned to the token's userId.
-	const upstream = await docApiGet(
-		`/users/${encodeURIComponent(claims.userId)}/documents`,
-		qs,
-	).catch(() => null);
-	if (!upstream || !upstream.ok) {
-		return c.json({ error: "document search failed" }, 502);
-	}
-	return c.json(await upstream.json());
+	const documents = await searchPassages(db(), {
+		workspaceId,
+		query: body.query,
+		documentIds,
+		limit: SEARCH_LIMIT,
+	}).catch(() => null);
+	if (!documents) return c.json({ error: "document search failed" }, 502);
+	return c.json({ documents });
 });
 
 app.post("/v1/documents/fetch", async (c) => {
@@ -112,30 +111,33 @@ app.post("/v1/documents/fetch", async (c) => {
 		.catch(() => ({}) as { documentId?: string });
 	if (!body.documentId) return c.json({ error: "documentId is required" }, 400);
 
-	// Document scope: the agent may fetch only the single in-scope document.
-	if (claims.scope === "document" && body.documentId !== claims.summaryId) {
-		return forbidden(c, "document out of scope");
+	const workspaceId = claims.userId;
+
+	// Server-side scope enforcement — the document must be in scope.
+	if (claims.scope === "document") {
+		const docId = await resolveDocumentId(db(), {
+			summaryId: claims.summaryId ?? "",
+			memberCode: claims.userId,
+		});
+		if (!docId || body.documentId !== docId) {
+			return forbidden(c, "document out of scope");
+		}
+	} else if (claims.scope === "collection") {
+		const allowed = await resolveCollectionDocumentIds(db(), {
+			collectionId: claims.collectionId ?? "",
+			workspaceId,
+			memberCode: claims.userId,
+		});
+		if (!allowed.includes(body.documentId)) {
+			return forbidden(c, "document not in collection");
+		}
 	}
 
-	const upstream = await docApiGet(
-		`/users/${encodeURIComponent(claims.userId)}/documents/${encodeURIComponent(body.documentId)}`,
-		new URLSearchParams(),
-	).catch(() => null);
-	if (!upstream) return c.json({ error: "document fetch failed" }, 502);
-	if (upstream.status === 404) return c.json({ error: "not found" }, 404);
-	if (!upstream.ok) return c.json({ error: "document fetch failed" }, 502);
-
-	const doc = (await upstream.json()) as FetchedDocument;
-
-	// Collection scope: the fetched document must belong to the in-scope
-	// collection (the upstream call only enforces user ownership).
-	if (
-		claims.scope === "collection" &&
-		!doc.collections?.includes(claims.collectionId ?? "")
-	) {
-		return forbidden(c, "document not in collection");
-	}
-
+	const doc = await fetchDocument(db(), {
+		workspaceId,
+		documentId: body.documentId,
+	}).catch(() => null);
+	if (doc === null) return c.json({ error: "not found" }, 404);
 	return c.json(doc);
 });
 

--- a/apps/document-gateway/src/index.ts
+++ b/apps/document-gateway/src/index.ts
@@ -3,8 +3,8 @@ import { type Context, Hono } from "hono";
 import { type Db, getDb } from "./db";
 import { gwEnv } from "./env";
 import {
+	documentInCollection,
 	fetchDocument,
-	resolveCollectionDocumentIds,
 	resolveDocumentId,
 	searchPassages,
 } from "./queries";
@@ -61,10 +61,26 @@ function isKnownScope(
 	return scope === "global" || scope === "collection" || scope === "document";
 }
 
+/**
+ * Fail closed on the identity/scope ids too: the workspace pin and scope
+ * narrowing are only safe if these are non-empty. Returns an error message to
+ * forbid on, or null when the claims are usable.
+ */
+function scopeError(claims: LlmTokenClaims): string | null {
+	if (!claims.userId) return "missing user";
+	if (claims.scope === "collection" && !claims.collectionId)
+		return "missing collection";
+	if (claims.scope === "document" && !claims.summaryId)
+		return "missing document";
+	return null;
+}
+
 app.post("/v1/documents/search", async (c) => {
 	const claims = bearerClaims(c);
 	if (!claims) return unauthorized(c);
 	if (!isKnownScope(claims.scope)) return forbidden(c, "unknown scope");
+	const bad = scopeError(claims);
+	if (bad) return forbidden(c, bad);
 
 	const body = await c.req
 		.json<{ query?: string }>()
@@ -73,37 +89,40 @@ app.post("/v1/documents/search", async (c) => {
 
 	const workspaceId = claims.userId;
 
-	// Server-side scope enforcement — narrow the searchable documents.
-	let documentIds: string[] | null = null;
-	if (claims.scope === "document") {
-		const docId = await resolveDocumentId(db(), {
-			summaryId: claims.summaryId ?? "",
-			memberCode: claims.userId,
-		});
-		if (!docId) return c.json({ documents: [] });
-		documentIds = [docId];
-	} else if (claims.scope === "collection") {
-		documentIds = await resolveCollectionDocumentIds(db(), {
-			collectionId: claims.collectionId ?? "",
-			workspaceId,
-		});
-		if (documentIds.length === 0) return c.json({ documents: [] });
-	}
+	try {
+		// Server-side scope enforcement — narrow what is searchable.
+		let documentIds: string[] | null = null;
+		let collectionId: string | null = null;
+		if (claims.scope === "document") {
+			const docId = await resolveDocumentId(db(), {
+				summaryId: claims.summaryId ?? "",
+				memberCode: claims.userId,
+			});
+			if (!docId) return c.json({ documents: [] });
+			documentIds = [docId];
+		} else if (claims.scope === "collection") {
+			collectionId = claims.collectionId ?? "";
+		}
 
-	const documents = await searchPassages(db(), {
-		workspaceId,
-		query: body.query,
-		documentIds,
-		limit: SEARCH_LIMIT,
-	}).catch(() => null);
-	if (!documents) return c.json({ error: "document search failed" }, 502);
-	return c.json({ documents });
+		const documents = await searchPassages(db(), {
+			workspaceId,
+			query: body.query,
+			documentIds,
+			collectionId,
+			limit: SEARCH_LIMIT,
+		});
+		return c.json({ documents });
+	} catch {
+		return c.json({ error: "document search failed" }, 502);
+	}
 });
 
 app.post("/v1/documents/fetch", async (c) => {
 	const claims = bearerClaims(c);
 	if (!claims) return unauthorized(c);
 	if (!isKnownScope(claims.scope)) return forbidden(c, "unknown scope");
+	const bad = scopeError(claims);
+	if (bad) return forbidden(c, bad);
 
 	const body = await c.req
 		.json<{ documentId?: string }>()
@@ -112,31 +131,34 @@ app.post("/v1/documents/fetch", async (c) => {
 
 	const workspaceId = claims.userId;
 
-	// Server-side scope enforcement — the document must be in scope.
-	if (claims.scope === "document") {
-		const docId = await resolveDocumentId(db(), {
-			summaryId: claims.summaryId ?? "",
-			memberCode: claims.userId,
-		});
-		if (!docId || body.documentId !== docId) {
-			return forbidden(c, "document out of scope");
+	try {
+		// Server-side scope enforcement — the document must be in scope.
+		if (claims.scope === "document") {
+			const docId = await resolveDocumentId(db(), {
+				summaryId: claims.summaryId ?? "",
+				memberCode: claims.userId,
+			});
+			if (!docId || body.documentId !== docId) {
+				return forbidden(c, "document out of scope");
+			}
+		} else if (claims.scope === "collection") {
+			const inCollection = await documentInCollection(db(), {
+				collectionId: claims.collectionId ?? "",
+				workspaceId,
+				documentId: body.documentId,
+			});
+			if (!inCollection) return forbidden(c, "document not in collection");
 		}
-	} else if (claims.scope === "collection") {
-		const allowed = await resolveCollectionDocumentIds(db(), {
-			collectionId: claims.collectionId ?? "",
-			workspaceId,
-		});
-		if (!allowed.includes(body.documentId)) {
-			return forbidden(c, "document not in collection");
-		}
-	}
 
-	const doc = await fetchDocument(db(), {
-		workspaceId,
-		documentId: body.documentId,
-	}).catch(() => null);
-	if (doc === null) return c.json({ error: "not found" }, 404);
-	return c.json(doc);
+		const doc = await fetchDocument(db(), {
+			workspaceId,
+			documentId: body.documentId,
+		});
+		if (doc === null) return c.json({ error: "not found" }, 404);
+		return c.json(doc);
+	} catch {
+		return c.json({ error: "document fetch failed" }, 502);
+	}
 });
 
 export default {

--- a/apps/document-gateway/src/queries.ts
+++ b/apps/document-gateway/src/queries.ts
@@ -115,10 +115,15 @@ export async function resolveDocumentId(
  * Collection scope: resolve the turn's collectionId (= content_collection
  * compat_str_id) to the KB document ids in that collection, pinned to the
  * workspace. Returns [] if the collection is unknown or empty.
+ *
+ * User scoping is the `p.workspace_id = $2` pin, NOT `content_collection
+ * .member_code` (which is stored in a different representation — verified
+ * against staging: pinning by workspace returns the collection's docs and a
+ * cross-workspace collectionId yields nothing).
  */
 export async function resolveCollectionDocumentIds(
 	db: Db,
-	opts: { collectionId: string; workspaceId: string; memberCode: string },
+	opts: { collectionId: string; workspaceId: string },
 ): Promise<string[]> {
 	const rows = await db.query<{ document_id: string }>(
 		`SELECT DISTINCT p.document_id
@@ -126,10 +131,9 @@ export async function resolveCollectionDocumentIds(
 		   JOIN passage_collection pc ON pc.collection_id = c.compat_int_id::text
 		   JOIN passage p ON p.id = pc.passage_id
 		  WHERE c.compat_str_id = $1
-		    AND c.member_code = $2
-		    AND p.workspace_id = $3
+		    AND p.workspace_id = $2
 		    AND p.status = 'active'`,
-		[opts.collectionId, opts.memberCode, opts.workspaceId],
+		[opts.collectionId, opts.workspaceId],
 	);
 	return rows.map((r) => r.document_id);
 }

--- a/apps/document-gateway/src/queries.ts
+++ b/apps/document-gateway/src/queries.ts
@@ -1,0 +1,135 @@
+import type { Db } from "./db";
+
+/**
+ * Read-side of the MyMemo knowledge base, FTS-only (no dense/vector, no rerank).
+ *
+ * Scope mapping (derived from the platform's compat layer):
+ *   - workspace_id  = the user's member_code (personal workspace)
+ *   - summaryId     = platform_knowledge.id = content_asset.compat_int_id
+ *                     → content_asset.kb_document_id = document.id
+ *   - collectionId  = platform_collection.compat_id = content_collection.compat_str_id
+ *                     → content_collection.compat_int_id = passage_collection.collection_id
+ */
+
+export interface SearchHit {
+	passageId: string;
+	documentId: string;
+	title: string;
+	snippet: string;
+}
+
+export interface FetchedDocument {
+	documentId: string;
+	title: string;
+	content: string;
+}
+
+/**
+ * Lexical full-text search over passages, scoped to a workspace and (optionally)
+ * a set of document ids. Uses the precomputed `search_tsv` column with the
+ * `simple` config — no language detection / CJK tokenization (FTS-only).
+ */
+export async function searchPassages(
+	db: Db,
+	opts: {
+		workspaceId: string;
+		query: string;
+		documentIds: string[] | null;
+		limit: number;
+	},
+): Promise<SearchHit[]> {
+	const rows = await db.query<{
+		passage_id: string;
+		document_id: string;
+		title: string;
+		snippet: string;
+	}>(
+		`SELECT p.id AS passage_id, p.document_id, d.title,
+		        left(p.passage_text, 220) AS snippet,
+		        ts_rank_cd(p.search_tsv, plainto_tsquery('simple', $2)) AS score
+		   FROM passage p
+		   JOIN document d ON d.id = p.document_id
+		  WHERE p.workspace_id = $1
+		    AND p.status = 'active'
+		    AND d.status = 'active'
+		    AND ($3::text[] IS NULL OR p.document_id = ANY($3))
+		    AND p.search_tsv @@ plainto_tsquery('simple', $2)
+		  ORDER BY score DESC
+		  LIMIT $4`,
+		[opts.workspaceId, opts.query, opts.documentIds, opts.limit],
+	);
+	return rows.map((r) => ({
+		passageId: r.passage_id,
+		documentId: r.document_id,
+		title: r.title ?? "",
+		snippet: r.snippet ?? "",
+	}));
+}
+
+/** Fetch a single document's full content, pinned to the workspace. */
+export async function fetchDocument(
+	db: Db,
+	opts: { workspaceId: string; documentId: string },
+): Promise<FetchedDocument | null> {
+	const rows = await db.query<{
+		document_id: string;
+		title: string;
+		content: string;
+	}>(
+		`SELECT id AS document_id, title, canonical_markdown AS content
+		   FROM document
+		  WHERE id = $1 AND workspace_id = $2 AND status = 'active'
+		  LIMIT 1`,
+		[opts.documentId, opts.workspaceId],
+	);
+	const row = rows[0];
+	if (!row) return null;
+	return {
+		documentId: row.document_id,
+		title: row.title ?? "",
+		content: row.content ?? "",
+	};
+}
+
+/**
+ * Document scope: resolve the turn's summaryId (= platform_knowledge.id) to the
+ * KB document.id, pinned to the user's member_code. Returns null if not found.
+ */
+export async function resolveDocumentId(
+	db: Db,
+	opts: { summaryId: string; memberCode: string },
+): Promise<string | null> {
+	const rows = await db.query<{ kb_document_id: string }>(
+		`SELECT kb_document_id
+		   FROM content_asset
+		  WHERE compat_int_id = $1::bigint
+		    AND member_code = $2
+		    AND kb_document_id <> ''
+		  LIMIT 1`,
+		[opts.summaryId, opts.memberCode],
+	);
+	return rows[0]?.kb_document_id ?? null;
+}
+
+/**
+ * Collection scope: resolve the turn's collectionId (= content_collection
+ * compat_str_id) to the KB document ids in that collection, pinned to the
+ * workspace. Returns [] if the collection is unknown or empty.
+ */
+export async function resolveCollectionDocumentIds(
+	db: Db,
+	opts: { collectionId: string; workspaceId: string; memberCode: string },
+): Promise<string[]> {
+	const rows = await db.query<{ document_id: string }>(
+		`SELECT DISTINCT p.document_id
+		   FROM content_collection c
+		   JOIN passage_collection pc ON pc.collection_id = c.compat_int_id::text
+		   JOIN passage p ON p.id = pc.passage_id
+		  WHERE c.compat_str_id = $1
+		    AND c.member_code = $2
+		    AND p.workspace_id = $3
+		    AND p.status = 'active'`,
+		[opts.collectionId, opts.memberCode, opts.workspaceId],
+	);
+	return rows.map((r) => r.document_id);
+}

--- a/apps/document-gateway/src/queries.ts
+++ b/apps/document-gateway/src/queries.ts
@@ -25,32 +25,47 @@ export interface FetchedDocument {
 }
 
 /**
- * Lexical full-text search over passages, scoped to a workspace and (optionally)
- * a set of document ids. Uses the precomputed `search_tsv` column with the
- * `simple` config — no language detection / CJK tokenization (FTS-only).
+ * Lexical full-text search over passages, scoped to a workspace and narrowed by
+ * the turn's scope: an optional collection (joined via passage_collection) and/or
+ * an optional set of document ids. Uses the precomputed `search_tsv` column with
+ * the `simple` config — no language detection / CJK tokenization (FTS-only).
  */
 export async function searchPassages(
 	db: Db,
 	opts: {
 		workspaceId: string;
 		query: string;
-		documentIds: string[] | null;
+		documentIds: string[] | null; // document scope: restrict to these ids
+		collectionId: string | null; // collection scope: join passage_collection
 		limit: number;
 	},
 ): Promise<SearchHit[]> {
-	// Build the optional document filter with one bind param per id — Bun.sql
-	// does not bind a JS array to a Postgres text[] (it sends "a,b", not "{a,b}"),
-	// so `= ANY($n)` is unusable. `IN ($3,$4,…)` keeps every id a scalar param.
 	const params: unknown[] = [opts.workspaceId, opts.query];
-	let docFilter = "";
+	let joins = "";
+	let filters = "";
+
+	// Collection scope: join membership in one query — no pre-materialized id
+	// list, so no extra round trip and no Postgres parameter-limit blow-up on a
+	// huge collection. compat_str_id → compat_int_id → passage_collection.
+	if (opts.collectionId) {
+		params.push(opts.collectionId);
+		joins +=
+			" JOIN passage_collection pc ON pc.passage_id = p.id" +
+			" JOIN content_collection c ON c.compat_int_id::text = pc.collection_id";
+		filters += ` AND c.compat_str_id = $${params.length}`;
+	}
+
+	// Document scope: restrict to specific ids. Bun.sql can't bind a JS array to
+	// text[] (it sends "a,b", not "{a,b}"), so emit one `$n` per id for IN (...).
 	if (opts.documentIds) {
 		if (opts.documentIds.length === 0) return [];
 		const slots = opts.documentIds
 			.map((_, i) => `$${params.length + i + 1}`)
 			.join(", ");
 		params.push(...opts.documentIds);
-		docFilter = `AND p.document_id IN (${slots})`;
+		filters += ` AND p.document_id IN (${slots})`;
 	}
+
 	const limitSlot = `$${params.length + 1}`;
 	params.push(opts.limit);
 
@@ -64,11 +79,10 @@ export async function searchPassages(
 		        left(p.passage_text, 220) AS snippet,
 		        ts_rank_cd(p.search_tsv, plainto_tsquery('simple', $2)) AS score
 		   FROM passage p
-		   JOIN document d ON d.id = p.document_id
+		   JOIN document d ON d.id = p.document_id${joins}
 		  WHERE p.workspace_id = $1
 		    AND p.status = 'active'
-		    AND d.status = 'active'
-		    ${docFilter}
+		    AND d.status = 'active'${filters}
 		    AND p.search_tsv @@ plainto_tsquery('simple', $2)
 		  ORDER BY score DESC
 		  LIMIT ${limitSlot}`,
@@ -133,28 +147,29 @@ export async function resolveDocumentId(
 }
 
 /**
- * Collection scope: resolve the turn's collectionId (= content_collection
- * compat_str_id) to the KB document ids in that collection, pinned to the
- * workspace. Returns [] if the collection is unknown or empty.
+ * Collection scope (fetch): is `documentId` in the turn's collection, within the
+ * user's workspace? compat_str_id → compat_int_id → passage_collection.
  *
  * User scoping is the `p.workspace_id = $2` pin, NOT `content_collection
  * .member_code` (which is stored in a different representation — verified
- * against staging: pinning by workspace returns the collection's docs and a
- * cross-workspace collectionId yields nothing).
+ * against staging: pinning by workspace matches the collection's docs and a
+ * cross-workspace collectionId matches nothing).
  */
-export async function resolveCollectionDocumentIds(
+export async function documentInCollection(
 	db: Db,
-	opts: { collectionId: string; workspaceId: string },
-): Promise<string[]> {
-	const rows = await db.query<{ document_id: string }>(
-		`SELECT DISTINCT p.document_id
+	opts: { collectionId: string; workspaceId: string; documentId: string },
+): Promise<boolean> {
+	const rows = await db.query(
+		`SELECT 1
 		   FROM content_collection c
 		   JOIN passage_collection pc ON pc.collection_id = c.compat_int_id::text
 		   JOIN passage p ON p.id = pc.passage_id
 		  WHERE c.compat_str_id = $1
 		    AND p.workspace_id = $2
-		    AND p.status = 'active'`,
-		[opts.collectionId, opts.workspaceId],
+		    AND p.document_id = $3
+		    AND p.status = 'active'
+		  LIMIT 1`,
+		[opts.collectionId, opts.workspaceId, opts.documentId],
 	);
-	return rows.map((r) => r.document_id);
+	return rows.length > 0;
 }

--- a/apps/document-gateway/src/queries.ts
+++ b/apps/document-gateway/src/queries.ts
@@ -76,7 +76,9 @@ export async function fetchDocument(
 		title: string;
 		content: string;
 	}>(
-		`SELECT id AS document_id, title, canonical_markdown AS content
+		// Clip to 50k chars (matches the production read_document) so a large
+		// document can't dump hundreds of KB into the agent's context.
+		`SELECT id AS document_id, title, left(canonical_markdown, 50000) AS content
 		   FROM document
 		  WHERE id = $1 AND workspace_id = $2 AND status = 'active'
 		  LIMIT 1`,
@@ -99,6 +101,9 @@ export async function resolveDocumentId(
 	db: Db,
 	opts: { summaryId: string; memberCode: string },
 ): Promise<string | null> {
+	// summaryId is platform_knowledge.id (a bigint). Fail closed on anything
+	// non-numeric rather than letting `$1::bigint` raise a SQL error.
+	if (!/^\d+$/.test(opts.summaryId)) return null;
 	const rows = await db.query<{ kb_document_id: string }>(
 		`SELECT kb_document_id
 		   FROM content_asset

--- a/apps/document-gateway/src/queries.ts
+++ b/apps/document-gateway/src/queries.ts
@@ -38,6 +38,22 @@ export async function searchPassages(
 		limit: number;
 	},
 ): Promise<SearchHit[]> {
+	// Build the optional document filter with one bind param per id — Bun.sql
+	// does not bind a JS array to a Postgres text[] (it sends "a,b", not "{a,b}"),
+	// so `= ANY($n)` is unusable. `IN ($3,$4,…)` keeps every id a scalar param.
+	const params: unknown[] = [opts.workspaceId, opts.query];
+	let docFilter = "";
+	if (opts.documentIds) {
+		if (opts.documentIds.length === 0) return [];
+		const slots = opts.documentIds
+			.map((_, i) => `$${params.length + i + 1}`)
+			.join(", ");
+		params.push(...opts.documentIds);
+		docFilter = `AND p.document_id IN (${slots})`;
+	}
+	const limitSlot = `$${params.length + 1}`;
+	params.push(opts.limit);
+
 	const rows = await db.query<{
 		passage_id: string;
 		document_id: string;
@@ -52,11 +68,11 @@ export async function searchPassages(
 		  WHERE p.workspace_id = $1
 		    AND p.status = 'active'
 		    AND d.status = 'active'
-		    AND ($3::text[] IS NULL OR p.document_id = ANY($3))
+		    ${docFilter}
 		    AND p.search_tsv @@ plainto_tsquery('simple', $2)
 		  ORDER BY score DESC
-		  LIMIT $4`,
-		[opts.workspaceId, opts.query, opts.documentIds, opts.limit],
+		  LIMIT ${limitSlot}`,
+		params,
 	);
 	return rows.map((r) => ({
 		passageId: r.passage_id,

--- a/apps/mymemo-docs/src/index.test.ts
+++ b/apps/mymemo-docs/src/index.test.ts
@@ -7,7 +7,6 @@ import { build } from "../build";
 
 interface SearchBody {
 	query?: string;
-	collectionId?: string;
 }
 
 let CLI: string;
@@ -73,22 +72,18 @@ describe("mymemo-docs --help (citty-generated)", () => {
 		expect(exitCode).toBe(0);
 		expect(stdout).toContain("search");
 		expect(stdout).toContain("fetch");
-		expect(stdout).toContain("Find documents matching a query");
-		expect(stdout).toContain("Print a single document's full content");
-	});
-
-	it("documents the --collection option under `search --help`", async () => {
-		const { exitCode, stdout } = await runHelp(["search", "--help"]);
-		expect(exitCode).toBe(0);
-		expect(stdout).toContain("--collection");
-		expect(stdout).toContain("QUERY");
+		expect(stdout).toContain("Find passages matching a query");
+		expect(stdout).toContain("Print a document's full content");
 	});
 
 	it("documents the search output format in --help (keeps the prompt's promise true)", async () => {
-		const { stdout } = await runHelp(["search", "--help"]);
+		const { exitCode, stdout } = await runHelp(["search", "--help"]);
+		expect(exitCode).toBe(0);
+		expect(stdout).toContain("QUERY");
 		// The system prompt tells the agent to learn the output format from
 		// --help, so the documented shape must actually appear here.
 		expect(stdout).toContain("JSON object per line");
+		expect(stdout).toContain("passageId");
 		expect(stdout).toContain("documentId");
 		expect(stdout).toContain("title");
 		expect(stdout).toContain("snippet");
@@ -96,11 +91,21 @@ describe("mymemo-docs --help (citty-generated)", () => {
 });
 
 describe("mymemo-docs search output (NDJSON)", () => {
-	it("emits one parseable JSON object per document and escapes newlines", async () => {
+	it("emits one parseable JSON object per hit and escapes newlines", async () => {
 		searchResponse = {
 			documents: [
-				{ documentId: "d1", title: "ML intro", snippet: "line one\nline two" },
-				{ documentId: "d2", title: "Neural\tnets", snippet: "s2" },
+				{
+					passageId: "p1",
+					documentId: "d1",
+					title: "ML intro",
+					snippet: "line one\nline two",
+				},
+				{
+					passageId: "p2",
+					documentId: "d2",
+					title: "Neural\tnets",
+					snippet: "s2",
+				},
 			],
 		};
 		const { exitCode, stdout } = await runSearch(["machine learning"]);
@@ -111,7 +116,11 @@ describe("mymemo-docs search output (NDJSON)", () => {
 		// line contract: exactly 2 non-empty lines, each valid JSON.
 		const lines = stdout.split("\n").filter((l) => l.length > 0);
 		expect(lines).toHaveLength(2);
-		const first = JSON.parse(lines[0] as string) as { documentId?: string };
+		const first = JSON.parse(lines[0] as string) as {
+			passageId?: string;
+			documentId?: string;
+		};
+		expect(first.passageId).toBe("p1");
 		expect(first.documentId).toBe("d1");
 		expect((JSON.parse(lines[1] as string) as { title?: string }).title).toBe(
 			"Neural\tnets",
@@ -135,40 +144,27 @@ describe("mymemo-docs search output (NDJSON)", () => {
 		expect(stdout).toBe("");
 	});
 
-	it("always emits a documentId key even if the hit omits it", async () => {
-		searchResponse = { documents: [{ title: "no id here" }] };
+	it("always emits passageId + documentId keys even if the hit omits them", async () => {
+		searchResponse = { documents: [{ title: "no ids here" }] };
 		const { exitCode, stdout } = await runSearch(["x"]);
 		searchResponse = { documents: [] };
 		expect(exitCode).toBe(0);
 		const obj = JSON.parse(stdout.trim()) as Record<string, unknown>;
-		expect(obj).toHaveProperty("documentId");
+		expect(obj.passageId).toBe("");
 		expect(obj.documentId).toBe("");
 	});
 });
 
 describe("mymemo-docs search arg parsing", () => {
-	it("preserves a quoted multi-word query when --collection is absent", async () => {
+	it("preserves a quoted multi-word query", async () => {
 		const { exitCode, sent } = await runSearch(["machine learning"]);
 		expect(exitCode).toBe(0);
 		expect(sent?.query).toBe("machine learning");
-		expect(sent?.collectionId).toBeUndefined();
 	});
 
 	it("joins an unquoted multi-word query without dropping the first word", async () => {
 		const { exitCode, sent } = await runSearch(["machine", "learning"]);
 		expect(exitCode).toBe(0);
 		expect(sent?.query).toBe("machine learning");
-	});
-
-	it("extracts --collection and keeps the surrounding query intact", async () => {
-		const { exitCode, sent } = await runSearch([
-			"neural",
-			"--collection",
-			"col-1",
-			"nets",
-		]);
-		expect(exitCode).toBe(0);
-		expect(sent?.query).toBe("neural nets");
-		expect(sent?.collectionId).toBe("col-1");
 	});
 });

--- a/apps/mymemo-docs/src/index.ts
+++ b/apps/mymemo-docs/src/index.ts
@@ -18,13 +18,13 @@ const BASE = process.env.MYMEMO_DOC_GATEWAY_URL;
 const TOKEN = process.env.MYMEMO_DOC_TOKEN;
 
 interface SearchHit {
+	passageId: string;
 	documentId: string;
 	title?: string;
 	snippet?: string;
 }
 
 interface FetchedDocument {
-	cite?: string;
 	title?: string;
 	content?: string;
 }
@@ -49,7 +49,7 @@ const search = defineCommand({
 	meta: {
 		name: "search",
 		description:
-			"Find documents matching a query. Prints one JSON object per line: {documentId, title, snippet}.",
+			"Find passages matching a query. Prints one JSON object per line: {passageId, documentId, title, snippet}. Cite the passageId; fetch the documentId for full content. (Search is scoped to the turn automatically.)",
 	},
 	args: {
 		query: {
@@ -57,18 +57,15 @@ const search = defineCommand({
 			required: true,
 			description: "Search text (wrap a multi-word query in quotes).",
 		},
-		collection: {
-			type: "string",
-			description: "Restrict the search to a collection id.",
-		},
 	},
 	async run({ args }) {
-		// args._ holds every positional (citty keeps --collection out of it), so
-		// joining reproduces the query whether quoted or unquoted.
+		// args._ holds every positional, so joining reproduces the query whether
+		// quoted or unquoted. Scope (collection/document) is enforced by the
+		// gateway from the signed token — the agent cannot widen it here.
 		const query = args._.join(" ");
 		const result = await call<{ documents?: SearchHit[] }>(
 			"/v1/documents/search",
-			{ query, collectionId: args.collection },
+			{ query },
 		);
 		// Tolerate a malformed upstream payload (null / non-array) instead of
 		// crashing — treat anything that isn't an array as zero results.
@@ -83,6 +80,7 @@ const search = defineCommand({
 		for (const d of documents) {
 			console.log(
 				JSON.stringify({
+					passageId: d.passageId ?? "",
 					documentId: d.documentId ?? "",
 					title: d.title ?? "",
 					snippet: d.snippet ?? "",
@@ -96,20 +94,19 @@ const fetchCommand = defineCommand({
 	meta: {
 		name: "fetch",
 		description:
-			"Print a single document's full content, preceded by a 'cite:' line (the citation path) and a 'title:' line.",
+			"Print a document's full content (preceded by a 'title:' line) by its documentId from a search result.",
 	},
 	args: {
 		documentId: {
 			type: "positional",
 			required: true,
-			description: "The id of the document to fetch.",
+			description: "A documentId from a search result.",
 		},
 	},
 	async run({ args }) {
 		const doc = await call<FetchedDocument>("/v1/documents/fetch", {
 			documentId: args.documentId,
 		});
-		console.log(`cite: ${doc.cite ?? ""}`);
 		console.log(`title: ${doc.title ?? ""}`);
 		console.log("---");
 		console.log(doc.content ?? "");

--- a/compose.yaml
+++ b/compose.yaml
@@ -10,6 +10,7 @@ services:
       - ./apps/chat-api/.env
     depends_on:
       - llm-gateway
+      - document-gateway
     restart: always
     networks:
       - mymemo-network
@@ -27,6 +28,27 @@ services:
       - 8081:8081
     env_file:
       - ./apps/llm-gateway/.env
+    restart: always
+    networks:
+      - mymemo-network
+
+  # Control plane: the only service holding the read-only KB DATABASE_URL.
+  # Sandboxed agents reach it via MYMEMO_DOC_GATEWAY_URL with the same per-turn
+  # bearer token; it verifies the token, enforces the signed scope, and reads
+  # the MyMemo KB Postgres (FTS) directly.
+  # Note: DATABASE_URL must point at a Postgres reachable from this service (the
+  # staging RDS is private — needs an in-VPC host or tunnel), and
+  # DOCUMENT_GATEWAY_PUBLIC_URL (set for chat-api) must resolve to an address
+  # reachable from inside the E2B sandbox, not just this compose network.
+  document-gateway:
+    container_name: document-gateway
+    build:
+      context: .
+      dockerfile: apps/document-gateway/Dockerfile
+    ports:
+      - 8082:8082
+    env_file:
+      - ./apps/document-gateway/.env
     restart: always
     networks:
       - mymemo-network

--- a/docs/llm-gateway-architecture.html
+++ b/docs/llm-gateway-architecture.html
@@ -215,7 +215,7 @@
       for the model and a <b>document-gateway</b> for the user's documents. chat-api mints one short-lived,
       <b>scope-bound</b> bearer token per turn; the gateways are the <b>only</b> places the real
       <code style="font-family:var(--mono);color:var(--red)">ANTHROPIC_API_KEY</code> and
-      <code style="font-family:var(--mono);color:var(--amber)">MYMEMO_DOC_API_KEY</code> live.
+      <code style="font-family:var(--mono);color:var(--amber)">DATABASE_URL</code> live.
     </p>
   </header>
 
@@ -225,7 +225,7 @@
       <div class="n">01</div>
       <div>
         <h2>Topology &amp; trust boundary</h2>
-        <p>Two zones. Credentials are color-coded: <b style="color:var(--red)">● provider key</b>, <b style="color:var(--amber)">● document-API key</b>, <b style="color:var(--green)">● bearer token</b>.</p>
+        <p>Two zones. Credentials are color-coded: <b style="color:var(--red)">● provider key</b>, <b style="color:var(--amber)">● KB database URL</b>, <b style="color:var(--green)">● bearer token</b>.</p>
       </div>
     </div>
 
@@ -245,8 +245,8 @@
           </div>
 
           <div class="node">
-            <div class="nh"><span class="nm">document-gateway</span><span class="badge db">MYMEMO_DOC_API_KEY</span></div>
-            <div class="role">Stateless service. Verifies the same token, <b>enforces its signed scope</b> (global / collection / document) server-side, pins every call to the token's <code>userId</code>, and proxies search/fetch to the MyMemo document API. The only document-key holder.</div>
+            <div class="nh"><span class="nm">document-gateway</span><span class="badge db">DATABASE_URL</span></div>
+            <div class="role">Stateless service. Verifies the same token, <b>enforces its signed scope</b> (global / collection / document) server-side, pins every call to the token's <code>userId</code> (the KB <code>workspace_id</code>), and reads the user's MyMemo knowledge base (Postgres) directly — FTS over passages. The only holder of the read-only <code>DATABASE_URL</code>.</div>
           </div>
         </div>
 
@@ -270,7 +270,7 @@
         <div>The agent has <b>nowhere else to reach</b> — srt's network allowlist denies every egress except the two gateway hosts. Its only token is a 10-minute, single-user <span style="color:var(--green);font-weight:600">Bearer token</span> whose <b>scope is signed in</b>, so a prompt-injected agent can't widen its document access, has nothing worth stealing, <em>and</em> nowhere to send a stolen secret.</div>
       </div>
       <div class="external">
-        <span class="dot"></span>EXTERNAL &nbsp;·&nbsp; <b>api.anthropic.com</b> — reached only by llm-gateway (with the injected <span style="color:var(--red)">x-api-key</span>) &nbsp;·&nbsp; <b>MyMemo document API</b> — reached only by document-gateway (with the injected <span style="color:var(--amber)">doc key</span>)
+        <span class="dot"></span>EXTERNAL &nbsp;·&nbsp; <b>api.anthropic.com</b> — reached only by llm-gateway (with the injected <span style="color:var(--red)">x-api-key</span>) &nbsp;·&nbsp; <b>MyMemo KB Postgres (RDS)</b> — read only by document-gateway (with <span style="color:var(--amber)">DATABASE_URL</span>)
       </div>
     </div>
 
@@ -278,7 +278,7 @@
       <div class="cf k">
         <h4>● the real keys — contained</h4>
         <p>Each lives on one service, is used in one place, and crosses one external edge.</p>
-        <div class="path"><span class="hot">llm-gateway</span> &nbsp;set x-api-key&nbsp; → &nbsp;api.anthropic.com<br/><span class="hot">document-gateway</span> &nbsp;set doc key&nbsp; → &nbsp;MyMemo doc API</div>
+        <div class="path"><span class="hot">llm-gateway</span> &nbsp;set x-api-key&nbsp; → &nbsp;api.anthropic.com<br/><span class="hot">document-gateway</span> &nbsp;DATABASE_URL&nbsp; → &nbsp;MyMemo KB Postgres</div>
       </div>
       <div class="cf t">
         <h4>● the token — travels</h4>
@@ -316,11 +316,11 @@
       </div></div>
       <div class="step"><div class="num"></div><div class="body">
         <div class="t">Spawn the agent (srt)</div>
-        <div class="d">Daemon spawns <code>bun agent.js</code> under <a href="https://github.com/anthropic-experimental/sandbox-runtime" target="_blank" rel="noopener">srt</a> (bwrap on Linux · sandbox-exec on macOS) — filesystem allowlist for the workspace cwd, network allowlist for the gateway hosts only. Env: <code class="tok">ANTHROPIC_BASE_URL</code>/<code class="tok">ANTHROPIC_AUTH_TOKEN</code> + <code class="tok">MYMEMO_DOC_GATEWAY_URL</code>/<code class="tok">MYMEMO_DOC_TOKEN</code>, <b>no</b> <code class="key">ANTHROPIC_API_KEY</code>, <b>no</b> <code class="key">MYMEMO_DOC_API_KEY</code>.</div>
+        <div class="d">Daemon spawns <code>bun agent.js</code> under <a href="https://github.com/anthropic-experimental/sandbox-runtime" target="_blank" rel="noopener">srt</a> (bwrap on Linux · sandbox-exec on macOS) — filesystem allowlist for the workspace cwd, network allowlist for the gateway hosts only. Env: <code class="tok">ANTHROPIC_BASE_URL</code>/<code class="tok">ANTHROPIC_AUTH_TOKEN</code> + <code class="tok">MYMEMO_DOC_GATEWAY_URL</code>/<code class="tok">MYMEMO_DOC_TOKEN</code>, <b>no</b> <code class="key">ANTHROPIC_API_KEY</code>, <b>no</b> <code class="key">DATABASE_URL</code>.</div>
       </div></div>
       <div class="step"><div class="num"></div><div class="body">
         <div class="t">agent → document-gateway (on demand)</div>
-        <div class="d">When it needs documents the agent runs <code>mymemo-docs search</code>/<code>fetch</code> (a CLI on its <code>PATH</code>) → <code>document-gateway</code> verifies the token, <b>enforces the signed scope</b>, and proxies to the MyMemo doc API with the real <code class="key">doc key</code>. Nothing is materialized to the sandbox FS.</div>
+        <div class="d">When it needs documents the agent runs <code>mymemo-docs search</code>/<code>fetch</code> (a CLI on its <code>PATH</code>) → <code>document-gateway</code> verifies the token, <b>enforces the signed scope</b>, and reads the KB Postgres (FTS over passages) with the read-only <code class="key">DATABASE_URL</code>. Nothing is materialized to the sandbox FS.</div>
       </div></div>
       <div class="step"><div class="num"></div><div class="body">
         <div class="t">claude → llm-gateway</div>
@@ -362,7 +362,7 @@
     </div>
     <table class="mtx rv">
       <thead>
-        <tr><th>Component</th><th>ANTHROPIC_API_KEY</th><th>MYMEMO_DOC_API_KEY</th><th>LLM_TOKEN_SECRET</th><th>Talks to</th></tr>
+        <tr><th>Component</th><th>ANTHROPIC_API_KEY</th><th>DATABASE_URL</th><th>LLM_TOKEN_SECRET</th><th>Talks to</th></tr>
       </thead>
       <tbody>
         <tr>
@@ -384,7 +384,7 @@
           <td class="c no">✕</td>
           <td class="c only">✓ only here</td>
           <td class="c yes">✓ <span class="sm">verify + enforce scope</span></td>
-          <td>← sandboxes · → MyMemo doc API</td>
+          <td>← sandboxes · → KB Postgres</td>
         </tr>
         <tr>
           <td class="comp">sandbox-daemon</td>
@@ -422,7 +422,7 @@
          ├─ <span class="a">mymemo-docs</span>          <span class="c"># CLI on PATH · search/fetch via document-gateway</span>
          ├─ <span class="g">✓ llm-gateway</span>        <span class="c"># model calls — allowed outbound</span>
          ├─ <span class="g">✓ document-gateway</span>   <span class="c"># document calls — allowed outbound</span>
-         └─ <span class="r">✗ everywhere else</span>     <span class="c"># anthropic, MyMemo doc API, public internet — denied</span>
+         └─ <span class="r">✗ everywhere else</span>     <span class="c"># anthropic, KB Postgres, public internet — denied</span>
     </div>
   </section>
 


### PR DESCRIPTION
## What

The `document-gateway` was a stub proxying to a "MyMemo document API" that doesn't exist. The production agent (`general-api-python-service`) instead reads a Postgres **knowledge base** (`workspace`/`document`/`document_section`/`passage`) via hybrid FTS+vector retrieval. This re-points our gateway at that DB, **FTS-only** (lexical `search_tsv`; no dense/vector or rerank), and enforces the turn's signed scope as SQL.

## Design (derived from the production code + validated against staging)

- **env**: `DATABASE_URL` (+ optional `DB_PASSWORD` splice, `sslmode`) replaces `MYMEMO_DOC_API_*`.
- **`db.ts`**: `Bun.sql` pool behind an injectable `Db` seam so query logic is unit-testable without a live RDS.
- **`queries.ts`**: `searchPassages` (`search_tsv @@ plainto_tsquery('simple', …)`), `fetchDocument` (`canonical_markdown`), and compat-id resolvers.
- **scope** (server-side, fail-closed): `workspace_id = member_code` (= token `userId`).
  - `global` → whole workspace
  - `document` → `summaryId` (`platform_knowledge.id`) → `content_asset.kb_document_id`
  - `collection` → `collectionId` (`content_collection.compat_str_id`) → `passage_collection` docs, pinned by the passage `workspace_id`
  - `status='active'` on passage and document.
- **`mymemo-docs` CLI**: NDJSON now carries `passageId` (the citation id); dropped `--collection` (scope is token-enforced); `fetch` drops the `cite:` line.
- **sandbox prompt**: cite the `passageId` from search; collection/document scope is auto-enforced.

## Validated against the live staging KB

Ran the **exact SQL** against staging (29.5k workspaces, 692k docs, 12.8M passages) via a one-off ECS task:

- ✅ `searchPassages`: 8 FTS hits with scores; `docids` filter works.
- ✅ `fetchDocument`: returned a 297 KB `canonical_markdown`.
- ✅ `resolveDocumentId`: `summaryId → kb_document_id` resolves.
- ✅ `workspace_id == member_code` at scale (~92.5%; rest are team workspaces).
- 🐛→✅ **collection scope fix** (`c10d567`): was filtering on `content_collection.member_code` (stored differently → matched 0/4.1M links). Now pinned by passage `workspace_id`; re-validated to resolve the collection's docs, and a cross-workspace `collectionId` returns 0 (the pin is the guard).

## Tests
Query logic is unit-tested with a fake `Db` (scope enforcement, compat resolution, 403/404). Full suite green; tsc + biome clean.

## Follow-ups (out of scope here)
- **Team workspaces** (~7.5% of docs; `workspace_id = team_code`) — needs `teamCode` added to the token.
- **Chinese FTS** is degraded (no jieba tokenization) vs production.
- **Deploy**: the gateway now needs `DATABASE_URL` and to run in-VPC (ECS); `compose.yaml` still omits it. The `Bun.sql` client wiring (`db.ts`) is verified at deploy — the RDS is private.

Closes #117 once the contract follow-ups are confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)