### PR TITLE
feat(chat-api): durable workspace store interface (MYM-10)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,6 +160,7 @@ Optional:
 - `LOG_LEVEL` (default: `info`)
 - `PORT` (default: 3000)
 - `E2B_TEMPLATE` (default: `sandbox-template-dev`)
+- `WORKSPACE_STORE_ROOT` — root dir of the durable workspace store (local filesystem `WorkspaceStore` adapter). Holds per-user/per-conversation work, output, and the docs manifest, plus per-run event logs, following the path model `users/{userId}/conversations/{conversationId}/…` and `users/{userId}/runs/{runId}/events.jsonl`. Defaults to `.workspace-store` under the process cwd (writable in the container). **For durability across container recycles, point this at a mounted persistent volume in production**
 
 ### gateway
 

--- a/apps/chat-api/.dockerignore
+++ b/apps/chat-api/.dockerignore
@@ -13,3 +13,4 @@ helm-charts
 .editorconfig
 .idea
 coverage*
+.workspace-store

--- a/apps/chat-api/.gitignore
+++ b/apps/chat-api/.gitignore
@@ -10,6 +10,9 @@ dist
 build
 .next
 
+# Default durable workspace store root (WORKSPACE_STORE_ROOT)
+.workspace-store
+
 # Generated: bundled mymemo-docs CLI (source is sandbox-template/mymemo-docs.ts)
 sandbox-template/mymemo-docs
 .turbo

--- a/apps/chat-api/Dockerfile
+++ b/apps/chat-api/Dockerfile
@@ -45,6 +45,10 @@ COPY --from=prerelease /usr/src/app/packages/llm-token packages/llm-token
 COPY --from=prerelease /usr/src/app/package.json .
 
 WORKDIR /usr/src/app/apps/chat-api
+# Default durable workspace store root (WORKSPACE_STORE_ROOT). Created and owned
+# by the `bun` user so the local filesystem adapter can write out of the box;
+# mount a persistent volume here in production for durability across recycles.
+RUN mkdir -p .workspace-store && chown -R bun:bun .workspace-store
 USER bun
 EXPOSE 3000/tcp
 ENTRYPOINT [ "bun", "run", "src/index.ts" ]

--- a/apps/chat-api/src/config/env.ts
+++ b/apps/chat-api/src/config/env.ts
@@ -11,6 +11,18 @@ export const apiEnv = (() => {
 	invariant(Bun.env.LLM_TOKEN_SECRET, "LLM_TOKEN_SECRET is required");
 	invariant(Bun.env.GATEWAY_PUBLIC_URL, "GATEWAY_PUBLIC_URL is required");
 
+	// Durable workspace store root. Optional with a writable fallback so it works
+	// out of the box, but the fallback is process-local and lost on container
+	// recycle — warn loudly so a missing volume mount in production surfaces here
+	// instead of as silent data loss.
+	const workspaceStoreRoot =
+		Bun.env.WORKSPACE_STORE_ROOT || join(process.cwd(), ".workspace-store");
+	if (!Bun.env.WORKSPACE_STORE_ROOT) {
+		console.warn(
+			`WORKSPACE_STORE_ROOT is not set; durable workspace state will be written to ${workspaceStoreRoot} and will NOT survive container recycles. Set it to a mounted persistent volume in production.`,
+		);
+	}
+
 	return {
 		DAEMON_AUTH_TOKEN: Bun.env.DAEMON_AUTH_TOKEN,
 		// HMAC secret for the session tokens minted into each sandbox turn. Shared
@@ -30,8 +42,7 @@ export const apiEnv = (() => {
 		// box (in the container the cwd is the app dir, which is writable by the
 		// `bun` user); in production point this at a mounted persistent volume so
 		// durable conversation and run state survives container recycles.
-		WORKSPACE_STORE_ROOT:
-			Bun.env.WORKSPACE_STORE_ROOT || join(process.cwd(), ".workspace-store"),
+		WORKSPACE_STORE_ROOT: workspaceStoreRoot,
 	} as const;
 })();
 

--- a/apps/chat-api/src/config/env.ts
+++ b/apps/chat-api/src/config/env.ts
@@ -24,6 +24,10 @@ export const apiEnv = (() => {
 		GATEWAY_PUBLIC_URL: Bun.env.GATEWAY_PUBLIC_URL.replace(/\/+$/, ""),
 		LOG_LEVEL: Bun.env.LOG_LEVEL || "info",
 		E2B_TEMPLATE: Bun.env.E2B_TEMPLATE || "sandbox-template-dev",
+		// Root directory of the durable workspace store (local filesystem adapter).
+		// Mount a persistent volume here in production; durable conversation and run
+		// state lives under it following the `WorkspaceStore` path model.
+		WORKSPACE_STORE_ROOT: Bun.env.WORKSPACE_STORE_ROOT || "/workspace-store",
 	} as const;
 })();
 

--- a/apps/chat-api/src/config/env.ts
+++ b/apps/chat-api/src/config/env.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import invariant from "tiny-invariant";
 
 /**
@@ -25,9 +26,12 @@ export const apiEnv = (() => {
 		LOG_LEVEL: Bun.env.LOG_LEVEL || "info",
 		E2B_TEMPLATE: Bun.env.E2B_TEMPLATE || "sandbox-template-dev",
 		// Root directory of the durable workspace store (local filesystem adapter).
-		// Mount a persistent volume here in production; durable conversation and run
-		// state lives under it following the `WorkspaceStore` path model.
-		WORKSPACE_STORE_ROOT: Bun.env.WORKSPACE_STORE_ROOT || "/workspace-store",
+		// Defaults to a writable dir under the process cwd so it works out of the
+		// box (in the container the cwd is the app dir, which is writable by the
+		// `bun` user); in production point this at a mounted persistent volume so
+		// durable conversation and run state survives container recycles.
+		WORKSPACE_STORE_ROOT:
+			Bun.env.WORKSPACE_STORE_ROOT || join(process.cwd(), ".workspace-store"),
 	} as const;
 })();
 

--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-orchestration.test.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-orchestration.test.ts
@@ -48,10 +48,13 @@ describe("runSandboxChat", () => {
 	let runSandboxChat: typeof import("./sandbox-orchestration").runSandboxChat;
 	let singletonModule: typeof import("./singleton");
 	let proxyModule: typeof import("./sandbox-proxy");
+	let workspaceStoreModule: typeof import("@/features/workspace-store");
 	let spyCreate: ReturnType<typeof spyOn>;
 	let spyEnsureDaemon: ReturnType<typeof spyOn>;
 	let spyForwardTurn: ReturnType<typeof spyOn>;
 	let spyKill: ReturnType<typeof spyOn>;
+	let spyHydrate: ReturnType<typeof spyOn>;
+	let spySync: ReturnType<typeof spyOn>;
 
 	beforeEach(async () => {
 		Bun.env.E2B_API_KEY = "test-e2b-key";
@@ -61,6 +64,26 @@ describe("runSandboxChat", () => {
 		({ runSandboxChat } = await import("./sandbox-orchestration"));
 		singletonModule = await import("./singleton");
 		proxyModule = await import("./sandbox-proxy");
+		workspaceStoreModule = await import("@/features/workspace-store");
+
+		// Keep the durable store off the filesystem for orchestration tests; the
+		// store itself is exercised in workspace-store tests.
+		spyHydrate = spyOn(
+			workspaceStoreModule.workspaceStore,
+			"hydrateConversationWorkspace",
+		).mockResolvedValue({
+			paths: {
+				conversation: "/tmp/conv",
+				work: "/tmp/conv/work",
+				output: "/tmp/conv/output",
+				docs: "/tmp/conv/docs",
+			},
+			docsManifest: { version: 1, documents: [] },
+		});
+		spySync = spyOn(
+			workspaceStoreModule.workspaceStore,
+			"syncConversationWorkspace",
+		).mockResolvedValue(undefined);
 
 		const sandbox = createMockSandbox();
 		spyCreate = spyOn(
@@ -85,6 +108,8 @@ describe("runSandboxChat", () => {
 		spyEnsureDaemon?.mockRestore();
 		spyForwardTurn?.mockRestore();
 		spyKill?.mockRestore();
+		spyHydrate?.mockRestore();
+		spySync?.mockRestore();
 		mock.restore();
 	});
 
@@ -320,6 +345,80 @@ describe("runSandboxChat", () => {
 		await runSandboxChat(
 			makeOptions({ scope: "document", summaryId: "sum-1" }),
 		);
+	});
+
+	it("hydrates the durable workspace before forwarding the turn", async () => {
+		const order: string[] = [];
+		spyHydrate.mockImplementation(async () => {
+			order.push("hydrate");
+			return {
+				paths: {
+					conversation: "/tmp/conv",
+					work: "/tmp/conv/work",
+					output: "/tmp/conv/output",
+					docs: "/tmp/conv/docs",
+				},
+				docsManifest: { version: 1, documents: [] },
+			};
+		});
+		spyForwardTurn = spyOn(
+			proxyModule,
+			"forwardChatTurnToSandbox",
+		).mockImplementation(async () => {
+			order.push("forward");
+		});
+
+		await runSandboxChat(
+			makeOptions({ userId: "user-1", conversationId: "conv-1" }),
+		);
+
+		expect(spyHydrate).toHaveBeenCalledWith({
+			userId: "user-1",
+			conversationId: "conv-1",
+		});
+		expect(order).toEqual(["hydrate", "forward"]);
+	});
+
+	it("syncs the durable workspace after a successful turn", async () => {
+		spyForwardTurn = spyOn(
+			proxyModule,
+			"forwardChatTurnToSandbox",
+		).mockResolvedValue(undefined);
+
+		await runSandboxChat(
+			makeOptions({ userId: "user-1", conversationId: "conv-1" }),
+		);
+
+		expect(spySync).toHaveBeenCalledWith({
+			userId: "user-1",
+			conversationId: "conv-1",
+		});
+	});
+
+	it("syncs the durable workspace even when the turn fails", async () => {
+		spyForwardTurn = spyOn(
+			proxyModule,
+			"forwardChatTurnToSandbox",
+		).mockRejectedValue(new Error("daemon unreachable"));
+
+		await expect(runSandboxChat(makeOptions())).rejects.toThrow(
+			"daemon unreachable",
+		);
+
+		expect(spySync).toHaveBeenCalled();
+	});
+
+	it("does not let a sync failure mask the turn result or skip teardown", async () => {
+		spyForwardTurn = spyOn(
+			proxyModule,
+			"forwardChatTurnToSandbox",
+		).mockResolvedValue(undefined);
+		spySync.mockRejectedValue(new Error("durable store down"));
+
+		const result = await runSandboxChat(makeOptions());
+
+		expect(result).toEqual({ status: "completed" });
+		expect(spyKill).toHaveBeenCalled();
 	});
 
 	it("propagates proxy errors", async () => {

--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-orchestration.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-orchestration.ts
@@ -2,6 +2,7 @@ import { type LlmTokenClaims, mintLlmToken } from "@mymemo/llm-token";
 import { apiEnv, type ChatMessagesScope } from "@/config/env";
 import type { ChatLogger } from "@/features/chat/chat.logger";
 import { buildSandboxAgentPrompt } from "@/features/sandbox-agent";
+import { workspaceStore } from "@/features/workspace-store";
 import { SandboxCreationError } from "./errors";
 import { forwardChatTurnToSandbox, type TurnRequest } from "./sandbox-proxy";
 import { sandboxManager } from "./singleton";
@@ -62,6 +63,14 @@ export async function runSandboxChat(
 	});
 
 	const attempt = async () => {
+		// Prepare the durable workspace before the run. Done before leasing a
+		// sandbox so the durable layout and working-set manifest exist regardless
+		// of whether the sandbox comes up.
+		await workspaceStore.hydrateConversationWorkspace({
+			userId,
+			conversationId,
+		});
+
 		const sandbox = await sandboxManager.createSandbox(userId, logger);
 
 		// Sandboxes are ephemeral — one per turn — so they must be torn down when
@@ -145,6 +154,23 @@ export async function runSandboxChat(
 
 			return { status: "completed" } as const;
 		} finally {
+			// A sandbox was leased, so persist the durable workspace whether the
+			// turn succeeded, failed, or was canceled. A sync failure must not mask
+			// the turn's own outcome, and the sandbox must still be torn down.
+			try {
+				await workspaceStore.syncConversationWorkspace({
+					userId,
+					conversationId,
+				});
+			} catch (syncErr) {
+				logger.error({
+					msg: "Workspace sync failed",
+					userId,
+					conversationId,
+					runId,
+					error: syncErr instanceof Error ? syncErr.message : String(syncErr),
+				});
+			}
 			await sandboxManager.killSandbox(userId, sandbox, logger);
 		}
 	};

--- a/apps/chat-api/src/features/workspace-store/docs-manifest.ts
+++ b/apps/chat-api/src/features/workspace-store/docs-manifest.ts
@@ -1,0 +1,141 @@
+/**
+ * Durable docs manifest. This is the chat-api-side view of the same
+ * `manifest.json` the sandbox-daemon maintains inside each conversation's
+ * `docs/` directory (see `apps/sandbox-daemon/docs-manifest.ts` — that file is
+ * the source of truth for the on-disk format). The durable store keeps its own
+ * copy under `users/{userId}/conversations/{conversationId}/docs/manifest.json`
+ * so the working set survives a sandbox being torn down.
+ *
+ * The same two correctness properties as the daemon apply:
+ *   - Reads fail closed. A present-but-unparseable manifest throws rather than
+ *     being silently treated as empty and overwritten.
+ *   - Writes are atomic. We write a sibling temp file and rename it into place,
+ *     so a reader never observes a half-written `manifest.json`.
+ */
+
+import { readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+/** Current on-disk schema version. Must match the daemon's manifest version. */
+export const DOCS_MANIFEST_VERSION = 1;
+
+const MANIFEST_FILENAME = "manifest.json";
+
+export interface DocsManifestEntry {
+	/** Remote document id (stable across hydrations). */
+	documentId: string;
+	/** Human-readable title from the source. */
+	title: string;
+	/** Path to the hydrated file, relative to the `docs/` directory. */
+	localPath: string;
+	/** Where the document came from (e.g. the gateway document source). */
+	source: string;
+	/** ISO-8601 time the document was hydrated or last updated. */
+	hydratedAt: string;
+	/** The run that caused this hydration. */
+	runId: string;
+}
+
+export interface DocsManifest {
+	version: typeof DOCS_MANIFEST_VERSION;
+	documents: DocsManifestEntry[];
+}
+
+/** Raised when a manifest file exists but cannot be parsed or validated. */
+export class MalformedManifestError extends Error {
+	constructor(message: string) {
+		super(`Malformed docs manifest: ${message}`);
+		this.name = "MalformedManifestError";
+	}
+}
+
+/** Path to the manifest file inside a `docs/` directory. */
+export function docsManifestPath(docsDir: string): string {
+	return join(docsDir, MANIFEST_FILENAME);
+}
+
+/** A fresh, empty manifest. */
+export function emptyDocsManifest(): DocsManifest {
+	return { version: DOCS_MANIFEST_VERSION, documents: [] };
+}
+
+function isManifestEntry(value: unknown): value is DocsManifestEntry {
+	if (typeof value !== "object" || value === null) return false;
+	const e = value as Record<string, unknown>;
+	return (
+		typeof e.documentId === "string" &&
+		typeof e.title === "string" &&
+		typeof e.localPath === "string" &&
+		typeof e.source === "string" &&
+		typeof e.hydratedAt === "string" &&
+		typeof e.runId === "string"
+	);
+}
+
+function parseManifest(raw: string): DocsManifest {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch (cause) {
+		throw new MalformedManifestError(
+			`invalid JSON (${(cause as Error).message})`,
+		);
+	}
+	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+		throw new MalformedManifestError("expected a JSON object");
+	}
+	const obj = parsed as Record<string, unknown>;
+	if (obj.version !== DOCS_MANIFEST_VERSION) {
+		throw new MalformedManifestError(
+			`unsupported version ${JSON.stringify(obj.version)}`,
+		);
+	}
+	if (!Array.isArray(obj.documents)) {
+		throw new MalformedManifestError("`documents` must be an array");
+	}
+	for (const [i, entry] of obj.documents.entries()) {
+		if (!isManifestEntry(entry)) {
+			throw new MalformedManifestError(`invalid entry at index ${i}`);
+		}
+	}
+	return { version: DOCS_MANIFEST_VERSION, documents: obj.documents };
+}
+
+/**
+ * Read the manifest from a `docs/` directory. Returns an empty manifest if the
+ * file does not exist yet (a missing manifest is a valid empty working set).
+ * Throws {@link MalformedManifestError} if the file exists but is unparseable.
+ */
+export function readDocsManifest(docsDir: string): DocsManifest {
+	let raw: string;
+	try {
+		raw = readFileSync(docsManifestPath(docsDir), "utf8");
+	} catch (cause) {
+		if ((cause as NodeJS.ErrnoException).code === "ENOENT") {
+			return emptyDocsManifest();
+		}
+		throw cause;
+	}
+	return parseManifest(raw);
+}
+
+/**
+ * Atomically write a manifest into a `docs/` directory. Writes a sibling temp
+ * file and renames it into place so a partial write can never be observed as
+ * `manifest.json`. The `docs/` directory must already exist.
+ */
+export function writeDocsManifest(
+	docsDir: string,
+	manifest: DocsManifest,
+): void {
+	const target = docsManifestPath(docsDir);
+	const tmp = `${target}.tmp`;
+	try {
+		writeFileSync(tmp, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+		renameSync(tmp, target);
+	} catch (cause) {
+		// Don't leave a partial temp file behind on a failed write (e.g. ENOSPC).
+		rmSync(tmp, { force: true });
+		throw cause;
+	}
+}

--- a/apps/chat-api/src/features/workspace-store/index.ts
+++ b/apps/chat-api/src/features/workspace-store/index.ts
@@ -1,0 +1,20 @@
+export {
+	DOCS_MANIFEST_VERSION,
+	type DocsManifest,
+	type DocsManifestEntry,
+	emptyDocsManifest,
+	MalformedManifestError,
+} from "./docs-manifest";
+export {
+	createLocalWorkspaceStore,
+	LocalWorkspaceStore,
+} from "./local-workspace-store";
+export type { DurableConversationPaths } from "./paths";
+export { workspaceStore } from "./singleton";
+export type {
+	ConversationRef,
+	HydrateResult,
+	RunEvent,
+	RunRef,
+	WorkspaceStore,
+} from "./workspace-store";

--- a/apps/chat-api/src/features/workspace-store/local-workspace-store.test.ts
+++ b/apps/chat-api/src/features/workspace-store/local-workspace-store.test.ts
@@ -7,12 +7,13 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, sep } from "node:path";
 import { type DocsManifest, MalformedManifestError } from "./docs-manifest";
 import {
 	createLocalWorkspaceStore,
 	type LocalWorkspaceStore,
 } from "./local-workspace-store";
+import { encodeUserSegment } from "./paths";
 
 let root: string;
 let store: LocalWorkspaceStore;
@@ -37,7 +38,13 @@ describe("LocalWorkspaceStore durable path model", () => {
 			conversationId: "conv-1",
 		});
 
-		const base = join(root, "users", "user-1", "conversations", "conv-1");
+		const base = join(
+			root,
+			"users",
+			encodeUserSegment("user-1"),
+			"conversations",
+			"conv-1",
+		);
 		expect(paths.conversation).toBe(base);
 		expect(paths.work).toBe(join(base, "work"));
 		expect(paths.output).toBe(join(base, "output"));
@@ -69,7 +76,13 @@ describe("LocalWorkspaceStore durable path model", () => {
 	it("sync ensures the durable layout exists", async () => {
 		const ref = { userId: "user-1", conversationId: "conv-1" };
 		await store.syncConversationWorkspace(ref);
-		const base = join(root, "users", "user-1", "conversations", "conv-1");
+		const base = join(
+			root,
+			"users",
+			encodeUserSegment("user-1"),
+			"conversations",
+			"conv-1",
+		);
 		expect(existsSync(join(base, "work"))).toBe(true);
 		expect(existsSync(join(base, "output"))).toBe(true);
 		expect(existsSync(join(base, "docs"))).toBe(true);
@@ -81,7 +94,7 @@ describe("LocalWorkspaceStore durable path model", () => {
 		const manifestPath = join(
 			root,
 			"users",
-			"user-1",
+			encodeUserSegment("user-1"),
 			"conversations",
 			"conv-1",
 			"docs",
@@ -95,7 +108,14 @@ describe("LocalWorkspaceStore durable path model", () => {
 		await store.appendRunEvent(ref, { type: "run_started" });
 		await store.appendRunEvent(ref, { type: "run_completed", ok: true });
 
-		const file = join(root, "users", "user-1", "runs", "run-1", "events.jsonl");
+		const file = join(
+			root,
+			"users",
+			encodeUserSegment("user-1"),
+			"runs",
+			"run-1",
+			"events.jsonl",
+		);
 		const lines = readFileSync(file, "utf8").trim().split("\n");
 		expect(lines.map((l) => JSON.parse(l))).toEqual([
 			{ type: "run_started" },
@@ -115,8 +135,12 @@ describe("LocalWorkspaceStore isolation and traversal", () => {
 			conversationId: "conv-1",
 		});
 		expect(a.paths.conversation).not.toBe(b.paths.conversation);
-		expect(a.paths.conversation).toContain(join("users", "user-a"));
-		expect(b.paths.conversation).toContain(join("users", "user-b"));
+		expect(a.paths.conversation).toContain(
+			join("users", encodeUserSegment("user-a")),
+		);
+		expect(b.paths.conversation).toContain(
+			join("users", encodeUserSegment("user-b")),
+		);
 	});
 
 	it("keeps different conversations in separate trees for the same user", async () => {
@@ -151,18 +175,11 @@ describe("LocalWorkspaceStore isolation and traversal", () => {
 		expect(other.documents).toEqual([]);
 	});
 
-	const traversalIds = ["../evil", "..", "a/b", "a\0b", "with space", ""];
+	// conversationId and runId are chat-api-allocated in a known-safe shape, so a
+	// malformed value is rejected outright.
+	const unsafeIds = ["../evil", "..", "a/b", "a\0b", "with space", ""];
 
-	for (const bad of traversalIds) {
-		it(`rejects traversal-prone userId ${JSON.stringify(bad)}`, async () => {
-			await expect(
-				store.hydrateConversationWorkspace({
-					userId: bad,
-					conversationId: "conv-1",
-				}),
-			).rejects.toThrow(/Invalid userId/);
-		});
-
+	for (const bad of unsafeIds) {
 		it(`rejects traversal-prone conversationId ${JSON.stringify(bad)}`, async () => {
 			await expect(
 				store.hydrateConversationWorkspace({
@@ -179,13 +196,56 @@ describe("LocalWorkspaceStore isolation and traversal", () => {
 		});
 	}
 
-	it("rejects an over-long id", async () => {
+	it("rejects an over-long conversationId", async () => {
 		await expect(
 			store.hydrateConversationWorkspace({
-				userId: "u".repeat(129),
+				userId: "user-1",
+				conversationId: "c".repeat(129),
+			}),
+		).rejects.toThrow(/Invalid conversationId/);
+	});
+
+	// userId is the caller-supplied member code (unconstrained charset/length),
+	// so it is hashed into a path-safe segment rather than rejected — except an
+	// empty id, which is never valid.
+	it("rejects an empty userId", async () => {
+		await expect(
+			store.hydrateConversationWorkspace({
+				userId: "",
 				conversationId: "conv-1",
 			}),
 		).rejects.toThrow(/Invalid userId/);
+	});
+
+	for (const bad of ["../evil", "..", "a/b", "a\0b", "with space"]) {
+		it(`neutralizes traversal-prone userId ${JSON.stringify(bad)} instead of escaping root`, async () => {
+			const { paths } = await store.hydrateConversationWorkspace({
+				userId: bad,
+				conversationId: "conv-1",
+			});
+			// The user segment is a hex hash containing no path separators, so the
+			// conversation dir stays strictly under <root>/users.
+			expect(paths.conversation.startsWith(join(root, "users") + sep)).toBe(
+				true,
+			);
+			expect(existsSync(paths.work)).toBe(true);
+		});
+	}
+
+	it("accepts a member-code userId that is not path-safe or over-long", async () => {
+		// e.g. an email-shaped member code, or one longer than a filesystem name
+		// limit — these worked end-to-end before the durable store existed.
+		const memberCode = `${"u".repeat(200)}@corp.com`;
+		const { paths } = await store.hydrateConversationWorkspace({
+			userId: memberCode,
+			conversationId: "conv-1",
+		});
+		expect(existsSync(paths.work)).toBe(true);
+		expect(encodeUserSegment(memberCode)).toMatch(/^[0-9a-f]{64}$/);
+	});
+
+	it("maps distinct member codes to distinct user segments", async () => {
+		expect(encodeUserSegment("user-a")).not.toBe(encodeUserSegment("user-b"));
 	});
 });
 

--- a/apps/chat-api/src/features/workspace-store/local-workspace-store.test.ts
+++ b/apps/chat-api/src/features/workspace-store/local-workspace-store.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+	existsSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type DocsManifest, MalformedManifestError } from "./docs-manifest";
+import {
+	createLocalWorkspaceStore,
+	type LocalWorkspaceStore,
+} from "./local-workspace-store";
+
+let root: string;
+let store: LocalWorkspaceStore;
+
+beforeEach(() => {
+	root = mkdtempSync(join(tmpdir(), "workspace-store-test-"));
+	store = createLocalWorkspaceStore(root) as LocalWorkspaceStore;
+});
+
+afterEach(() => {
+	rmSync(root, { recursive: true, force: true });
+});
+
+function manifest(documents: DocsManifest["documents"] = []): DocsManifest {
+	return { version: 1, documents };
+}
+
+describe("LocalWorkspaceStore durable path model", () => {
+	it("hydrate creates work, output, and docs under users/{userId}/conversations/{conversationId}", async () => {
+		const { paths, docsManifest } = await store.hydrateConversationWorkspace({
+			userId: "user-1",
+			conversationId: "conv-1",
+		});
+
+		const base = join(root, "users", "user-1", "conversations", "conv-1");
+		expect(paths.conversation).toBe(base);
+		expect(paths.work).toBe(join(base, "work"));
+		expect(paths.output).toBe(join(base, "output"));
+		expect(paths.docs).toBe(join(base, "docs"));
+		expect(existsSync(paths.work)).toBe(true);
+		expect(existsSync(paths.output)).toBe(true);
+		expect(existsSync(paths.docs)).toBe(true);
+		// A fresh conversation has an empty working set.
+		expect(docsManifest).toEqual(manifest());
+	});
+
+	it("hydrate is idempotent and preserves an existing manifest", async () => {
+		const ref = { userId: "user-1", conversationId: "conv-1" };
+		await store.hydrateConversationWorkspace(ref);
+		const entry = {
+			documentId: "doc-1",
+			title: "Doc 1",
+			localPath: "doc-1.md",
+			source: "kb",
+			hydratedAt: "2026-06-16T00:00:00.000Z",
+			runId: "run-1",
+		};
+		await store.writeDocsManifest(ref, manifest([entry]));
+
+		const { docsManifest } = await store.hydrateConversationWorkspace(ref);
+		expect(docsManifest.documents).toEqual([entry]);
+	});
+
+	it("sync ensures the durable layout exists", async () => {
+		const ref = { userId: "user-1", conversationId: "conv-1" };
+		await store.syncConversationWorkspace(ref);
+		const base = join(root, "users", "user-1", "conversations", "conv-1");
+		expect(existsSync(join(base, "work"))).toBe(true);
+		expect(existsSync(join(base, "output"))).toBe(true);
+		expect(existsSync(join(base, "docs"))).toBe(true);
+	});
+
+	it("writes the docs manifest at users/{userId}/conversations/{conversationId}/docs/manifest.json", async () => {
+		const ref = { userId: "user-1", conversationId: "conv-1" };
+		await store.writeDocsManifest(ref, manifest());
+		const manifestPath = join(
+			root,
+			"users",
+			"user-1",
+			"conversations",
+			"conv-1",
+			"docs",
+			"manifest.json",
+		);
+		expect(existsSync(manifestPath)).toBe(true);
+	});
+
+	it("appends run events as NDJSON at users/{userId}/runs/{runId}/events.jsonl", async () => {
+		const ref = { userId: "user-1", runId: "run-1" };
+		await store.appendRunEvent(ref, { type: "run_started" });
+		await store.appendRunEvent(ref, { type: "run_completed", ok: true });
+
+		const file = join(root, "users", "user-1", "runs", "run-1", "events.jsonl");
+		const lines = readFileSync(file, "utf8").trim().split("\n");
+		expect(lines.map((l) => JSON.parse(l))).toEqual([
+			{ type: "run_started" },
+			{ type: "run_completed", ok: true },
+		]);
+	});
+});
+
+describe("LocalWorkspaceStore isolation and traversal", () => {
+	it("keeps different users in separate trees", async () => {
+		const a = await store.hydrateConversationWorkspace({
+			userId: "user-a",
+			conversationId: "conv-1",
+		});
+		const b = await store.hydrateConversationWorkspace({
+			userId: "user-b",
+			conversationId: "conv-1",
+		});
+		expect(a.paths.conversation).not.toBe(b.paths.conversation);
+		expect(a.paths.conversation).toContain(join("users", "user-a"));
+		expect(b.paths.conversation).toContain(join("users", "user-b"));
+	});
+
+	it("keeps different conversations in separate trees for the same user", async () => {
+		const a = await store.hydrateConversationWorkspace({
+			userId: "user-1",
+			conversationId: "conv-a",
+		});
+		const b = await store.hydrateConversationWorkspace({
+			userId: "user-1",
+			conversationId: "conv-b",
+		});
+		expect(a.paths.conversation).not.toBe(b.paths.conversation);
+	});
+
+	it("does not leak one conversation's manifest into another", async () => {
+		const entry = {
+			documentId: "doc-1",
+			title: "Doc 1",
+			localPath: "doc-1.md",
+			source: "kb",
+			hydratedAt: "2026-06-16T00:00:00.000Z",
+			runId: "run-1",
+		};
+		await store.writeDocsManifest(
+			{ userId: "user-1", conversationId: "conv-a" },
+			manifest([entry]),
+		);
+		const other = await store.readDocsManifest({
+			userId: "user-1",
+			conversationId: "conv-b",
+		});
+		expect(other.documents).toEqual([]);
+	});
+
+	const traversalIds = ["../evil", "..", "a/b", "a\0b", "with space", ""];
+
+	for (const bad of traversalIds) {
+		it(`rejects traversal-prone userId ${JSON.stringify(bad)}`, async () => {
+			await expect(
+				store.hydrateConversationWorkspace({
+					userId: bad,
+					conversationId: "conv-1",
+				}),
+			).rejects.toThrow(/Invalid userId/);
+		});
+
+		it(`rejects traversal-prone conversationId ${JSON.stringify(bad)}`, async () => {
+			await expect(
+				store.hydrateConversationWorkspace({
+					userId: "user-1",
+					conversationId: bad,
+				}),
+			).rejects.toThrow(/Invalid conversationId/);
+		});
+
+		it(`rejects traversal-prone runId ${JSON.stringify(bad)}`, async () => {
+			await expect(
+				store.appendRunEvent({ userId: "user-1", runId: bad }, { type: "x" }),
+			).rejects.toThrow(/Invalid runId/);
+		});
+	}
+
+	it("rejects an over-long id", async () => {
+		await expect(
+			store.hydrateConversationWorkspace({
+				userId: "u".repeat(129),
+				conversationId: "conv-1",
+			}),
+		).rejects.toThrow(/Invalid userId/);
+	});
+});
+
+describe("LocalWorkspaceStore manifest read failure mode", () => {
+	it("fails closed on a corrupt manifest rather than returning empty", async () => {
+		const ref = { userId: "user-1", conversationId: "conv-1" };
+		const { paths } = await store.hydrateConversationWorkspace(ref);
+		writeFileSync(join(paths.docs, "manifest.json"), "{ not json", "utf8");
+
+		await expect(store.readDocsManifest(ref)).rejects.toThrow(
+			MalformedManifestError,
+		);
+	});
+});

--- a/apps/chat-api/src/features/workspace-store/local-workspace-store.ts
+++ b/apps/chat-api/src/features/workspace-store/local-workspace-store.ts
@@ -1,0 +1,89 @@
+/**
+ * Local filesystem adapter for {@link WorkspaceStore}. Stores durable workspace
+ * state under a single root directory following the durable path model in
+ * `paths.ts`. In production the root should be a mounted persistent volume; in
+ * tests it points at a temp dir.
+ *
+ * Scope note: `hydrate`/`sync` currently establish and preserve the durable
+ * layout and manifest. Copying the agent's `work/` and `output/` files between
+ * the sandbox and durable storage requires a sandbox file bridge that does not
+ * exist yet (the daemon proxy only streams events), so it is left to a later
+ * task. The abstraction and call sites are in place so that wiring is additive.
+ */
+
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import {
+	type DocsManifest,
+	readDocsManifest as readManifestFromDir,
+	writeDocsManifest as writeManifestToDir,
+} from "./docs-manifest";
+import {
+	resolveDurableConversationPaths,
+	resolveDurableRunEventsPath,
+} from "./paths";
+import type {
+	ConversationRef,
+	HydrateResult,
+	RunEvent,
+	RunRef,
+	WorkspaceStore,
+} from "./workspace-store";
+
+export class LocalWorkspaceStore implements WorkspaceStore {
+	constructor(private readonly rootDir: string) {}
+
+	private conversationPaths(ref: ConversationRef) {
+		return resolveDurableConversationPaths(
+			this.rootDir,
+			ref.userId,
+			ref.conversationId,
+		);
+	}
+
+	private ensureConversationLayout(ref: ConversationRef) {
+		const paths = this.conversationPaths(ref);
+		mkdirSync(paths.work, { recursive: true });
+		mkdirSync(paths.output, { recursive: true });
+		mkdirSync(paths.docs, { recursive: true });
+		return paths;
+	}
+
+	async hydrateConversationWorkspace(
+		ref: ConversationRef,
+	): Promise<HydrateResult> {
+		const paths = this.ensureConversationLayout(ref);
+		return { paths, docsManifest: readManifestFromDir(paths.docs) };
+	}
+
+	async syncConversationWorkspace(ref: ConversationRef): Promise<void> {
+		this.ensureConversationLayout(ref);
+	}
+
+	async readDocsManifest(ref: ConversationRef): Promise<DocsManifest> {
+		return readManifestFromDir(this.conversationPaths(ref).docs);
+	}
+
+	async writeDocsManifest(
+		ref: ConversationRef,
+		manifest: DocsManifest,
+	): Promise<void> {
+		const paths = this.conversationPaths(ref);
+		mkdirSync(paths.docs, { recursive: true });
+		writeManifestToDir(paths.docs, manifest);
+	}
+
+	async appendRunEvent(ref: RunRef, event: RunEvent): Promise<void> {
+		const file = resolveDurableRunEventsPath(
+			this.rootDir,
+			ref.userId,
+			ref.runId,
+		);
+		mkdirSync(dirname(file), { recursive: true });
+		appendFileSync(file, `${JSON.stringify(event)}\n`, "utf8");
+	}
+}
+
+export function createLocalWorkspaceStore(rootDir: string): WorkspaceStore {
+	return new LocalWorkspaceStore(rootDir);
+}

--- a/apps/chat-api/src/features/workspace-store/paths.ts
+++ b/apps/chat-api/src/features/workspace-store/paths.ts
@@ -1,0 +1,89 @@
+/**
+ * Durable workspace path model. The durable store mirrors the sandbox workspace
+ * but is keyed by user so it is isolated per user and per conversation:
+ *
+ *   users/{userId}/conversations/{conversationId}/work/
+ *   users/{userId}/conversations/{conversationId}/output/
+ *   users/{userId}/conversations/{conversationId}/docs/manifest.json
+ *   users/{userId}/runs/{runId}/events.jsonl
+ *
+ * `userId`, `conversationId`, and `runId` all originate outside this module, so
+ * each is validated before it is ever joined into a path. A value containing
+ * `/`, `..`, or NUL could otherwise escape its subtree and reach another user's
+ * or conversation's data. The charset is an allowlist, matching the daemon's
+ * `assertValidConversationId`: anything outside it is rejected, never rewritten.
+ */
+
+import { join } from "node:path";
+
+const VALID_ID = /^[A-Za-z0-9_-]+$/;
+const MAX_ID_LENGTH = 128;
+
+/**
+ * Throw if `value` is missing, too long, or contains any character that could
+ * escape its directory. `label` names the field for the error message.
+ */
+export function assertValidId(
+	label: string,
+	value: unknown,
+): asserts value is string {
+	if (
+		typeof value !== "string" ||
+		value.length === 0 ||
+		value.length > MAX_ID_LENGTH ||
+		!VALID_ID.test(value)
+	) {
+		throw new Error(`Invalid ${label}: ${JSON.stringify(value)}`);
+	}
+}
+
+export interface DurableConversationPaths {
+	/** users/{userId}/conversations/{conversationId} */
+	conversation: string;
+	/** .../work */
+	work: string;
+	/** .../output */
+	output: string;
+	/** .../docs */
+	docs: string;
+}
+
+/**
+ * Compute the durable paths for a conversation. Pure: validates the ids and
+ * joins paths, but touches no filesystem.
+ */
+export function resolveDurableConversationPaths(
+	root: string,
+	userId: string,
+	conversationId: string,
+): DurableConversationPaths {
+	assertValidId("userId", userId);
+	assertValidId("conversationId", conversationId);
+	const conversation = join(
+		root,
+		"users",
+		userId,
+		"conversations",
+		conversationId,
+	);
+	return {
+		conversation,
+		work: join(conversation, "work"),
+		output: join(conversation, "output"),
+		docs: join(conversation, "docs"),
+	};
+}
+
+/**
+ * Compute the durable NDJSON event-log path for a run. Pure: validates the ids
+ * and joins paths, but touches no filesystem.
+ */
+export function resolveDurableRunEventsPath(
+	root: string,
+	userId: string,
+	runId: string,
+): string {
+	assertValidId("userId", userId);
+	assertValidId("runId", runId);
+	return join(root, "users", userId, "runs", runId, "events.jsonl");
+}

--- a/apps/chat-api/src/features/workspace-store/paths.ts
+++ b/apps/chat-api/src/features/workspace-store/paths.ts
@@ -7,13 +7,21 @@
  *   users/{userId}/conversations/{conversationId}/docs/manifest.json
  *   users/{userId}/runs/{runId}/events.jsonl
  *
- * `userId`, `conversationId`, and `runId` all originate outside this module, so
- * each is validated before it is ever joined into a path. A value containing
- * `/`, `..`, or NUL could otherwise escape its subtree and reach another user's
- * or conversation's data. The charset is an allowlist, matching the daemon's
- * `assertValidConversationId`: anything outside it is rejected, never rewritten.
+ * Each id is made path-safe before it is ever joined into a path, so a value
+ * containing `/`, `..`, or NUL cannot escape its subtree and reach another
+ * user's or conversation's data:
+ *   - `conversationId` and `runId` are allocated by chat-api in a known-safe
+ *     shape (the chat schema restricts `conversationId` to the same charset;
+ *     `runId` is a UUID), so they are validated against an allowlist and a
+ *     malformed value is rejected, never rewritten — matching the daemon's
+ *     `assertValidConversationId`.
+ *   - `userId` is the caller-supplied member code, which has no enforced
+ *     charset and may exceed a filesystem name limit, so it cannot be used as a
+ *     path segment directly. It is hashed into a fixed-length, path-safe segment
+ *     instead (see `encodeUserSegment`).
  */
 
+import { createHash } from "node:crypto";
 import { join } from "node:path";
 
 const VALID_ID = /^[A-Za-z0-9_-]+$/;
@@ -21,7 +29,8 @@ const MAX_ID_LENGTH = 128;
 
 /**
  * Throw if `value` is missing, too long, or contains any character that could
- * escape its directory. `label` names the field for the error message.
+ * escape its directory. `label` names the field for the error message. Use only
+ * for ids chat-api allocates in a known-safe shape (`conversationId`, `runId`).
  */
 export function assertValidId(
 	label: string,
@@ -35,6 +44,20 @@ export function assertValidId(
 	) {
 		throw new Error(`Invalid ${label}: ${JSON.stringify(value)}`);
 	}
+}
+
+/**
+ * Derive a path-safe directory segment from a `userId` (member code). The member
+ * code's charset and length are unconstrained, so it is hashed rather than used
+ * verbatim: any input maps to a fixed `[0-9a-f]{64}` segment that cannot
+ * traverse out of the `users/` directory, and distinct ids map to distinct
+ * segments, so per-user isolation holds. Throws only on a missing/empty id.
+ */
+export function encodeUserSegment(userId: unknown): string {
+	if (typeof userId !== "string" || userId.length === 0) {
+		throw new Error(`Invalid userId: ${JSON.stringify(userId)}`);
+	}
+	return createHash("sha256").update(userId, "utf8").digest("hex");
 }
 
 export interface DurableConversationPaths {
@@ -57,12 +80,11 @@ export function resolveDurableConversationPaths(
 	userId: string,
 	conversationId: string,
 ): DurableConversationPaths {
-	assertValidId("userId", userId);
 	assertValidId("conversationId", conversationId);
 	const conversation = join(
 		root,
 		"users",
-		userId,
+		encodeUserSegment(userId),
 		"conversations",
 		conversationId,
 	);
@@ -83,7 +105,13 @@ export function resolveDurableRunEventsPath(
 	userId: string,
 	runId: string,
 ): string {
-	assertValidId("userId", userId);
 	assertValidId("runId", runId);
-	return join(root, "users", userId, "runs", runId, "events.jsonl");
+	return join(
+		root,
+		"users",
+		encodeUserSegment(userId),
+		"runs",
+		runId,
+		"events.jsonl",
+	);
 }

--- a/apps/chat-api/src/features/workspace-store/singleton.ts
+++ b/apps/chat-api/src/features/workspace-store/singleton.ts
@@ -1,0 +1,10 @@
+import { apiEnv } from "@/config/env";
+import { createLocalWorkspaceStore } from "./local-workspace-store";
+
+/**
+ * Process-wide durable workspace store. A local filesystem adapter rooted at
+ * `WORKSPACE_STORE_ROOT` until an object-storage provider is finalized.
+ */
+export const workspaceStore = createLocalWorkspaceStore(
+	apiEnv.WORKSPACE_STORE_ROOT,
+);

--- a/apps/chat-api/src/features/workspace-store/workspace-store.ts
+++ b/apps/chat-api/src/features/workspace-store/workspace-store.ts
@@ -1,0 +1,64 @@
+/**
+ * Durable workspace store. The sandbox filesystem is ephemeral — a sandbox is
+ * leased for a turn and torn down — so the durable record of a conversation's
+ * working set lives outside the sandbox, behind this abstraction.
+ *
+ * The interface is async so a later object-storage adapter can implement it
+ * without changing callers; the first adapter (`LocalWorkspaceStore`) is a
+ * local filesystem implementation used while the object-storage provider is not
+ * finalized.
+ */
+
+import type { DocsManifest } from "./docs-manifest";
+import type { DurableConversationPaths } from "./paths";
+
+/** Identifies a conversation's durable workspace, scoped to its owner. */
+export interface ConversationRef {
+	userId: string;
+	conversationId: string;
+}
+
+/** Identifies a single run's durable event log, scoped to its owner. */
+export interface RunRef {
+	userId: string;
+	runId: string;
+}
+
+/**
+ * One appended run event. `type` names the event; any other structured fields
+ * are carried through verbatim into the NDJSON log.
+ */
+export interface RunEvent {
+	type: string;
+	[key: string]: unknown;
+}
+
+export interface HydrateResult {
+	paths: DurableConversationPaths;
+	/** The conversation's current working set as recorded durably. */
+	docsManifest: DocsManifest;
+}
+
+export interface WorkspaceStore {
+	/**
+	 * Prepare a conversation's durable workspace before a run and return its
+	 * current state. Idempotent.
+	 */
+	hydrateConversationWorkspace(ref: ConversationRef): Promise<HydrateResult>;
+
+	/**
+	 * Persist a conversation's durable workspace after a run (whether it
+	 * succeeded, failed, or was canceled). Idempotent.
+	 */
+	syncConversationWorkspace(ref: ConversationRef): Promise<void>;
+
+	readDocsManifest(ref: ConversationRef): Promise<DocsManifest>;
+
+	writeDocsManifest(
+		ref: ConversationRef,
+		manifest: DocsManifest,
+	): Promise<void>;
+
+	/** Append one event to a run's durable NDJSON event log. */
+	appendRunEvent(ref: RunRef, event: RunEvent): Promise<void>;
+}

--- a/apps/chat-api/src/test-setup.ts
+++ b/apps/chat-api/src/test-setup.ts
@@ -1,8 +1,15 @@
 // Set required env vars before any module evaluation.
 // This runs as a Bun test preload so env.ts IIFE won't crash.
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 Bun.env.E2B_API_KEY = Bun.env.E2B_API_KEY ?? "test-e2b-key";
 Bun.env.DAEMON_AUTH_TOKEN =
 	Bun.env.DAEMON_AUTH_TOKEN ?? "test-daemon-auth-token";
 Bun.env.LLM_TOKEN_SECRET = Bun.env.LLM_TOKEN_SECRET ?? "test-llm-token-secret";
 Bun.env.GATEWAY_PUBLIC_URL =
 	Bun.env.GATEWAY_PUBLIC_URL ?? "https://gateway.test";
+// Keep the durable workspace store off the host's real root during tests.
+Bun.env.WORKSPACE_STORE_ROOT =
+	Bun.env.WORKSPACE_STORE_ROOT ??
+	join(tmpdir(), "chat-api-workspace-store-test");


### PR DESCRIPTION
## Summary

Implements **MYM-10 / Task 6: Add durable workspace store interface** (Milestone 2).

Defines a `WorkspaceStore` abstraction with a local filesystem adapter and wires hydrate-before-run / sync-after-run into sandbox orchestration. No agent or chat-api↔daemon protocol changes — additive on the orchestration side only.

### What's included
- **`WorkspaceStore` interface** (`workspace-store.ts`) with the required operations: `hydrateConversationWorkspace`, `syncConversationWorkspace`, `readDocsManifest`, `writeDocsManifest`, `appendRunEvent`. Async so a later object-storage adapter can implement it without changing callers.
- **`LocalWorkspaceStore`** (`local-workspace-store.ts`) follows the durable path model:
  ```
  users/{userId}/conversations/{conversationId}/work/
  users/{userId}/conversations/{conversationId}/output/
  users/{userId}/conversations/{conversationId}/docs/manifest.json
  users/{userId}/runs/{runId}/events.jsonl
  ```
- **Path safety** (`paths.ts`):
  - `conversationId` and `runId` are chat-api-allocated in a known-safe shape, so they are validated against an allowlist (`^[A-Za-z0-9_-]+$`, max 128) and rejected if malformed.
  - `userId` is the caller-supplied member code (unconstrained charset/length), so it is **hashed** into a fixed-length, path-safe segment (`encodeUserSegment` → `sha256` → `[0-9a-f]{64}`) rather than rejected. Traversal stays impossible and per-user isolation holds, without locking out exotic/long member codes.
- **Durable docs manifest** (`docs-manifest.ts`): mirrors the daemon's on-disk format (atomic temp-file rename write, fail-closed read on corruption).
- **Orchestration wiring** (`sandbox-orchestration.ts`): hydrate before a run; sync in `finally` after the run succeeds, fails, or is canceled when a sandbox was leased. A sync failure is logged and never masks the turn outcome or skips teardown.
- **`WORKSPACE_STORE_ROOT`** env configures the durable root. Defaults to `${cwd}/.workspace-store` (writable by the non-root container user; the Dockerfile creates+chowns it). When unset, the app logs a startup warning that the fallback is non-durable. Point it at a mounted persistent volume in production. Documented in AGENTS.md; gitignored and dockerignored.

### Scope note
Copying the agent's `work/`/`output/` files between the sandbox and durable storage requires a sandbox file bridge that doesn't exist yet (the daemon proxy only streams events). `hydrate`/`sync` currently establish and preserve the durable layout and manifest; actual file transfer is left to a later task (E2E in Task 19 / MYM-23). The abstraction and call sites are in place so that wiring is additive.

## Acceptance criteria
- [x] chat-api calls hydrate before a run.
- [x] chat-api calls sync after a run succeeds, fails, or is canceled when a sandbox was leased.
- [x] The local adapter follows the durable path model.
- [x] Tests verify no cross-user, cross-conversation, or path traversal access is possible.

## Tests
- New `local-workspace-store.test.ts` (real adapter against a temp dir): path model, hydrate idempotency + manifest preservation, NDJSON run events, cross-user / cross-conversation isolation, traversal **neutralization** for userId (`../`, `..`, `a/b`, NUL, spaces) + **rejection** for conversationId/runId, empty-userId rejection, long/non-path-safe member codes accepted, distinct codes → distinct segments, fail-closed corrupt manifest.
- Extended `sandbox-orchestration.test.ts`: hydrate-before-forward ordering, sync-after-success, sync-after-failure, and sync-failure-does-not-mask-result.
- Full chat-api suite: **83 pass / 0 fail**. Biome + tsc clean on changed files.

## Follow-ups (tracked)
- Extract the duplicated `docs-manifest` format + id allowlist into a shared `packages/*` so the daemon↔chat-api on-disk contract is enforced at compile time (currently kept in sync by "must match" comments).
- `readDocsManifest` / `writeDocsManifest` / `appendRunEvent` are implemented + tested but get their orchestration consumers in Tasks 7 (MYM-11) and 10 (MYM-14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)