### PR TITLE
feat(daemon): persist Claude SDK session transcripts (MYM-27)

### DIFF
--- a/apps/sandbox-daemon/agent-entry.ts
+++ b/apps/sandbox-daemon/agent-entry.ts
@@ -4,7 +4,7 @@
  * (no daemon secrets).
  *
  * Stdin:   single JSON object —
- *            { userQuery, systemPrompt, cwd, sessionId? }
+ *            { userQuery, systemPrompt, cwd, sessionId?, userId?, conversationId? }
  * Stdout:  NDJSON, one event per line —
  *            { type: "text_delta", text: "..." }
  *            { type: "session_id", sessionId: "..." }
@@ -23,12 +23,15 @@
 
 import { runAgent } from "./agent";
 import type { AgentEvent } from "./ipc-protocol";
+import { createSessionStore, SESSION_STORE_ROOT_ENV } from "./session-store";
 
 interface AgentConfig {
 	userQuery: string;
 	systemPrompt: string;
 	cwd: string;
 	sessionId?: string;
+	userId?: string;
+	conversationId?: string;
 }
 
 function emit(event: AgentEvent): void {
@@ -60,6 +63,11 @@ function parseConfig(raw: string): AgentConfig {
 		cwd: parsed.cwd,
 		sessionId:
 			typeof parsed.sessionId === "string" ? parsed.sessionId : undefined,
+		userId: typeof parsed.userId === "string" ? parsed.userId : undefined,
+		conversationId:
+			typeof parsed.conversationId === "string"
+				? parsed.conversationId
+				: undefined,
 	};
 }
 
@@ -76,25 +84,38 @@ async function main() {
 		process.exit(1);
 	}
 
-	let failed = false;
-	await runAgent(config, {
-		onTextDelta: async (text) => {
-			emit({ type: "text_delta", text });
-		},
-		onSessionId: async (sessionId) => {
-			emit({ type: "session_id", sessionId });
-		},
-		onHeartbeat: () => {
-			emit({ type: "heartbeat" });
-		},
-		onCompleted: async () => {
-			emit({ type: "completed" });
-		},
-		onFailed: async (message) => {
-			failed = true;
-			emit({ type: "failed", message });
-		},
+	// Mirror SDK session transcripts to durable storage when configured, so
+	// `resume` survives a fresh or recycled sandbox. Disabled (null) when no
+	// root is set or identity is missing — the SDK then keeps its local
+	// transcript only.
+	const sessionStore = createSessionStore({
+		rootDir: process.env[SESSION_STORE_ROOT_ENV],
+		userId: config.userId,
+		conversationId: config.conversationId,
 	});
+
+	let failed = false;
+	await runAgent(
+		{ ...config, sessionStore: sessionStore ?? undefined },
+		{
+			onTextDelta: async (text) => {
+				emit({ type: "text_delta", text });
+			},
+			onSessionId: async (sessionId) => {
+				emit({ type: "session_id", sessionId });
+			},
+			onHeartbeat: () => {
+				emit({ type: "heartbeat" });
+			},
+			onCompleted: async () => {
+				emit({ type: "completed" });
+			},
+			onFailed: async (message) => {
+				failed = true;
+				emit({ type: "failed", message });
+			},
+		},
+	);
 
 	process.exit(failed ? 1 : 0);
 }

--- a/apps/sandbox-daemon/agent.test.ts
+++ b/apps/sandbox-daemon/agent.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+import type { SessionStore } from "@anthropic-ai/claude-agent-sdk";
+import { buildQueryOptions } from "./agent";
+
+const base = {
+	userQuery: "hello",
+	systemPrompt: "be helpful",
+	cwd: "/workspace/conversations/c/work",
+};
+
+// A no-op store; buildQueryOptions only needs to forward the reference.
+const fakeStore: SessionStore = {
+	async append() {},
+	async load() {
+		return null;
+	},
+};
+
+describe("buildQueryOptions", () => {
+	it("forwards a sessionStore to query() when durable storage is configured", () => {
+		const opts = buildQueryOptions({ ...base, sessionStore: fakeStore });
+		expect(opts.sessionStore).toBe(fakeStore);
+	});
+
+	it("omits sessionStore when durable storage is not configured", () => {
+		const opts = buildQueryOptions(base);
+		expect("sessionStore" in opts).toBe(false);
+	});
+
+	it("never disables local writes (persistSession stays unset) with a store", () => {
+		// The mirror hook fires after the local write; persistSession:false would
+		// silence it. Guard against a regression that pairs them.
+		const opts = buildQueryOptions({ ...base, sessionStore: fakeStore });
+		expect("persistSession" in opts).toBe(false);
+	});
+
+	it("sets resume only when a prior sessionId is supplied", () => {
+		expect(buildQueryOptions(base).resume).toBeUndefined();
+		expect(buildQueryOptions({ ...base, sessionId: "sess-1" }).resume).toBe(
+			"sess-1",
+		);
+	});
+});

--- a/apps/sandbox-daemon/agent.ts
+++ b/apps/sandbox-daemon/agent.ts
@@ -7,6 +7,7 @@ import {
 	type HookCallbackMatcher,
 	type HookEvent,
 	query,
+	type SessionStore,
 } from "@anthropic-ai/claude-agent-sdk";
 import { createHeartbeatController } from "./heartbeat";
 
@@ -15,6 +16,13 @@ export interface AgentRunOptions {
 	systemPrompt: string;
 	cwd: string;
 	sessionId?: string;
+	/**
+	 * Mirror SDK session transcripts to durable storage so `resume` survives a
+	 * fresh or recycled sandbox. Omit to keep today's behavior (local transcript
+	 * only). Never paired with `persistSession: false` — the mirror hook fires
+	 * after the local write, so local writes must stay enabled.
+	 */
+	sessionStore?: SessionStore;
 }
 
 export interface AgentCallbacks {
@@ -27,13 +35,15 @@ export interface AgentCallbacks {
 }
 
 /**
- * Run a Claude Agent SDK query and stream results through callbacks.
+ * Build the Claude Agent SDK `query()` options for a turn. Pure (apart from
+ * reading `CLAUDE_CODE_PATH`) so the wiring — `resume`, and the `sessionStore`
+ * transcript mirror — is unit-testable without spawning the SDK. `hooks` is
+ * layered on separately by `runAgent` since it closes over the heartbeat.
  */
-export async function runAgent(
+export function buildQueryOptions(
 	options: AgentRunOptions,
-	callbacks: AgentCallbacks,
-): Promise<void> {
-	const { userQuery, systemPrompt, cwd, sessionId } = options;
+): Record<string, unknown> {
+	const { systemPrompt, cwd, sessionId, sessionStore } = options;
 
 	const queryOptions: Record<string, unknown> = {
 		cwd,
@@ -51,6 +61,28 @@ export async function runAgent(
 	if (sessionId) {
 		queryOptions.resume = sessionId;
 	}
+
+	// When durable session storage is configured, mirror the SDK transcript to
+	// it. Deliberately leave `persistSession` unset (defaults on): the mirror
+	// hook runs after the local write, so disabling local writes would silence
+	// it.
+	if (sessionStore) {
+		queryOptions.sessionStore = sessionStore;
+	}
+
+	return queryOptions;
+}
+
+/**
+ * Run a Claude Agent SDK query and stream results through callbacks.
+ */
+export async function runAgent(
+	options: AgentRunOptions,
+	callbacks: AgentCallbacks,
+): Promise<void> {
+	const { userQuery } = options;
+
+	const queryOptions = buildQueryOptions(options);
 
 	// Tool execution emits nothing on stdout, so without this a single tool that
 	// runs longer than the idle window trips the daemon watchdog. Pre/PostToolUse
@@ -111,6 +143,17 @@ export async function runAgent(
 
 	try {
 		for await (const msg of result) {
+			// Transcript-mirror failures are non-fatal (the batch is dropped,
+			// at-most-once) but must not be silent — the turn answers correctly yet
+			// resume may be incomplete. Surface to stderr, which the daemon drains
+			// into its log; the turn itself continues.
+			if (msg.type === "system" && msg.subtype === "mirror_error") {
+				console.error(
+					`session transcript mirror failed (resume may be incomplete): ${msg.error}`,
+				);
+				continue;
+			}
+
 			if (!emittedSessionId && msg.type === "stream_event") {
 				await callbacks.onSessionId(msg.session_id);
 				emittedSessionId = true;

--- a/apps/sandbox-daemon/child-spawn.test.ts
+++ b/apps/sandbox-daemon/child-spawn.test.ts
@@ -11,7 +11,11 @@ import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AgentEvent } from "./child-spawn";
-import { buildAgentSpawnArgv, spawnAgent } from "./child-spawn";
+import {
+	assertSessionStoreRootSafe,
+	buildAgentSpawnArgv,
+	spawnAgent,
+} from "./child-spawn";
 
 describe("buildAgentSpawnArgv", () => {
 	it("wraps bun /workspace/agent.js with bwrap and the agreed flags", () => {
@@ -138,6 +142,33 @@ describe("buildAgentSpawnArgv", () => {
 			(a, i) => a === "--bind" && argv[i + 1] === root && argv[i + 2] === root,
 		);
 		expect(wholeRootBind).toBe(-1);
+	});
+
+	it("rejects a store root that would mask a required mount", () => {
+		const mounts = [
+			"/workspace/agent.js",
+			"/workspace/conversations/c/work",
+			"/home/user/.claude/projects",
+		];
+		// Ancestor of the agent bundle / cwd — the --tmpfs root would shadow them.
+		expect(() => assertSessionStoreRootSafe("/workspace", mounts)).toThrow(
+			/masks required mount/,
+		);
+		expect(() => assertSessionStoreRootSafe("/", mounts)).toThrow(
+			/masks required mount/,
+		);
+		// Relative paths are rejected outright (bwrap needs absolute).
+		expect(() => assertSessionStoreRootSafe("relative/path", mounts)).toThrow(
+			/absolute path/,
+		);
+		// A dedicated root outside the workspace is fine.
+		expect(() =>
+			assertSessionStoreRootSafe("/session-store", mounts),
+		).not.toThrow();
+		// A sibling under /workspace that masks nothing required is fine.
+		expect(() =>
+			assertSessionStoreRootSafe("/workspace/sessions", mounts),
+		).not.toThrow();
 	});
 
 	it("respects SANDBOX_BWRAP_PATH and SANDBOX_BUN_PATH env overrides", () => {

--- a/apps/sandbox-daemon/child-spawn.test.ts
+++ b/apps/sandbox-daemon/child-spawn.test.ts
@@ -106,29 +106,38 @@ describe("buildAgentSpawnArgv", () => {
 		expect(argv).not.toContain("/workspace/daemon.log");
 	});
 
-	it("re-binds the session-store root rw only when configured", () => {
-		const original = process.env.AGENT_SESSION_STORE_ROOT;
-		try {
-			// Unset: no bind for it.
-			delete process.env.AGENT_SESSION_STORE_ROOT;
-			expect(buildAgentSpawnArgv("/tmp/cwd")).not.toContain(
-				"/durable/sessions",
-			);
+	it("adds no session-store mount when not configured", () => {
+		const argv = buildAgentSpawnArgv("/tmp/cwd");
+		expect(argv).not.toContain("/durable");
+	});
 
-			// Set: re-bound rw so the agent's SessionStore mirror can write.
-			process.env.AGENT_SESSION_STORE_ROOT = "/durable/sessions";
-			const argv = buildAgentSpawnArgv("/tmp/cwd");
-			const idx = argv.findIndex(
-				(a, i) =>
-					a === "--bind" &&
-					argv[i + 1] === "/durable/sessions" &&
-					argv[i + 2] === "/durable/sessions",
-			);
-			expect(idx).toBeGreaterThan(-1);
-		} finally {
-			if (original === undefined) delete process.env.AGENT_SESSION_STORE_ROOT;
-			else process.env.AGENT_SESSION_STORE_ROOT = original;
-		}
+	it("binds ONLY this conversation's sessions dir and masks the rest of the root", () => {
+		// The agent is prompt-injectable with Bash/Read; binding the whole
+		// multi-tenant root would expose other users' transcripts. Assert we
+		// --tmpfs the root (so the broad `--ro-bind / /` can't leak siblings) and
+		// re-bind ONLY the per-conversation sessions dir.
+		const root = "/durable";
+		const sessionsDir = "/durable/users/abc123/conversations/conv-1/sessions";
+		const argv = buildAgentSpawnArgv("/tmp/cwd", { root, sessionsDir });
+
+		const tmpfsRootIdx = argv.findIndex(
+			(a, i) => a === "--tmpfs" && argv[i + 1] === root,
+		);
+		const bindConvIdx = argv.findIndex(
+			(a, i) =>
+				a === "--bind" &&
+				argv[i + 1] === sessionsDir &&
+				argv[i + 2] === sessionsDir,
+		);
+		expect(tmpfsRootIdx).toBeGreaterThan(-1);
+		expect(bindConvIdx).toBeGreaterThan(-1);
+		// Mask must precede the narrow re-bind, or the bind is shadowed.
+		expect(tmpfsRootIdx).toBeLessThan(bindConvIdx);
+		// The whole root is never bound rw — only the conversation subtree.
+		const wholeRootBind = argv.findIndex(
+			(a, i) => a === "--bind" && argv[i + 1] === root && argv[i + 2] === root,
+		);
+		expect(wholeRootBind).toBe(-1);
 	});
 
 	it("respects SANDBOX_BWRAP_PATH and SANDBOX_BUN_PATH env overrides", () => {

--- a/apps/sandbox-daemon/child-spawn.test.ts
+++ b/apps/sandbox-daemon/child-spawn.test.ts
@@ -144,16 +144,24 @@ describe("buildAgentSpawnArgv", () => {
 		expect(wholeRootBind).toBe(-1);
 	});
 
-	it("rejects a store root that would mask a required mount", () => {
+	it("rejects a store root that overlaps any sandbox-managed mount", () => {
 		const mounts = [
 			"/workspace/agent.js",
 			"/workspace/conversations/c/work",
 			"/home/user/.claude/projects",
 		];
-		// Ancestor of the agent bundle / cwd — the --tmpfs root would shadow them.
+		// Inside an ephemeral tmpfs — sandbox-local or re-masked, so resume silently
+		// never works.
 		expect(() => assertSessionStoreRootSafe("/workspace", mounts)).toThrow(
-			/masks required mount/,
+			/ephemeral/,
 		);
+		expect(() =>
+			assertSessionStoreRootSafe("/workspace/sessions", mounts),
+		).toThrow(/ephemeral/);
+		expect(() => assertSessionStoreRootSafe("/tmp/sessions", mounts)).toThrow(
+			/ephemeral/,
+		);
+		// Ancestor of a required re-bind — our --tmpfs root would shadow it.
 		expect(() => assertSessionStoreRootSafe("/", mounts)).toThrow(
 			/masks required mount/,
 		);
@@ -161,13 +169,12 @@ describe("buildAgentSpawnArgv", () => {
 		expect(() => assertSessionStoreRootSafe("relative/path", mounts)).toThrow(
 			/absolute path/,
 		);
-		// A dedicated root outside the workspace is fine.
+		// A dedicated durable root outside every sandbox-managed mount is fine.
 		expect(() =>
 			assertSessionStoreRootSafe("/session-store", mounts),
 		).not.toThrow();
-		// A sibling under /workspace that masks nothing required is fine.
 		expect(() =>
-			assertSessionStoreRootSafe("/workspace/sessions", mounts),
+			assertSessionStoreRootSafe("/mnt/durable/sessions", mounts),
 		).not.toThrow();
 	});
 
@@ -256,7 +263,12 @@ describe("spawnAgent agent environment", () => {
 	it("forwards the session-store root + identity when configured, omits them otherwise", async () => {
 		originalHome = Bun.env.HOME;
 		Bun.env.HOME = join(tmpdir(), `spawn-agent-store-${Date.now()}`);
-		const storeRoot = join(tmpdir(), `session-store-spawn-${Date.now()}`);
+		// A DURABLE root: not under /workspace or /tmp (tmpdir() is /tmp on Linux,
+		// which assertSessionStoreRootSafe now rejects). Use the package dir.
+		const storeRoot = join(
+			process.cwd(),
+			`.session-store-spawn-test-${Date.now()}`,
+		);
 		const originalRoot = process.env.AGENT_SESSION_STORE_ROOT;
 
 		const writes: string[] = [];
@@ -311,6 +323,7 @@ describe("spawnAgent agent environment", () => {
 			if (originalRoot === undefined)
 				delete process.env.AGENT_SESSION_STORE_ROOT;
 			else process.env.AGENT_SESSION_STORE_ROOT = originalRoot;
+			rmSync(storeRoot, { recursive: true, force: true });
 		}
 	});
 });

--- a/apps/sandbox-daemon/child-spawn.test.ts
+++ b/apps/sandbox-daemon/child-spawn.test.ts
@@ -106,6 +106,31 @@ describe("buildAgentSpawnArgv", () => {
 		expect(argv).not.toContain("/workspace/daemon.log");
 	});
 
+	it("re-binds the session-store root rw only when configured", () => {
+		const original = process.env.AGENT_SESSION_STORE_ROOT;
+		try {
+			// Unset: no bind for it.
+			delete process.env.AGENT_SESSION_STORE_ROOT;
+			expect(buildAgentSpawnArgv("/tmp/cwd")).not.toContain(
+				"/durable/sessions",
+			);
+
+			// Set: re-bound rw so the agent's SessionStore mirror can write.
+			process.env.AGENT_SESSION_STORE_ROOT = "/durable/sessions";
+			const argv = buildAgentSpawnArgv("/tmp/cwd");
+			const idx = argv.findIndex(
+				(a, i) =>
+					a === "--bind" &&
+					argv[i + 1] === "/durable/sessions" &&
+					argv[i + 2] === "/durable/sessions",
+			);
+			expect(idx).toBeGreaterThan(-1);
+		} finally {
+			if (original === undefined) delete process.env.AGENT_SESSION_STORE_ROOT;
+			else process.env.AGENT_SESSION_STORE_ROOT = original;
+		}
+	});
+
 	it("respects SANDBOX_BWRAP_PATH and SANDBOX_BUN_PATH env overrides", () => {
 		const original = {
 			bwrap: process.env.SANDBOX_BWRAP_PATH,
@@ -186,6 +211,67 @@ describe("spawnAgent agent environment", () => {
 		expect(env.MYMEMO_DOC_TOKEN).toBe("doc-456");
 		// The whole point of the gateway: no provider key reaches the agent.
 		expect("ANTHROPIC_API_KEY" in env).toBe(false);
+	});
+
+	it("forwards the session-store root + identity when configured, omits them otherwise", async () => {
+		originalHome = Bun.env.HOME;
+		Bun.env.HOME = join(tmpdir(), `spawn-agent-store-${Date.now()}`);
+		const storeRoot = join(tmpdir(), `session-store-spawn-${Date.now()}`);
+		const originalRoot = process.env.AGENT_SESSION_STORE_ROOT;
+
+		const writes: string[] = [];
+		const capturingProc = () => ({
+			stdin: {
+				write: (s: string) => writes.push(s),
+				end: () => Promise.resolve(),
+			},
+			stdout: new ReadableStream<Uint8Array>({
+				start(c) {
+					c.close();
+				},
+			}),
+			stderr: new ReadableStream<Uint8Array>({
+				start(c) {
+					c.close();
+				},
+			}),
+			exited: Promise.resolve(0),
+		});
+
+		try {
+			process.env.AGENT_SESSION_STORE_ROOT = storeRoot;
+			spawnSpy = spyOn(Bun, "spawn").mockReturnValue(
+				capturingProc() as unknown as ReturnType<typeof Bun.spawn>,
+			);
+
+			await spawnAgent({
+				userQuery: "q",
+				systemPrompt: "s",
+				cwd: "/workspace/conversations/conv-1/work",
+				userId: "member-abc",
+				conversationId: "conv-1",
+				llmBaseUrl: "https://gateway.example",
+				docGatewayUrl: "https://docs.example",
+				llmToken: "tok",
+				docToken: "doc",
+				onEvent: async () => {},
+			});
+
+			const call = spawnSpy.mock.calls[0] as [
+				string[],
+				{ env: Record<string, string> },
+			];
+			// Root is forwarded to the agent process so it builds a SessionStore.
+			expect(call[1].env.AGENT_SESSION_STORE_ROOT).toBe(storeRoot);
+			// Identity is threaded through the stdin config for key derivation.
+			const config = JSON.parse(writes.join(""));
+			expect(config.userId).toBe("member-abc");
+			expect(config.conversationId).toBe("conv-1");
+		} finally {
+			if (originalRoot === undefined)
+				delete process.env.AGENT_SESSION_STORE_ROOT;
+			else process.env.AGENT_SESSION_STORE_ROOT = originalRoot;
+		}
 	});
 });
 

--- a/apps/sandbox-daemon/child-spawn.ts
+++ b/apps/sandbox-daemon/child-spawn.ts
@@ -78,6 +78,17 @@ function getClaudeProjectsDir(): string {
 	return `${home}/.claude/projects`;
 }
 
+// Durable root the agent's SessionStore mirror writes to (must match
+// SESSION_STORE_ROOT_ENV in session-store.ts, which the agent reads). Unset =
+// session mirroring disabled, so no extra bwrap bind. When set it points
+// outside /workspace (which is tmpfs-masked) at a path that survives sandbox
+// recycle, so it must be re-bound rw inside bwrap and exist before spawn.
+const SESSION_STORE_ROOT_ENV = "AGENT_SESSION_STORE_ROOT";
+function getSessionStoreRoot(): string | undefined {
+	const root = process.env[SESSION_STORE_ROOT_ENV];
+	return root && root.length > 0 ? root : undefined;
+}
+
 /**
  * Build the argv for the bwrap-wrapped agent process. Extracted as a pure
  * helper so the flag set is easy to inspect and unit-test.
@@ -119,6 +130,7 @@ function getClaudeProjectsDir(): string {
 export function buildAgentSpawnArgv(cwd: string): string[] {
 	const agentBundle = getAgentBundlePath();
 	const claudeProjectsDir = getClaudeProjectsDir();
+	const sessionStoreRoot = getSessionStoreRoot();
 	return [
 		getBwrapExecutable(),
 		"--ro-bind",
@@ -135,6 +147,11 @@ export function buildAgentSpawnArgv(cwd: string): string[] {
 		"--bind",
 		claudeProjectsDir,
 		claudeProjectsDir,
+		// 7. --bind <sessionStoreRoot> ...     — re-expose the durable session
+		//                                         transcript root rw so the agent's
+		//                                         SessionStore mirror can write it.
+		//                                         Only when configured.
+		...(sessionStoreRoot ? ["--bind", sessionStoreRoot, sessionStoreRoot] : []),
 		"--tmpfs",
 		"/tmp",
 		"--proc",
@@ -160,6 +177,15 @@ export function buildAgentSpawnArgv(cwd: string): string[] {
  */
 function ensureClaudeProjectsDir(): void {
 	mkdirSync(getClaudeProjectsDir(), { recursive: true });
+}
+
+/**
+ * Pre-create the session-transcript root so its bwrap --bind has a source.
+ * No-op when session mirroring is disabled. Idempotent.
+ */
+function ensureSessionStoreRoot(): void {
+	const root = getSessionStoreRoot();
+	if (root) mkdirSync(root, { recursive: true });
 }
 
 function narrowAgentEvent(raw: Record<string, unknown>): AgentEvent | null {
@@ -246,6 +272,10 @@ export interface SpawnAgentInput {
 	systemPrompt: string;
 	cwd: string;
 	sessionId?: string;
+	/** Trusted member code — keys the durable session-transcript store. */
+	userId?: string;
+	/** Trusted conversation id — keys the durable session-transcript store. */
+	conversationId?: string;
 	/** LLM gateway base URL — set as ANTHROPIC_BASE_URL for the Claude binary. */
 	llmBaseUrl: string;
 	/** Document gateway base URL — set as MYMEMO_DOC_GATEWAY_URL for the CLI. */
@@ -274,6 +304,8 @@ export async function spawnAgent(
 	const { onEvent, llmBaseUrl, docGatewayUrl, llmToken, docToken, ...config } =
 		input;
 	ensureClaudeProjectsDir();
+	ensureSessionStoreRoot();
+	const sessionStoreRoot = getSessionStoreRoot();
 	const proc = Bun.spawn(buildAgentSpawnArgv(config.cwd), {
 		env: {
 			// The agent holds no provider key — it talks to the LLM gateway, which
@@ -287,6 +319,11 @@ export async function spawnAgent(
 			MYMEMO_DOC_TOKEN: docToken,
 			PATH: process.env.PATH ?? "",
 			CLAUDE_CODE_PATH: process.env.CLAUDE_CODE_PATH ?? "/usr/local/bin/claude",
+			// Where the agent's SessionStore mirrors transcripts. Only forwarded
+			// when configured; absent => the agent disables session mirroring.
+			...(sessionStoreRoot
+				? { [SESSION_STORE_ROOT_ENV]: sessionStoreRoot }
+				: {}),
 		},
 		stdout: "pipe",
 		stderr: "pipe",

--- a/apps/sandbox-daemon/child-spawn.ts
+++ b/apps/sandbox-daemon/child-spawn.ts
@@ -89,14 +89,28 @@ function getSessionStoreRoot(): string | undefined {
 	return root && root.length > 0 ? root : undefined;
 }
 
+// Mounts the agent gets that are EPHEMERAL: tmpfs that vanishes when the
+// per-turn sandbox is killed. A store root at or under either is useless —
+// `/workspace` is sandbox-local (no resume across recycle) and `/tmp` is also
+// re-masked by the later `--tmpfs /tmp`, silently dropping the mirror.
+const EPHEMERAL_ROOTS = [WORKSPACE_ROOT, "/tmp"];
+
+/** True when `child` is `parent` or nested beneath it (both pre-resolved). */
+function isAtOrUnder(child: string, parent: string): boolean {
+	return (
+		child === parent || child.startsWith(parent === "/" ? "/" : `${parent}/`)
+	);
+}
+
 /**
- * Throw if the configured store root would mask a mount the agent needs. We
- * `--tmpfs` the root to hide other tenants' transcripts; bwrap applies mounts in
- * order and last wins, so a root that is an ancestor of (or equal to) the agent
- * bundle, cwd, or `~/.claude/projects` would shadow those re-binds and break
- * every turn. A durable root nested inside the ephemeral sandbox workspace is
- * also wrong (it would not survive recycle), so reject it loudly rather than
- * silently wedge the agent. Requires an absolute path.
+ * Throw unless the configured store root is a durable path that overlaps no
+ * sandbox-managed mount. Two failure modes, both from bwrap applying mounts in
+ * order (last wins):
+ *  - root AT/UNDER an ephemeral tmpfs (`/workspace`, `/tmp`) — the transcript is
+ *    sandbox-local or gets re-masked, so resume silently never works.
+ *  - root that is an ANCESTOR of a required re-bind (agent bundle, cwd,
+ *    `~/.claude/projects`) — our `--tmpfs <root>` shadows it and wedges the turn.
+ * Requires an absolute path. Reject loudly rather than mirror into a void.
  */
 export function assertSessionStoreRootSafe(
 	root: string,
@@ -108,12 +122,15 @@ export function assertSessionStoreRootSafe(
 		);
 	}
 	const r = resolve(root);
-	// `${r}/` is "//" when r is "/", which nothing starts with — handle root "/"
-	// (an ancestor of everything absolute) explicitly.
-	const prefix = r === "/" ? "/" : `${r}/`;
+	for (const ephemeral of EPHEMERAL_ROOTS) {
+		if (isAtOrUnder(r, resolve(ephemeral))) {
+			throw new Error(
+				`${SESSION_STORE_ROOT_ENV} (${root}) is inside the ephemeral ${ephemeral}; transcripts there don't survive sandbox recycle — use a durable path outside ${EPHEMERAL_ROOTS.join(" and ")}`,
+			);
+		}
+	}
 	for (const mount of mounts) {
-		const m = resolve(mount);
-		if (m === r || m.startsWith(prefix)) {
+		if (isAtOrUnder(resolve(mount), r)) {
 			throw new Error(
 				`${SESSION_STORE_ROOT_ENV} (${root}) masks required mount ${mount}; use a dedicated path outside the sandbox workspace`,
 			);

--- a/apps/sandbox-daemon/child-spawn.ts
+++ b/apps/sandbox-daemon/child-spawn.ts
@@ -11,6 +11,7 @@
  */
 
 import { mkdirSync } from "node:fs";
+import { resolve } from "node:path";
 import type { AgentEvent } from "./ipc-protocol";
 import { resolveConversationSessionsDir } from "./session-store-paths";
 
@@ -86,6 +87,38 @@ const SESSION_STORE_ROOT_ENV = "AGENT_SESSION_STORE_ROOT";
 function getSessionStoreRoot(): string | undefined {
 	const root = process.env[SESSION_STORE_ROOT_ENV];
 	return root && root.length > 0 ? root : undefined;
+}
+
+/**
+ * Throw if the configured store root would mask a mount the agent needs. We
+ * `--tmpfs` the root to hide other tenants' transcripts; bwrap applies mounts in
+ * order and last wins, so a root that is an ancestor of (or equal to) the agent
+ * bundle, cwd, or `~/.claude/projects` would shadow those re-binds and break
+ * every turn. A durable root nested inside the ephemeral sandbox workspace is
+ * also wrong (it would not survive recycle), so reject it loudly rather than
+ * silently wedge the agent. Requires an absolute path.
+ */
+export function assertSessionStoreRootSafe(
+	root: string,
+	mounts: string[],
+): void {
+	if (!root.startsWith("/")) {
+		throw new Error(
+			`${SESSION_STORE_ROOT_ENV} must be an absolute path: ${JSON.stringify(root)}`,
+		);
+	}
+	const r = resolve(root);
+	// `${r}/` is "//" when r is "/", which nothing starts with — handle root "/"
+	// (an ancestor of everything absolute) explicitly.
+	const prefix = r === "/" ? "/" : `${r}/`;
+	for (const mount of mounts) {
+		const m = resolve(mount);
+		if (m === r || m.startsWith(prefix)) {
+			throw new Error(
+				`${SESSION_STORE_ROOT_ENV} (${root}) masks required mount ${mount}; use a dedicated path outside the sandbox workspace`,
+			);
+		}
+	}
 }
 
 /**
@@ -338,6 +371,13 @@ export async function spawnAgent(
 		config.conversationId,
 	);
 	if (sessionStoreBind) {
+		// Reject a root that would mask the agent bundle, cwd, or ~/.claude before
+		// we spawn — otherwise the --tmpfs root silently shadows them.
+		assertSessionStoreRootSafe(sessionStoreBind.root, [
+			getAgentBundlePath(),
+			config.cwd,
+			getClaudeProjectsDir(),
+		]);
 		mkdirSync(sessionStoreBind.sessionsDir, { recursive: true });
 	}
 	const proc = Bun.spawn(buildAgentSpawnArgv(config.cwd, sessionStoreBind), {

--- a/apps/sandbox-daemon/child-spawn.ts
+++ b/apps/sandbox-daemon/child-spawn.ts
@@ -12,6 +12,7 @@
 
 import { mkdirSync } from "node:fs";
 import type { AgentEvent } from "./ipc-protocol";
+import { resolveConversationSessionsDir } from "./session-store-paths";
 
 export type { AgentEvent } from "./ipc-protocol";
 
@@ -80,13 +81,32 @@ function getClaudeProjectsDir(): string {
 
 // Durable root the agent's SessionStore mirror writes to (must match
 // SESSION_STORE_ROOT_ENV in session-store.ts, which the agent reads). Unset =
-// session mirroring disabled, so no extra bwrap bind. When set it points
-// outside /workspace (which is tmpfs-masked) at a path that survives sandbox
-// recycle, so it must be re-bound rw inside bwrap and exist before spawn.
+// session mirroring disabled, so no extra bwrap bind.
 const SESSION_STORE_ROOT_ENV = "AGENT_SESSION_STORE_ROOT";
 function getSessionStoreRoot(): string | undefined {
 	const root = process.env[SESSION_STORE_ROOT_ENV];
 	return root && root.length > 0 ? root : undefined;
+}
+
+/**
+ * The single durable subtree this turn's agent may touch: the current
+ * conversation's `sessions/` dir, plus the root that must be masked first.
+ * The agent is prompt-injectable and holds Bash/Read, so binding the whole
+ * durable root (every user, every conversation) would let one turn read or
+ * overwrite another tenant's transcripts. We instead `--tmpfs` the root (so the
+ * broad `--ro-bind / /` can't leak siblings either) and re-bind ONLY this dir.
+ * Returns undefined when mirroring is disabled or identity is missing.
+ */
+function resolveSessionStoreBind(
+	userId: string | undefined,
+	conversationId: string | undefined,
+): { root: string; sessionsDir: string } | undefined {
+	const root = getSessionStoreRoot();
+	if (!root || !userId || !conversationId) return undefined;
+	return {
+		root,
+		sessionsDir: resolveConversationSessionsDir(root, userId, conversationId),
+	};
 }
 
 /**
@@ -117,7 +137,13 @@ function getSessionStoreRoot(): string | undefined {
  *                                             for ensuring the dir exists
  *                                             before spawn (see
  *                                             ensureClaudeProjectsDir).
- *   6. --tmpfs /tmp                        — fresh scratch space.
+ *   6. --tmpfs <store root> + --bind <conv> — when session mirroring is on,
+ *                                             mask the whole durable transcript
+ *                                             root, then re-bind ONLY this
+ *                                             conversation's `sessions/` dir rw.
+ *                                             Other tenants' transcripts are
+ *                                             never visible to the agent.
+ *   7. --tmpfs /tmp                        — fresh scratch space.
  *
  * Namespaces:
  *   - --unshare-user, --unshare-pid, --unshare-uts, --unshare-ipc.
@@ -127,10 +153,12 @@ function getSessionStoreRoot(): string | undefined {
  * Lifetime:
  *   - --die-with-parent so a daemon crash takes bwrap + the agent with it.
  */
-export function buildAgentSpawnArgv(cwd: string): string[] {
+export function buildAgentSpawnArgv(
+	cwd: string,
+	sessionStoreBind?: { root: string; sessionsDir: string },
+): string[] {
 	const agentBundle = getAgentBundlePath();
 	const claudeProjectsDir = getClaudeProjectsDir();
-	const sessionStoreRoot = getSessionStoreRoot();
 	return [
 		getBwrapExecutable(),
 		"--ro-bind",
@@ -147,11 +175,19 @@ export function buildAgentSpawnArgv(cwd: string): string[] {
 		"--bind",
 		claudeProjectsDir,
 		claudeProjectsDir,
-		// 7. --bind <sessionStoreRoot> ...     — re-expose the durable session
-		//                                         transcript root rw so the agent's
-		//                                         SessionStore mirror can write it.
-		//                                         Only when configured.
-		...(sessionStoreRoot ? ["--bind", sessionStoreRoot, sessionStoreRoot] : []),
+		// Mask the entire durable transcript root (defeats the broad `--ro-bind /
+		// /` read-through for other tenants), then re-expose ONLY this
+		// conversation's `sessions/` dir rw. Order matters: tmpfs first, bind
+		// second, so the narrow bind wins for its subpath.
+		...(sessionStoreBind
+			? [
+					"--tmpfs",
+					sessionStoreBind.root,
+					"--bind",
+					sessionStoreBind.sessionsDir,
+					sessionStoreBind.sessionsDir,
+				]
+			: []),
 		"--tmpfs",
 		"/tmp",
 		"--proc",
@@ -177,15 +213,6 @@ export function buildAgentSpawnArgv(cwd: string): string[] {
  */
 function ensureClaudeProjectsDir(): void {
 	mkdirSync(getClaudeProjectsDir(), { recursive: true });
-}
-
-/**
- * Pre-create the session-transcript root so its bwrap --bind has a source.
- * No-op when session mirroring is disabled. Idempotent.
- */
-function ensureSessionStoreRoot(): void {
-	const root = getSessionStoreRoot();
-	if (root) mkdirSync(root, { recursive: true });
 }
 
 function narrowAgentEvent(raw: Record<string, unknown>): AgentEvent | null {
@@ -304,9 +331,16 @@ export async function spawnAgent(
 	const { onEvent, llmBaseUrl, docGatewayUrl, llmToken, docToken, ...config } =
 		input;
 	ensureClaudeProjectsDir();
-	ensureSessionStoreRoot();
-	const sessionStoreRoot = getSessionStoreRoot();
-	const proc = Bun.spawn(buildAgentSpawnArgv(config.cwd), {
+	// Bind only this conversation's transcript subtree into the agent (never the
+	// whole multi-tenant root). Pre-create it so the bwrap --bind has a source.
+	const sessionStoreBind = resolveSessionStoreBind(
+		config.userId,
+		config.conversationId,
+	);
+	if (sessionStoreBind) {
+		mkdirSync(sessionStoreBind.sessionsDir, { recursive: true });
+	}
+	const proc = Bun.spawn(buildAgentSpawnArgv(config.cwd, sessionStoreBind), {
 		env: {
 			// The agent holds no provider key — it talks to the LLM gateway, which
 			// injects the real key. ANTHROPIC_AUTH_TOKEN is sent as a Bearer header.
@@ -319,10 +353,11 @@ export async function spawnAgent(
 			MYMEMO_DOC_TOKEN: docToken,
 			PATH: process.env.PATH ?? "",
 			CLAUDE_CODE_PATH: process.env.CLAUDE_CODE_PATH ?? "/usr/local/bin/claude",
-			// Where the agent's SessionStore mirrors transcripts. Only forwarded
-			// when configured; absent => the agent disables session mirroring.
-			...(sessionStoreRoot
-				? { [SESSION_STORE_ROOT_ENV]: sessionStoreRoot }
+			// Where the agent's SessionStore mirrors transcripts. Forwarded only
+			// when the per-conversation subtree is bound above; absent => the agent
+			// builds no store and mirroring is disabled.
+			...(sessionStoreBind
+				? { [SESSION_STORE_ROOT_ENV]: sessionStoreBind.root }
 				: {}),
 		},
 		stdout: "pipe",

--- a/apps/sandbox-daemon/package.json
+++ b/apps/sandbox-daemon/package.json
@@ -11,6 +11,6 @@
 	},
 	"dependencies": {
 		"hono": "^4.10.1",
-		"@anthropic-ai/claude-agent-sdk": "0.2.97"
+		"@anthropic-ai/claude-agent-sdk": "0.2.117"
 	}
 }

--- a/apps/sandbox-daemon/routes/turn.ts
+++ b/apps/sandbox-daemon/routes/turn.ts
@@ -79,6 +79,7 @@ app.post("/turn", async (c) => {
 
 	const {
 		request_id,
+		user_id,
 		conversation_id,
 		run_id,
 		message,
@@ -122,6 +123,10 @@ app.post("/turn", async (c) => {
 					systemPrompt: system_prompt,
 					cwd,
 					sessionId: agent_session_id,
+					// Identity keys the durable session-transcript store; both arrive
+					// validated from the trusted turn request.
+					userId: user_id,
+					conversationId: conversation_id,
 					llmBaseUrl: llm_base_url,
 					docGatewayUrl: doc_gateway_url,
 					llmToken: llm_token,

--- a/apps/sandbox-daemon/session-store-paths.ts
+++ b/apps/sandbox-daemon/session-store-paths.ts
@@ -1,0 +1,71 @@
+/**
+ * Durable session-transcript path scheme, shared by the agent-side adapter
+ * (`session-store.ts`, which writes the files) and the daemon-side spawner
+ * (`child-spawn.ts`, which binds exactly one conversation's subtree into the
+ * agent's bwrap namespace). Kept free of the Claude Agent SDK import so it can
+ * live in the daemon bundle without pulling the SDK in.
+ *
+ * Layout (matches the chat-api `WorkspaceStore` model):
+ *   {root}/users/{sha256(userId)}/conversations/{conversationId}/sessions/
+ */
+
+import { createHash } from "node:crypto";
+import { join } from "node:path";
+
+const VALID_ID = /^[A-Za-z0-9_-]+$/;
+const MAX_ID_LENGTH = 128;
+
+/**
+ * Throw unless `value` is a non-empty, length-bounded id from the safe charset.
+ * Used for `conversationId` and the SDK `sessionId`, both of which arrive in a
+ * known-safe shape (chat-api charset / SDK UUID). A malformed value is rejected,
+ * never rewritten, so the stored path always matches the id the caller used.
+ */
+export function assertSafeId(
+	label: string,
+	value: unknown,
+): asserts value is string {
+	if (
+		typeof value !== "string" ||
+		value.length === 0 ||
+		value.length > MAX_ID_LENGTH ||
+		!VALID_ID.test(value)
+	) {
+		throw new Error(`Invalid ${label}: ${JSON.stringify(value)}`);
+	}
+}
+
+/**
+ * Hash a `userId` into a fixed-length, path-safe segment. The member code has
+ * no enforced charset or length, so it is hashed rather than used verbatim:
+ * any input maps to `[0-9a-f]{64}`, distinct ids map to distinct segments
+ * (per-user isolation), and nothing can traverse out of `users/`.
+ */
+export function encodeUserSegment(userId: unknown): string {
+	if (typeof userId !== "string" || userId.length === 0) {
+		throw new Error(`Invalid userId: ${JSON.stringify(userId)}`);
+	}
+	return createHash("sha256").update(userId, "utf8").digest("hex");
+}
+
+/**
+ * Resolve the per-conversation `sessions/` directory under the durable root.
+ * This is the ONLY subtree a turn's agent may touch — the daemon binds exactly
+ * this path into the agent's bwrap namespace, so a prompt-injected agent cannot
+ * reach another user's or conversation's transcripts even with Bash/Read.
+ */
+export function resolveConversationSessionsDir(
+	root: string,
+	userId: string,
+	conversationId: string,
+): string {
+	assertSafeId("conversationId", conversationId);
+	return join(
+		root,
+		"users",
+		encodeUserSegment(userId),
+		"conversations",
+		conversationId,
+		"sessions",
+	);
+}

--- a/apps/sandbox-daemon/session-store.test.ts
+++ b/apps/sandbox-daemon/session-store.test.ts
@@ -80,6 +80,33 @@ describe("FileSystemSessionStore append/load", () => {
 		expect(await store.load(k)).toBeNull();
 	});
 
+	it("isolates a truncated tail so the next append is not corrupted", async () => {
+		// A prior turn SIGKILL'd mid-append leaves an unterminated fragment with no
+		// trailing newline. The NEXT turn's append must not concatenate onto it —
+		// otherwise load() skips the fragment AND the new turn's first entry.
+		const store = makeStore({ conversationId: "conv-tail-repair" });
+		const k = key("tail-session");
+		await store.append(k, [{ type: "user", uuid: "1" }]);
+
+		const file = join(
+			testRoot,
+			"users",
+			createHash("sha256").update(USER, "utf8").digest("hex"),
+			"conversations",
+			"conv-tail-repair",
+			"sessions",
+			"tail-session.jsonl",
+		);
+		appendFileSync(file, '{"type":"assistant","uuid":"PARTIAL"', "utf8"); // killed mid-write
+
+		// The new turn completes and appends.
+		await store.append(k, [{ type: "user", uuid: "2" }]);
+
+		const loaded = await store.load(k);
+		// Only the corrupt fragment is dropped; entry 1 and the new entry 2 survive.
+		expect((loaded ?? []).map((e) => e.uuid)).toEqual(["1", "2"]);
+	});
+
 	it("tolerates a truncated trailing line instead of failing the whole load", async () => {
 		// Simulate a turn SIGKILL'd mid-append: intact entries followed by a
 		// truncated final JSON object. load() must return the intact prefix, not

--- a/apps/sandbox-daemon/session-store.test.ts
+++ b/apps/sandbox-daemon/session-store.test.ts
@@ -1,0 +1,189 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { SessionKey } from "@anthropic-ai/claude-agent-sdk";
+import { createSessionStore, FileSystemSessionStore } from "./session-store";
+
+const testRoot = join(tmpdir(), `session-store-test-${Date.now()}`);
+
+beforeAll(() => {
+	mkdirSync(testRoot, { recursive: true });
+});
+
+afterAll(() => {
+	rmSync(testRoot, { recursive: true, force: true });
+});
+
+const USER = "member-code-abc";
+const CONVERSATION = "conv-1";
+const SESSION = "11111111-2222-3333-4444-555555555555";
+
+function makeStore(
+	overrides: Partial<{
+		userId: string;
+		conversationId: string;
+	}> = {},
+): FileSystemSessionStore {
+	return new FileSystemSessionStore({
+		rootDir: testRoot,
+		userId: overrides.userId ?? USER,
+		conversationId: overrides.conversationId ?? CONVERSATION,
+	});
+}
+
+// projectKey is SDK-derived from cwd; the store must ignore it for tenancy.
+function key(sessionId: string, subpath?: string): SessionKey {
+	return { projectKey: "ignored-cwd-key", sessionId, subpath };
+}
+
+describe("FileSystemSessionStore append/load", () => {
+	it("loads back the entries it appended, in order", async () => {
+		const store = makeStore();
+		const k = key(SESSION);
+		const entries = [
+			{ type: "user", uuid: "a", text: "hi" },
+			{ type: "assistant", uuid: "b", text: "hello" },
+		];
+
+		await store.append(k, entries);
+		const loaded = await store.load(k);
+
+		expect(loaded).toEqual(entries);
+	});
+
+	it("preserves order across multiple append batches", async () => {
+		const store = makeStore({ conversationId: "conv-batches" });
+		const k = key(SESSION);
+
+		await store.append(k, [{ type: "user", uuid: "1" }]);
+		await store.append(k, [
+			{ type: "assistant", uuid: "2" },
+			{ type: "user", uuid: "3" },
+		]);
+		await store.append(k, [{ type: "assistant", uuid: "4" }]);
+
+		const loaded = await store.load(k);
+		expect((loaded ?? []).map((e) => e.uuid)).toEqual(["1", "2", "3", "4"]);
+	});
+
+	it("returns null for a session that was never written", async () => {
+		const store = makeStore({ conversationId: "conv-empty" });
+		expect(await store.load(key("never-written"))).toBeNull();
+	});
+
+	it("treats an empty append batch as a no-op (still unknown)", async () => {
+		const store = makeStore({ conversationId: "conv-noop" });
+		const k = key(SESSION);
+		await store.append(k, []);
+		expect(await store.load(k)).toBeNull();
+	});
+});
+
+describe("resume across a fresh daemon/sandbox context", () => {
+	it("a new store instance loads a transcript written by an earlier one", async () => {
+		const conversationId = "conv-resume";
+		const k = key("resume-session");
+		const entries = [
+			{ type: "user", uuid: "x" },
+			{ type: "assistant", uuid: "y" },
+		];
+
+		// First sandbox: write the transcript, then it goes away.
+		await makeStore({ conversationId }).append(k, entries);
+
+		// Fresh sandbox/daemon: brand-new store over the same durable root.
+		const resumed = await makeStore({ conversationId }).load(k);
+		expect(resumed).toEqual(entries);
+	});
+});
+
+describe("tenant isolation", () => {
+	it("does not leak a transcript across users", async () => {
+		const conversationId = "conv-shared-id";
+		const k = key("shared-session");
+		await makeStore({ userId: "user-a", conversationId }).append(k, [
+			{ type: "user", uuid: "secret" },
+		]);
+
+		const other = await makeStore({ userId: "user-b", conversationId }).load(k);
+		expect(other).toBeNull();
+	});
+
+	it("does not leak a transcript across conversations", async () => {
+		const k = key("shared-session-2");
+		await makeStore({ conversationId: "conv-x" }).append(k, [
+			{ type: "user", uuid: "secret" },
+		]);
+
+		const other = await makeStore({ conversationId: "conv-y" }).load(k);
+		expect(other).toBeNull();
+	});
+});
+
+describe("path/key traversal rejection", () => {
+	const store = makeStore({ conversationId: "conv-traversal" });
+
+	it("rejects a sessionId that could escape the sessions dir", async () => {
+		for (const bad of [
+			"..",
+			"../sibling",
+			"../../etc/passwd",
+			"a/b",
+			"foo/../bar",
+			"sess\0null",
+			"",
+			"a".repeat(129),
+		]) {
+			await expect(store.append(key(bad), [{ type: "user" }])).rejects.toThrow(
+				/Invalid sessionId/,
+			);
+			await expect(store.load(key(bad))).rejects.toThrow(/Invalid sessionId/);
+		}
+	});
+
+	it("rejects a subpath that could escape the session dir", async () => {
+		for (const bad of ["..", "../x", "a/../b", "/abs", "sub\0null", ""]) {
+			await expect(
+				store.append(key(SESSION, bad), [{ type: "user" }]),
+			).rejects.toThrow(/Invalid session subpath/);
+		}
+	});
+
+	it("accepts a well-formed nested subpath", async () => {
+		const k = key(SESSION, "subagents/agent-7");
+		await store.append(k, [{ type: "user", uuid: "sub" }]);
+		expect(await store.load(k)).toEqual([{ type: "user", uuid: "sub" }]);
+	});
+
+	it("rejects a malformed conversationId at construction", () => {
+		expect(() => makeStore({ conversationId: "../escape" })).toThrow(
+			/Invalid conversationId/,
+		);
+		expect(existsSync(join(testRoot, "..", "escape"))).toBe(false);
+	});
+
+	it("rejects an empty userId at construction", () => {
+		expect(() => makeStore({ userId: "" })).toThrow(/Invalid userId/);
+	});
+});
+
+describe("createSessionStore", () => {
+	it("returns null when durable storage is not configured", () => {
+		expect(createSessionStore({})).toBeNull();
+		expect(createSessionStore({ rootDir: testRoot })).toBeNull();
+		expect(createSessionStore({ rootDir: testRoot, userId: USER })).toBeNull();
+		expect(
+			createSessionStore({ userId: USER, conversationId: CONVERSATION }),
+		).toBeNull();
+	});
+
+	it("returns a store when root and identity are all present", () => {
+		const store = createSessionStore({
+			rootDir: testRoot,
+			userId: USER,
+			conversationId: CONVERSATION,
+		});
+		expect(store).toBeInstanceOf(FileSystemSessionStore);
+	});
+});

--- a/apps/sandbox-daemon/session-store.test.ts
+++ b/apps/sandbox-daemon/session-store.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { appendFileSync, existsSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { SessionKey } from "@anthropic-ai/claude-agent-sdk";
@@ -77,6 +78,31 @@ describe("FileSystemSessionStore append/load", () => {
 		const k = key(SESSION);
 		await store.append(k, []);
 		expect(await store.load(k)).toBeNull();
+	});
+
+	it("tolerates a truncated trailing line instead of failing the whole load", async () => {
+		// Simulate a turn SIGKILL'd mid-append: intact entries followed by a
+		// truncated final JSON object. load() must return the intact prefix, not
+		// throw (which would fail the resuming turn entirely).
+		const store = makeStore({ conversationId: "conv-truncated" });
+		const k = key("truncated-session");
+		await store.append(k, [
+			{ type: "user", uuid: "1" },
+			{ type: "assistant", uuid: "2" },
+		]);
+		const file = join(
+			testRoot,
+			"users",
+			createHash("sha256").update(USER, "utf8").digest("hex"),
+			"conversations",
+			"conv-truncated",
+			"sessions",
+			"truncated-session.jsonl",
+		);
+		appendFileSync(file, '{"type":"user","uuid":"3"', "utf8"); // truncated, no newline
+
+		const loaded = await store.load(k);
+		expect((loaded ?? []).map((e) => e.uuid)).toEqual(["1", "2"]);
 	});
 });
 

--- a/apps/sandbox-daemon/session-store.ts
+++ b/apps/sandbox-daemon/session-store.ts
@@ -27,7 +27,16 @@
  * than lost, but no `listSubkeys` is implemented.
  */
 
-import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import {
+	appendFileSync,
+	closeSync,
+	existsSync,
+	mkdirSync,
+	openSync,
+	readFileSync,
+	readSync,
+	statSync,
+} from "node:fs";
 import { dirname, join } from "node:path";
 import type {
 	SessionKey,
@@ -52,6 +61,25 @@ function assertSafeSubpath(subpath: string): void {
 		if (segment.length === 0 || !VALID_ID.test(segment)) {
 			throw new Error(`Invalid session subpath: ${JSON.stringify(subpath)}`);
 		}
+	}
+}
+
+/**
+ * True if `file` is missing, empty, or already ends in `\n` — i.e. a fresh
+ * append would start on a clean line. Reads only the final byte so it stays
+ * cheap on large transcripts.
+ */
+function endsWithNewline(file: string): boolean {
+	if (!existsSync(file)) return true;
+	const size = statSync(file).size;
+	if (size === 0) return true;
+	const fd = openSync(file, "r");
+	try {
+		const buf = Buffer.alloc(1);
+		readSync(fd, buf, 0, 1, size - 1);
+		return buf[0] === 0x0a; // '\n'
+	} finally {
+		closeSync(fd);
 	}
 }
 
@@ -97,12 +125,19 @@ export class FileSystemSessionStore implements SessionStore {
 	 * Append a transcript batch as JSONL, preserving call order. One
 	 * `appendFileSync` per batch keeps entries within a batch contiguous and in
 	 * order; concurrent processes interleave by commit time, per the contract.
+	 *
+	 * If a prior turn was SIGKILL'd mid-append the file can end with an
+	 * unterminated fragment and no trailing newline. We prepend a newline in that
+	 * case so the corrupt tail stays on its own (load-skippable) line instead of
+	 * the first new entry being concatenated onto it — otherwise `load()` would
+	 * drop this completed turn's first entry along with the fragment.
 	 */
 	async append(key: SessionKey, entries: SessionStoreEntry[]): Promise<void> {
 		if (entries.length === 0) return;
 		const file = this.fileFor(key);
 		mkdirSync(dirname(file), { recursive: true });
-		const lines = `${entries.map((e) => JSON.stringify(e)).join("\n")}\n`;
+		const sep = endsWithNewline(file) ? "" : "\n";
+		const lines = `${sep}${entries.map((e) => JSON.stringify(e)).join("\n")}\n`;
 		appendFileSync(file, lines, "utf8");
 	}
 

--- a/apps/sandbox-daemon/session-store.ts
+++ b/apps/sandbox-daemon/session-store.ts
@@ -1,0 +1,172 @@
+/**
+ * Local filesystem adapter for the Claude Agent SDK `SessionStore` (the
+ * transcript-mirror hook). The SDK keeps its authoritative JSONL transcript
+ * under `~/.claude/projects/` and, after each local write succeeds, mirrors the
+ * same entries here via `append`. On a fresh or recycled sandbox the SDK calls
+ * `load` once before spawning its subprocess to materialize a prior transcript,
+ * which is how `resume: agentSessionId` survives a sandbox that no longer has
+ * the local copy.
+ *
+ * Storage is keyed by user, conversation, and SDK session id following the same
+ * durable path model the chat-api `WorkspaceStore` uses:
+ *
+ *   {root}/users/{sha256(userId)}/conversations/{conversationId}/sessions/{sessionId}.jsonl
+ *
+ * `userId` and `conversationId` are bound at construction from the trusted turn
+ * request — they are NOT taken from the SDK-provided key, whose `projectKey` is
+ * derived from the agent cwd and carries no tenancy meaning. Per-user and
+ * per-conversation isolation therefore holds structurally: a store built for
+ * one {user, conversation} can only ever read or write that subtree. The
+ * SDK-supplied `sessionId`/`subpath` are validated before they are joined into
+ * a path so a malformed value cannot escape the conversation's `sessions/` dir.
+ *
+ * Subagent transcript resume is intentionally unsupported: the sandbox agent
+ * runs without the Task tool, so it never spawns subagents and the SDK never
+ * needs `listSubkeys` to discover their transcripts. `append`/`load` still
+ * accept a `subpath` (validated) so a stray subagent batch is stored rather
+ * than lost, but no `listSubkeys` is implemented.
+ */
+
+import { createHash } from "node:crypto";
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import type {
+	SessionKey,
+	SessionStore,
+	SessionStoreEntry,
+} from "@anthropic-ai/claude-agent-sdk";
+
+const VALID_ID = /^[A-Za-z0-9_-]+$/;
+const MAX_ID_LENGTH = 128;
+
+/**
+ * Throw unless `value` is a non-empty, length-bounded id from the safe charset.
+ * Used for `conversationId` and the SDK `sessionId`, both of which arrive in a
+ * known-safe shape (chat-api charset / SDK UUID). A malformed value is rejected,
+ * never rewritten, so the stored path always matches the id the caller used.
+ */
+function assertSafeId(label: string, value: unknown): asserts value is string {
+	if (
+		typeof value !== "string" ||
+		value.length === 0 ||
+		value.length > MAX_ID_LENGTH ||
+		!VALID_ID.test(value)
+	) {
+		throw new Error(`Invalid ${label}: ${JSON.stringify(value)}`);
+	}
+}
+
+/**
+ * Validate an optional `subpath` (e.g. `subagents/agent-7`). `/` is allowed as
+ * a separator, but every segment must be from the safe charset — this rejects
+ * `..`, absolute paths, and NUL before the subpath is joined into a file path.
+ */
+function assertSafeSubpath(subpath: string): void {
+	const segments = subpath.split("/");
+	for (const segment of segments) {
+		if (segment.length === 0 || !VALID_ID.test(segment)) {
+			throw new Error(`Invalid session subpath: ${JSON.stringify(subpath)}`);
+		}
+	}
+}
+
+/**
+ * Hash a `userId` into a fixed-length, path-safe segment. The member code has
+ * no enforced charset or length, so it is hashed rather than used verbatim:
+ * any input maps to `[0-9a-f]{64}`, distinct ids map to distinct segments
+ * (per-user isolation), and nothing can traverse out of `users/`.
+ */
+function encodeUserSegment(userId: string): string {
+	return createHash("sha256").update(userId, "utf8").digest("hex");
+}
+
+export interface SessionStoreConfig {
+	/** Durable root dir. In the sandbox this is bound rw; in tests a temp dir. */
+	rootDir: string;
+	/** Trusted member code from the turn request. */
+	userId: string;
+	/** Trusted conversation id from the turn request. */
+	conversationId: string;
+}
+
+export class FileSystemSessionStore implements SessionStore {
+	private readonly sessionsDir: string;
+
+	constructor(config: SessionStoreConfig) {
+		if (typeof config.userId !== "string" || config.userId.length === 0) {
+			throw new Error(`Invalid userId: ${JSON.stringify(config.userId)}`);
+		}
+		assertSafeId("conversationId", config.conversationId);
+		this.sessionsDir = join(
+			config.rootDir,
+			"users",
+			encodeUserSegment(config.userId),
+			"conversations",
+			config.conversationId,
+			"sessions",
+		);
+	}
+
+	/**
+	 * Resolve the JSONL file for a key. Ignores `key.projectKey` (SDK-derived
+	 * from cwd, not tenancy) and uses the {user, conversation} bound at
+	 * construction. Validates the SDK-supplied `sessionId`/`subpath` so neither
+	 * can escape `sessionsDir`.
+	 */
+	private fileFor(key: SessionKey): string {
+		assertSafeId("sessionId", key.sessionId);
+		if (key.subpath === undefined) {
+			return join(this.sessionsDir, `${key.sessionId}.jsonl`);
+		}
+		assertSafeSubpath(key.subpath);
+		return join(this.sessionsDir, key.sessionId, `${key.subpath}.jsonl`);
+	}
+
+	/**
+	 * Append a transcript batch as JSONL, preserving call order. One
+	 * `appendFileSync` per batch keeps entries within a batch contiguous and in
+	 * order; concurrent processes interleave by commit time, per the contract.
+	 */
+	async append(key: SessionKey, entries: SessionStoreEntry[]): Promise<void> {
+		if (entries.length === 0) return;
+		const file = this.fileFor(key);
+		mkdirSync(dirname(file), { recursive: true });
+		const lines = `${entries.map((e) => JSON.stringify(e)).join("\n")}\n`;
+		appendFileSync(file, lines, "utf8");
+	}
+
+	/**
+	 * Load a full session for resume. Returns the appended entry sequence, or
+	 * `null` for a session that was never written (the SDK then starts fresh).
+	 */
+	async load(key: SessionKey): Promise<SessionStoreEntry[] | null> {
+		const file = this.fileFor(key);
+		if (!existsSync(file)) return null;
+		const raw = readFileSync(file, "utf8");
+		const entries: SessionStoreEntry[] = [];
+		for (const line of raw.split("\n")) {
+			if (line.length === 0) continue;
+			entries.push(JSON.parse(line) as SessionStoreEntry);
+		}
+		return entries;
+	}
+}
+
+/**
+ * Build a session store from config, or `null` when durable session storage is
+ * not configured (no root) — the caller then runs with the SDK's default local
+ * transcript only, today's behavior.
+ */
+export function createSessionStore(
+	config: Partial<SessionStoreConfig>,
+): FileSystemSessionStore | null {
+	if (!config.rootDir || !config.userId || !config.conversationId) return null;
+	return new FileSystemSessionStore({
+		rootDir: config.rootDir,
+		userId: config.userId,
+		conversationId: config.conversationId,
+	});
+}
+
+/** Env var naming the durable session-transcript root. Unset = disabled. */
+export const SESSION_STORE_ROOT_ENV = "AGENT_SESSION_STORE_ROOT";

--- a/apps/sandbox-daemon/session-store.ts
+++ b/apps/sandbox-daemon/session-store.ts
@@ -146,7 +146,18 @@ export class FileSystemSessionStore implements SessionStore {
 		const entries: SessionStoreEntry[] = [];
 		for (const line of raw.split("\n")) {
 			if (line.length === 0) continue;
-			entries.push(JSON.parse(line) as SessionStoreEntry);
+			try {
+				entries.push(JSON.parse(line) as SessionStoreEntry);
+			} catch {
+				// A transcript line can be truncated if a prior turn was SIGKILL'd
+				// (idle/max-turn watchdog) mid-append. Tolerate it: skip the
+				// unparseable line so resume degrades to the intact prefix, rather
+				// than the SDK failing the whole turn when load() rejects. Logged so
+				// the corruption is observable.
+				console.error(
+					"skipping unparseable session transcript line on load (truncated write?)",
+				);
+			}
 		}
 		return entries;
 	}

--- a/apps/sandbox-daemon/session-store.ts
+++ b/apps/sandbox-daemon/session-store.ts
@@ -27,7 +27,6 @@
  * than lost, but no `listSubkeys` is implemented.
  */
 
-import { createHash } from "node:crypto";
 import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import type {
@@ -35,26 +34,12 @@ import type {
 	SessionStore,
 	SessionStoreEntry,
 } from "@anthropic-ai/claude-agent-sdk";
+import {
+	assertSafeId,
+	resolveConversationSessionsDir,
+} from "./session-store-paths";
 
 const VALID_ID = /^[A-Za-z0-9_-]+$/;
-const MAX_ID_LENGTH = 128;
-
-/**
- * Throw unless `value` is a non-empty, length-bounded id from the safe charset.
- * Used for `conversationId` and the SDK `sessionId`, both of which arrive in a
- * known-safe shape (chat-api charset / SDK UUID). A malformed value is rejected,
- * never rewritten, so the stored path always matches the id the caller used.
- */
-function assertSafeId(label: string, value: unknown): asserts value is string {
-	if (
-		typeof value !== "string" ||
-		value.length === 0 ||
-		value.length > MAX_ID_LENGTH ||
-		!VALID_ID.test(value)
-	) {
-		throw new Error(`Invalid ${label}: ${JSON.stringify(value)}`);
-	}
-}
 
 /**
  * Validate an optional `subpath` (e.g. `subagents/agent-7`). `/` is allowed as
@@ -70,16 +55,6 @@ function assertSafeSubpath(subpath: string): void {
 	}
 }
 
-/**
- * Hash a `userId` into a fixed-length, path-safe segment. The member code has
- * no enforced charset or length, so it is hashed rather than used verbatim:
- * any input maps to `[0-9a-f]{64}`, distinct ids map to distinct segments
- * (per-user isolation), and nothing can traverse out of `users/`.
- */
-function encodeUserSegment(userId: string): string {
-	return createHash("sha256").update(userId, "utf8").digest("hex");
-}
-
 export interface SessionStoreConfig {
 	/** Durable root dir. In the sandbox this is bound rw; in tests a temp dir. */
 	rootDir: string;
@@ -93,17 +68,13 @@ export class FileSystemSessionStore implements SessionStore {
 	private readonly sessionsDir: string;
 
 	constructor(config: SessionStoreConfig) {
-		if (typeof config.userId !== "string" || config.userId.length === 0) {
-			throw new Error(`Invalid userId: ${JSON.stringify(config.userId)}`);
-		}
-		assertSafeId("conversationId", config.conversationId);
-		this.sessionsDir = join(
+		// Shares the exact path scheme the daemon binds into the agent's bwrap
+		// namespace (see session-store-paths.ts), so the dir the SDK writes is the
+		// one — and only one — re-exposed read-write to this turn.
+		this.sessionsDir = resolveConversationSessionsDir(
 			config.rootDir,
-			"users",
-			encodeUserSegment(config.userId),
-			"conversations",
+			config.userId,
 			config.conversationId,
-			"sessions",
 		);
 	}
 

--- a/bun.lock
+++ b/bun.lock
@@ -56,7 +56,7 @@
       "name": "sandbox-daemon",
       "version": "0.1.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.2.97",
+        "@anthropic-ai/claude-agent-sdk": "0.2.117",
         "hono": "^4.10.1",
       },
     },
@@ -66,9 +66,25 @@
     },
   },
   "packages": {
-    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.97", "", { "dependencies": { "@anthropic-ai/sdk": "^0.80.0", "@modelcontextprotocol/sdk": "^1.27.1" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-754teaU0nfrn9BC0YWzPjSbJj253GfPUtuUnkrde7LGsaKtFSjEEuQJq5skJvpozqcn+B8frrtWVPkvFdnupTw=="],
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.117", "", { "dependencies": { "@anthropic-ai/sdk": "^0.81.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.117", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.117", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.117", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.117", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.117", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.117", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.117", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.117" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-pVBss1Vu0w87nKCBhWtjMggSgCh6GVUtdRmuE58ZvXv0E2q0JcnUCQHehmn92BAW0+VCwPY8q/k7uKWkgwz/gA=="],
 
-    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.80.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-WeXLn7zNVk3yjeshn+xZHvld6AoFUOR3Sep6pSoHho5YbSi6HwcirqgPA5ccFuW8QTVJAAU7N8uQQC6Wa9TG+g=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.117", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ZeC/Lz8XMKQ5w+GmjTziPR8bSSarBtNCJMkMAYRT9ekNmyXSWXEwGLENe5TDDmtpzNNzAB1mQNuIYoqTsqgV3w=="],
+
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.117", "", { "os": "darwin", "cpu": "x64" }, "sha512-DKyggGzzpDcr9S435xlpbpwkEYKZNbePSekug75tJclK8l4ddD9+M9BFgMiSUq9F1Zt53kUaRDihDu/cBKvkdQ=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.117", "", { "os": "linux", "cpu": "arm64" }, "sha512-jyHmyZQavpPOe3zxBRX3KbdOAJ8JwZ8m/wMr5bhHhhcstugm/vJx6IIs7D44VvFjk+8sqdvR2ZrliL8PUcJL0g=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.117", "", { "os": "linux", "cpu": "arm64" }, "sha512-bJU5gEOmM4VCOn4h8vipOKgdhPATePQ23mMpvyVqtVyipWppHfOUfVkqXb+SrF/hfkNSMYxDuoKxbJ+MmKtGjg=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.2.117", "", { "os": "linux", "cpu": "x64" }, "sha512-Zb5PXKrDNbQ1dyNYwxZMNL+F2Dhgjh9f9B21wZUJqkhJL69hRJwJyxO42HiNmB2zGCaTxQTyjPhLdB/eQJo74Q=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.117", "", { "os": "linux", "cpu": "x64" }, "sha512-LIkKTAYZGugEVssAuWCPqlDWSqhVZAveNPNsfKLbuG1naIMCR04fUqil6i3d3mAAfk7FaS5D4IdHp45psi+GDw=="],
+
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.117", "", { "os": "win32", "cpu": "arm64" }, "sha512-uetggH3B83PiH0a9D/5MVXB5Hqnlr2DVajehwAP2x0Mt4DBd632ICnHpu6pnSP+vVkWgq3FgQlkHe91RfP+peA=="],
+
+    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.2.117", "", { "os": "win32", "cpu": "x64" }, "sha512-TT4KngAokDTJSvQ2mrAP6ZRkXj50OLj7Tb1zZA4CnkmrrEidgs4KrMx7er1ZwoivngIvCekV9+TbtC9giknr5w=="],
+
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.81.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw=="],
 
     "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
@@ -99,38 +115,6 @@
     "@hono/node-server": ["@hono/node-server@1.19.13", "", { "peerDependencies": { "hono": "^4" } }, "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ=="],
 
     "@hono/standard-validator": ["@hono/standard-validator@0.1.5", "", { "peerDependencies": { "@standard-schema/spec": "1.0.0", "hono": ">=3.9.0" } }, "sha512-EIyZPPwkyLn6XKwFj5NBEWHXhXbgmnVh2ceIFo5GO7gKI9WmzTjPDKnppQB0KrqKeAkq3kpoW4SIbu5X1dgx3w=="],
-
-    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
-
-    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
-
-    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
-
-    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
-
-    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
-
-    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
-
-    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
-
-    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
-
-    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
-
-    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
-
-    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
-
-    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
-
-    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
-
-    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
-
-    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
-
-    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
     "@isaacs/cliui": ["@isaacs/cliui@9.0.0", "", {}, "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg=="],
 


### PR DESCRIPTION
## What

Implements **MYM-27 (Task 6a)**: an external Claude Agent SDK `SessionStore` adapter so `agentSessionId` resume state survives a fresh or recycled sandbox.

Closes [MYM-27](https://linear.app/mymemo-agent/issue/MYM-27).

## Changes

- **`session-store.ts`** (new): `FileSystemSessionStore implements SessionStore` — `append`/`load`, keyed by `users/{sha256(userId)}/conversations/{conversationId}/sessions/{sessionId}.jsonl`. The SDK-supplied `sessionId`/`subpath` are validated for traversal before being joined into a path; `userId`/`conversationId` are bound from the trusted turn request (not the SDK `projectKey`), so tenant isolation is structural. `listSubkeys` is intentionally omitted — the agent runs without the Task tool, so subagent transcript resume is unsupported (documented in the module header).
- **`agent.ts`**: extracted a pure `buildQueryOptions()`; passes `sessionStore` to `query()` when configured and never with `persistSession:false`; logs the SDK `mirror_error` message so best-effort mirror failures are observable.
- **Identity wiring**: thread `userId`/`conversationId` through `turn.ts → child-spawn.ts → agent-entry.ts`. `child-spawn` adds a bwrap rw-bind + env passthrough for `AGENT_SESSION_STORE_ROOT` so the sandboxed agent can write the mirror.
- **Gating**: behavior is gated on `AGENT_SESSION_STORE_ROOT`. Unset → today's behavior (local `~/.claude/projects` transcript only); no extra bind, no env forwarded.
- **SDK bump**: `@anthropic-ai/claude-agent-sdk` `0.2.97 → 0.2.117` (the pinned 0.2.97 has no `sessionStore` option).

## Acceptance criteria → coverage

- `runAgent` passes `sessionStore` to `query()` when configured → `agent.test.ts`
- adapter `append`/`load`; `listSubkeys` documented as unsupported → `session-store.ts` header + `session-store.test.ts`
- keyed by user/conversation/sessionId, no cross-access → isolation tests
- resume by `agentSessionId` in a fresh daemon/sandbox context → fresh-instance round-trip test
- append ordering, load sequence, unknown → `null`, path/key traversal rejection → adapter tests
- mirror errors surfaced in logs → `mirror_error` → `console.error` (drained into daemon log)
- does **not** set `persistSession:false` with `sessionStore` → guarded by a `buildQueryOptions` test

## Tests

- `bun test` in `apps/sandbox-daemon`: **81 pass / 0 fail** (was 61; +20 new).
- Repo-wide `bun run test`: all workspaces green (llm-token 14, chat-api 83, gateway 34, mymemo-docs 8, sandbox-daemon 81).
- `bun run build` produces both bundles; daemon bundle stays 27.9 KB (adapter runtime lands only in `agent.js`).

## Risk / follow-ups

- The SDK bump (20 patch releases) is the main risk; the existing daemon stream/result handling is unchanged and all tests + both bundles build clean.
- Durable cross-recycle persistence depends on `AGENT_SESSION_STORE_ROOT` pointing at storage that outlives the sandbox (a mounted volume) and on chat-api hydrate/sync covering that root — wiring the root into the chat-api orchestration + `WorkspaceStore` sync is left to the leasing/orchestration tasks. Until then the adapter is correct and tested but dormant (env unset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)