### PR TITLE
feat(daemon): isolate SDK transcripts via per-conversation CLAUDE_CONFIG_DIR (MYM-33)

### DIFF
--- a/apps/sandbox-daemon/child-spawn.test.ts
+++ b/apps/sandbox-daemon/child-spawn.test.ts
@@ -2,6 +2,7 @@ import {
 	afterAll,
 	afterEach,
 	beforeAll,
+	beforeEach,
 	describe,
 	expect,
 	it,
@@ -19,7 +20,10 @@ import {
 
 describe("buildAgentSpawnArgv", () => {
 	it("wraps bun /workspace/agent.js with bwrap and the agreed flags", () => {
-		const argv = buildAgentSpawnArgv("/workspace/data/u1/canonical");
+		const argv = buildAgentSpawnArgv(
+			"/workspace/data/u1/canonical",
+			"/workspace/data/u1/claude-config",
+		);
 
 		expect(argv[0]).toBe("bwrap");
 
@@ -50,7 +54,10 @@ describe("buildAgentSpawnArgv", () => {
 
 	it("masks /workspace, then re-binds only the agent bundle and selected scope", () => {
 		const cwd = "/workspace/data/u2/scopes/request-doc-42";
-		const argv = buildAgentSpawnArgv(cwd);
+		const argv = buildAgentSpawnArgv(
+			cwd,
+			"/workspace/data/u2/scopes/claude-config",
+		);
 
 		const roRootIdx = argv.findIndex(
 			(a, i) => a === "--ro-bind" && argv[i + 1] === "/" && argv[i + 2] === "/",
@@ -85,24 +92,40 @@ describe("buildAgentSpawnArgv", () => {
 		expect(tmpfsWorkspaceIdx).toBeLessThan(bindCwdIdx);
 	});
 
-	it("re-binds ~/.claude/projects rw so the Claude SDK can persist sessions", () => {
-		// Claude Agent SDK writes session transcripts under ~/.claude/projects;
-		// with --ro-bind / / that path would be read-only and both the
-		// first-turn write and resume on subsequent turns would silently
-		// fail. Pin that we re-bind it rw.
-		const argv = buildAgentSpawnArgv("/workspace/data/u1/canonical");
-		const projectsDir = `${Bun.env.HOME ?? "/home/user"}/.claude/projects`;
+	it("re-binds the per-conversation SDK config home rw, as a sibling of cwd (not the project .claude)", () => {
+		// CLAUDE_CONFIG_DIR is a sibling of the agent's work/ cwd, deliberately not
+		// named `.claude` and not under cwd, so the SDK's config + transcript writes
+		// can't collide with the agent's project-local `.claude`. The shared
+		// ~/.claude is no longer bound, so it stays read-only.
+		const cwd = "/workspace/conversations/conv-1/work";
+		const configDir = "/workspace/conversations/conv-1/claude-config";
+		const argv = buildAgentSpawnArgv(cwd, configDir);
+
 		const idx = argv.findIndex(
 			(a, i) =>
 				a === "--bind" &&
-				argv[i + 1] === projectsDir &&
-				argv[i + 2] === projectsDir,
+				argv[i + 1] === configDir &&
+				argv[i + 2] === configDir,
 		);
 		expect(idx).toBeGreaterThan(-1);
+		// Config home is NOT under cwd and is not named `.claude`.
+		expect(configDir.startsWith(`${cwd}/`)).toBe(false);
+		expect(argv.some((a) => a.includes("/.claude"))).toBe(false);
+		// The config home lives under /workspace, so its rw --bind MUST come after
+		// the `--tmpfs /workspace` mask — otherwise the mask shadows it read-only
+		// and the SDK's first-turn config/transcript write wedges the turn.
+		const tmpfsWorkspaceIdx = argv.findIndex(
+			(a, i) => a === "--tmpfs" && argv[i + 1] === "/workspace",
+		);
+		expect(tmpfsWorkspaceIdx).toBeGreaterThan(-1);
+		expect(tmpfsWorkspaceIdx).toBeLessThan(idx);
 	});
 
 	it("does not expose /workspace/daemon.log, daemon.js, or sync.js", () => {
-		const argv = buildAgentSpawnArgv("/workspace/data/u1/canonical");
+		const argv = buildAgentSpawnArgv(
+			"/workspace/data/u1/canonical",
+			"/workspace/data/u1/claude-config",
+		);
 		// None of these paths should appear anywhere in the argv — they are
 		// covered by the --tmpfs /workspace and never re-bound.
 		expect(argv).not.toContain("/workspace/daemon.js");
@@ -111,7 +134,7 @@ describe("buildAgentSpawnArgv", () => {
 	});
 
 	it("adds no session-store mount when not configured", () => {
-		const argv = buildAgentSpawnArgv("/tmp/cwd");
+		const argv = buildAgentSpawnArgv("/tmp/cwd", "/tmp/claude-config");
 		expect(argv).not.toContain("/durable");
 	});
 
@@ -122,7 +145,10 @@ describe("buildAgentSpawnArgv", () => {
 		// re-bind ONLY the per-conversation sessions dir.
 		const root = "/durable";
 		const sessionsDir = "/durable/users/abc123/conversations/conv-1/sessions";
-		const argv = buildAgentSpawnArgv("/tmp/cwd", { root, sessionsDir });
+		const argv = buildAgentSpawnArgv("/tmp/cwd", "/tmp/claude-config", {
+			root,
+			sessionsDir,
+		});
 
 		const tmpfsRootIdx = argv.findIndex(
 			(a, i) => a === "--tmpfs" && argv[i + 1] === root,
@@ -188,7 +214,7 @@ describe("buildAgentSpawnArgv", () => {
 		process.env.SANDBOX_BUN_PATH = "/custom/bun";
 		process.env.SANDBOX_AGENT_PATH = "/custom/agent.js";
 		try {
-			const argv = buildAgentSpawnArgv("/tmp/cwd");
+			const argv = buildAgentSpawnArgv("/tmp/cwd", "/tmp/claude-config");
 			expect(argv[0]).toBe("/custom/bwrap");
 			expect(argv.slice(-2)).toEqual(["/custom/bun", "/custom/agent.js"]);
 		} finally {
@@ -201,12 +227,22 @@ describe("buildAgentSpawnArgv", () => {
 
 describe("spawnAgent agent environment", () => {
 	let spawnSpy: ReturnType<typeof spyOn> | undefined;
-	let originalHome: string | undefined;
+	let baseDir: string;
+	let cwd: string;
+	let claudeConfigDir: string;
+
+	beforeEach(() => {
+		// Model the conversation workspace: cwd is `<base>/work` and the SDK config
+		// home is its sibling `<base>/claude-config` (the layout createConversation-
+		// Workspace materializes). Both sit under baseDir and clean up together.
+		baseDir = mkdtempSync(join(tmpdir(), "spawn-agent-"));
+		cwd = join(baseDir, "work");
+		claudeConfigDir = join(baseDir, "claude-config");
+	});
 
 	afterEach(() => {
 		spawnSpy?.mockRestore();
-		if (originalHome === undefined) delete Bun.env.HOME;
-		else Bun.env.HOME = originalHome;
+		rmSync(baseDir, { recursive: true, force: true });
 	});
 
 	function fakeProc() {
@@ -227,10 +263,6 @@ describe("spawnAgent agent environment", () => {
 	}
 
 	it("passes the gateway base url + bearer token and never a provider key", async () => {
-		// Keep ensureClaudeProjectsDir's mkdir inside a temp HOME.
-		originalHome = Bun.env.HOME;
-		Bun.env.HOME = join(tmpdir(), `spawn-agent-${Date.now()}`);
-
 		spawnSpy = spyOn(Bun, "spawn").mockReturnValue(
 			fakeProc() as unknown as ReturnType<typeof Bun.spawn>,
 		);
@@ -238,7 +270,8 @@ describe("spawnAgent agent environment", () => {
 		await spawnAgent({
 			userQuery: "q",
 			systemPrompt: "s",
-			cwd: "/workspace/data/u1/canonical",
+			cwd,
+			claudeConfigDir,
 			llmBaseUrl: "https://gateway.example",
 			docGatewayUrl: "https://docs.example",
 			llmToken: "tok-123",
@@ -256,13 +289,14 @@ describe("spawnAgent agent environment", () => {
 		// Document access uses its own gateway url + (aud: documents) token.
 		expect(env.MYMEMO_DOC_GATEWAY_URL).toBe("https://docs.example");
 		expect(env.MYMEMO_DOC_TOKEN).toBe("doc-456");
+		// SDK config + transcripts are isolated per conversation in a sibling of
+		// cwd (not the project `.claude`, not the shared ~/.claude).
+		expect(env.CLAUDE_CONFIG_DIR).toBe(claudeConfigDir);
 		// The whole point of the gateway: no provider key reaches the agent.
 		expect("ANTHROPIC_API_KEY" in env).toBe(false);
 	});
 
 	it("forwards the session-store root + identity when configured, omits them otherwise", async () => {
-		originalHome = Bun.env.HOME;
-		Bun.env.HOME = join(tmpdir(), `spawn-agent-store-${Date.now()}`);
 		// A DURABLE root: not under /workspace or /tmp (tmpdir() is /tmp on Linux,
 		// which assertSessionStoreRootSafe now rejects). Use the package dir.
 		const storeRoot = join(
@@ -299,7 +333,8 @@ describe("spawnAgent agent environment", () => {
 			await spawnAgent({
 				userQuery: "q",
 				systemPrompt: "s",
-				cwd: "/workspace/conversations/conv-1/work",
+				cwd,
+				claudeConfigDir,
 				userId: "member-abc",
 				conversationId: "conv-1",
 				llmBaseUrl: "https://gateway.example",
@@ -335,7 +370,6 @@ describe("spawnAgent idle timeout", () => {
 	// NDJSON + watchdog wiring rather than mocking it.
 	let tmpDir: string;
 	const fixtures: Record<string, string> = {};
-	let originalHome: string | undefined;
 
 	const ENV_VARS = [
 		"SANDBOX_BWRAP_PATH",
@@ -347,10 +381,9 @@ describe("spawnAgent idle timeout", () => {
 
 	beforeAll(() => {
 		tmpDir = mkdtempSync(join(tmpdir(), "child-spawn-"));
-
-		// Keep ensureClaudeProjectsDir's mkdir inside the temp dir.
-		originalHome = Bun.env.HOME;
-		Bun.env.HOME = tmpDir;
+		// makeInput models the conversation workspace under tmpDir: cwd is
+		// `<tmpDir>/work` and the config home `<tmpDir>/claude-config`. The
+		// bwrap-shim strips the bind flags, so neither needs to exist on disk.
 
 		fixtures.bwrapShim = join(tmpDir, "bwrap-shim.sh");
 		writeFileSync(
@@ -415,8 +448,6 @@ describe("spawnAgent idle timeout", () => {
 			if (originalEnv[key] === undefined) delete process.env[key];
 			else process.env[key] = originalEnv[key];
 		}
-		if (originalHome === undefined) delete Bun.env.HOME;
-		else Bun.env.HOME = originalHome;
 		rmSync(tmpDir, { recursive: true, force: true });
 	});
 
@@ -424,7 +455,8 @@ describe("spawnAgent idle timeout", () => {
 		return {
 			userQuery: "test",
 			systemPrompt: "test",
-			cwd: tmpDir,
+			cwd: join(tmpDir, "work"),
+			claudeConfigDir: join(tmpDir, "claude-config"),
 			llmBaseUrl: "https://gateway.example",
 			docGatewayUrl: "https://docs.example",
 			llmToken: "tok-test",

--- a/apps/sandbox-daemon/child-spawn.ts
+++ b/apps/sandbox-daemon/child-spawn.ts
@@ -69,17 +69,6 @@ function getAgentMaxTurnMs(): number {
 // Changing it requires updating all three.
 const WORKSPACE_ROOT = "/workspace";
 
-// The Claude Agent SDK persists session transcripts to
-// ~/.claude/projects/ by default. With --ro-bind / / that directory is
-// read-only inside bwrap, which breaks both the first-turn write and any
-// `resume: sessionId` on later turns. Re-bind just this subtree as rw.
-// Confined to the specific directory the SDK writes to so the rest of
-// ~/.claude (settings, auth state) stays read-only.
-function getClaudeProjectsDir(): string {
-	const home = Bun.env.HOME ?? "/home/user";
-	return `${home}/.claude/projects`;
-}
-
 // Durable root the agent's SessionStore mirror writes to (must match
 // SESSION_STORE_ROOT_ENV in session-store.ts, which the agent reads). Unset =
 // session mirroring disabled, so no extra bwrap bind.
@@ -108,8 +97,8 @@ function isAtOrUnder(child: string, parent: string): boolean {
  * order (last wins):
  *  - root AT/UNDER an ephemeral tmpfs (`/workspace`, `/tmp`) — the transcript is
  *    sandbox-local or gets re-masked, so resume silently never works.
- *  - root that is an ANCESTOR of a required re-bind (agent bundle, cwd,
- *    `~/.claude/projects`) — our `--tmpfs <root>` shadows it and wedges the turn.
+ *  - root that is an ANCESTOR of a required re-bind (agent bundle, cwd, the SDK
+ *    config home) — our `--tmpfs <root>` shadows it and wedges the turn.
  * Requires an absolute path. Reject loudly rather than mirror into a void.
  */
 export function assertSessionStoreRootSafe(
@@ -180,13 +169,13 @@ function resolveSessionStoreBind(
  *                                             dir; documents are fetched via
  *                                             the `mymemo-docs` CLI, not
  *                                             read from disk).
- *   5. --bind ~/.claude/projects ...       — re-expose the Claude Agent SDK's
- *                                             session transcript directory
- *                                             rw so resume across turns
- *                                             works. Caller is responsible
- *                                             for ensuring the dir exists
- *                                             before spawn (see
- *                                             ensureClaudeProjectsDir).
+ *   5. --bind <claudeConfigDir> ...        — re-expose the per-conversation
+ *                                             CLAUDE_CONFIG_DIR (a sibling of
+ *                                             cwd, from the workspace layout) rw
+ *                                             so the SDK can write its config +
+ *                                             session transcripts. The dir is
+ *                                             created by createConversationWorkspace
+ *                                             before spawn.
  *   6. --tmpfs <store root> + --bind <conv> — when session mirroring is on,
  *                                             mask the whole durable transcript
  *                                             root, then re-bind ONLY this
@@ -205,10 +194,10 @@ function resolveSessionStoreBind(
  */
 export function buildAgentSpawnArgv(
 	cwd: string,
+	claudeConfigDir: string,
 	sessionStoreBind?: { root: string; sessionsDir: string },
 ): string[] {
 	const agentBundle = getAgentBundlePath();
-	const claudeProjectsDir = getClaudeProjectsDir();
 	return [
 		getBwrapExecutable(),
 		"--ro-bind",
@@ -222,9 +211,11 @@ export function buildAgentSpawnArgv(
 		"--bind",
 		cwd,
 		cwd,
+		// The SDK's per-conversation CLAUDE_CONFIG_DIR — a sibling of cwd, re-bound
+		// rw so config + transcript writes land in an isolated, non-project dir.
 		"--bind",
-		claudeProjectsDir,
-		claudeProjectsDir,
+		claudeConfigDir,
+		claudeConfigDir,
 		// Mask the entire durable transcript root (defeats the broad `--ro-bind /
 		// /` read-through for other tenants), then re-expose ONLY this
 		// conversation's `sessions/` dir rw. Order matters: tmpfs first, bind
@@ -253,16 +244,6 @@ export function buildAgentSpawnArgv(
 		getBunExecutable(),
 		agentBundle,
 	];
-}
-
-/**
- * Pre-create ~/.claude/projects so the bwrap --bind has something to mount.
- * Idempotent. Must be called before spawnAgent on every turn — bwrap fails
- * if the source path doesn't exist, and the SDK can't create it itself
- * (the rest of ~/.claude is read-only inside the sandbox).
- */
-function ensureClaudeProjectsDir(): void {
-	mkdirSync(getClaudeProjectsDir(), { recursive: true });
 }
 
 function narrowAgentEvent(raw: Record<string, unknown>): AgentEvent | null {
@@ -348,6 +329,13 @@ export interface SpawnAgentInput {
 	userQuery: string;
 	systemPrompt: string;
 	cwd: string;
+	/**
+	 * Per-conversation CLAUDE_CONFIG_DIR (a sibling of cwd, from the workspace
+	 * layout). Set on the agent and re-bound rw so the SDK's config + transcript
+	 * writes stay isolated from the agent's project `.claude`. Created by the
+	 * caller (createConversationWorkspace) before spawn, like cwd.
+	 */
+	claudeConfigDir: string;
 	sessionId?: string;
 	/** Trusted member code — keys the durable session-transcript store. */
 	userId?: string;
@@ -378,9 +366,15 @@ export interface SpawnAgentResult {
 export async function spawnAgent(
 	input: SpawnAgentInput,
 ): Promise<SpawnAgentResult> {
-	const { onEvent, llmBaseUrl, docGatewayUrl, llmToken, docToken, ...config } =
-		input;
-	ensureClaudeProjectsDir();
+	const {
+		onEvent,
+		llmBaseUrl,
+		docGatewayUrl,
+		llmToken,
+		docToken,
+		claudeConfigDir,
+		...config
+	} = input;
 	// Bind only this conversation's transcript subtree into the agent (never the
 	// whole multi-tenant root). Pre-create it so the bwrap --bind has a source.
 	const sessionStoreBind = resolveSessionStoreBind(
@@ -388,39 +382,47 @@ export async function spawnAgent(
 		config.conversationId,
 	);
 	if (sessionStoreBind) {
-		// Reject a root that would mask the agent bundle, cwd, or ~/.claude before
-		// we spawn — otherwise the --tmpfs root silently shadows them.
+		// Reject a root that would mask the agent bundle, cwd, or the SDK config
+		// home before we spawn — otherwise the --tmpfs root silently shadows them.
 		assertSessionStoreRootSafe(sessionStoreBind.root, [
 			getAgentBundlePath(),
 			config.cwd,
-			getClaudeProjectsDir(),
+			claudeConfigDir,
 		]);
 		mkdirSync(sessionStoreBind.sessionsDir, { recursive: true });
 	}
-	const proc = Bun.spawn(buildAgentSpawnArgv(config.cwd, sessionStoreBind), {
-		env: {
-			// The agent holds no provider key — it talks to the LLM gateway, which
-			// injects the real key. ANTHROPIC_AUTH_TOKEN is sent as a Bearer header.
-			ANTHROPIC_BASE_URL: llmBaseUrl,
-			ANTHROPIC_AUTH_TOKEN: llmToken,
-			// Document access: the `mymemo-docs` CLI (on PATH) calls the document
-			// gateway with its own (aud: "documents") token. The gateway enforces
-			// the token's signed scope, so the agent holds no document credential.
-			MYMEMO_DOC_GATEWAY_URL: docGatewayUrl,
-			MYMEMO_DOC_TOKEN: docToken,
-			PATH: process.env.PATH ?? "",
-			CLAUDE_CODE_PATH: process.env.CLAUDE_CODE_PATH ?? "/usr/local/bin/claude",
-			// Where the agent's SessionStore mirrors transcripts. Forwarded only
-			// when the per-conversation subtree is bound above; absent => the agent
-			// builds no store and mirroring is disabled.
-			...(sessionStoreBind
-				? { [SESSION_STORE_ROOT_ENV]: sessionStoreBind.root }
-				: {}),
+	const proc = Bun.spawn(
+		buildAgentSpawnArgv(config.cwd, claudeConfigDir, sessionStoreBind),
+		{
+			env: {
+				// The agent holds no provider key — it talks to the LLM gateway, which
+				// injects the real key. ANTHROPIC_AUTH_TOKEN is sent as a Bearer header.
+				ANTHROPIC_BASE_URL: llmBaseUrl,
+				ANTHROPIC_AUTH_TOKEN: llmToken,
+				// Document access: the `mymemo-docs` CLI (on PATH) calls the document
+				// gateway with its own (aud: "documents") token. The gateway enforces
+				// the token's signed scope, so the agent holds no document credential.
+				MYMEMO_DOC_GATEWAY_URL: docGatewayUrl,
+				MYMEMO_DOC_TOKEN: docToken,
+				PATH: process.env.PATH ?? "",
+				CLAUDE_CODE_PATH:
+					process.env.CLAUDE_CODE_PATH ?? "/usr/local/bin/claude",
+				// Per-conversation config + transcript home (a sibling of cwd, not the
+				// project `.claude`). Sandbox-local, so the SDK's local writes are
+				// isolated per conversation and the shared ~/.claude stays read-only.
+				CLAUDE_CONFIG_DIR: claudeConfigDir,
+				// Where the agent's SessionStore mirrors transcripts. Forwarded only
+				// when the per-conversation subtree is bound above; absent => the agent
+				// builds no store and mirroring is disabled.
+				...(sessionStoreBind
+					? { [SESSION_STORE_ROOT_ENV]: sessionStoreBind.root }
+					: {}),
+			},
+			stdout: "pipe",
+			stderr: "pipe",
+			stdin: "pipe",
 		},
-		stdout: "pipe",
-		stderr: "pipe",
-		stdin: "pipe",
-	});
+	);
 
 	proc.stdin.write(JSON.stringify(config));
 	await proc.stdin.end();

--- a/apps/sandbox-daemon/routes/turn.ts
+++ b/apps/sandbox-daemon/routes/turn.ts
@@ -122,6 +122,10 @@ app.post("/turn", async (c) => {
 					userQuery: message,
 					systemPrompt: system_prompt,
 					cwd,
+					// Per-conversation CLAUDE_CONFIG_DIR — owned by the workspace
+					// layout (a sibling of cwd), bound rw and set on the agent so its
+					// SDK config + transcripts stay isolated from the project `.claude`.
+					claudeConfigDir: workspace.claudeConfig,
 					sessionId: agent_session_id,
 					// Identity keys the durable session-transcript store; both arrive
 					// validated from the trusted turn request.

--- a/apps/sandbox-daemon/workspace.test.ts
+++ b/apps/sandbox-daemon/workspace.test.ts
@@ -85,6 +85,7 @@ describe("resolveConversationWorkspace", () => {
 			docs: join(testRoot, "conversations", "conv-99", "docs"),
 			work: join(testRoot, "conversations", "conv-99", "work"),
 			output: join(testRoot, "conversations", "conv-99", "output"),
+			claudeConfig: join(testRoot, "conversations", "conv-99", "claude-config"),
 		});
 	});
 
@@ -96,9 +97,15 @@ describe("resolveConversationWorkspace", () => {
 });
 
 describe("createConversationWorkspace", () => {
-	it("creates system, docs, work, and output directories", () => {
+	it("creates system, docs, work, output, and claude-config directories", () => {
 		const ws = createConversationWorkspace("conv-create");
-		for (const dir of [ws.system, ws.docs, ws.work, ws.output]) {
+		for (const dir of [
+			ws.system,
+			ws.docs,
+			ws.work,
+			ws.output,
+			ws.claudeConfig,
+		]) {
 			expect(existsSync(dir)).toBe(true);
 			expect(statSync(dir).isDirectory()).toBe(true);
 		}

--- a/apps/sandbox-daemon/workspace.ts
+++ b/apps/sandbox-daemon/workspace.ts
@@ -7,8 +7,16 @@
  *     conversations/
  *       {conversationId}/
  *         docs/
- *         work/      <- the agent's working directory (cwd)
+ *         work/          <- the agent's working directory (cwd)
  *         output/
+ *         claude-config/ <- the agent SDK's CLAUDE_CONFIG_DIR (config + transcripts)
+ *
+ * `claude-config/` is the per-conversation home the daemon points the Claude
+ * Agent SDK at via CLAUDE_CONFIG_DIR. It is a SIBLING of `work/`, not a child,
+ * and deliberately NOT named `.claude`: the SDK reads project-level config from
+ * `<cwd>/.claude` (settings, commands, agents, CLAUDE.md), so a child named
+ * `.claude` would collide the SDK's own state (`projects/`, transcripts, …) with
+ * the agent's project config. Keeping it a distinct sibling separates the two.
  *
  * The agent runs from the conversation's `work/` dir. `conversationId` arrives
  * from the untrusted turn request, so it is validated before it is ever joined
@@ -70,6 +78,8 @@ export interface ConversationWorkspace {
 	work: string;
 	/** /workspace/conversations/{conversationId}/output */
 	output: string;
+	/** /workspace/conversations/{conversationId}/claude-config — the agent SDK's CLAUDE_CONFIG_DIR */
+	claudeConfig: string;
 }
 
 /**
@@ -89,6 +99,7 @@ export function resolveConversationWorkspace(
 		docs: join(conversation, "docs"),
 		work: join(conversation, "work"),
 		output: join(conversation, "output"),
+		claudeConfig: join(conversation, "claude-config"),
 	};
 }
 
@@ -105,5 +116,6 @@ export function createConversationWorkspace(
 	mkdirSync(ws.docs, { recursive: true });
 	mkdirSync(ws.work, { recursive: true });
 	mkdirSync(ws.output, { recursive: true });
+	mkdirSync(ws.claudeConfig, { recursive: true });
 	return ws;
 }


### PR DESCRIPTION
## What

Point the Claude Agent SDK at a **per-conversation `CLAUDE_CONFIG_DIR`** instead of the default `~/.claude`, so its local config + session transcripts are isolated per user/conversation.

The config home is now a first-class member of the conversation workspace layout:

```
/workspace/conversations/{id}/
  docs/  work/  output/  claude-config/   ← CLAUDE_CONFIG_DIR
```

- `claude-config/` is added to `ConversationWorkspace` and created by `createConversationWorkspace` (same ownership model as `work/`).
- `turn.ts` threads `workspace.claudeConfig` into `spawnAgent`; `child-spawn.ts` sets `CLAUDE_CONFIG_DIR` and re-binds that dir rw via bwrap, **replacing** the old `~/.claude/projects` rw bind. `~/.claude` is no longer bound at all → it stays fully read-only.

## Why

Previously the agent used the default `~/.claude/projects` (re-bound rw via bwrap), not a per-conversation config dir, so local SDK transcript writes weren't isolated. (Review follow-up to MYM-27.)

## Reviewer notes

- **The config home is a SIBLING of the agent's `work/` cwd and deliberately NOT named `.claude`.** Claude Code reads *project-level* config from `<cwd>/.claude` (settings, commands, agents, CLAUDE.md); pointing `CLAUDE_CONFIG_DIR` (the user-level config home) at a child named `.claude` would collide the SDK's own state (`projects/`, transcripts, `todos/`) with the agent's project config. A distinct sibling keeps them separated.
- **Durable cross-sandbox resume is unchanged.** It flows through the `SessionStore` mirror (`AGENT_SESSION_STORE_ROOT`), keyed by `{user, conversation, sessionId}` and independent of `CLAUDE_CONFIG_DIR`. The local config home is the SDK's ephemeral copy (it was already fresh per per-turn sandbox).
- Confirmed against the SDK source (`@anthropic-ai/claude-agent-sdk` v0.2.117): config dir resolves to `CLAUDE_CONFIG_DIR ?? ~/.claude`, transcripts live under `<dir>/projects`, and the SDK documents this exact pattern ("Use CLAUDE_CONFIG_DIR=… for ephemeral local writes with external mirroring").

## Testing

- `bun test` — 85/85 daemon tests pass (added an assertion that the config-home bind follows `--tmpfs /workspace`; updated workspace + spawn tests for the new layout/signature).
- `biome check .` clean; `bun run build` produces both bundles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)