### PR TITLE
feat(daemon): implement docs manifest (MYM-9)

### DIFF
--- a/apps/sandbox-daemon/docs-manifest.test.ts
+++ b/apps/sandbox-daemon/docs-manifest.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+	existsSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	DOCS_MANIFEST_VERSION,
+	type DocsManifestEntry,
+	docsManifestPath,
+	emptyDocsManifest,
+	MalformedManifestError,
+	readDocsManifest,
+	upsertDocsManifestEntry,
+	writeDocsManifest,
+} from "./docs-manifest";
+
+let docsDir: string;
+
+beforeEach(() => {
+	docsDir = mkdtempSync(join(tmpdir(), "docs-manifest-test-"));
+});
+
+afterEach(() => {
+	rmSync(docsDir, { recursive: true, force: true });
+});
+
+function entry(overrides: Partial<DocsManifestEntry> = {}): DocsManifestEntry {
+	return {
+		documentId: "doc-1",
+		title: "First Doc",
+		localPath: "doc-1.md",
+		source: "kb",
+		hydratedAt: "2026-06-16T00:00:00.000Z",
+		runId: "run-1",
+		...overrides,
+	};
+}
+
+describe("readDocsManifest", () => {
+	it("returns an empty manifest when the file is missing", () => {
+		const manifest = readDocsManifest(docsDir);
+		expect(manifest).toEqual(emptyDocsManifest());
+		expect(manifest.documents).toEqual([]);
+		// Reading must not create the file.
+		expect(existsSync(docsManifestPath(docsDir))).toBe(false);
+	});
+
+	it("reads and preserves an existing manifest", () => {
+		const original = emptyDocsManifest();
+		original.documents.push(
+			entry(),
+			entry({ documentId: "doc-2", title: "Second" }),
+		);
+		writeDocsManifest(docsDir, original);
+
+		const read = readDocsManifest(docsDir);
+		expect(read).toEqual(original);
+	});
+
+	it("throws on invalid JSON", () => {
+		writeFileSync(docsManifestPath(docsDir), "{ not json", "utf8");
+		expect(() => readDocsManifest(docsDir)).toThrow(MalformedManifestError);
+	});
+
+	it("throws on a non-object root", () => {
+		writeFileSync(docsManifestPath(docsDir), "[]", "utf8");
+		expect(() => readDocsManifest(docsDir)).toThrow(/expected a JSON object/);
+	});
+
+	it("throws on an unsupported version", () => {
+		writeFileSync(
+			docsManifestPath(docsDir),
+			JSON.stringify({ version: 999, documents: [] }),
+			"utf8",
+		);
+		expect(() => readDocsManifest(docsDir)).toThrow(/unsupported version/);
+	});
+
+	it("throws when documents is not an array", () => {
+		writeFileSync(
+			docsManifestPath(docsDir),
+			JSON.stringify({ version: DOCS_MANIFEST_VERSION, documents: {} }),
+			"utf8",
+		);
+		expect(() => readDocsManifest(docsDir)).toThrow(
+			/`documents` must be an array/,
+		);
+	});
+
+	it("throws on an entry missing required fields", () => {
+		writeFileSync(
+			docsManifestPath(docsDir),
+			JSON.stringify({
+				version: DOCS_MANIFEST_VERSION,
+				documents: [{ documentId: "doc-1", title: "no paths" }],
+			}),
+			"utf8",
+		);
+		expect(() => readDocsManifest(docsDir)).toThrow(/invalid entry at index 0/);
+	});
+});
+
+describe("writeDocsManifest", () => {
+	it("creates the manifest file when missing", () => {
+		expect(existsSync(docsManifestPath(docsDir))).toBe(false);
+		writeDocsManifest(docsDir, emptyDocsManifest());
+		expect(existsSync(docsManifestPath(docsDir))).toBe(true);
+	});
+
+	it("writes pretty-printed JSON that round-trips", () => {
+		const manifest = emptyDocsManifest();
+		manifest.documents.push(entry());
+		writeDocsManifest(docsDir, manifest);
+
+		const raw = readFileSync(docsManifestPath(docsDir), "utf8");
+		expect(raw).toContain("\n");
+		expect(JSON.parse(raw)).toEqual(manifest);
+	});
+
+	it("leaves no temp file behind", () => {
+		writeDocsManifest(docsDir, emptyDocsManifest());
+		expect(existsSync(`${docsManifestPath(docsDir)}.tmp`)).toBe(false);
+	});
+});
+
+describe("upsertDocsManifestEntry", () => {
+	it("creates the manifest and appends on first write", () => {
+		const manifest = upsertDocsManifestEntry(docsDir, entry());
+		expect(manifest.documents).toEqual([entry()]);
+		expect(readDocsManifest(docsDir)).toEqual(manifest);
+	});
+
+	it("replaces an existing entry by documentId without duplicating", () => {
+		upsertDocsManifestEntry(docsDir, entry());
+		const updated = upsertDocsManifestEntry(
+			docsDir,
+			entry({
+				title: "Updated",
+				hydratedAt: "2026-06-17T00:00:00.000Z",
+				runId: "run-2",
+			}),
+		);
+		expect(updated.documents).toHaveLength(1);
+		expect(updated.documents[0]).toMatchObject({
+			documentId: "doc-1",
+			title: "Updated",
+			runId: "run-2",
+		});
+	});
+
+	it("preserves other entries when upserting", () => {
+		upsertDocsManifestEntry(docsDir, entry());
+		const updated = upsertDocsManifestEntry(
+			docsDir,
+			entry({ documentId: "doc-2" }),
+		);
+		expect(updated.documents.map((d) => d.documentId).sort()).toEqual([
+			"doc-1",
+			"doc-2",
+		]);
+	});
+});

--- a/apps/sandbox-daemon/docs-manifest.ts
+++ b/apps/sandbox-daemon/docs-manifest.ts
@@ -1,0 +1,163 @@
+/**
+ * Docs manifest. Each conversation workspace tracks the documents hydrated into
+ * its `docs/` directory in a single `manifest.json`:
+ *
+ *   /workspace/conversations/{conversationId}/docs/
+ *     manifest.json   <- this file
+ *     {hydrated documents...}
+ *
+ * The manifest is the durable record of what the working set contains: for each
+ * hydrated document it stores its id, title, local path, source, the time it was
+ * hydrated or last updated, and the run that caused the hydration.
+ *
+ * Two correctness properties matter here:
+ *   - Reads fail closed. A manifest that is present but unparseable is a signal
+ *     that something corrupted the workspace; we throw rather than silently
+ *     treating it as empty and overwriting whatever was there.
+ *   - Writes are atomic. We write to a temp file in the same directory and
+ *     rename it into place, so a crash mid-write can never leave a half-written
+ *     `manifest.json` behind.
+ */
+
+import { readFileSync, renameSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+/** Current on-disk schema version. Bumped only on a breaking format change. */
+export const DOCS_MANIFEST_VERSION = 1;
+
+const MANIFEST_FILENAME = "manifest.json";
+
+export interface DocsManifestEntry {
+	/** Remote document id (stable across hydrations). */
+	documentId: string;
+	/** Human-readable title from the source. */
+	title: string;
+	/** Path to the hydrated file, relative to the `docs/` directory. */
+	localPath: string;
+	/** Where the document came from (e.g. the gateway document source). */
+	source: string;
+	/** ISO-8601 time the document was hydrated or last updated. */
+	hydratedAt: string;
+	/** The run that caused this hydration. */
+	runId: string;
+}
+
+export interface DocsManifest {
+	version: typeof DOCS_MANIFEST_VERSION;
+	documents: DocsManifestEntry[];
+}
+
+/** Raised when a manifest file exists but cannot be parsed or validated. */
+export class MalformedManifestError extends Error {
+	constructor(message: string) {
+		super(`Malformed docs manifest: ${message}`);
+		this.name = "MalformedManifestError";
+	}
+}
+
+/** Path to the manifest file inside a conversation's `docs/` directory. */
+export function docsManifestPath(docsDir: string): string {
+	return join(docsDir, MANIFEST_FILENAME);
+}
+
+/** A fresh, empty manifest. */
+export function emptyDocsManifest(): DocsManifest {
+	return { version: DOCS_MANIFEST_VERSION, documents: [] };
+}
+
+function isManifestEntry(value: unknown): value is DocsManifestEntry {
+	if (typeof value !== "object" || value === null) return false;
+	const e = value as Record<string, unknown>;
+	return (
+		typeof e.documentId === "string" &&
+		typeof e.title === "string" &&
+		typeof e.localPath === "string" &&
+		typeof e.source === "string" &&
+		typeof e.hydratedAt === "string" &&
+		typeof e.runId === "string"
+	);
+}
+
+function parseManifest(raw: string): DocsManifest {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch (cause) {
+		throw new MalformedManifestError(
+			`invalid JSON (${(cause as Error).message})`,
+		);
+	}
+	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+		throw new MalformedManifestError("expected a JSON object");
+	}
+	const obj = parsed as Record<string, unknown>;
+	if (obj.version !== DOCS_MANIFEST_VERSION) {
+		throw new MalformedManifestError(
+			`unsupported version ${JSON.stringify(obj.version)}`,
+		);
+	}
+	if (!Array.isArray(obj.documents)) {
+		throw new MalformedManifestError("`documents` must be an array");
+	}
+	for (const [i, entry] of obj.documents.entries()) {
+		if (!isManifestEntry(entry)) {
+			throw new MalformedManifestError(`invalid entry at index ${i}`);
+		}
+	}
+	return { version: DOCS_MANIFEST_VERSION, documents: obj.documents };
+}
+
+/**
+ * Read the manifest from a conversation's `docs/` directory.
+ *
+ * Returns an empty manifest if the file does not exist yet (a missing manifest
+ * is a valid empty working set). Throws {@link MalformedManifestError} if the
+ * file exists but is unparseable, so callers fail closed instead of clobbering
+ * a corrupt-but-meaningful file.
+ */
+export function readDocsManifest(docsDir: string): DocsManifest {
+	let raw: string;
+	try {
+		raw = readFileSync(docsManifestPath(docsDir), "utf8");
+	} catch (cause) {
+		if ((cause as NodeJS.ErrnoException).code === "ENOENT") {
+			return emptyDocsManifest();
+		}
+		throw cause;
+	}
+	return parseManifest(raw);
+}
+
+/**
+ * Atomically write a manifest into a conversation's `docs/` directory. Writes a
+ * sibling temp file and renames it into place so a partial write can never be
+ * observed as `manifest.json`. The `docs/` directory must already exist.
+ */
+export function writeDocsManifest(
+	docsDir: string,
+	manifest: DocsManifest,
+): void {
+	const target = docsManifestPath(docsDir);
+	const tmp = `${target}.tmp`;
+	writeFileSync(tmp, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+	renameSync(tmp, target);
+}
+
+/**
+ * Read the manifest, insert or replace the entry for `entry.documentId`, and
+ * write it back atomically. Re-hydrating a document updates its existing entry
+ * in place rather than appending a duplicate. Returns the updated manifest.
+ */
+export function upsertDocsManifestEntry(
+	docsDir: string,
+	entry: DocsManifestEntry,
+): DocsManifest {
+	const manifest = readDocsManifest(docsDir);
+	const documents = manifest.documents.filter(
+		(d) => d.documentId !== entry.documentId,
+	);
+	documents.push(entry);
+	const updated: DocsManifest = { version: DOCS_MANIFEST_VERSION, documents };
+	writeDocsManifest(docsDir, updated);
+	return updated;
+}

--- a/apps/sandbox-daemon/docs-manifest.ts
+++ b/apps/sandbox-daemon/docs-manifest.ts
@@ -15,11 +15,13 @@
  *     that something corrupted the workspace; we throw rather than silently
  *     treating it as empty and overwriting whatever was there.
  *   - Writes are atomic. We write to a temp file in the same directory and
- *     rename it into place, so a crash mid-write can never leave a half-written
- *     `manifest.json` behind.
+ *     rename it into place, so a reader never observes a half-written
+ *     `manifest.json`: it sees either the old file or the complete new one.
+ *     (This guards against torn writes, not against power-loss durability —
+ *     the bytes are not fsync'd before the rename.)
  */
 
-import { readFileSync, renameSync, writeFileSync } from "node:fs";
+import { readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 /** Current on-disk schema version. Bumped only on a breaking format change. */
@@ -139,8 +141,14 @@ export function writeDocsManifest(
 ): void {
 	const target = docsManifestPath(docsDir);
 	const tmp = `${target}.tmp`;
-	writeFileSync(tmp, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
-	renameSync(tmp, target);
+	try {
+		writeFileSync(tmp, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+		renameSync(tmp, target);
+	} catch (cause) {
+		// Don't leave a partial temp file behind on a failed write (e.g. ENOSPC).
+		rmSync(tmp, { force: true });
+		throw cause;
+	}
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements **MYM-9 / Task 5: Implement docs manifest** (Milestone 2: Workspace Layout And Manifests).

Adds `docs/manifest.json` support for documents hydrated into a conversation's sandbox workspace (`/workspace/conversations/{conversationId}/docs/`). Each manifest entry tracks the fields the plan requires: `documentId`, `title`, `localPath`, `source`, `hydratedAt`, and the `runId` that caused hydration.

New module `apps/sandbox-daemon/docs-manifest.ts`:

- **`readDocsManifest(docsDir)`** — returns an empty manifest when the file is missing (a missing manifest is a valid empty working set); throws `MalformedManifestError` when the file exists but is unparseable/invalid, so callers **fail closed** instead of clobbering a corrupt-but-meaningful file.
- **`writeDocsManifest(docsDir, manifest)`** — **atomic** write via sibling temp file + `renameSync`, so a crash mid-write can never leave a half-written `manifest.json`.
- **`upsertDocsManifestEntry(docsDir, entry)`** — read-modify-write that replaces an existing entry by `documentId` (no duplicates) and preserves the rest. This is the write primitive `search_documents` (Task 7) will use.

Validation is strict: top-level object, supported `version`, `documents` array, and every entry shape-checked.

## Acceptance criteria → coverage

| Criterion | Where |
|---|---|
| Manifest is created when missing | `writeDocsManifest` / `upsertDocsManifestEntry` first write; tested |
| Existing manifests read and preserved | `readDocsManifest` round-trip + upsert-preserves tests |
| Malformed manifests fail closed with a clear error | `MalformedManifestError`; invalid-JSON / non-object / bad-version / bad-entry tests |
| Writes avoid corrupt partial output | temp-file + rename; "leaves no temp file behind" test |
| Unit tests cover empty, existing, malformed | 13 tests in `docs-manifest.test.ts` |

## Tests run

- `bun test docs-manifest.test.ts` → **13 pass / 0 fail**
- `bun run check` (biome) → clean

Pre-existing unrelated failure: `routes/turn.integration.test.ts` cannot resolve the `hono` package because dependencies are not installed in this worktree. Independent of this change (the new module imports only `node:fs`/`node:path`).

## Remaining risk / follow-ups

- Module is not yet wired into the daemon turn flow — it is consumed by **MYM-11 (Task 7: search_documents)** and surfaced through the `WorkspaceStore` abstraction in **MYM-10 (Task 6)**, which this issue blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)