### PR TITLE
feat(token): add audiences + separate llm/doc tokens (MYM-7)

### DIFF
--- a/apps/chat-api/scripts/smoke-gateway.ts
+++ b/apps/chat-api/scripts/smoke-gateway.ts
@@ -53,7 +53,12 @@ function check(name: string, ok: boolean, detail = ""): void {
 
 function mint(ttlMs?: number): string {
 	return mintLlmToken(
-		{ userId: "smoke", sandboxId: "smoke-sbx", requestId: crypto.randomUUID() },
+		{
+			aud: "llm",
+			userId: "smoke",
+			sandboxId: "smoke-sbx",
+			requestId: crypto.randomUUID(),
+		},
 		SECRET,
 		ttlMs,
 	);

--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-orchestration.test.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-orchestration.test.ts
@@ -107,23 +107,80 @@ describe("runSandboxChat", () => {
 		);
 	});
 
-	it("mints a verifiable llm token bound to the user and sandbox, plus the gateway url", async () => {
+	it("mints verifiable per-audience llm and doc tokens bound to the user, sandbox, and run", async () => {
 		spyForwardTurn = spyOn(
 			proxyModule,
 			"forwardChatTurnToSandbox",
 		).mockImplementation(async (opts) => {
 			expect(opts.turnRequest.llm_base_url).toBe("https://gateway.test");
 			expect(opts.turnRequest.doc_gateway_url).toBe("https://gateway.test");
-			const verified = verifyLlmToken(
+
+			// LLM token verifies only for the llm audience, not documents.
+			const llm = verifyLlmToken(
 				opts.turnRequest.llm_token,
 				"test-llm-token-secret",
+				"llm",
 			);
-			expect(verified?.userId).toBe("user-1");
-			expect(verified?.sandboxId).toBe("sbx-123");
-			expect(verified?.requestId).toBe(opts.turnRequest.request_id);
+			expect(llm?.aud).toBe("llm");
+			expect(llm?.userId).toBe("user-1");
+			expect(llm?.sandboxId).toBe("sbx-123");
+			expect(llm?.requestId).toBe(opts.turnRequest.request_id);
+			expect(llm?.conversationId).toBe("conv-1");
+			expect(llm?.runId).toBe("run-1");
+			expect(
+				verifyLlmToken(
+					opts.turnRequest.llm_token,
+					"test-llm-token-secret",
+					"documents",
+				),
+			).toBeNull();
+
+			// Doc token verifies only for the documents audience, not llm.
+			const doc = verifyLlmToken(
+				opts.turnRequest.doc_token,
+				"test-llm-token-secret",
+				"documents",
+			);
+			expect(doc?.aud).toBe("documents");
+			expect(doc?.userId).toBe("user-1");
+			expect(doc?.runId).toBe("run-1");
+			expect(
+				verifyLlmToken(
+					opts.turnRequest.doc_token,
+					"test-llm-token-secret",
+					"llm",
+				),
+			).toBeNull();
 		});
 
 		await runSandboxChat(makeOptions());
+	});
+
+	it("signs the document scope into the doc token, not the llm token", async () => {
+		spyForwardTurn = spyOn(
+			proxyModule,
+			"forwardChatTurnToSandbox",
+		).mockImplementation(async (opts) => {
+			const doc = verifyLlmToken(
+				opts.turnRequest.doc_token,
+				"test-llm-token-secret",
+				"documents",
+			);
+			expect(doc?.scope).toBe("collection");
+			expect(doc?.collectionId).toBe("col-1");
+			// The LLM token carries no document scope.
+			const llm = verifyLlmToken(
+				opts.turnRequest.llm_token,
+				"test-llm-token-secret",
+				"llm",
+			);
+			expect(llm?.scope).toBeUndefined();
+			expect(llm?.collectionId).toBeUndefined();
+		});
+
+		await runSandboxChat(
+			makeOptions({ scope: "collection", collectionId: "col-1" }),
+		);
 	});
 
 	it("propagates conversationId and runId into the daemon turn request", async () => {

--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-orchestration.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-orchestration.ts
@@ -1,4 +1,4 @@
-import { mintLlmToken } from "@mymemo/llm-token";
+import { type LlmTokenClaims, mintLlmToken } from "@mymemo/llm-token";
 import { apiEnv, type ChatMessagesScope } from "@/config/env";
 import type { ChatLogger } from "@/features/chat/chat.logger";
 import { buildSandboxAgentPrompt } from "@/features/sandbox-agent";
@@ -86,6 +86,20 @@ export async function runSandboxChat(
 			});
 
 			const requestId = crypto.randomUUID();
+
+			// Two single-audience capability tokens for this turn. They share the
+			// same identity/run claims; only `aud` and the document scope differ.
+			// The gateway enforces audience per route, so the LLM token cannot read
+			// documents and the document token cannot spend on the LLM. The daemon
+			// sets the LLM token as the agent's ANTHROPIC_AUTH_TOKEN and the doc
+			// token as its MYMEMO_DOC_TOKEN.
+			const baseClaims: Omit<LlmTokenClaims, "exp" | "aud"> = {
+				userId,
+				sandboxId: sandbox.sandboxId,
+				requestId,
+				conversationId,
+				runId,
+			};
 			const turnRequest: TurnRequest = {
 				request_id: requestId,
 				user_id: userId,
@@ -99,15 +113,17 @@ export async function runSandboxChat(
 				system_prompt: systemPrompt,
 				llm_base_url: apiEnv.GATEWAY_PUBLIC_URL,
 				doc_gateway_url: apiEnv.GATEWAY_PUBLIC_URL,
-				// One per-turn capability token. The gateway's LLM proxy uses
-				// {userId,sandboxId,requestId}; its document routes additionally
-				// enforce the signed scope. The daemon sets it as both the LLM and
-				// the document bearer token on the agent.
+				// LLM token: no document scope — the LLM proxy ignores it.
 				llm_token: mintLlmToken(
+					{ ...baseClaims, aud: "llm" },
+					apiEnv.LLM_TOKEN_SECRET,
+				),
+				// Document token: carries the signed scope the document routes
+				// enforce server-side (the agent cannot widen it).
+				doc_token: mintLlmToken(
 					{
-						userId,
-						sandboxId: sandbox.sandboxId,
-						requestId,
+						...baseClaims,
+						aud: "documents",
 						scope: toSandboxScope(scope),
 						collectionId: collectionId ?? undefined,
 						summaryId: summaryId ?? undefined,

--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-proxy.test.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-proxy.test.ts
@@ -13,7 +13,9 @@ function makeTurnRequest(overrides: Partial<TurnRequest> = {}): TurnRequest {
 		message: "hello",
 		system_prompt: "you are helpful",
 		llm_base_url: "https://gateway.test",
+		doc_gateway_url: "https://gateway.test",
 		llm_token: "test-token",
+		doc_token: "test-doc-token",
 		...overrides,
 	};
 }

--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-proxy.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-proxy.ts
@@ -18,10 +18,16 @@ export interface TurnRequest {
 	/** Document gateway base URL the sandbox agent's `mymemo-docs` CLI calls. */
 	doc_gateway_url: string;
 	/**
-	 * Short-lived bearer token the agent presents to both gateways. Carries the
-	 * signed turn scope that the document gateway enforces.
+	 * Short-lived bearer token (aud: "llm") the agent presents to the LLM proxy.
+	 * Set as the agent's ANTHROPIC_AUTH_TOKEN.
 	 */
 	llm_token: string;
+	/**
+	 * Short-lived bearer token (aud: "documents") the agent's `mymemo-docs` CLI
+	 * presents to the document routes. Carries the signed turn scope the gateway
+	 * enforces. Set as the agent's MYMEMO_DOC_TOKEN.
+	 */
+	doc_token: string;
 }
 
 interface ForwardOptions {

--- a/apps/gateway/src/gateway.test.ts
+++ b/apps/gateway/src/gateway.test.ts
@@ -33,9 +33,17 @@ const fakeDb: Db = {
 
 const app = createGateway(config, fakeDb);
 
+// Defaults to the document audience since most callers below are the document
+// reader suite; LLM-proxy callers pass `aud: "llm"` explicitly.
 function token(extra: Partial<Omit<LlmTokenClaims, "exp">> = {}): string {
 	return mintLlmToken(
-		{ userId: "u1", sandboxId: "sbx", requestId: "req", ...extra },
+		{
+			aud: "documents",
+			userId: "u1",
+			sandboxId: "sbx",
+			requestId: "req",
+			...extra,
+		},
 		SECRET,
 	);
 }
@@ -57,7 +65,7 @@ const callOf = (k: ReturnType<typeof kind>) =>
 describe("gateway · llm proxy", () => {
 	const validToken = () =>
 		mintLlmToken(
-			{ userId: "u1", sandboxId: "sbx-1", requestId: "req-1" },
+			{ aud: "llm", userId: "u1", sandboxId: "sbx-1", requestId: "req-1" },
 			SECRET,
 		);
 
@@ -80,6 +88,31 @@ describe("gateway · llm proxy", () => {
 			headers: { authorization: "Bearer not-a-real-token" },
 		});
 		expect(res.status).toBe(401);
+	});
+
+	it("rejects a token minted for the documents audience (no upstream call)", async () => {
+		fetchSpy = spyOn(globalThis, "fetch").mockRejectedValue(
+			new Error("should not forward"),
+		);
+		const docToken = mintLlmToken(
+			{
+				aud: "documents",
+				userId: "u1",
+				sandboxId: "sbx-1",
+				requestId: "req-1",
+			},
+			SECRET,
+		);
+		const res = await app.request("/v1/messages", {
+			method: "POST",
+			headers: {
+				authorization: `Bearer ${docToken}`,
+				"content-type": "application/json",
+			},
+			body: JSON.stringify({ model: "claude-sonnet-4-6", messages: [] }),
+		});
+		expect(res.status).toBe(401);
+		expect(fetchSpy).not.toHaveBeenCalled();
 	});
 
 	it("injects x-api-key and forwards anthropic headers for a valid token", async () => {
@@ -169,6 +202,16 @@ describe("gateway · document reader (FTS / Postgres)", () => {
 		const res = await app.request("/v1/documents/search", {
 			method: "POST",
 			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ query: "x" }),
+		});
+		expect(res.status).toBe(401);
+		expect(calls).toHaveLength(0);
+	});
+
+	it("rejects a token minted for the llm audience (no DB touched)", async () => {
+		const res = await app.request("/v1/documents/search", {
+			method: "POST",
+			headers: headers(token({ aud: "llm", scope: "global" })),
 			body: JSON.stringify({ query: "x" }),
 		});
 		expect(res.status).toBe(401);
@@ -477,7 +520,7 @@ describe("gateway · routing isolation", () => {
 		);
 		const res = await app.request("/v1/messages", {
 			method: "POST",
-			headers: headers(token({ scope: "global" })),
+			headers: headers(token({ aud: "llm", scope: "global" })),
 			body: "{}",
 		});
 		expect(res.status).toBe(200);
@@ -492,7 +535,7 @@ describe("gateway · routing isolation", () => {
 		);
 		const res = await app.request("/v1/files", {
 			method: "POST",
-			headers: headers(token({ scope: "global" })),
+			headers: headers(token({ aud: "llm", scope: "global" })),
 			body: "{}",
 		});
 		expect(res.status).toBe(404);

--- a/apps/gateway/src/gateway.ts
+++ b/apps/gateway/src/gateway.ts
@@ -1,4 +1,8 @@
-import { type LlmTokenClaims, verifyLlmToken } from "@mymemo/llm-token";
+import {
+	type LlmTokenClaims,
+	type TokenAudience,
+	verifyLlmToken,
+} from "@mymemo/llm-token";
 import { type Context, Hono } from "hono";
 import type { GatewayConfig } from "./config";
 import type { Db } from "./db";
@@ -27,7 +31,10 @@ import {
  *      so a prompt-injected agent cannot widen it. Search is FTS-only.
  *
  * Both code paths verify the token with the same verifyLlmToken +
- * config.llmTokenSecret (see `bearerClaims`). Route registration order is
+ * config.llmTokenSecret (see `bearerClaims`), but each passes its own required
+ * audience: the document routes accept only `aud: "documents"` tokens and the
+ * LLM proxy accepts only `aud: "llm"`, so a token minted for one family cannot
+ * be replayed against the other. Route registration order is
  * correctness-critical: Hono matches in registration order and the LLM proxy is
  * a catch-all, so the document routes MUST be registered before it (see below).
  *
@@ -66,11 +73,18 @@ const RESPONSE_DROP_HEADERS = new Set([
 
 const SEARCH_LIMIT = 8;
 
-// Single token-verify helper shared by both route families.
-function bearerClaims(c: Context, secret: string): LlmTokenClaims | null {
+// Single token-verify helper shared by both route families. Each family passes
+// its own audience so a token minted for the other family fails closed here:
+// an `llm` token cannot reach the document routes and a `documents` token
+// cannot reach the LLM proxy.
+function bearerClaims(
+	c: Context,
+	secret: string,
+	audience: TokenAudience,
+): LlmTokenClaims | null {
 	const auth = c.req.header("authorization")?.trim() ?? "";
 	const token = /^Bearer\s+(.+)$/i.exec(auth)?.[1] ?? "";
-	return verifyLlmToken(token, secret);
+	return verifyLlmToken(token, secret, audience);
 }
 
 function unauthorized(c: Context) {
@@ -107,6 +121,25 @@ function scopeError(claims: LlmTokenClaims): string | null {
 }
 
 /**
+ * Shared guard for the document routes: verify the bearer token for the
+ * "documents" audience and fail closed on an unknown scope or empty
+ * identity/scope ids. Returns the usable claims, or a Response to return as-is.
+ * Both /v1/documents/* routes share this contract, so the enforcement lives in
+ * one place and the two routes cannot drift apart.
+ */
+function requireDocumentClaims(
+	c: Context,
+	secret: string,
+): LlmTokenClaims | Response {
+	const claims = bearerClaims(c, secret, "documents");
+	if (!claims) return unauthorized(c);
+	if (!isKnownScope(claims.scope)) return forbidden(c, "unknown scope");
+	const bad = scopeError(claims);
+	if (bad) return forbidden(c, bad);
+	return claims;
+}
+
+/**
  * Build the gateway app from injected config + db. Pure: config in, app out.
  * The only place the environment is read is the entrypoint (`index.ts`).
  */
@@ -126,11 +159,8 @@ export function createGateway(config: GatewayConfig, db: Db): Hono {
 	// 2. Document reader. Registered before the catch-all so /v1/documents/* is
 	//    handled here and never reaches the Anthropic proxy.
 	app.post("/v1/documents/search", async (c) => {
-		const claims = bearerClaims(c, config.llmTokenSecret);
-		if (!claims) return unauthorized(c);
-		if (!isKnownScope(claims.scope)) return forbidden(c, "unknown scope");
-		const bad = scopeError(claims);
-		if (bad) return forbidden(c, bad);
+		const claims = requireDocumentClaims(c, config.llmTokenSecret);
+		if (claims instanceof Response) return claims;
 
 		const body = await c.req
 			.json<{ query?: string }>()
@@ -168,11 +198,8 @@ export function createGateway(config: GatewayConfig, db: Db): Hono {
 	});
 
 	app.post("/v1/documents/fetch", async (c) => {
-		const claims = bearerClaims(c, config.llmTokenSecret);
-		if (!claims) return unauthorized(c);
-		if (!isKnownScope(claims.scope)) return forbidden(c, "unknown scope");
-		const bad = scopeError(claims);
-		if (bad) return forbidden(c, bad);
+		const claims = requireDocumentClaims(c, config.llmTokenSecret);
+		if (claims instanceof Response) return claims;
 
 		const body = await c.req
 			.json<{ documentId?: string }>()
@@ -220,7 +247,7 @@ export function createGateway(config: GatewayConfig, db: Db): Hono {
 }
 
 async function proxyToAnthropic(c: Context, config: GatewayConfig) {
-	const claims = bearerClaims(c, config.llmTokenSecret);
+	const claims = bearerClaims(c, config.llmTokenSecret, "llm");
 	if (!claims) {
 		return c.json(
 			{

--- a/apps/gateway/src/index.integration.test.ts
+++ b/apps/gateway/src/index.integration.test.ts
@@ -30,7 +30,7 @@ let app: ReturnType<typeof createGateway>;
 
 function tok(extra: Record<string, unknown> = {}): string {
 	return mintLlmToken(
-		{ userId: WS, sandboxId: "s", requestId: "r", ...extra },
+		{ aud: "documents", userId: WS, sandboxId: "s", requestId: "r", ...extra },
 		SECRET,
 	);
 }
@@ -174,6 +174,7 @@ describe.skipIf(!RUN)(
 		it("a different workspace sees nothing (the workspace pin)", async () => {
 			const t = mintLlmToken(
 				{
+					aud: "documents",
 					userId: "other-member",
 					sandboxId: "s",
 					requestId: "r",

--- a/apps/sandbox-daemon/child-spawn.test.ts
+++ b/apps/sandbox-daemon/child-spawn.test.ts
@@ -168,7 +168,9 @@ describe("spawnAgent agent environment", () => {
 			systemPrompt: "s",
 			cwd: "/workspace/data/u1/canonical",
 			llmBaseUrl: "https://gateway.example",
+			docGatewayUrl: "https://docs.example",
 			llmToken: "tok-123",
+			docToken: "doc-456",
 			onEvent: async () => {},
 		});
 
@@ -179,6 +181,9 @@ describe("spawnAgent agent environment", () => {
 		const env = call[1].env;
 		expect(env.ANTHROPIC_BASE_URL).toBe("https://gateway.example");
 		expect(env.ANTHROPIC_AUTH_TOKEN).toBe("tok-123");
+		// Document access uses its own gateway url + (aud: documents) token.
+		expect(env.MYMEMO_DOC_GATEWAY_URL).toBe("https://docs.example");
+		expect(env.MYMEMO_DOC_TOKEN).toBe("doc-456");
 		// The whole point of the gateway: no provider key reaches the agent.
 		expect("ANTHROPIC_API_KEY" in env).toBe(false);
 	});
@@ -284,6 +289,7 @@ describe("spawnAgent idle timeout", () => {
 			llmBaseUrl: "https://gateway.example",
 			docGatewayUrl: "https://docs.example",
 			llmToken: "tok-test",
+			docToken: "doc-test",
 			onEvent,
 		};
 	}

--- a/apps/sandbox-daemon/child-spawn.ts
+++ b/apps/sandbox-daemon/child-spawn.ts
@@ -251,11 +251,16 @@ export interface SpawnAgentInput {
 	/** Document gateway base URL — set as MYMEMO_DOC_GATEWAY_URL for the CLI. */
 	docGatewayUrl: string;
 	/**
-	 * Short-lived bearer token — set as ANTHROPIC_AUTH_TOKEN (LLM gateway) and
-	 * MYMEMO_DOC_TOKEN (document gateway). The signed scope is enforced by the
-	 * document gateway.
+	 * Short-lived LLM bearer token (aud: "llm") — set as ANTHROPIC_AUTH_TOKEN for
+	 * the Claude binary. Holds no document scope.
 	 */
 	llmToken: string;
+	/**
+	 * Short-lived document bearer token (aud: "documents") — set as
+	 * MYMEMO_DOC_TOKEN for the `mymemo-docs` CLI. Carries the signed scope the
+	 * document gateway enforces.
+	 */
+	docToken: string;
 	onEvent: (event: AgentEvent) => void | Promise<void>;
 }
 
@@ -266,7 +271,8 @@ export interface SpawnAgentResult {
 export async function spawnAgent(
 	input: SpawnAgentInput,
 ): Promise<SpawnAgentResult> {
-	const { onEvent, llmBaseUrl, docGatewayUrl, llmToken, ...config } = input;
+	const { onEvent, llmBaseUrl, docGatewayUrl, llmToken, docToken, ...config } =
+		input;
 	ensureClaudeProjectsDir();
 	const proc = Bun.spawn(buildAgentSpawnArgv(config.cwd), {
 		env: {
@@ -275,10 +281,10 @@ export async function spawnAgent(
 			ANTHROPIC_BASE_URL: llmBaseUrl,
 			ANTHROPIC_AUTH_TOKEN: llmToken,
 			// Document access: the `mymemo-docs` CLI (on PATH) calls the document
-			// gateway with this token. The gateway enforces the token's signed
-			// scope, so the agent holds no document credential.
+			// gateway with its own (aud: "documents") token. The gateway enforces
+			// the token's signed scope, so the agent holds no document credential.
 			MYMEMO_DOC_GATEWAY_URL: docGatewayUrl,
-			MYMEMO_DOC_TOKEN: llmToken,
+			MYMEMO_DOC_TOKEN: docToken,
 			PATH: process.env.PATH ?? "",
 			CLAUDE_CODE_PATH: process.env.CLAUDE_CODE_PATH ?? "/usr/local/bin/claude",
 		},

--- a/apps/sandbox-daemon/routes/turn.integration.test.ts
+++ b/apps/sandbox-daemon/routes/turn.integration.test.ts
@@ -71,6 +71,7 @@ describe("POST /turn integration", () => {
 			llm_base_url: "https://gateway.test",
 			doc_gateway_url: "https://docs.test",
 			llm_token: "test-token",
+			doc_token: "test-doc-token",
 			...overrides,
 		};
 	}
@@ -205,7 +206,7 @@ describe("POST /turn integration", () => {
 		expect(started?.run_id).toBe("run-88");
 	});
 
-	it("forwards llm_base_url and llm_token from the body to spawnAgent", async () => {
+	it("forwards llm/doc base urls and both tokens from the body to spawnAgent", async () => {
 		let captured: SpawnAgentInput | undefined;
 		mockSpawnAgent.mockImplementation((input) => {
 			captured = input;
@@ -222,7 +223,21 @@ describe("POST /turn integration", () => {
 		await res.text();
 
 		expect(captured?.llmBaseUrl).toBe("https://gateway.test");
+		expect(captured?.docGatewayUrl).toBe("https://docs.test");
 		expect(captured?.llmToken).toBe("test-token");
+		expect(captured?.docToken).toBe("test-doc-token");
+	});
+
+	it("rejects a turn missing the doc_token (400, no spawn)", async () => {
+		const body = makeTurnBody();
+		body.doc_token = "";
+		const res = await app.request("/turn", {
+			method: "POST",
+			headers: turnHeaders(),
+			body: JSON.stringify(body),
+		});
+		expect(res.status).toBe(400);
+		expect(mockSpawnAgent).not.toHaveBeenCalled();
 	});
 
 	it("forwards session_id from agent.js", async () => {

--- a/apps/sandbox-daemon/routes/turn.ts
+++ b/apps/sandbox-daemon/routes/turn.ts
@@ -43,6 +43,7 @@ interface TurnRequest {
 	llm_base_url: string;
 	doc_gateway_url: string;
 	llm_token: string;
+	doc_token: string;
 }
 
 function ndjsonLine(obj: Record<string, unknown>): string {
@@ -69,7 +70,8 @@ app.post("/turn", async (c) => {
 		!body.system_prompt ||
 		!body.llm_base_url ||
 		!body.doc_gateway_url ||
-		!body.llm_token
+		!body.llm_token ||
+		!body.doc_token
 	) {
 		return c.json({ error: "Missing required fields" }, 400);
 	}
@@ -84,6 +86,7 @@ app.post("/turn", async (c) => {
 		llm_base_url,
 		doc_gateway_url,
 		llm_token,
+		doc_token,
 	} = body;
 
 	const lock = acquireTurn(request_id);
@@ -119,6 +122,7 @@ app.post("/turn", async (c) => {
 					llmBaseUrl: llm_base_url,
 					docGatewayUrl: doc_gateway_url,
 					llmToken: llm_token,
+					docToken: doc_token,
 					onEvent: async (event) => {
 						if (event.type === "completed") {
 							// We emit our own `completed` below.

--- a/packages/llm-token/index.test.ts
+++ b/packages/llm-token/index.test.ts
@@ -4,6 +4,7 @@ import { type LlmTokenClaims, mintLlmToken, verifyLlmToken } from "./index";
 
 const SECRET = "test-secret";
 const claims: Omit<LlmTokenClaims, "exp"> = {
+	aud: "llm",
 	userId: "u1",
 	sandboxId: "sbx-1",
 	requestId: "req-1",
@@ -73,13 +74,19 @@ describe("llm-token", () => {
 	it("rejects a validly-signed object with a missing or non-numeric exp", () => {
 		expect(
 			verifyLlmToken(
-				signedToken({ userId: "u", sandboxId: "s", requestId: "r" }),
+				signedToken({
+					aud: "llm",
+					userId: "u",
+					sandboxId: "s",
+					requestId: "r",
+				}),
 				SECRET,
 			),
 		).toBeNull();
 		expect(
 			verifyLlmToken(
 				signedToken({
+					aud: "llm",
 					userId: "u",
 					sandboxId: "s",
 					requestId: "r",
@@ -100,9 +107,59 @@ describe("llm-token", () => {
 		// JSON.stringify(Infinity) === "null", so craft raw JSON: 1e999 → Infinity,
 		// which `Infinity < Date.now()` would treat as never-expiring.
 		const body = Buffer.from(
-			'{"userId":"u","sandboxId":"s","requestId":"r","exp":1e999}',
+			'{"aud":"llm","userId":"u","sandboxId":"s","requestId":"r","exp":1e999}',
 		).toString("base64url");
 		const sig = createHmac("sha256", SECRET).update(body).digest("base64url");
 		expect(verifyLlmToken(`${body}.${sig}`, SECRET)).toBeNull();
+	});
+
+	// ── Audience (aud) ──
+	it("rejects a validly-signed token with a missing audience", () => {
+		expect(
+			verifyLlmToken(
+				signedToken({
+					userId: "u",
+					sandboxId: "s",
+					requestId: "r",
+					exp: Date.now() + 1000,
+				}),
+				SECRET,
+			),
+		).toBeNull();
+	});
+
+	it("rejects a validly-signed token with an invalid audience value", () => {
+		expect(
+			verifyLlmToken(
+				signedToken({
+					aud: "admin",
+					userId: "u",
+					sandboxId: "s",
+					requestId: "r",
+					exp: Date.now() + 1000,
+				}),
+				SECRET,
+			),
+		).toBeNull();
+	});
+
+	it("rejects a token whose audience does not match the expected audience", () => {
+		const llmTok = mintLlmToken({ ...claims, aud: "llm" }, SECRET);
+		const docTok = mintLlmToken({ ...claims, aud: "documents" }, SECRET);
+		// Right audience verifies; wrong audience fails closed.
+		expect(verifyLlmToken(llmTok, SECRET, "llm")?.aud).toBe("llm");
+		expect(verifyLlmToken(llmTok, SECRET, "documents")).toBeNull();
+		expect(verifyLlmToken(docTok, SECRET, "documents")?.aud).toBe("documents");
+		expect(verifyLlmToken(docTok, SECRET, "llm")).toBeNull();
+	});
+
+	it("round-trips conversationId and runId claims", () => {
+		const token = mintLlmToken(
+			{ ...claims, conversationId: "conv-1", runId: "run-1" },
+			SECRET,
+		);
+		const verified = verifyLlmToken(token, SECRET);
+		expect(verified?.conversationId).toBe("conv-1");
+		expect(verified?.runId).toBe("run-1");
 	});
 });

--- a/packages/llm-token/index.ts
+++ b/packages/llm-token/index.ts
@@ -12,16 +12,31 @@
 
 import { createHmac, timingSafeEqual } from "node:crypto";
 
+/**
+ * Which gateway route family a token is valid for. The gateway enforces this
+ * per route, so an `llm` token cannot reach the document routes and vice versa:
+ * a leaked LLM token cannot read documents, and a leaked document token cannot
+ * spend on the LLM. chat-api mints one token per audience for each turn.
+ */
+export type TokenAudience = "llm" | "documents";
+
 export interface LlmTokenClaims {
+	/** Route family this token is valid for; enforced by the gateway. */
+	aud: TokenAudience;
 	userId: string;
 	sandboxId: string;
 	requestId: string;
 	/** Expiry as ms since epoch. */
 	exp: number;
+	/** Product-visible conversation thread id this run belongs to. */
+	conversationId?: string;
+	/** Backend execution attempt id. */
+	runId?: string;
 	/**
-	 * The turn's document scope. The document-gateway enforces these server-side
-	 * (the agent cannot widen them, since they're signed). The llm-gateway
-	 * ignores them. Absent for turns that don't touch documents.
+	 * The turn's document scope. The document routes enforce this server-side
+	 * (the agent cannot widen it, since it's signed). Set on the
+	 * documents-audience token (always — `global` is the workspace-wide search
+	 * scope); the llm-audience token omits it.
 	 */
 	scope?: "global" | "collection" | "document";
 	/** Present iff scope === "collection". */
@@ -40,6 +55,10 @@ function isLlmTokenClaims(value: unknown): value is LlmTokenClaims {
 	if (typeof value !== "object" || value === null) return false;
 	const c = value as Record<string, unknown>;
 	return (
+		// Audience is security-critical and route-enforced, so a token whose `aud`
+		// is missing or not one of the known values is rejected outright rather
+		// than left for a route to mis-handle.
+		(c.aud === "llm" || c.aud === "documents") &&
 		typeof c.userId === "string" &&
 		typeof c.sandboxId === "string" &&
 		typeof c.requestId === "string" &&
@@ -62,6 +81,12 @@ export function mintLlmToken(
 export function verifyLlmToken(
 	token: string,
 	secret: string,
+	/**
+	 * When provided, the token's `aud` must match or verification fails closed.
+	 * Each gateway route family passes its own audience so a token minted for the
+	 * other family is rejected.
+	 */
+	audience?: TokenAudience,
 ): LlmTokenClaims | null {
 	const dot = token.indexOf(".");
 	if (dot < 1) return null;
@@ -87,5 +112,6 @@ export function verifyLlmToken(
 	// callers never see a non-object or a missing/non-numeric exp (which would
 	// make `exp < Date.now()` falsy and silently "never expire").
 	if (!isLlmTokenClaims(parsed)) return null;
+	if (audience !== undefined && parsed.aud !== audience) return null;
 	return parsed.exp < Date.now() ? null : parsed;
 }


### PR DESCRIPTION
## Summary

Implements **MYM-7 — Task 3: Add token audiences** from the *Agent Workspace Implementation* project.

Per-turn capability tokens now carry a required `aud: "llm" | "documents"` claim (plus optional `conversationId`/`runId`), and the single shared token is split into **two single-audience tokens**. The gateway enforces audience per route, so a token minted for one route family cannot be replayed against the other.

## Changes

- **`packages/llm-token`** — `aud` is required and validated in the shape guard; `verifyLlmToken(token, secret, audience?)` fails closed on an audience mismatch. Added optional `conversationId`/`runId` claims and a `TokenAudience` type.
- **`apps/gateway`** — document routes (`/v1/documents/*`) verify with `aud: "documents"`; the LLM proxy (`/v1/messages*`) verifies with `aud: "llm"`. Wrong-audience tokens fail closed (401).
- **`apps/chat-api` orchestration** — mints a `llm_token` (aud `llm`, no document scope) and a `doc_token` (aud `documents`, carrying the signed scope), threading `conversationId`/`runId` from the chat controller into the claims.
- **`apps/sandbox-daemon`** — carries `doc_token` through the `/turn` request and sets it as `MYMEMO_DOC_TOKEN`; the LLM token remains `ANTHROPIC_AUTH_TOKEN`. The sandbox still receives no provider key or DB credential.

## Acceptance criteria

- ✅ LLM routes reject tokens with `aud: "documents"`.
- ✅ Document routes reject tokens with `aud: "llm"`.
- ✅ Token tests cover missing, invalid, and wrong-audience values.
- ✅ Token tests cover expired tokens (pre-existing, retained).
- ✅ The daemon receives separate `llm_token` and `doc_token` values.
- ✅ The sandbox environment never contains provider keys or database credentials (`child-spawn` test asserts no `ANTHROPIC_API_KEY`).

## Tests

All workspace suites pass (`bun run test`): llm-token 14, chat-api 44, gateway 34, mymemo-docs 8, sandbox-daemon 34. Biome clean on changed files.

## Notes / risk

- MYM-6 (run-identity propagation into orchestration) is marked Done in Linear but its code is **not in `main`**. To satisfy MYM-7's requirement that `conversationId`/`runId` appear in token claims, this PR threads those two fields from the controller into `runSandboxChat`. If MYM-6's branch later merges, watch for overlap in `chat.controller.ts` / `sandbox-orchestration.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)