### PR TITLE
feat(chat-api): propagate run identity to sandbox turns (MYM-6)

### DIFF
--- a/apps/chat-api/src/features/chat/chat.controller.ts
+++ b/apps/chat-api/src/features/chat/chat.controller.ts
@@ -73,6 +73,8 @@ export async function complete(
 
 	await runSandboxChat({
 		userId: memberCode,
+		conversationId: resolvedConversationId,
+		runId,
 		query: chatContent,
 		scope,
 		collectionId: normalizedCollectionId,

--- a/apps/chat-api/src/features/chat/chat.route.test.ts
+++ b/apps/chat-api/src/features/chat/chat.route.test.ts
@@ -14,11 +14,18 @@ Bun.env.GATEWAY_PUBLIC_URL =
 // Orchestration is mocked so no E2B sandbox, gateway, database, or provider
 // call is made. A mutable holder lets each test swap the run behavior.
 type RunOpts = {
+	userId: string;
+	conversationId: string;
+	runId: string;
 	onSandboxId: (id: string) => Promise<void>;
 	onAgentSessionId: (id: string) => Promise<void>;
 	onTextDelta: (text: string) => Promise<void>;
 	onTextEnd: () => Promise<void>;
 };
+
+// Captures the options the route passed into orchestration, so tests can assert
+// run identity is propagated from the chat route down to the sandbox turn.
+let lastRunOpts: RunOpts | undefined;
 
 let runSandboxChatImpl: (opts: RunOpts) => Promise<unknown> = async (opts) => {
 	await opts.onSandboxId("sbx-test");
@@ -31,7 +38,10 @@ let runSandboxChatImpl: (opts: RunOpts) => Promise<unknown> = async (opts) => {
 class FakeConversationBusyError extends Error {}
 
 mock.module("@/features/sandbox-orchestration", () => ({
-	runSandboxChat: (opts: RunOpts) => runSandboxChatImpl(opts),
+	runSandboxChat: (opts: RunOpts) => {
+		lastRunOpts = opts;
+		return runSandboxChatImpl(opts);
+	},
 	ConversationBusyError: FakeConversationBusyError,
 }));
 
@@ -73,6 +83,7 @@ function parseSSE(raw: string): SSEFrame[] {
 
 describe("POST /v1/chat", () => {
 	beforeEach(() => {
+		lastRunOpts = undefined;
 		runSandboxChatImpl = async (opts) => {
 			await opts.onSandboxId("sbx-test");
 			await opts.onAgentSessionId("agent-sess-test");
@@ -131,6 +142,23 @@ describe("POST /v1/chat", () => {
 		const { conversationId } = JSON.parse(convFrame!.data);
 		expect(typeof conversationId).toBe("string");
 		expect(conversationId.length).toBeGreaterThan(0);
+	});
+
+	it("propagates userId, conversationId, and runId into orchestration", async () => {
+		const res = await postChat({
+			chatContent: "hi",
+			conversationId: "conv-xyz",
+		});
+		const frames = parseSSE(await res.text());
+		const runId = JSON.parse(
+			frames.find((f) => f.event === "run_id")!.data,
+		).runId;
+
+		expect(lastRunOpts).toBeDefined();
+		expect(lastRunOpts!.userId).toBe("member-1");
+		// The id the route forwards must match the one announced to the client.
+		expect(lastRunOpts!.conversationId).toBe("conv-xyz");
+		expect(lastRunOpts!.runId).toBe(runId);
 	});
 
 	it("carries a run_id and agent_session_id payload", async () => {

--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-orchestration.test.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-orchestration.test.ts
@@ -28,6 +28,8 @@ function makeOptions(
 ): RunSandboxChatOptions {
 	return {
 		userId: "user-1",
+		conversationId: "conv-1",
+		runId: "run-1",
 		query: "hello",
 		scope: "general" as const,
 		collectionId: null,
@@ -122,6 +124,20 @@ describe("runSandboxChat", () => {
 		});
 
 		await runSandboxChat(makeOptions());
+	});
+
+	it("propagates conversationId and runId into the daemon turn request", async () => {
+		spyForwardTurn = spyOn(
+			proxyModule,
+			"forwardChatTurnToSandbox",
+		).mockImplementation(async (opts) => {
+			expect(opts.turnRequest.conversation_id).toBe("conv-42");
+			expect(opts.turnRequest.run_id).toBe("run-99");
+		});
+
+		await runSandboxChat(
+			makeOptions({ conversationId: "conv-42", runId: "run-99" }),
+		);
 	});
 
 	it("forwards agentSessionId as agent_session_id", async () => {

--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-orchestration.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-orchestration.ts
@@ -16,6 +16,10 @@ function toSandboxScope(scope: ChatMessagesScope): SandboxScopeType {
 
 export interface RunSandboxChatOptions {
 	userId: string;
+	/** Product-visible thread id for this turn. */
+	conversationId: string;
+	/** Identifies this single backend execution attempt. */
+	runId: string;
 	query: string;
 	scope: ChatMessagesScope;
 	collectionId: string | null;
@@ -36,6 +40,8 @@ export async function runSandboxChat(
 ): Promise<RunSandboxChatResult> {
 	const {
 		userId,
+		conversationId,
+		runId,
 		query,
 		scope,
 		collectionId,
@@ -47,6 +53,13 @@ export async function runSandboxChat(
 		onSandboxId,
 		logger,
 	} = options;
+
+	logger.info({
+		msg: "Sandbox chat run starting",
+		userId,
+		conversationId,
+		runId,
+	});
 
 	const attempt = async () => {
 		const sandbox = await sandboxManager.createSandbox(userId, logger);
@@ -76,6 +89,8 @@ export async function runSandboxChat(
 			const turnRequest: TurnRequest = {
 				request_id: requestId,
 				user_id: userId,
+				conversation_id: conversationId,
+				run_id: runId,
 				scope_type: toSandboxScope(scope),
 				collection_id: collectionId ?? undefined,
 				summary_id: summaryId ?? undefined,
@@ -128,6 +143,8 @@ export async function runSandboxChat(
 		logger.error({
 			msg: "Sandbox creation failed, retrying",
 			userId,
+			conversationId,
+			runId,
 			error: err.message,
 		});
 
@@ -137,6 +154,8 @@ export async function runSandboxChat(
 			logger.error({
 				msg: "Sandbox creation retry also failed",
 				userId,
+				conversationId,
+				runId,
 				error: retryErr instanceof Error ? retryErr.message : String(retryErr),
 			});
 			throw retryErr;

--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-proxy.test.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-proxy.test.ts
@@ -7,6 +7,8 @@ function makeTurnRequest(overrides: Partial<TurnRequest> = {}): TurnRequest {
 	return {
 		request_id: "req-1",
 		user_id: "user-1",
+		conversation_id: "conv-1",
+		run_id: "run-1",
 		scope_type: "global",
 		message: "hello",
 		system_prompt: "you are helpful",

--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-proxy.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-proxy.ts
@@ -3,6 +3,10 @@ import { ConversationBusyError } from "./errors";
 export interface TurnRequest {
 	request_id: string;
 	user_id: string;
+	/** Product-visible thread id. Stable across turns of one conversation. */
+	conversation_id: string;
+	/** Identifies this single backend execution attempt. */
+	run_id: string;
 	scope_type: "global" | "collection" | "document";
 	collection_id?: string;
 	summary_id?: string;

--- a/apps/sandbox-daemon/routes/turn.integration.test.ts
+++ b/apps/sandbox-daemon/routes/turn.integration.test.ts
@@ -171,6 +171,20 @@ describe("POST /turn integration", () => {
 		expect(deltas).toEqual(["Hello ", "World"]);
 	});
 
+	it("rejects a body missing conversation_id or run_id with 400", async () => {
+		const body: Record<string, unknown> = makeTurnBody();
+		delete body.conversation_id;
+		const res = await app.request("/turn", {
+			method: "POST",
+			headers: turnHeaders(),
+			body: JSON.stringify(body),
+		});
+
+		expect(res.status).toBe(400);
+		expect(await res.json()).toEqual({ error: "Missing required fields" });
+		expect(mockSpawnAgent).not.toHaveBeenCalled();
+	});
+
 	it("surfaces conversation_id and run_id on the started event", async () => {
 		mockSpawnAgent.mockImplementation((input) =>
 			emitAgent(input, [{ type: "completed" }]),

--- a/apps/sandbox-daemon/routes/turn.integration.test.ts
+++ b/apps/sandbox-daemon/routes/turn.integration.test.ts
@@ -63,6 +63,8 @@ describe("POST /turn integration", () => {
 		return {
 			request_id: `req-${reqCounter}-${Date.now()}`,
 			user_id: "user-1",
+			conversation_id: "conv-1",
+			run_id: "run-1",
 			scope_type: "global",
 			message: "hello",
 			system_prompt: "you are helpful",
@@ -167,6 +169,26 @@ describe("POST /turn integration", () => {
 			.filter((e) => e.type === "text_delta")
 			.map((e) => e.text);
 		expect(deltas).toEqual(["Hello ", "World"]);
+	});
+
+	it("surfaces conversation_id and run_id on the started event", async () => {
+		mockSpawnAgent.mockImplementation((input) =>
+			emitAgent(input, [{ type: "completed" }]),
+		);
+
+		const res = await app.request("/turn", {
+			method: "POST",
+			headers: turnHeaders(),
+			body: JSON.stringify(
+				makeTurnBody({ conversation_id: "conv-77", run_id: "run-88" }),
+			),
+		});
+
+		const events = parseNdjson(await res.text());
+		const started = events.find((e) => e.type === "started");
+		expect(started).toBeDefined();
+		expect(started?.conversation_id).toBe("conv-77");
+		expect(started?.run_id).toBe("run-88");
 	});
 
 	it("forwards llm_base_url and llm_token from the body to spawnAgent", async () => {

--- a/apps/sandbox-daemon/routes/turn.ts
+++ b/apps/sandbox-daemon/routes/turn.ts
@@ -63,6 +63,8 @@ app.post("/turn", async (c) => {
 	if (
 		!body.request_id ||
 		!body.user_id ||
+		!body.conversation_id ||
+		!body.run_id ||
 		!body.message ||
 		!body.system_prompt ||
 		!body.llm_base_url ||

--- a/apps/sandbox-daemon/routes/turn.ts
+++ b/apps/sandbox-daemon/routes/turn.ts
@@ -32,6 +32,8 @@ function authTokenMatches(
 interface TurnRequest {
 	request_id: string;
 	user_id: string;
+	conversation_id: string;
+	run_id: string;
 	scope_type: "global" | "collection" | "document";
 	collection_id?: string;
 	summary_id?: string;
@@ -72,6 +74,8 @@ app.post("/turn", async (c) => {
 
 	const {
 		request_id,
+		conversation_id,
+		run_id,
 		message,
 		agent_session_id,
 		system_prompt,
@@ -91,7 +95,14 @@ app.post("/turn", async (c) => {
 			c.header("Content-Type", "application/x-ndjson");
 
 			try {
-				await s.write(ndjsonLine({ type: "started", turn_id: request_id }));
+				await s.write(
+					ndjsonLine({
+						type: "started",
+						turn_id: request_id,
+						conversation_id,
+						run_id,
+					}),
+				);
 
 				const cwd = getAgentCwd();
 				mkdirSync(cwd, { recursive: true });


### PR DESCRIPTION
## Summary

Implements **MYM-6 / Task 2: Add run identity propagation** (Milestone 1: Core Runtime Identity).

Passes `{ userId, conversationId, runId }` from the chat controller into sandbox orchestration, includes `conversation_id`/`run_id` in the sandbox-daemon `/turn` request, and adds them to run-level structured logs.

## Changes
- **chat.controller.ts** — forwards `resolvedConversationId` and `runId` into `runSandboxChat` (both were already generated at request entry by Task 1).
- **sandbox-orchestration.ts** — `RunSandboxChatOptions` gains `conversationId`/`runId`; wired into the `TurnRequest` body and into a new run-start `info` log plus the existing retry-failure `error` logs (`userId`, `conversationId`, `runId`).
- **sandbox-proxy.ts** — `TurnRequest` carries `conversation_id` and `run_id`.
- **sandbox-daemon/routes/turn.ts** — daemon `TurnRequest` interface accepts the two fields and surfaces them on the `started` NDJSON event so receipt is observable.

## Acceptance criteria
- [x] Every sandbox turn has a stable `runId` (generated at request entry, threaded through).
- [x] The daemon receives `conversation_id` and `run_id`.
- [x] Logs include `userId`, `conversationId`, and `runId` on run-level events.
- [x] Tests assert run/conversation IDs propagate from the chat route to the mocked sandbox turn request.

## Tests
- `chat.route.test.ts` — asserts the route forwards `userId`/`conversationId`/`runId` into orchestration, matching the emitted SSE frames.
- `sandbox-orchestration.test.ts` — asserts `conversationId`/`runId` reach `turnRequest.conversation_id`/`run_id`.
- `turn.integration.test.ts` — asserts the daemon surfaces `conversation_id`/`run_id` on the `started` event.
- Full suites green: chat-api **45 pass**, sandbox-daemon **34 pass**.

## Remaining risk / notes
- Pre-existing (not introduced here): `sandbox-proxy.test.ts`'s `makeTurnRequest` helper omits the already-required `doc_gateway_url`, so `tsc --noEmit` flags it on `main` as well. Left untouched to keep this change surgical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)