### PR TITLE
feat(chat-api): replace session vocabulary with conversationId/runId (MYM-5)

### DIFF
--- a/apps/chat-api/src/features/chat/chat.controller.ts
+++ b/apps/chat-api/src/features/chat/chat.controller.ts
@@ -10,8 +10,14 @@ export async function complete(
 	mymemoEventSender: MymemoEventSender,
 	logger: ChatLogger,
 ) {
-	const { chatContent, collectionId, summaryId, sessionId, memberCode } =
+	const { chatContent, collectionId, summaryId, conversationId, memberCode } =
 		request;
+
+	// Generated at request entry. `runId` identifies this single backend
+	// execution attempt; `resolvedConversationId` is the product-visible thread
+	// id, generated here when the client does not supply one.
+	const runId = crypto.randomUUID();
+	const resolvedConversationId = conversationId ?? crypto.randomUUID();
 
 	const normalizedCollectionId = collectionId?.trim() ?? null;
 	const normalizedSummaryId = summaryId?.trim() ?? null;
@@ -26,6 +32,14 @@ export async function complete(
 	const sendEvent = (message: EventMessage): Promise<void> =>
 		mymemoEventSender.send({ id: crypto.randomUUID(), message });
 
+	// Announce run identity up front so clients can persist the thread id and
+	// correlate the run before any text streams.
+	await sendEvent({
+		type: "conversation_id",
+		conversationId: resolvedConversationId,
+	});
+	await sendEvent({ type: "run_id", runId });
+
 	const onTextDelta = async (text: string) => {
 		try {
 			await sendEvent({ type: "text_delta", text });
@@ -38,13 +52,14 @@ export async function complete(
 		await sendEvent({ type: "done" });
 	};
 
-	const onSessionId = async (newSessionId: string) => {
-		// Skip echoing a sessionId the client already supplied.
-		if (newSessionId === sessionId) return;
+	const onAgentSessionId = async (agentSessionId: string) => {
 		try {
-			await sendEvent({ type: "session_id", sessionId: newSessionId });
+			await sendEvent({ type: "agent_session_id", agentSessionId });
 		} catch (err) {
-			logger.error({ message: "Failed to send session_id event", error: err });
+			logger.error({
+				message: "Failed to send agent_session_id event",
+				error: err,
+			});
 		}
 	};
 
@@ -62,10 +77,12 @@ export async function complete(
 		scope,
 		collectionId: normalizedCollectionId,
 		summaryId: normalizedSummaryId,
-		sessionId: sessionId ?? null,
+		// The client no longer supplies Claude SDK resume state; conversation
+		// continuity via `conversationId` is wired in a later milestone.
+		agentSessionId: null,
 		onTextDelta,
 		onTextEnd,
-		onSessionId,
+		onAgentSessionId,
 		onSandboxId,
 		logger,
 	});

--- a/apps/chat-api/src/features/chat/chat.events.ts
+++ b/apps/chat-api/src/features/chat/chat.events.ts
@@ -7,7 +7,9 @@ export type EventMessage =
 	| ErrorEvent
 	| TextDeltaEvent
 	| DoneEvent
-	| SessionIdEvent
+	| ConversationIdEvent
+	| RunIdEvent
+	| AgentSessionIdEvent
 	| SandboxIdEvent;
 
 export interface ErrorEvent {
@@ -15,9 +17,21 @@ export interface ErrorEvent {
 	message: string;
 }
 
-export interface SessionIdEvent {
-	type: "session_id";
-	sessionId: string;
+export interface ConversationIdEvent {
+	type: "conversation_id";
+	conversationId: string;
+}
+
+export interface RunIdEvent {
+	type: "run_id";
+	runId: string;
+}
+
+// Claude SDK resume state surfaced by the daemon. Internal continuity token,
+// distinct from the product-visible `conversation_id`.
+export interface AgentSessionIdEvent {
+	type: "agent_session_id";
+	agentSessionId: string;
 }
 
 export interface SandboxIdEvent {

--- a/apps/chat-api/src/features/chat/chat.route.test.ts
+++ b/apps/chat-api/src/features/chat/chat.route.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+// Orchestration is mocked so no E2B sandbox, gateway, database, or provider
+// call is made. A mutable holder lets each test swap the run behavior.
+type RunOpts = {
+	onSandboxId: (id: string) => Promise<void>;
+	onAgentSessionId: (id: string) => Promise<void>;
+	onTextDelta: (text: string) => Promise<void>;
+	onTextEnd: () => Promise<void>;
+};
+
+let runSandboxChatImpl: (opts: RunOpts) => Promise<unknown> = async (opts) => {
+	await opts.onSandboxId("sbx-test");
+	await opts.onAgentSessionId("agent-sess-test");
+	await opts.onTextDelta("Hello");
+	await opts.onTextEnd();
+	return { status: "completed" };
+};
+
+class FakeConversationBusyError extends Error {}
+
+mock.module("@/features/sandbox-orchestration", () => ({
+	runSandboxChat: (opts: RunOpts) => runSandboxChatImpl(opts),
+	ConversationBusyError: FakeConversationBusyError,
+}));
+
+const { default: app } = await import("@/index");
+
+const IDENTITY_HEADERS = {
+	"content-type": "application/json",
+	"x-member-code": "member-1",
+	"x-partner-code": "partner-1",
+};
+
+function postChat(body: unknown, headers: Record<string, string> = {}) {
+	return app.request("/v1/chat", {
+		method: "POST",
+		headers: { ...IDENTITY_HEADERS, ...headers },
+		body: JSON.stringify(body),
+	});
+}
+
+interface SSEFrame {
+	event: string;
+	data: string;
+}
+
+function parseSSE(raw: string): SSEFrame[] {
+	const frames: SSEFrame[] = [];
+	for (const block of raw.split("\n\n")) {
+		let event = "";
+		let data = "";
+		for (const line of block.split("\n")) {
+			if (line.startsWith("event:")) event = line.slice("event:".length).trim();
+			else if (line.startsWith("data:"))
+				data = line.slice("data:".length).trim();
+		}
+		if (event) frames.push({ event, data });
+	}
+	return frames;
+}
+
+describe("POST /v1/chat", () => {
+	beforeEach(() => {
+		runSandboxChatImpl = async (opts) => {
+			await opts.onSandboxId("sbx-test");
+			await opts.onAgentSessionId("agent-sess-test");
+			await opts.onTextDelta("Hello");
+			await opts.onTextEnd();
+			return { status: "completed" };
+		};
+	});
+
+	it("rejects a body containing sessionId with 400", async () => {
+		const res = await postChat({ chatContent: "hi", sessionId: "sess-1" });
+		expect(res.status).toBe(400);
+	});
+
+	it("rejects missing identity headers with 401", async () => {
+		const res = await app.request("/v1/chat", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ chatContent: "hi" }),
+		});
+		expect(res.status).toBe(401);
+	});
+
+	it("emits the target SSE event vocabulary on the happy path", async () => {
+		const res = await postChat({ chatContent: "hi" });
+		expect(res.status).toBe(200);
+		const frames = parseSSE(await res.text());
+		const events = frames.map((f) => f.event).filter((e) => e !== "ping");
+
+		expect(events).toContain("conversation_id");
+		expect(events).toContain("run_id");
+		expect(events).toContain("agent_session_id");
+		expect(events).toContain("sandbox_id");
+		expect(events).toContain("text_delta");
+		expect(events).toContain("done");
+		// The old client-facing vocabulary must be gone.
+		expect(events).not.toContain("session_id");
+	});
+
+	it("echoes a client-supplied conversationId", async () => {
+		const res = await postChat({
+			chatContent: "hi",
+			conversationId: "conv-xyz",
+		});
+		const frames = parseSSE(await res.text());
+		const convFrame = frames.find((f) => f.event === "conversation_id");
+		expect(convFrame).toBeDefined();
+		expect(JSON.parse(convFrame!.data).conversationId).toBe("conv-xyz");
+	});
+
+	it("generates a conversationId when the client omits it", async () => {
+		const res = await postChat({ chatContent: "hi" });
+		const frames = parseSSE(await res.text());
+		const convFrame = frames.find((f) => f.event === "conversation_id");
+		expect(convFrame).toBeDefined();
+		const { conversationId } = JSON.parse(convFrame!.data);
+		expect(typeof conversationId).toBe("string");
+		expect(conversationId.length).toBeGreaterThan(0);
+	});
+
+	it("carries a run_id and agent_session_id payload", async () => {
+		const res = await postChat({ chatContent: "hi" });
+		const frames = parseSSE(await res.text());
+		const runFrame = frames.find((f) => f.event === "run_id");
+		const agentFrame = frames.find((f) => f.event === "agent_session_id");
+		expect(JSON.parse(runFrame!.data).runId.length).toBeGreaterThan(0);
+		expect(JSON.parse(agentFrame!.data).agentSessionId).toBe("agent-sess-test");
+	});
+});

--- a/apps/chat-api/src/features/chat/chat.route.test.ts
+++ b/apps/chat-api/src/features/chat/chat.route.test.ts
@@ -1,5 +1,16 @@
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 
+// Importing `@/index` below eagerly evaluates `config/env.ts`, which throws
+// when these are unset. The bunfig preload (`test-setup.ts`) covers this when
+// tests run from `apps/chat-api`, but not when `bun test` runs from the repo
+// root, so set them here too to keep this file self-sufficient.
+Bun.env.E2B_API_KEY = Bun.env.E2B_API_KEY ?? "test-e2b-key";
+Bun.env.DAEMON_AUTH_TOKEN =
+	Bun.env.DAEMON_AUTH_TOKEN ?? "test-daemon-auth-token";
+Bun.env.LLM_TOKEN_SECRET = Bun.env.LLM_TOKEN_SECRET ?? "test-llm-token-secret";
+Bun.env.GATEWAY_PUBLIC_URL =
+	Bun.env.GATEWAY_PUBLIC_URL ?? "https://gateway.test";
+
 // Orchestration is mocked so no E2B sandbox, gateway, database, or provider
 // call is made. A mutable holder lets each test swap the run behavior.
 type RunOpts = {

--- a/apps/chat-api/src/features/chat/chat.schema.test.ts
+++ b/apps/chat-api/src/features/chat/chat.schema.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "bun:test";
+import { ChatBodyRequest } from "./chat.schema";
+
+describe("ChatBodyRequest", () => {
+	it("accepts a minimal body without conversationId", () => {
+		const result = ChatBodyRequest.safeParse({ chatContent: "hello" });
+		expect(result.success).toBe(true);
+	});
+
+	it("accepts a body with conversationId", () => {
+		const result = ChatBodyRequest.safeParse({
+			chatContent: "hello",
+			conversationId: "conv-123",
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.conversationId).toBe("conv-123");
+		}
+	});
+
+	it("rejects a body containing sessionId", () => {
+		const result = ChatBodyRequest.safeParse({
+			chatContent: "hello",
+			sessionId: "sess-123",
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects an empty conversationId", () => {
+		const result = ChatBodyRequest.safeParse({
+			chatContent: "hello",
+			conversationId: "",
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects unknown keys (strict)", () => {
+		const result = ChatBodyRequest.safeParse({
+			chatContent: "hello",
+			memberCode: "member-1",
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("still accepts collectionId and summaryId", () => {
+		const result = ChatBodyRequest.safeParse({
+			chatContent: "hello",
+			collectionId: "col-1",
+			summaryId: "sum-1",
+		});
+		expect(result.success).toBe(true);
+	});
+});

--- a/apps/chat-api/src/features/chat/chat.schema.ts
+++ b/apps/chat-api/src/features/chat/chat.schema.ts
@@ -16,11 +16,12 @@ export const ChatBodyRequest = z
 		collectionId: z.string().max(MAX_IDENTIFIER_LENGTH).nullish(),
 		summaryId: z.string().max(MAX_IDENTIFIER_LENGTH).nullish(),
 
-		// Daemon-managed conversation session. When omitted, the daemon
-		// allocates a new session; when present, the daemon resumes that
-		// session. Clients are responsible for persisting the latest
-		// sessionId emitted via the `session_id` SSE event.
-		sessionId: z.string().min(1).max(MAX_IDENTIFIER_LENGTH).optional(),
+		// Product-visible conversation thread id. When omitted, chat-api
+		// generates one and emits it via the `conversation_id` SSE event;
+		// clients persist it and send it back to continue the same thread.
+		// This is NOT the Claude SDK resume state — that is `agentSessionId`,
+		// managed server-side and never accepted from the client.
+		conversationId: z.string().min(1).max(MAX_IDENTIFIER_LENGTH).optional(),
 	})
 	.strict();
 export type ChatBodyRequest = z.infer<typeof ChatBodyRequest>;

--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-orchestration.test.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-orchestration.test.ts
@@ -32,10 +32,10 @@ function makeOptions(
 		scope: "general" as const,
 		collectionId: null,
 		summaryId: null,
-		sessionId: null,
+		agentSessionId: null,
 		onTextDelta: async () => {},
 		onTextEnd: async () => {},
-		onSessionId: async () => {},
+		onAgentSessionId: async () => {},
 		onSandboxId: async () => {},
 		logger: silentLogger,
 		...overrides,
@@ -124,7 +124,7 @@ describe("runSandboxChat", () => {
 		await runSandboxChat(makeOptions());
 	});
 
-	it("forwards request sessionId as agent_session_id", async () => {
+	it("forwards agentSessionId as agent_session_id", async () => {
 		spyForwardTurn = spyOn(
 			proxyModule,
 			"forwardChatTurnToSandbox",
@@ -132,10 +132,10 @@ describe("runSandboxChat", () => {
 			expect(opts.turnRequest.agent_session_id).toBe("client-session");
 		});
 
-		await runSandboxChat(makeOptions({ sessionId: "client-session" }));
+		await runSandboxChat(makeOptions({ agentSessionId: "client-session" }));
 	});
 
-	it("omits agent_session_id when no sessionId provided", async () => {
+	it("omits agent_session_id when no agentSessionId provided", async () => {
 		spyForwardTurn = spyOn(
 			proxyModule,
 			"forwardChatTurnToSandbox",
@@ -143,7 +143,7 @@ describe("runSandboxChat", () => {
 			expect(opts.turnRequest.agent_session_id).toBeUndefined();
 		});
 
-		await runSandboxChat(makeOptions({ sessionId: null }));
+		await runSandboxChat(makeOptions({ agentSessionId: null }));
 	});
 
 	it("always creates a fresh sandbox for the user", async () => {
@@ -190,7 +190,7 @@ describe("runSandboxChat", () => {
 		expect(received).toEqual(["sbx-123"]);
 	});
 
-	it("surfaces daemon-emitted session_id via callback", async () => {
+	it("surfaces daemon-emitted session id via onAgentSessionId callback", async () => {
 		const received: string[] = [];
 		spyForwardTurn = spyOn(
 			proxyModule,
@@ -201,7 +201,7 @@ describe("runSandboxChat", () => {
 
 		await runSandboxChat(
 			makeOptions({
-				onSessionId: async (id) => {
+				onAgentSessionId: async (id) => {
 					received.push(id);
 				},
 			}),

--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-orchestration.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-orchestration.ts
@@ -20,10 +20,11 @@ export interface RunSandboxChatOptions {
 	scope: ChatMessagesScope;
 	collectionId: string | null;
 	summaryId: string | null;
-	sessionId: string | null;
+	/** Claude SDK resume state. Null starts a fresh agent session. */
+	agentSessionId: string | null;
 	onTextDelta: (text: string) => Promise<void>;
 	onTextEnd: () => Promise<void>;
-	onSessionId: (sessionId: string) => Promise<void>;
+	onAgentSessionId: (agentSessionId: string) => Promise<void>;
 	onSandboxId: (sandboxId: string) => Promise<void>;
 	logger: ChatLogger;
 }
@@ -39,10 +40,10 @@ export async function runSandboxChat(
 		scope,
 		collectionId,
 		summaryId,
-		sessionId,
+		agentSessionId,
 		onTextDelta,
 		onTextEnd,
-		onSessionId,
+		onAgentSessionId,
 		onSandboxId,
 		logger,
 	} = options;
@@ -79,7 +80,7 @@ export async function runSandboxChat(
 				collection_id: collectionId ?? undefined,
 				summary_id: summaryId ?? undefined,
 				message: query,
-				agent_session_id: sessionId ?? undefined,
+				agent_session_id: agentSessionId ?? undefined,
 				system_prompt: systemPrompt,
 				llm_base_url: apiEnv.GATEWAY_PUBLIC_URL,
 				doc_gateway_url: apiEnv.GATEWAY_PUBLIC_URL,
@@ -106,7 +107,9 @@ export async function runSandboxChat(
 				turnRequest,
 				onTextDelta,
 				onTextEnd,
-				onSessionId,
+				// The proxy surfaces the daemon's Claude SDK session id, which we
+				// expose as the agent session id.
+				onSessionId: onAgentSessionId,
 			});
 
 			return { status: "completed" } as const;


### PR DESCRIPTION
Implements **MYM-5 / Task 1: Replace chat request and session vocabulary** from the Agent Workspace Implementation project.

## What changed
- **`ChatBodyRequest`**: removed client-facing `sessionId`; added optional `conversationId` (the product-visible thread id, generated by chat-api when omitted). `.strict()` means a body carrying `sessionId` is rejected with 400.
- **`runId`** is generated at request entry in the controller.
- **SSE vocabulary** now emits: `conversation_id`, `run_id`, `agent_session_id`, `sandbox_id`, `text_delta`, `done`, `error`. The old `session_id` event is gone.
- **`agentSessionId`** is the name for Claude SDK resume state everywhere it is exposed: `RunSandboxChatOptions.sessionId` → `agentSessionId`, `onSessionId` → `onAgentSessionId`. The controller passes `agentSessionId: null` (the client no longer supplies resume state; conversation continuity via `conversationId` arrives in a later milestone).

## Scope notes
- The daemon NDJSON wire event (`session_id`) and the internal `sandbox-proxy` callback are left untouched — that is the sandbox-daemon's own contract. The orchestration adapts it via `onSessionId: onAgentSessionId`.
- Propagating `conversationId`/`runId` into the daemon turn request and logs is **Task 2 (MYM-6)** and intentionally not included here.

## Tests
- `chat.schema.test.ts` — `ChatBodyRequest.safeParse(...)`: accepts with/without `conversationId`, rejects `sessionId`, rejects empty `conversationId`, rejects unknown keys.
- `chat.route.test.ts` — in-process `app.request(...)` with orchestration mocked (no E2B/gateway/db/provider): 400 on `sessionId` body, 401 on missing identity, full target SSE vocabulary on happy path, `conversationId` echo + generation, `run_id`/`agent_session_id` payloads.
- Updated existing `sandbox-orchestration.test.ts` to the renamed API.

`bun test` (chat-api): **43 pass / 0 fail**.

Linear: https://linear.app/mymemo-agent/issue/MYM-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)