### PR TITLE
fix(sandbox-daemon): keep healthy long-tool turns alive under the idle watchdog

### DIFF
--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-proxy.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-proxy.ts
@@ -45,101 +45,134 @@ export async function forwardChatTurnToSandbox(
 		onSessionId,
 	} = options;
 
-	const response = await fetch(`${daemonUrl}/turn`, {
-		method: "POST",
-		headers: {
-			"Content-Type": "application/json",
-			"x-daemon-auth-token": daemonAuthToken,
-		},
-		body: JSON.stringify(turnRequest),
-		signal: AbortSignal.timeout(120_000),
-	});
+	// Idle-based timeout over the streamed body, re-armed on every chunk —
+	// turns are legitimately long, so an absolute timeout over the whole read
+	// would abort healthy ones. The window sits at the daemon's Bun idleTimeout
+	// (240s, > the daemon's 120s agent watchdog); during a healthy turn the
+	// daemon's text + `heartbeat` events keep resetting it, and on a genuine
+	// hang the daemon surfaces a `failed` event well before this fires. So this
+	// only trips if the daemon goes fully silent (e.g. the process died).
+	const IDLE_TIMEOUT_MS = 240_000;
+	const idleController = new AbortController();
+	let idleTimer: ReturnType<typeof setTimeout> | undefined;
+	const armIdle = () => {
+		clearTimeout(idleTimer);
+		idleTimer = setTimeout(
+			() =>
+				idleController.abort(
+					new Error(`daemon idle timeout: no bytes for ${IDLE_TIMEOUT_MS}ms`),
+				),
+			IDLE_TIMEOUT_MS,
+		);
+	};
 
-	if (response.status === 409) {
-		throw new ConversationBusyError("Sandbox is busy processing another turn");
-	}
+	try {
+		armIdle();
+		const response = await fetch(`${daemonUrl}/turn`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"x-daemon-auth-token": daemonAuthToken,
+			},
+			body: JSON.stringify(turnRequest),
+			signal: idleController.signal,
+		});
 
-	if (!response.ok) {
-		const text = await response.text().catch(() => "");
-		throw new Error(`Daemon returned ${response.status}: ${text}`);
-	}
+		if (response.status === 409) {
+			throw new ConversationBusyError(
+				"Sandbox is busy processing another turn",
+			);
+		}
 
-	if (!response.body) {
-		throw new Error("Daemon returned no response body");
-	}
+		if (!response.ok) {
+			const text = await response.text().catch(() => "");
+			throw new Error(`Daemon returned ${response.status}: ${text}`);
+		}
 
-	let agentError: string | null = null;
-	let buffer = "";
+		if (!response.body) {
+			throw new Error("Daemon returned no response body");
+		}
 
-	const reader = response.body.getReader();
-	const decoder = new TextDecoder();
+		let agentError: string | null = null;
+		let buffer = "";
 
-	while (true) {
-		const { done, value } = await reader.read();
-		if (done) break;
+		const reader = response.body.getReader();
+		const decoder = new TextDecoder();
 
-		buffer += decoder.decode(value, { stream: true });
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			armIdle();
 
-		let newlineIndex = buffer.indexOf("\n");
-		while (newlineIndex !== -1) {
-			const line = buffer.slice(0, newlineIndex).trim();
-			buffer = buffer.slice(newlineIndex + 1);
+			buffer += decoder.decode(value, { stream: true });
 
-			if (line) {
-				let parsed: unknown;
-				try {
-					parsed = JSON.parse(line);
-				} catch {
-					// Non-JSON line, ignore
-					parsed = null;
-				}
-				if (typeof parsed === "object" && parsed !== null) {
-					const evt = parsed as { type?: string } & Record<string, unknown>;
-					switch (evt.type) {
-						case "text_delta":
-							if (typeof evt.text === "string") {
-								await onTextDelta(evt.text);
-							}
-							break;
-						case "session_id":
-							if (typeof evt.sessionId === "string") {
-								await onSessionId(evt.sessionId);
-							}
-							break;
-						case "completed":
-							break;
-						case "failed":
-							agentError = (evt.message as string) ?? "Turn failed";
-							break;
-						case "started":
-							break;
-						case "result":
-							break;
-						case "error":
-							agentError = (evt.message as string) ?? "Unknown agent error";
-							break;
+			let newlineIndex = buffer.indexOf("\n");
+			while (newlineIndex !== -1) {
+				const line = buffer.slice(0, newlineIndex).trim();
+				buffer = buffer.slice(newlineIndex + 1);
+
+				if (line) {
+					let parsed: unknown;
+					try {
+						parsed = JSON.parse(line);
+					} catch {
+						// Non-JSON line, ignore
+						parsed = null;
+					}
+					if (typeof parsed === "object" && parsed !== null) {
+						const evt = parsed as { type?: string } & Record<string, unknown>;
+						switch (evt.type) {
+							case "text_delta":
+								if (typeof evt.text === "string") {
+									await onTextDelta(evt.text);
+								}
+								break;
+							case "session_id":
+								if (typeof evt.sessionId === "string") {
+									await onSessionId(evt.sessionId);
+								}
+								break;
+							case "heartbeat":
+								// Daemon liveness keepalive — re-arms armIdle() above
+								// (every chunk does); never surfaced to the client.
+								break;
+							case "completed":
+								break;
+							case "failed":
+								agentError = (evt.message as string) ?? "Turn failed";
+								break;
+							case "started":
+								break;
+							case "result":
+								break;
+							case "error":
+								agentError = (evt.message as string) ?? "Unknown agent error";
+								break;
+						}
 					}
 				}
+
+				newlineIndex = buffer.indexOf("\n");
 			}
-
-			newlineIndex = buffer.indexOf("\n");
 		}
-	}
 
-	// Flush remaining buffer
-	if (buffer.trim()) {
-		try {
-			const parsed = JSON.parse(buffer.trim());
-			if (parsed?.type === "failed")
-				agentError = parsed.message ?? "Turn failed";
-		} catch {
-			// Ignore
+		// Flush remaining buffer
+		if (buffer.trim()) {
+			try {
+				const parsed = JSON.parse(buffer.trim());
+				if (parsed?.type === "failed")
+					agentError = parsed.message ?? "Turn failed";
+			} catch {
+				// Ignore
+			}
 		}
-	}
 
-	if (agentError) {
-		throw new Error(`Sandbox agent error: ${agentError}`);
-	}
+		if (agentError) {
+			throw new Error(`Sandbox agent error: ${agentError}`);
+		}
 
-	await onTextEnd();
+		await onTextEnd();
+	} finally {
+		clearTimeout(idleTimer);
+	}
 }

--- a/apps/sandbox-daemon/agent-entry.ts
+++ b/apps/sandbox-daemon/agent-entry.ts
@@ -8,6 +8,7 @@
  * Stdout:  NDJSON, one event per line —
  *            { type: "text_delta", text: "..." }
  *            { type: "session_id", sessionId: "..." }
+ *            { type: "heartbeat" }        (liveness while a tool runs)
  *            { type: "completed" }
  *            { type: "failed", message: "..." }
  * Exit:    0 on completed, 1 on failed.
@@ -82,6 +83,9 @@ async function main() {
 		},
 		onSessionId: async (sessionId) => {
 			emit({ type: "session_id", sessionId });
+		},
+		onHeartbeat: () => {
+			emit({ type: "heartbeat" });
 		},
 		onCompleted: async () => {
 			emit({ type: "completed" });

--- a/apps/sandbox-daemon/agent.ts
+++ b/apps/sandbox-daemon/agent.ts
@@ -3,7 +3,12 @@
  * Ported from agent-runner.mjs to TypeScript, adapted for daemon use.
  */
 
-import { query } from "@anthropic-ai/claude-agent-sdk";
+import {
+	type HookCallbackMatcher,
+	type HookEvent,
+	query,
+} from "@anthropic-ai/claude-agent-sdk";
+import { createHeartbeatController } from "./heartbeat";
 
 export interface AgentRunOptions {
 	userQuery: string;
@@ -15,6 +20,8 @@ export interface AgentRunOptions {
 export interface AgentCallbacks {
 	onTextDelta: (text: string) => void | Promise<void>;
 	onSessionId: (sessionId: string) => void | Promise<void>;
+	/** Internal liveness tick emitted while a tool is executing (no client text). */
+	onHeartbeat: () => void | Promise<void>;
 	onCompleted: () => void | Promise<void>;
 	onFailed: (message: string) => void | Promise<void>;
 }
@@ -44,6 +51,49 @@ export async function runAgent(
 	if (sessionId) {
 		queryOptions.resume = sessionId;
 	}
+
+	// Tool execution emits nothing on stdout, so without this a single tool that
+	// runs longer than the idle window trips the daemon watchdog. Pre/PostToolUse
+	// hooks bracket every tool's wall-clock; while one is in flight we tick a
+	// `heartbeat` to keep the watchdog (and the daemon↔chat-api socket) armed.
+	const heartbeat = createHeartbeatController(() => {
+		void callbacks.onHeartbeat();
+	});
+	const hooks: Partial<Record<HookEvent, HookCallbackMatcher[]>> = {
+		PreToolUse: [
+			{
+				hooks: [
+					async (_input, toolUseId) => {
+						heartbeat.onToolStart(toolUseId ?? "");
+						return {};
+					},
+				],
+			},
+		],
+		PostToolUse: [
+			{
+				hooks: [
+					async (_input, toolUseId) => {
+						heartbeat.onToolEnd(toolUseId ?? "");
+						return {};
+					},
+				],
+			},
+		],
+		// Tool errors take this path instead of PostToolUse; stop the heartbeat
+		// here too so a failing tool doesn't leak the interval.
+		PostToolUseFailure: [
+			{
+				hooks: [
+					async (_input, toolUseId) => {
+						heartbeat.onToolEnd(toolUseId ?? "");
+						return {};
+					},
+				],
+			},
+		],
+	};
+	queryOptions.hooks = hooks;
 
 	let result: ReturnType<typeof query>;
 	try {
@@ -91,5 +141,8 @@ export async function runAgent(
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
 		await callbacks.onFailed(`Agent stream error: ${message}`);
+	} finally {
+		// Never leak the interval past the turn, even if a hook's Post* never fired.
+		heartbeat.stop();
 	}
 }

--- a/apps/sandbox-daemon/child-spawn.test.ts
+++ b/apps/sandbox-daemon/child-spawn.test.ts
@@ -197,6 +197,7 @@ describe("spawnAgent idle timeout", () => {
 		"SANDBOX_BWRAP_PATH",
 		"SANDBOX_AGENT_PATH",
 		"SANDBOX_AGENT_IDLE_TIMEOUT_MS",
+		"SANDBOX_AGENT_MAX_TURN_MS",
 	];
 	const originalEnv: Record<string, string | undefined> = {};
 
@@ -229,6 +230,27 @@ describe("spawnAgent idle timeout", () => {
 		writeFileSync(
 			fixtures.agentSlow,
 			`for await (const _ of process.stdin) {}\nfor (let i = 0; i < 6; i++) {\n  process.stdout.write(JSON.stringify({ type: "text_delta", text: "tick" }) + "\\n");\n  await new Promise((r) => setTimeout(r, 500));\n}\nprocess.stdout.write(JSON.stringify({ type: "completed" }) + "\\n");\nprocess.exit(0);\n`,
+		);
+
+		// Agent that emits ONLY heartbeats (no text) 500ms apart for ~2.5s, then
+		// completes. Mirrors agentSlow but for the liveness path: tool execution
+		// is silent on stdout, so this is what keeps a long healthy tool from
+		// tripping the watchdog. With the 2s window it survives only if every
+		// heartbeat re-arms the timer.
+		fixtures.agentHeartbeat = join(tmpDir, "agent-heartbeat.ts");
+		writeFileSync(
+			fixtures.agentHeartbeat,
+			`for await (const _ of process.stdin) {}\nfor (let i = 0; i < 6; i++) {\n  process.stdout.write(JSON.stringify({ type: "heartbeat" }) + "\\n");\n  await new Promise((r) => setTimeout(r, 500));\n}\nprocess.stdout.write(JSON.stringify({ type: "completed" }) + "\\n");\nprocess.exit(0);\n`,
+		);
+
+		// Agent that heartbeats every 200ms forever and never completes —
+		// stands in for a tool that hangs but keeps the turn "alive". The idle
+		// watchdog can never fire (heartbeats keep re-arming it); only the
+		// absolute per-turn ceiling can stop it.
+		fixtures.agentHeartbeatForever = join(tmpDir, "agent-heartbeat-forever.ts");
+		writeFileSync(
+			fixtures.agentHeartbeatForever,
+			`for await (const _ of process.stdin) {}\nsetInterval(() => {\n  process.stdout.write(JSON.stringify({ type: "heartbeat" }) + "\\n");\n}, 200);\nawait new Promise(() => {});\n`,
 		);
 
 		// Agent that emits completed, closes stdout, then lingers forever —
@@ -318,4 +340,68 @@ describe("spawnAgent idle timeout", () => {
 		expect(events.find((e) => e.type === "completed")).toBeDefined();
 		expect(events.find((e) => e.type === "failed")).toBeUndefined();
 	}, 15_000);
+
+	// Regression for the watchdog bug: a long, text-silent gap that is bridged
+	// only by `heartbeat` events (the liveness a tool emits while executing)
+	// must NOT trip the watchdog, even though no token ever streams.
+	it("treats heartbeats as liveness: a silent-but-beating tool survives", async () => {
+		process.env.SANDBOX_AGENT_PATH = fixtures.agentHeartbeat;
+		process.env.SANDBOX_AGENT_IDLE_TIMEOUT_MS = "2000";
+		delete process.env.SANDBOX_AGENT_MAX_TURN_MS; // default ceiling, won't fire
+
+		const events: AgentEvent[] = [];
+		const result = await spawnAgent(makeInput((e) => events.push(e)));
+
+		expect(result.exitCode).toBe(0);
+		expect(events.find((e) => e.type === "failed")).toBeUndefined();
+		// No text was ever emitted — survival is due to heartbeats alone.
+		expect(events.find((e) => e.type === "text_delta")).toBeUndefined();
+		expect(events.filter((e) => e.type === "heartbeat").length).toBe(6);
+		expect(events.find((e) => e.type === "completed")).toBeDefined();
+	}, 15_000);
+
+	// The honest residual: a tool that hangs forever keeps heartbeating, so the
+	// idle watchdog can't see it. The absolute per-turn ceiling is the backstop.
+	it("kills a forever-beating turn via the absolute ceiling, not the idle timer", async () => {
+		process.env.SANDBOX_AGENT_PATH = fixtures.agentHeartbeatForever;
+		// Idle window large so it never fires; ceiling small so it does. The
+		// elapsed-time assertion proves the ceiling — not the idle timer — killed it.
+		process.env.SANDBOX_AGENT_IDLE_TIMEOUT_MS = "30000";
+		process.env.SANDBOX_AGENT_MAX_TURN_MS = "1500";
+
+		const events: AgentEvent[] = [];
+		const start = Date.now();
+		const result = await spawnAgent(makeInput((e) => events.push(e)));
+		const elapsed = Date.now() - start;
+
+		// Ceiling (1500ms) fired well before the idle window (30000ms).
+		expect(elapsed).toBeLessThan(10_000);
+		expect(result.exitCode).not.toBe(0);
+		// Heartbeats were flowing the whole time — liveness was never the issue.
+		expect(events.some((e) => e.type === "heartbeat")).toBe(true);
+		const failed = events.find((e) => e.type === "failed");
+		expect(failed).toBeDefined();
+		if (failed?.type === "failed") {
+			expect(failed.message).toContain("max duration");
+			expect(failed.message).toContain("1500");
+		}
+	}, 15_000);
+
+	// A malformed SANDBOX_AGENT_IDLE_TIMEOUT_MS must fall back to the default,
+	// not become NaN/0 — setTimeout(fn, NaN|0) fires immediately and would
+	// SIGKILL every turn at spawn.
+	it("falls back to the default idle timeout on a malformed env value", async () => {
+		process.env.SANDBOX_AGENT_PATH = fixtures.agentSlow;
+		delete process.env.SANDBOX_AGENT_MAX_TURN_MS; // default ceiling, won't fire
+
+		for (const bad of ["abc", ""]) {
+			process.env.SANDBOX_AGENT_IDLE_TIMEOUT_MS = bad;
+			const events: AgentEvent[] = [];
+			// With the default 120s window the ~2.5s fixture finishes cleanly;
+			// an immediate (NaN/0) fire would kill it before `completed`.
+			const result = await spawnAgent(makeInput((e) => events.push(e)));
+			expect(result.exitCode).toBe(0);
+			expect(events.find((e) => e.type === "failed")).toBeUndefined();
+		}
+	}, 20_000);
 });

--- a/apps/sandbox-daemon/child-spawn.ts
+++ b/apps/sandbox-daemon/child-spawn.ts
@@ -26,13 +26,38 @@ function getBwrapExecutable(): string {
 }
 
 // The agent is a streaming workload of unbounded but "chatty" duration, so a
-// wall-clock cap would kill healthy long turns. Instead we use an idle
-// timeout, re-armed on every NDJSON event: a healthy agent emits token
-// chunks / tool events continuously, so sustained silence means a hang.
+// wall-clock cap alone would kill healthy long turns. We bound it two ways:
+//
+//   1. An idle timeout, re-armed on every NDJSON event. Text streaming covers
+//      the model phase; a `heartbeat` (emitted by agent.ts while a tool runs —
+//      tool execution is otherwise silent on stdout) covers tool phases. So
+//      sustained silence now genuinely means a hang (a wedged model read), and
+//      a healthy long tool no longer trips this.
+//   2. A generous absolute per-turn ceiling as a backstop for the one case the
+//      idle timeout can't see: a tool that hangs forever keeps the heartbeat
+//      ticking, so without this it would never be killed and would pin the
+//      single-turn lock. Set far above any legitimate turn.
 const DEFAULT_AGENT_IDLE_TIMEOUT_MS = 120_000;
+const DEFAULT_AGENT_MAX_TURN_MS = 600_000;
+
+// Number("") -> 0 and Number("abc") -> NaN, and setTimeout(fn, 0|NaN) fires
+// immediately — a malformed env var would SIGKILL every turn at spawn. Fall
+// back to the default on any non-finite or non-positive value.
+function getPositiveMsEnv(value: string | undefined, fallback: number): number {
+	if (value === undefined) return fallback;
+	const n = Number(value);
+	return Number.isFinite(n) && n > 0 ? n : fallback;
+}
 function getAgentIdleTimeoutMs(): number {
-	return Number(
-		process.env.SANDBOX_AGENT_IDLE_TIMEOUT_MS ?? DEFAULT_AGENT_IDLE_TIMEOUT_MS,
+	return getPositiveMsEnv(
+		process.env.SANDBOX_AGENT_IDLE_TIMEOUT_MS,
+		DEFAULT_AGENT_IDLE_TIMEOUT_MS,
+	);
+}
+function getAgentMaxTurnMs(): number {
+	return getPositiveMsEnv(
+		process.env.SANDBOX_AGENT_MAX_TURN_MS,
+		DEFAULT_AGENT_MAX_TURN_MS,
 	);
 }
 
@@ -147,6 +172,8 @@ function narrowAgentEvent(raw: Record<string, unknown>): AgentEvent | null {
 			if (typeof raw.sessionId === "string")
 				return { type: "session_id", sessionId: raw.sessionId };
 			return null;
+		case "heartbeat":
+			return { type: "heartbeat" };
 		case "completed":
 			return { type: "completed" };
 		case "failed":
@@ -263,20 +290,33 @@ export async function spawnAgent(
 	proc.stdin.write(JSON.stringify(config));
 	await proc.stdin.end();
 
-	// Idle watchdog. The SIGKILL lands on the bwrap supervisor;
-	// --die-with-parent (in buildAgentSpawnArgv) propagates it to the inner
-	// agent, which closes stdout and unblocks the read loop below.
+	// Idle watchdog + absolute ceiling. Either SIGKILL lands on the bwrap
+	// supervisor; --die-with-parent (in buildAgentSpawnArgv) propagates it to the
+	// inner agent, which closes stdout and unblocks the read loop below.
 	const idleMs = getAgentIdleTimeoutMs();
+	const maxTurnMs = getAgentMaxTurnMs();
 	let timedOut = false;
+	let hitMaxTurn = false;
 	let idleTimer: ReturnType<typeof setTimeout> | undefined;
 	const armIdleTimer = () => {
 		clearTimeout(idleTimer);
 		idleTimer = setTimeout(() => {
 			timedOut = true;
+			// Cancel the backstop so it can't fire later and mislabel the cause.
+			clearTimeout(maxTurnTimer);
 			proc.kill("SIGKILL");
 		}, idleMs);
 	};
 	armIdleTimer();
+
+	// Absolute backstop — never re-armed. Bounds a turn that stays "alive" on
+	// heartbeats forever (e.g. a tool that hangs and never returns).
+	const maxTurnTimer = setTimeout(() => {
+		timedOut = true;
+		hitMaxTurn = true;
+		clearTimeout(idleTimer);
+		proc.kill("SIGKILL");
+	}, maxTurnMs);
 
 	// The timer stays armed through the post-loop stderr drain and exit wait,
 	// so a child that closes stdout but never exits is still killed. If the
@@ -302,11 +342,14 @@ export async function spawnAgent(
 		if (timedOut && !sawTerminalEvent) {
 			await onEvent({
 				type: "failed",
-				message: `agent idle timeout: no events for ${idleMs}ms`,
+				message: hitMaxTurn
+					? `agent turn exceeded max duration: ${maxTurnMs}ms`
+					: `agent idle timeout: no events for ${idleMs}ms`,
 			});
 		}
 		return { exitCode };
 	} finally {
 		clearTimeout(idleTimer);
+		clearTimeout(maxTurnTimer);
 	}
 }

--- a/apps/sandbox-daemon/daemon-entry.ts
+++ b/apps/sandbox-daemon/daemon-entry.ts
@@ -45,5 +45,9 @@ console.log(`Sandbox daemon starting on port ${port}`);
 export default {
 	port,
 	fetch: app.fetch,
-	idleTimeout: 120,
+	// Per-connection idle timeout (Bun caps this at 255s). Must sit above the
+	// agent idle watchdog (120s in child-spawn.ts) so that on a genuine hang the
+	// daemon emits its own `failed` event before Bun silently drops the socket.
+	// During a healthy long tool the agent's `heartbeat` events keep this armed.
+	idleTimeout: 240,
 };

--- a/apps/sandbox-daemon/heartbeat.test.ts
+++ b/apps/sandbox-daemon/heartbeat.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "bun:test";
+import { createHeartbeatController } from "./heartbeat";
+
+const NEVER = 1_000_000; // interval long enough to never fire mid-test
+
+describe("createHeartbeatController", () => {
+	it("does not beat until a tool starts", () => {
+		let beats = 0;
+		createHeartbeatController(() => beats++, NEVER);
+		expect(beats).toBe(0);
+	});
+
+	it("beats immediately on the first in-flight tool", () => {
+		let beats = 0;
+		const hb = createHeartbeatController(() => beats++, NEVER);
+		hb.onToolStart("a");
+		// Immediate beat so a tool that runs long from t=0 re-arms the watchdog.
+		expect(beats).toBe(1);
+		hb.stop();
+	});
+
+	it("keeps beating until the LAST parallel tool ends", () => {
+		let beats = 0;
+		const hb = createHeartbeatController(() => beats++, NEVER);
+		hb.onToolStart("a"); // immediate beat (1)
+		hb.onToolStart("b"); // already beating — no extra immediate beat
+		expect(beats).toBe(1);
+		hb.onToolEnd("a"); // b still in flight — interval stays armed
+		const stillArmed = beats;
+		hb.onToolStart("c"); // already beating — still no extra immediate beat
+		expect(beats).toBe(stillArmed);
+		hb.onToolEnd("b");
+		hb.onToolEnd("c"); // last one out
+		hb.stop();
+	});
+
+	it("runs the interval while in flight and clears it on the last end", async () => {
+		let beats = 0;
+		const hb = createHeartbeatController(() => beats++, 20);
+		hb.onToolStart("a");
+		await new Promise((r) => setTimeout(r, 90));
+		expect(beats).toBeGreaterThanOrEqual(2); // immediate + interval ticks
+		hb.onToolEnd("a");
+		const afterEnd = beats;
+		await new Promise((r) => setTimeout(r, 60));
+		// Interval must be cleared — no beats after the tool finished.
+		expect(beats).toBe(afterEnd);
+	});
+
+	it("stop() halts an in-flight heartbeat", async () => {
+		let beats = 0;
+		const hb = createHeartbeatController(() => beats++, 20);
+		hb.onToolStart("a");
+		await new Promise((r) => setTimeout(r, 50));
+		hb.stop();
+		const afterStop = beats;
+		await new Promise((r) => setTimeout(r, 60));
+		expect(beats).toBe(afterStop);
+	});
+
+	it("an unmatched onToolEnd is a no-op", () => {
+		let beats = 0;
+		const hb = createHeartbeatController(() => beats++, NEVER);
+		expect(() => hb.onToolEnd("never-started")).not.toThrow();
+		expect(beats).toBe(0);
+	});
+});

--- a/apps/sandbox-daemon/heartbeat.ts
+++ b/apps/sandbox-daemon/heartbeat.ts
@@ -1,0 +1,65 @@
+/**
+ * Liveness heartbeat for long-running tool execution.
+ *
+ * The daemon's idle watchdog (child-spawn.ts) re-arms on every NDJSON event the
+ * agent emits on stdout. But a tool actually executing — a Bash command, a
+ * `mymemo-docs` fetch, local data processing — emits nothing on stdout for its
+ * whole wall-clock duration. A single tool that runs longer than the idle window
+ * would therefore be SIGKILLed mid-flight even though the turn is perfectly
+ * healthy (the original watchdog bug).
+ *
+ * While any tool is in flight we emit a periodic `heartbeat` event so the
+ * watchdog — and the chat-api↔daemon connection it travels over — stays armed.
+ * Driven by the SDK's PreToolUse / PostToolUse hooks (see agent.ts). A Set keyed
+ * by tool_use_id handles parallel tool calls and makes a duplicate / unmatched
+ * stop a no-op.
+ *
+ * No SDK import here on purpose: this is pure timer logic so it is unit-testable
+ * without standing up a real `query()`.
+ */
+
+export const HEARTBEAT_INTERVAL_MS = 15_000;
+
+export interface HeartbeatController {
+	/** A tool started executing. First in-flight tool starts the heartbeat. */
+	onToolStart(toolUseId: string): void;
+	/** A tool finished. Heartbeat stops once nothing is in flight. */
+	onToolEnd(toolUseId: string): void;
+	/** Hard stop — always call on turn teardown so the interval never leaks. */
+	stop(): void;
+}
+
+export function createHeartbeatController(
+	onHeartbeat: () => void,
+	intervalMs: number = HEARTBEAT_INTERVAL_MS,
+): HeartbeatController {
+	const inFlight = new Set<string>();
+	let timer: ReturnType<typeof setInterval> | undefined;
+
+	return {
+		onToolStart(toolUseId) {
+			const wasIdle = inFlight.size === 0;
+			inFlight.add(toolUseId);
+			if (wasIdle) {
+				// Beat immediately so a tool that runs long from its very first
+				// moment re-arms the watchdog without waiting a full interval.
+				onHeartbeat();
+				timer = setInterval(onHeartbeat, intervalMs);
+			}
+		},
+		onToolEnd(toolUseId) {
+			inFlight.delete(toolUseId);
+			if (inFlight.size === 0 && timer !== undefined) {
+				clearInterval(timer);
+				timer = undefined;
+			}
+		},
+		stop() {
+			inFlight.clear();
+			if (timer !== undefined) {
+				clearInterval(timer);
+				timer = undefined;
+			}
+		},
+	};
+}

--- a/apps/sandbox-daemon/ipc-protocol.ts
+++ b/apps/sandbox-daemon/ipc-protocol.ts
@@ -10,5 +10,9 @@
 export type AgentEvent =
 	| { type: "text_delta"; text: string }
 	| { type: "session_id"; sessionId: string }
+	// Internal liveness signal emitted while a tool is executing. Re-arms the
+	// daemon's idle watchdog and keeps the chat-api↔daemon connection warm; it
+	// carries no payload and is never surfaced to the end client as text.
+	| { type: "heartbeat" }
 	| { type: "completed" }
 	| { type: "failed"; message: string };

--- a/apps/sandbox-daemon/routes/turn.ts
+++ b/apps/sandbox-daemon/routes/turn.ts
@@ -115,6 +115,11 @@ app.post("/turn", async (c) => {
 						if (event.type === "failed") {
 							turnFailed = true;
 						}
+						// Everything else (text_delta, session_id, heartbeat) is
+						// forwarded as-is. Forwarding `heartbeat` is load-bearing:
+						// it's the only traffic on this connection while a tool runs,
+						// so it keeps Bun's idleTimeout and chat-api's read alive.
+						// chat-api ignores it — it never reaches the end client.
 						await s.write(ndjsonLine(event));
 					},
 				});


### PR DESCRIPTION
## What & why

The per-turn agent idle watchdog (`child-spawn.ts`, added in e849bf1) re-armed a 120s timer **only on NDJSON stdout events**. But tool execution emits nothing on stdout for its whole wall-clock duration — `agent.ts` forwards only `content_block_delta` → `text_delta`. So a single `Bash` command, `mymemo-docs` fetch, or local data-processing step running >120s produced zero events → the watchdog SIGKILLed a **healthy** turn with `"agent idle timeout"`.

The 120s ceiling was duplicated across **three coupled layers**, so fixing one still let the turn die at the smallest:
1. `child-spawn.ts` — the agent idle watchdog (root cause)
2. `daemon-entry.ts` — Bun per-connection `idleTimeout: 120` (Bun closes the socket → chat-api sees an abrupt EOF)
3. `sandbox-proxy.ts` — `AbortSignal.timeout(120_000)`, an **absolute** cap over the whole body read

## Approach — option B (heartbeat during tools) + a generous absolute backstop

The watchdog had no real liveness signal during tool execution. This adds one:

- **`heartbeat` AgentEvent**, emitted while any tool is in flight, driven by the SDK's `PreToolUse`/`PostToolUse`/`PostToolUseFailure` hooks via a small, SDK-free controller (`heartbeat.ts`, immediate beat + 15s interval, Set-keyed by `tool_use_id` for parallel tools). The watchdog re-arms on it; the daemon forwards it as keepalive so the chat-api↔daemon socket stays warm; chat-api ignores it (never surfaced to the client).
- **Aligned the three timeouts** so the daemon's 120s watchdog is the single authoritative bound that always emits a terminal `failed`, and the outer two are strict backstops:

  | Layer | Before | After |
  |---|---|---|
  | Agent idle watchdog (`child-spawn.ts`) | 120s | **120s** — now bounds only no-tool / model-phase silence |
  | Bun `idleTimeout` (`daemon-entry.ts`) | 120s | **240s** — > watchdog so the daemon reports first; < Bun's 255s cap |
  | chat-api proxy (`sandbox-proxy.ts`) | absolute 120s | **idle-based 240s**, reset on every NDJSON chunk |

- **Absolute per-turn ceiling** (`DEFAULT_AGENT_MAX_TURN_MS = 600s`) as the backstop for a tool that hangs forever while still heartbeating — it would otherwise pin the single-turn lock.
- **Validation fix**: `getAgentIdleTimeoutMs` / `getAgentMaxTurnMs` now fall back to the default on a malformed env value. Previously `Number("abc") → NaN` and `Number("") → 0` made `setTimeout` fire immediately, SIGKILLing every turn at spawn.

## Residual failure mode (honest)

Option B cannot distinguish a slow-but-alive tool from a wedged one: a tool that hangs **forever** keeps heartbeating, so the idle watchdog never fires — it's terminated only by the 600s ceiling. So a wedged-but-beating turn can hold the single-turn lock for up to ~10 minutes, and conversely a legitimate turn needing >10 min of continuous tool work would hit the ceiling (both tunable via `SANDBOX_AGENT_MAX_TURN_MS`). Tightening further would require per-tool timeouts (e.g. `BASH_MAX_TIMEOUT_MS`), not included here.

## Tests

`agent.ts` and the silent-tool-gap scenario previously had no coverage. Added, extending the existing `child-spawn.test.ts` harness:
- **Regression:** a text-silent agent emitting only `heartbeat`s across a span exceeding the idle window survives; true silence still trips it.
- The absolute ceiling kills a forever-beating turn (elapsed ≪ idle window proves it was the ceiling, not the idle timer).
- A malformed `SANDBOX_AGENT_IDLE_TIMEOUT_MS` (`"abc"`, `""`) falls back to the default instead of firing at spawn.
- New `heartbeat.test.ts` unit-tests the controller (immediate beat, parallel tools, interval start/stop, unmatched end).

All green: **33** sandbox-daemon + **31** chat-api tests pass; Biome clean on all changed files.

## Reviewer notes

- Forwarding `heartbeat` through `routes/turn.ts` to chat-api is **load-bearing** (it's the only traffic on the connection during a long tool, keeping Bun's `idleTimeout` and chat-api's read alive) — there's a comment guarding against "optimizing" it away.
- The three timeout values live in three separate bundles/processes (chat-api, the daemon's Bun server, the sandbox agent), so they're coupled by cross-referencing comments rather than a shared constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)