### PR TITLE
chore: remove persistent-sandbox-era dead code, unused deps, and doc drift

### DIFF
--- a/MIGRATION_PLAN.md
+++ b/MIGRATION_PLAN.md
@@ -1,5 +1,22 @@
 # Migration Plan: Per-User Sandbox Daemon with State Reconciliation
 
+> **⚠️ SUPERSEDED — historical design doc, kept for context only.**
+>
+> This plan describes an earlier design that is **no longer the implemented
+> architecture**. In particular, the following no longer hold:
+>
+> - Sandboxes are **fresh per turn**, not one long-lived sandbox per user.
+> - There is **no Postgres → sandbox filesystem reconciliation** and documents
+>   are **not materialized to disk**. The agent fetches documents on demand via
+>   the `mymemo-docs` CLI, which calls the **document-gateway** (scope enforced
+>   server-side from a signed per-turn token).
+> - LLM calls route through the **llm-gateway**; the sandbox holds no provider
+>   key and no document credential.
+>
+> For the current architecture and trust boundaries, see
+> [AGENTS.md](./AGENTS.md). This file is retained only as a record of the
+> original migration thinking.
+
 ## Summary
 
 Use one E2B sandbox per user and make the sandbox the execution owner for that user.

--- a/README.md
+++ b/README.md
@@ -4,33 +4,42 @@ This repository contains multiple projects for the MyMemo ecosystem.
 
 ## Projects
 
-### 🔷 chat-api (TypeScript)
+The repository is a Bun workspace. See [AGENTS.md](./AGENTS.md) for the
+architecture and trust boundaries.
 
-Chat API service built with TypeScript/Bun.
+| App | Location | Role |
+|-----|----------|------|
+| **chat-api** | `apps/chat-api/` | AI chat service; orchestrates a per-user E2B sandbox per turn |
+| **sandbox-daemon** | `apps/sandbox-daemon/` | In-sandbox HTTP daemon; bundled and shipped into E2B, spawns the agent per turn |
+| **llm-gateway** | `apps/llm-gateway/` | Control plane; the only service holding the real `ANTHROPIC_API_KEY`. Verifies the per-turn token and proxies to Anthropic |
+| **document-gateway** | `apps/document-gateway/` | Control plane; verifies the per-turn token, enforces its signed scope, and proxies document search/fetch |
+| **mymemo-docs** | `apps/mymemo-docs/` | CLI on the sandbox PATH that the agent uses to reach the document-gateway |
 
-**Location:** `apps/chat-api/`
+Shared libraries live under `packages/` (e.g. `@mymemo/llm-token`).
 
 **Setup:**
 ```bash
+bun install          # from the repo root, installs all workspaces
 cd apps/chat-api
-bun install
 bun run dev
 ```
 
-See [apps/chat-api/README.md](./apps/chat-api/README.md) for detailed documentation.
+See [apps/chat-api/README.md](./apps/chat-api/README.md) for chat-api documentation.
 
 ## Repository Structure
 
 ```
 .
-├── apps/               # Deployable applications
-│   └── chat-api/       # TypeScript chat API service
-│       ├── src/
-│       ├── package.json
-│       └── ...
-├── packages/           # Shared libraries
-├── compose.yaml        # Local Docker Compose file
-└── README.md           # This file
+├── apps/                   # Deployable applications
+│   ├── chat-api/           # AI chat service (orchestrator)
+│   ├── sandbox-daemon/     # In-sandbox daemon shipped into E2B
+│   ├── llm-gateway/        # Anthropic proxy (holds the provider key)
+│   ├── document-gateway/   # Scoped document proxy
+│   └── mymemo-docs/        # In-sandbox docs CLI
+├── packages/               # Shared libraries (e.g. @mymemo/llm-token)
+├── AGENTS.md               # Architecture & agent guidance
+├── compose.yaml            # Local Docker Compose file
+└── README.md               # This file
 ```
 
 ## Development

--- a/apps/chat-api/package.json
+++ b/apps/chat-api/package.json
@@ -18,18 +18,12 @@
 		"hono": "^4.10.1",
 		"hono-openapi": "^1.1.0",
 		"hono-pino": "^0.10.3",
-		"json-bigint": "^1.0.0",
-		"p-limit": "^7.2.0",
 		"pino": "^9.14.0",
-		"pino-http": "^10.5.0",
-		"tar": "^7.5.13",
 		"tiny-invariant": "^1.3.3",
 		"zod": "^4.1.12"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.2.4",
-		"@types/bun": "^1.3.11",
-		"@types/json-bigint": "^1.0.4",
-		"@types/tar": "^7.0.87"
+		"@biomejs/biome": "^2.3.11",
+		"@types/bun": "^1.3.11"
 	}
 }

--- a/apps/chat-api/src/config/env.ts
+++ b/apps/chat-api/src/config/env.ts
@@ -20,7 +20,8 @@ export const apiEnv = (() => {
 	return {
 		DAEMON_AUTH_TOKEN: Bun.env.DAEMON_AUTH_TOKEN,
 		// HMAC secret for the session tokens minted into each sandbox turn. Shared
-		// only with llm-gateway, which verifies them.
+		// with llm-gateway and document-gateway, which both verify them (the
+		// document-gateway additionally enforces the token's signed scope).
 		LLM_TOKEN_SECRET: Bun.env.LLM_TOKEN_SECRET,
 		// Base URL the sandboxed agent points the Claude binary at
 		// (ANTHROPIC_BASE_URL). Must be reachable from inside the E2B sandbox.

--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-manager.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-manager.ts
@@ -119,8 +119,12 @@ export class SandboxManager {
 	}
 
 	/**
-	 * Ensure the sandbox daemon is running and up-to-date.
-	 * Returns the daemon URL and the fixed auth token clients must present.
+	 * Deploy the daemon + agent bundles onto the freshly created sandbox and
+	 * wait for the daemon to report healthy. Returns the daemon URL and the
+	 * fixed auth token clients must present.
+	 *
+	 * Sandboxes are created fresh per turn, so the daemon is never already
+	 * running — there is nothing to health-check or restart, only to deploy.
 	 */
 	async ensureSandboxDaemon(
 		userId: string,
@@ -131,25 +135,6 @@ export class SandboxManager {
 		const endpoint = { url: daemonUrl, authToken: apiEnv.DAEMON_AUTH_TOKEN };
 
 		const bundles = await getSandboxBundles();
-
-		try {
-			const health = await this.checkDaemonHealth(daemonUrl);
-			if (health && health.version === bundles.version) {
-				return endpoint;
-			}
-
-			if (health) {
-				logger.info({
-					msg: "Daemon version mismatch, restarting",
-					currentVersion: health.version,
-					expectedVersion: bundles.version,
-				});
-				await this.restartDaemon(sandbox, logger, bundles);
-				return endpoint;
-			}
-		} catch {
-			// Daemon not running, deploy it
-		}
 
 		logger.info({
 			msg: "Deploying sandbox daemon",
@@ -197,20 +182,6 @@ export class SandboxManager {
 		);
 
 		await this.startDaemonProcess(sandbox, logger, bundles.version);
-	}
-
-	private async restartDaemon(
-		sandbox: Sandbox,
-		logger: SyncLogger,
-		bundles: SandboxBundleSet,
-	): Promise<void> {
-		// Kill whatever process owns port 8080 (process name may not match pkill pattern)
-		await sandbox.commands.run("kill $(lsof -ti :8080) 2>/dev/null || true", {
-			timeoutMs: 5_000,
-		});
-
-		// Re-deploy with updated bundles
-		await this.deploySandboxBundles(sandbox, logger, bundles);
 	}
 
 	private async startDaemonProcess(

--- a/apps/chat-api/src/index.ts
+++ b/apps/chat-api/src/index.ts
@@ -1,13 +1,13 @@
 import { Hono } from "hono";
 import { requestId } from "hono/request-id";
 import { pinoLogger } from "hono-pino";
-// Import apiEnv to validate required environment variables at module load time
-import "./config/env";
+// Importing apiEnv validates required environment variables at module load time
+import { apiEnv } from "./config/env";
 import routes from "./routes";
 
 const app = new Hono();
 app.use(requestId());
-app.use(pinoLogger());
+app.use(pinoLogger({ pino: { level: apiEnv.LOG_LEVEL } }));
 
 app.get("/", (c) => {
 	return c.text("Hello Hono!");

--- a/apps/sandbox-daemon/routes/turn.ts
+++ b/apps/sandbox-daemon/routes/turn.ts
@@ -72,9 +72,6 @@ app.post("/turn", async (c) => {
 
 	const {
 		request_id,
-		scope_type,
-		collection_id,
-		summary_id,
 		message,
 		agent_session_id,
 		system_prompt,
@@ -95,25 +92,6 @@ app.post("/turn", async (c) => {
 
 			try {
 				await s.write(ndjsonLine({ type: "started", turn_id: request_id }));
-
-				if (scope_type === "collection" && !collection_id) {
-					await s.write(
-						ndjsonLine({
-							type: "failed",
-							message: "collection_id required for collection scope",
-						}),
-					);
-					return;
-				}
-				if (scope_type === "document" && !summary_id) {
-					await s.write(
-						ndjsonLine({
-							type: "failed",
-							message: "summary_id required for document scope",
-						}),
-					);
-					return;
-				}
 
 				const cwd = getAgentCwd();
 				mkdirSync(cwd, { recursive: true });

--- a/bun.lock
+++ b/bun.lock
@@ -21,19 +21,13 @@
         "hono": "^4.10.1",
         "hono-openapi": "^1.1.0",
         "hono-pino": "^0.10.3",
-        "json-bigint": "^1.0.0",
-        "p-limit": "^7.2.0",
         "pino": "^9.14.0",
-        "pino-http": "^10.5.0",
-        "tar": "^7.5.13",
         "tiny-invariant": "^1.3.3",
         "zod": "^4.1.12",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.2.4",
+        "@biomejs/biome": "^2.3.11",
         "@types/bun": "^1.3.11",
-        "@types/json-bigint": "^1.0.4",
-        "@types/tar": "^7.0.87",
       },
     },
     "apps/document-gateway": {
@@ -176,13 +170,9 @@
 
     "@types/bun": ["@types/bun@1.3.6", "", { "dependencies": { "bun-types": "1.3.6" } }, "sha512-uWCv6FO/8LcpREhenN1d1b6fcspAB+cefwD7uti8C8VffIv0Um08TKMn98FynpTiU38+y2dUO55T11NgDt8VAA=="],
 
-    "@types/json-bigint": ["@types/json-bigint@1.0.4", "", {}, "sha512-ydHooXLbOmxBbubnA7Eh+RpBzuaIiQjh8WGJYQB50JFGFrdxW7JzVlyEV7fAXw0T2sqJ1ysTneJbiyNLqZRAag=="],
-
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
     "@types/node": ["@types/node@24.7.0", "", { "dependencies": { "undici-types": "~7.14.0" } }, "sha512-IbKooQVqUBrlzWTi79E8Fw78l8k1RNtlDDNWsFZs7XonuQSJ8oNYfEeclhprUldXISRMLzBpILuKgPlIxm+/Yw=="],
-
-    "@types/tar": ["@types/tar@7.0.87", "", { "dependencies": { "tar": "*" } }, "sha512-3IxNBV8LeY5oi2ZFpvAhOtW1+mHswkzM7BuisVrwJgPv67GBO2rkLPQlEKtzfHuLdhDDczhkCZeT+RuizMay4A=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
@@ -193,8 +183,6 @@
     "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
-
-    "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
 
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
@@ -280,8 +268,6 @@
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
-    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
-
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
@@ -317,8 +303,6 @@
     "jackspeak": ["jackspeak@4.2.3", "", { "dependencies": { "@isaacs/cliui": "^9.0.0" } }, "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg=="],
 
     "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
-
-    "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
 
     "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
 
@@ -370,8 +354,6 @@
 
     "openapi-typescript-helpers": ["openapi-typescript-helpers@0.0.15", "", {}, "sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw=="],
 
-    "p-limit": ["p-limit@7.3.0", "", { "dependencies": { "yocto-queue": "^1.2.1" } }, "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw=="],
-
     "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
@@ -385,8 +367,6 @@
     "pino": ["pino@9.14.0", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^2.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^3.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w=="],
 
     "pino-abstract-transport": ["pino-abstract-transport@2.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw=="],
-
-    "pino-http": ["pino-http@10.5.0", "", { "dependencies": { "get-caller-file": "^2.0.5", "pino": "^9.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0" } }, "sha512-hD91XjgaKkSsdn8P7LaebrNzhGTdB086W3pyPihX0EzGPjq5uBJBXo4N5guqNaK6mUjg9aubMF7wDViYek9dRA=="],
 
     "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
 
@@ -480,13 +460,9 @@
 
     "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
-    "yocto-queue": ["yocto-queue@1.2.2", "", {}, "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="],
-
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
-
-    "chat-api/@biomejs/biome": ["@biomejs/biome@2.2.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.2.4", "@biomejs/cli-darwin-x64": "2.2.4", "@biomejs/cli-linux-arm64": "2.2.4", "@biomejs/cli-linux-arm64-musl": "2.2.4", "@biomejs/cli-linux-x64": "2.2.4", "@biomejs/cli-linux-x64-musl": "2.2.4", "@biomejs/cli-win32-arm64": "2.2.4", "@biomejs/cli-win32-x64": "2.2.4" }, "bin": { "biome": "bin/biome" } }, "sha512-TBHU5bUy/Ok6m8c0y3pZiuO/BZoY/OcGxoLlrfQof5s8ISVwbVBdFINPQZyFfKwil8XibYWb7JMwnT8wT4WVPg=="],
 
     "chat-api/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
@@ -495,22 +471,6 @@
     "llm-gateway/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
     "mymemo-docs/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
-
-    "chat-api/@biomejs/biome/@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RJe2uiyaloN4hne4d2+qVj3d3gFJFbmrr5PYtkkjei1O9c+BjGXgpUPVbi8Pl8syumhzJjFsSIYkcLt2VlVLMA=="],
-
-    "chat-api/@biomejs/biome/@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-cFsdB4ePanVWfTnPVaUX+yr8qV8ifxjBKMkZwN7gKb20qXPxd/PmwqUH8mY5wnM9+U0QwM76CxFyBRJhC9tQwg=="],
-
-    "chat-api/@biomejs/biome/@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-M/Iz48p4NAzMXOuH+tsn5BvG/Jb07KOMTdSVwJpicmhN309BeEyRyQX+n1XDF0JVSlu28+hiTQ2L4rZPvu7nMw=="],
-
-    "chat-api/@biomejs/biome/@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-7TNPkMQEWfjvJDaZRSkDCPT/2r5ESFPKx+TEev+I2BXDGIjfCZk2+b88FOhnJNHtksbOZv8ZWnxrA5gyTYhSsQ=="],
-
-    "chat-api/@biomejs/biome/@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-orr3nnf2Dpb2ssl6aihQtvcKtLySLta4E2UcXdp7+RTa7mfJjBgIsbS0B9GC8gVu0hjOu021aU8b3/I1tn+pVQ=="],
-
-    "chat-api/@biomejs/biome/@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-m41nFDS0ksXK2gwXL6W6yZTYPMH0LughqbsxInSKetoH6morVj43szqKx79Iudkp8WRT5SxSh7qVb8KCUiewGg=="],
-
-    "chat-api/@biomejs/biome/@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.2.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-NXnfTeKHDFUWfxAefa57DiGmu9VyKi0cDqFpdI+1hJWQjGJhJutHPX0b5m+eXvTKOaf+brU+P0JrQAZMb5yYaQ=="],
-
-    "chat-api/@biomejs/biome/@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.2.4", "", { "os": "win32", "cpu": "x64" }, "sha512-3Y4V4zVRarVh/B/eSHczR4LYoSVyv3Dfuvm3cWs5w/HScccS0+Wt/lHOcDTRYeHjQmMYVC3rIRWqyN2EI52+zg=="],
 
     "chat-api/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 


### PR DESCRIPTION
Cleanup pass aligning the codebase with the **fresh-per-turn sandbox** architecture. Net **−70 LOC**; no behavior change beyond removing dead paths.

## Dead code (behavioral)
- **`sandbox-manager.ts`** — `ensureSandboxDaemon` now deploys the daemon directly. On a fresh-per-turn sandbox the daemon is never already running, so the initial `/health` probe always missed while adding **up to 3s of latency per turn**, and the version-mismatch branch + `restartDaemon` were unreachable. `checkDaemonHealth` is retained — it's still used for startup readiness in `startDaemonProcess`.
- **`sandbox-daemon/routes/turn.ts`** — dropped the vestigial `scope_type`/`collection_id`/`summary_id` validation (and the now-unused destructured fields). Scope is signed into the per-turn token and enforced server-side by `document-gateway`; this daemon-side guard could only ever produce false failures. The wire fields remain on the `TurnRequest` interface.

## Cleanup
- **`apps/chat-api/package.json`** — removed 6 deps imported nowhere: `json-bigint`, `p-limit`, `tar`, `pino-http`, `@types/json-bigint`, `@types/tar`. Aligned Biome `2.2.4` → `^2.3.11` to match the root pin and `biome.json` schema (reformat produces zero churn).
- **`index.ts`** — wired `LOG_LEVEL` into `pinoLogger({ pino: { level } })`; it was parsed in `env.ts` but never used.

## Docs
- **`env.ts`** — the `LLM_TOKEN_SECRET` comment now notes it's shared with `document-gateway` too (which also enforces the signed scope).
- **`README.md`** — Projects section now lists all five apps (was just chat-api).
- **`MIGRATION_PLAN.md`** — added a **SUPERSEDED** banner pointing to `AGENTS.md`; it described the old Postgres-reconciliation / file-sync design as current.

## Verification
- `bun test` — chat-api **31 pass**, sandbox-daemon **24 pass** (incl. the turn integration test).
- `biome check` clean on touched files.
- No new `tsc` errors (the two pre-existing errors in `probe-agent-tools.ts` / `sandbox-proxy.test.ts` are unchanged by this PR).

## Out of scope / follow-ups
- `apps/chat-api/README.md` is badly stale (describes OpenAI GPT-4o / Vercel AI SDK). The findings only named the *root* README; the chat-api one is a larger rewrite, left for a separate change.
- `pino` is no longer imported directly but remains the logger backend via `hono-pino`, so it's kept.
- **Test gaps** flagged but not addressed here: `agent.ts`/`agent-entry.ts` are untested, and there's no client-disconnect or silent-tool-gap test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)