### PR TITLE
fix(docker): derive workspace manifests so frozen installs stop breaking

### DIFF
--- a/apps/chat-api/Dockerfile
+++ b/apps/chat-api/Dockerfile
@@ -1,20 +1,24 @@
 FROM oven/bun:1 AS base
 WORKDIR /usr/src/app
 
-# Install dependencies — need all workspace package.json files for lockfile resolution
-FROM base AS install
-RUN mkdir -p /temp/dev /temp/prod
+# Prune the context to just the workspace manifests. --frozen-lockfile needs
+# every member's package.json (the root lockfile describes them all), and
+# deriving the set this way means a new workspace member needs no Dockerfile
+# edit. Only package.json files plus the root lockfile survive, so the install
+# layers below still cache on manifest content alone.
+FROM base AS manifests
+COPY package.json bun.lock ./
+COPY apps apps
+COPY packages packages
+RUN find apps packages -type f ! -name package.json -delete \
+ && find apps packages -type d -empty -delete
 
-COPY package.json bun.lock /temp/dev/
-COPY apps/chat-api/package.json /temp/dev/apps/chat-api/
-COPY apps/sandbox-daemon/package.json /temp/dev/apps/sandbox-daemon/
-COPY packages/llm-token/package.json /temp/dev/packages/llm-token/
+# Install dependencies from the pruned manifests.
+FROM base AS install
+COPY --from=manifests /usr/src/app /temp/dev
 RUN cd /temp/dev && bun install --frozen-lockfile
 
-COPY package.json bun.lock /temp/prod/
-COPY apps/chat-api/package.json /temp/prod/apps/chat-api/
-COPY apps/sandbox-daemon/package.json /temp/prod/apps/sandbox-daemon/
-COPY packages/llm-token/package.json /temp/prod/packages/llm-token/
+COPY --from=manifests /usr/src/app /temp/prod
 RUN cd /temp/prod && bun install --frozen-lockfile --production
 
 # Copy source, prebuild daemon bundle, and run tests

--- a/apps/document-gateway/Dockerfile
+++ b/apps/document-gateway/Dockerfile
@@ -1,18 +1,21 @@
 FROM oven/bun:1 AS base
 WORKDIR /usr/src/app
 
-# Install dependencies — need all referenced workspace package.json files for
-# lockfile resolution.
+# Prune the context to just the workspace manifests. The root lockfile describes
+# every workspace member, so --frozen-lockfile needs each member's package.json
+# present (only package.json — no source). Deriving the set this way means a new
+# workspace member needs no Dockerfile edit, and the install layer still caches
+# on manifest content alone.
+FROM base AS manifests
+COPY package.json bun.lock ./
+COPY apps apps
+COPY packages packages
+RUN find apps packages -type f ! -name package.json -delete \
+ && find apps packages -type d -empty -delete
+
+# Install dependencies from the pruned manifests.
 FROM base AS install
-RUN mkdir -p /temp/prod
-COPY package.json bun.lock /temp/prod/
-# The root lockfile describes every workspace member, so --frozen-lockfile needs
-# each member's package.json present (only package.json — no source).
-COPY apps/document-gateway/package.json /temp/prod/apps/document-gateway/
-COPY apps/llm-gateway/package.json /temp/prod/apps/llm-gateway/
-COPY apps/chat-api/package.json /temp/prod/apps/chat-api/
-COPY apps/sandbox-daemon/package.json /temp/prod/apps/sandbox-daemon/
-COPY packages/llm-token/package.json /temp/prod/packages/llm-token/
+COPY --from=manifests /usr/src/app /temp/prod
 RUN cd /temp/prod && bun install --frozen-lockfile --production
 
 # Final release image

--- a/apps/llm-gateway/Dockerfile
+++ b/apps/llm-gateway/Dockerfile
@@ -1,18 +1,21 @@
 FROM oven/bun:1 AS base
 WORKDIR /usr/src/app
 
-# Install dependencies — need all referenced workspace package.json files for
-# lockfile resolution.
+# Prune the context to just the workspace manifests. The root lockfile describes
+# every workspace member, so --frozen-lockfile needs each member's package.json
+# present (only package.json — no source). Deriving the set this way means a new
+# workspace member needs no Dockerfile edit, and the install layer still caches
+# on manifest content alone.
+FROM base AS manifests
+COPY package.json bun.lock ./
+COPY apps apps
+COPY packages packages
+RUN find apps packages -type f ! -name package.json -delete \
+ && find apps packages -type d -empty -delete
+
+# Install dependencies from the pruned manifests.
 FROM base AS install
-RUN mkdir -p /temp/prod
-COPY package.json bun.lock /temp/prod/
-# The root lockfile describes every workspace member, so --frozen-lockfile needs
-# each member's package.json present (only package.json — no source).
-COPY apps/llm-gateway/package.json /temp/prod/apps/llm-gateway/
-COPY apps/document-gateway/package.json /temp/prod/apps/document-gateway/
-COPY apps/chat-api/package.json /temp/prod/apps/chat-api/
-COPY apps/sandbox-daemon/package.json /temp/prod/apps/sandbox-daemon/
-COPY packages/llm-token/package.json /temp/prod/packages/llm-token/
+COPY --from=manifests /usr/src/app /temp/prod
 RUN cd /temp/prod && bun install --frozen-lockfile --production
 
 # Final release image


### PR DESCRIPTION
## What

All three service Dockerfiles (`chat-api`, `llm-gateway`, `document-gateway`) failed to build. Each ran `bun install --frozen-lockfile` after copying the root `package.json` + `bun.lock` plus a **hand-listed subset** of workspace members' `package.json` files. The root lockfile records all six members — including `apps/mymemo-docs`, which **no** Dockerfile copied — so Bun computed a different workspace set than the lockfile and failed:

```
error: lockfile had changes, but lockfile is frozen
```

## Why this approach

The minimal fix would be to add the missing `COPY` lines. But that just re-arms the same trap: the member list is duplicated across four install stages in three files, and adding a seventh workspace member silently rebreaks every build again.

Instead, each Dockerfile now has a throwaway `manifests` stage that copies the `apps/` and `packages/` trees and prunes them down to just `package.json` files (root `bun.lock` preserved):

```dockerfile
FROM base AS manifests
COPY package.json bun.lock ./
COPY apps apps
COPY packages packages
RUN find apps packages -type f ! -name package.json -delete \
 && find apps packages -type d -empty -delete

FROM base AS install
COPY --from=manifests /usr/src/app /temp/prod   # (+ /temp/dev for chat-api)
RUN cd /temp/prod && bun install --frozen-lockfile --production
```

The install stage discovers every workspace member automatically — **a new member needs zero Dockerfile edits**.

## Reviewer notes

- The `find` is scoped to `apps packages`, so the root `bun.lock` is kept while stray nested lockfiles (`apps/chat-api/bun.lock`, `apps/sandbox-daemon/bun.lock`) are pruned — matching the old behavior, which only ever copied member `package.json`s.
- `.dockerignore` already excludes `**/node_modules`, so the wholesale `COPY apps apps` stays clean.
- **No build-cache regression**: the install layer caches on the pruned manifest content, so a source-only change leaves it untouched (verified).

## Verification

All three `docker build`s run from the repo root, end-to-end:

- ✅ **llm-gateway** & **document-gateway** build; release layers are byte-identical (same image SHA) to the explicit-list version.
- ✅ **chat-api** builds; prerelease `build:daemon` + `bun test` green (**31 pass, 0 fail**).
- ✅ **Cache check**: edited a source comment (no manifest change), rebuilt — both `bun install` layers stayed `CACHED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)