### PR TITLE
feat(daemon): implement search_documents MCP tool (MYM-11)

### DIFF
--- a/apps/chat-api/e2e/compose.e2e.test.ts
+++ b/apps/chat-api/e2e/compose.e2e.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Docker-compose end-to-end test (MYM-31 harness + MYM-11 search_documents).
+ *
+ * Exercises the full product path with the E2B sandbox replaced by the local
+ * `sandbox` container: chat-api → sandbox-daemon → agent → gateway → postgres.
+ * It proves two things over a real stack:
+ *
+ *   1. A chat turn streams the target SSE vocabulary (conversation_id, run_id,
+ *      sandbox_id, text_delta…, done) and no error — the docker path stands in
+ *      for E2B end to end.
+ *   2. The agent's in-process `search_documents` MCP tool actually hydrated a
+ *      seeded document: after the turn, the conversation's docs manifest inside
+ *      the sandbox container holds an entry for one of the seeded documents,
+ *      with a localPath + source + the turn's runId. That can only happen if
+ *      search → gateway → postgres → fetch → write-to-disk → manifest all worked.
+ *
+ * REAL LLM CALLS: the gateway proxies to the configured provider, so this test
+ * makes billable calls and depends on a capable model choosing to call
+ * search_documents. It is therefore OPT-IN and never runs in the normal unit
+ * suite. Enable with:
+ *
+ *   RUN_COMPOSE_E2E=1 bun test apps/chat-api/e2e/compose.e2e.test.ts
+ *
+ * Prerequisites (see README.md "Local end-to-end harness"):
+ *   - The stack is up: `docker compose up --build` from the repo root, with the
+ *     three apps/<svc>/.env files filled in (gateway needs a real
+ *     ANTHROPIC_API_KEY). Or set COMPOSE_E2E_AUTOSTART=1 to have this test run
+ *     `docker compose up -d --wait --build` itself (and tear it down after).
+ *
+ * Overridable knobs:
+ *   COMPOSE_CHAT_URL   base URL of chat-api          (default http://localhost:3000)
+ *   COMPOSE_E2E_AUTOSTART=1  bring the stack up/down within the test
+ *   COMPOSE_E2E_TIMEOUT_MS   per-turn ceiling        (default 120000)
+ */
+
+import {
+	afterAll,
+	beforeAll,
+	describe,
+	expect,
+	it,
+	setDefaultTimeout,
+} from "bun:test";
+import { resolve } from "node:path";
+
+const RUN = process.env.RUN_COMPOSE_E2E === "1";
+const CHAT_URL = process.env.COMPOSE_CHAT_URL ?? "http://localhost:3000";
+const AUTOSTART = process.env.COMPOSE_E2E_AUTOSTART === "1";
+const TURN_TIMEOUT_MS = Number(process.env.COMPOSE_E2E_TIMEOUT_MS) || 120_000;
+
+// bun:test hooks take no per-call timeout argument, and bringing the stack up
+// (optionally with `--build`) can take minutes. Raise the file-wide default so
+// the beforeAll bring-up + the long turn don't trip the 5s default. Only set it
+// when the suite will actually run.
+if (RUN) setDefaultTimeout(660_000);
+
+// apps/chat-api/e2e -> repo root (where compose.yaml lives).
+const REPO_ROOT = resolve(import.meta.dir, "../../..");
+
+// The seeded member + documents (apps/gateway/db/init.sql). The X-Member-Code
+// header maps to the KB workspace, so document search resolves against these.
+const MEMBER_CODE = "demo-member";
+const PARTNER_CODE = "demo-partner";
+const SEEDED_DOCUMENT_IDS = ["doc-ml-intro", "doc-mymemo-overview"];
+
+interface SSEFrame {
+	event: string;
+	data: string;
+}
+
+/** Parse an SSE body into {event, data} frames (mirrors chat.route.test.ts). */
+function parseSSE(raw: string): SSEFrame[] {
+	const frames: SSEFrame[] = [];
+	for (const block of raw.split("\n\n")) {
+		let event = "";
+		let data = "";
+		for (const line of block.split("\n")) {
+			if (line.startsWith("event:")) event = line.slice("event:".length).trim();
+			else if (line.startsWith("data:"))
+				data = line.slice("data:".length).trim();
+		}
+		if (event) frames.push({ event, data });
+	}
+	return frames;
+}
+
+/** Run a docker compose subcommand from the repo root; return {code, stdout, stderr}. */
+async function compose(
+	args: string[],
+	timeoutMs = 180_000,
+): Promise<{ code: number; stdout: string; stderr: string }> {
+	const proc = Bun.spawn(["docker", "compose", ...args], {
+		cwd: REPO_ROOT,
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const killer = setTimeout(() => proc.kill("SIGKILL"), timeoutMs);
+	try {
+		const [stdout, stderr, code] = await Promise.all([
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+			proc.exited,
+		]);
+		return { code, stdout, stderr };
+	} finally {
+		clearTimeout(killer);
+	}
+}
+
+/** True once chat-api answers /health (the stack is reachable). */
+async function chatApiHealthy(): Promise<boolean> {
+	try {
+		const res = await fetch(`${CHAT_URL}/health`, {
+			signal: AbortSignal.timeout(2_000),
+		});
+		return res.ok;
+	} catch {
+		return false;
+	}
+}
+
+async function waitForHealthy(timeoutMs: number): Promise<boolean> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (await chatApiHealthy()) return true;
+		await Bun.sleep(2_000);
+	}
+	return false;
+}
+
+/**
+ * Read the docs manifest for a conversation from inside the sandbox container.
+ * Returns null when the file does not exist (agent didn't hydrate anything).
+ */
+async function readConversationManifest(
+	conversationId: string,
+): Promise<{ version: number; documents: unknown[] } | null> {
+	const path = `/workspace/conversations/${conversationId}/docs/manifest.json`;
+	const { code, stdout } = await compose(
+		["exec", "-T", "sandbox", "sh", "-lc", `cat ${path} 2>/dev/null || true`],
+		15_000,
+	);
+	if (code !== 0 || stdout.trim() === "") return null;
+	return JSON.parse(stdout) as { version: number; documents: unknown[] };
+}
+
+let startedByTest = false;
+
+describe.skipIf(!RUN)(
+	"docker-compose E2E (E2B replaced by the sandbox container)",
+	() => {
+		beforeAll(async () => {
+			if (AUTOSTART && !(await chatApiHealthy())) {
+				const { code, stderr } = await compose(
+					["up", "-d", "--wait", "--build"],
+					600_000,
+				);
+				if (code !== 0) {
+					throw new Error(`docker compose up failed:\n${stderr}`);
+				}
+				startedByTest = true;
+			}
+
+			if (!(await waitForHealthy(60_000))) {
+				throw new Error(
+					`chat-api is not reachable at ${CHAT_URL}. Start the stack with ` +
+						`\`docker compose up --build\` (see README "Local end-to-end harness"), ` +
+						`or set COMPOSE_E2E_AUTOSTART=1.`,
+				);
+			}
+		});
+
+		afterAll(async () => {
+			// Only tear down what this test started; leave a user-managed stack alone.
+			if (startedByTest) await compose(["down"], 120_000);
+		});
+
+		it(
+			"streams a turn and hydrates a seeded document via search_documents",
+			async () => {
+				const res = await fetch(`${CHAT_URL}/v1/chat`, {
+					method: "POST",
+					headers: {
+						"content-type": "application/json",
+						"x-member-code": MEMBER_CODE,
+						"x-partner-code": PARTNER_CODE,
+					},
+					// Phrased to require the document tool: the answer is only in the
+					// seeded KB, so a correct turn must call search_documents.
+					body: JSON.stringify({
+						chatContent:
+							"Search my MyMemo documents for the introduction to machine " +
+							"learning and summarize it in one sentence.",
+					}),
+					signal: AbortSignal.timeout(TURN_TIMEOUT_MS),
+				});
+
+				expect(res.status).toBe(200);
+
+				const frames = parseSSE(await res.text());
+				const events = frames.map((f) => f.event).filter((e) => e !== "ping");
+
+				// 1. Protocol: the docker path streams the full target vocabulary and
+				//    completes without surfacing an error.
+				expect(events).toContain("conversation_id");
+				expect(events).toContain("run_id");
+				expect(events).toContain("sandbox_id");
+				expect(events).toContain("text_delta");
+				expect(events).toContain("done");
+				expect(events).not.toContain("error");
+
+				const conversationId = JSON.parse(
+					frames.find((f) => f.event === "conversation_id")!.data,
+				).conversationId as string;
+				const runId = JSON.parse(frames.find((f) => f.event === "run_id")!.data)
+					.runId as string;
+				expect(conversationId.length).toBeGreaterThan(0);
+
+				// 2. Hydration: search_documents wrote a seeded document into this
+				//    conversation's docs manifest, attributed to this run.
+				const manifest = await readConversationManifest(conversationId);
+				expect(
+					manifest,
+					`no docs manifest for conversation ${conversationId}; the agent did ` +
+						`not hydrate any document this turn`,
+				).not.toBeNull();
+				expect(manifest!.documents.length).toBeGreaterThan(0);
+
+				const entries = manifest!.documents as Array<{
+					documentId: string;
+					localPath: string;
+					source: string;
+					runId: string;
+				}>;
+				expect(
+					entries.some((e) => SEEDED_DOCUMENT_IDS.includes(e.documentId)),
+				).toBe(true);
+				const hydrated = entries.find((e) =>
+					SEEDED_DOCUMENT_IDS.includes(e.documentId),
+				)!;
+				expect(hydrated.localPath.length).toBeGreaterThan(0);
+				expect(hydrated.source.length).toBeGreaterThan(0);
+				expect(hydrated.runId).toBe(runId);
+			},
+			TURN_TIMEOUT_MS + 30_000,
+		);
+	},
+);

--- a/apps/sandbox-daemon/agent-entry.ts
+++ b/apps/sandbox-daemon/agent-entry.ts
@@ -32,6 +32,8 @@ interface AgentConfig {
 	sessionId?: string;
 	userId?: string;
 	conversationId?: string;
+	runId?: string;
+	docsDir?: string;
 }
 
 function emit(event: AgentEvent): void {
@@ -68,6 +70,8 @@ function parseConfig(raw: string): AgentConfig {
 			typeof parsed.conversationId === "string"
 				? parsed.conversationId
 				: undefined,
+		runId: typeof parsed.runId === "string" ? parsed.runId : undefined,
+		docsDir: typeof parsed.docsDir === "string" ? parsed.docsDir : undefined,
 	};
 }
 

--- a/apps/sandbox-daemon/agent-tools.test.ts
+++ b/apps/sandbox-daemon/agent-tools.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
 	ALLOWED_BUILTIN_TOOLS,
 	buildMymemoTools,
@@ -98,12 +101,121 @@ describe("MyMemo MCP tool registration", () => {
 		const tools = buildMymemoTools();
 		expect(tools.map((t) => t.name)).toEqual([SEARCH_DOCUMENTS_TOOL_NAME]);
 	});
+});
 
-	it("returns a recoverable tool error until MYM-11 implements the handler", async () => {
-		const [searchDocuments] = buildMymemoTools();
-		const result = await searchDocuments.handler({}, undefined);
-		expect(result.isError).toBe(true);
-		expect(JSON.stringify(result.content)).toContain("not implemented");
+describe("search_documents tool handler", () => {
+	const ENV = ["MYMEMO_DOC_GATEWAY_URL", "MYMEMO_DOC_TOKEN"] as const;
+	const original: Record<string, string | undefined> = {};
+	let docsDir: string;
+	let realFetch: typeof fetch;
+
+	beforeEach(() => {
+		for (const k of ENV) original[k] = process.env[k];
+		docsDir = mkdtempSync(join(tmpdir(), "agent-tools-handler-"));
+		realFetch = globalThis.fetch;
+	});
+
+	afterEach(() => {
+		for (const k of ENV) {
+			if (original[k] === undefined) delete process.env[k];
+			else process.env[k] = original[k];
+		}
+		globalThis.fetch = realFetch;
+		rmSync(docsDir, { recursive: true, force: true });
+	});
+
+	function handler(context?: { docsDir: string; runId: string }) {
+		const [searchDocuments] = buildMymemoTools(context);
+		return searchDocuments.handler;
+	}
+
+	it("fails closed (recoverable) when the document gateway env is missing", async () => {
+		delete process.env.MYMEMO_DOC_GATEWAY_URL;
+		delete process.env.MYMEMO_DOC_TOKEN;
+		const res = await handler({ docsDir, runId: "run-1" })(
+			{ query: "q" },
+			NO_OPTS,
+		);
+		expect(res.isError).toBe(true);
+		expect(JSON.stringify(res.content)).toContain("not configured");
+	});
+
+	it("fails closed (recoverable) when the workspace context is missing", async () => {
+		process.env.MYMEMO_DOC_GATEWAY_URL = "https://gateway.example";
+		process.env.MYMEMO_DOC_TOKEN = "doc-token";
+		const res = await handler(undefined)({ query: "q" }, NO_OPTS);
+		expect(res.isError).toBe(true);
+		expect(JSON.stringify(res.content)).toContain(
+			"workspace is not configured",
+		);
+	});
+
+	it("returns a non-error message when nothing matches", async () => {
+		process.env.MYMEMO_DOC_GATEWAY_URL = "https://gateway.example";
+		process.env.MYMEMO_DOC_TOKEN = "doc-token";
+		globalThis.fetch = (async () =>
+			new Response(JSON.stringify({ documents: [] }), {
+				status: 200,
+			})) as unknown as typeof fetch;
+
+		const res = await handler({ docsDir, runId: "run-1" })(
+			{ query: "q" },
+			NO_OPTS,
+		);
+		expect(res.isError).toBeFalsy();
+		expect(JSON.stringify(res.content)).toContain("No MyMemo documents");
+	});
+
+	it("hydrates and returns the documents as JSON content", async () => {
+		process.env.MYMEMO_DOC_GATEWAY_URL = "https://gateway.example";
+		process.env.MYMEMO_DOC_TOKEN = "doc-token";
+		globalThis.fetch = (async (url: string | URL) => {
+			const u = String(url);
+			if (u.endsWith("/search")) {
+				return new Response(
+					JSON.stringify({
+						documents: [{ documentId: "d1", title: "T1", snippet: "S1" }],
+					}),
+					{ status: 200 },
+				);
+			}
+			return new Response(
+				JSON.stringify({ documentId: "d1", title: "T1", content: "BODY" }),
+				{ status: 200 },
+			);
+		}) as unknown as typeof fetch;
+
+		const res = await handler({ docsDir, runId: "run-1" })(
+			{ query: "q" },
+			NO_OPTS,
+		);
+		expect(res.isError).toBeFalsy();
+		const text = (res.content[0] as { text: string }).text;
+		const parsed = JSON.parse(text);
+		expect(parsed.documents[0]).toMatchObject({
+			documentId: "d1",
+			source: "gateway",
+			title: "T1",
+			snippet: "S1",
+			localPath: join(docsDir, "d1.md"),
+		});
+		expect(readFileSync(join(docsDir, "d1.md"), "utf8")).toBe("BODY");
+	});
+
+	it("maps gateway errors to a recoverable tool error (isError), not a throw", async () => {
+		process.env.MYMEMO_DOC_GATEWAY_URL = "https://gateway.example";
+		process.env.MYMEMO_DOC_TOKEN = "doc-token";
+		globalThis.fetch = (async () =>
+			new Response("upstream boom", {
+				status: 502,
+			})) as unknown as typeof fetch;
+
+		const res = await handler({ docsDir, runId: "run-1" })(
+			{ query: "q" },
+			NO_OPTS,
+		);
+		expect(res.isError).toBe(true);
+		expect(JSON.stringify(res.content)).toContain("Document search failed");
 	});
 });
 

--- a/apps/sandbox-daemon/agent-tools.ts
+++ b/apps/sandbox-daemon/agent-tools.ts
@@ -33,9 +33,10 @@ import {
 	type CanUseTool,
 	createSdkMcpServer,
 	type McpSdkServerConfigWithInstance,
-	type SdkMcpToolDefinition,
 	tool,
 } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+import { searchAndHydrate } from "./search-documents";
 
 /** MCP server name; the agent sees its tools as `mcp__<server>__<tool>`. */
 export const MYMEMO_MCP_SERVER_NAME = "mymemo";
@@ -92,41 +93,106 @@ export function createCanUseTool(
 }
 
 /**
+ * Per-turn context the document tool needs to hydrate into the right place:
+ * which conversation `docs/` dir to write to, and which run to attribute the
+ * hydration to in the manifest. Threaded in from the daemon (see agent.ts) so
+ * this module reads no environment for paths/identity. The gateway URL + bearer
+ * token are read from the per-turn env inside the handler instead.
+ */
+export interface MymemoToolContext {
+	/** Absolute path to the conversation's `docs/` dir. */
+	docsDir: string;
+	/** The run that owns this turn (recorded in the docs manifest). */
+	runId: string;
+}
+
+function toolError(message: string): {
+	content: { type: "text"; text: string }[];
+	isError: true;
+} {
+	return { content: [{ type: "text", text: message }], isError: true };
+}
+
+/**
  * The MyMemo MCP tool definitions registered with the in-process server.
  *
- * Today this is the single document operation. Its handler is a placeholder:
- * the real search → fetch → hydrate → manifest flow is implemented in MYM-11
- * (Task 7). Until then it returns a recoverable tool error (`isError: true`) so
- * a premature call fails in a way the agent can explain, rather than silently
- * returning nothing.
+ * The single `search_documents` operation runs the search → fetch → hydrate →
+ * manifest flow (see search-documents.ts). The gateway URL + (aud: "documents")
+ * token come from the per-turn env the daemon set on the agent process; the
+ * conversation `docs/` dir and run id arrive via {@link MymemoToolContext}.
+ *
+ * Expected failures — gateway errors, or a missing env/context (a premature call
+ * before the turn is wired) — return a recoverable tool error (`isError: true`)
+ * so the agent can retry or explain, rather than throwing and crashing the query
+ * loop. No matches is a normal (non-error) empty result.
  */
-export function buildMymemoTools(): SdkMcpToolDefinition[] {
+export function buildMymemoTools(context?: MymemoToolContext) {
 	return [
 		tool(
 			SEARCH_DOCUMENTS_TOOL_NAME,
-			"Search the user's MyMemo documents and hydrate matches into the local conversation workspace. Returns snippets plus local file paths.",
-			{},
-			async () => ({
-				content: [
-					{
-						type: "text",
-						text: "search_documents is not implemented yet (pending MYM-11).",
-					},
-				],
-				isError: true,
-			}),
+			"Search the user's MyMemo documents and hydrate matches into the local conversation workspace. Returns one row per document with its documentId, source, title, snippet, and the local file path you can Read.",
+			{
+				query: z
+					.string()
+					.min(1)
+					.describe("What to search the user's MyMemo documents for."),
+			},
+			async ({ query }) => {
+				const gatewayUrl = process.env.MYMEMO_DOC_GATEWAY_URL;
+				const token = process.env.MYMEMO_DOC_TOKEN;
+				if (!gatewayUrl || !token) {
+					return toolError(
+						"Document gateway is not configured for this turn (missing MYMEMO_DOC_GATEWAY_URL / MYMEMO_DOC_TOKEN).",
+					);
+				}
+				if (!context) {
+					return toolError(
+						"Document workspace is not configured for this turn.",
+					);
+				}
+				try {
+					const documents = await searchAndHydrate(query, {
+						gatewayUrl,
+						token,
+						docsDir: context.docsDir,
+						runId: context.runId,
+					});
+					if (documents.length === 0) {
+						return {
+							content: [
+								{
+									type: "text",
+									text: "No MyMemo documents matched the query.",
+								},
+							],
+						};
+					}
+					return {
+						content: [
+							{ type: "text", text: JSON.stringify({ documents }, null, 2) },
+						],
+					};
+				} catch (err) {
+					const message = err instanceof Error ? err.message : String(err);
+					return toolError(`Document search failed: ${message}`);
+				}
+			},
 		),
 	];
 }
 
 /**
  * Register the MyMemo in-process MCP server exposing the document tool(s), so
- * `mcp__mymemo__search_documents` is available to the agent.
+ * `mcp__mymemo__search_documents` is available to the agent. `context` is
+ * forwarded to the tool handler; omit it only where the surface is inspected
+ * without being run (tests, registration checks).
  */
-export function createMymemoMcpServer(): McpSdkServerConfigWithInstance {
+export function createMymemoMcpServer(
+	context?: MymemoToolContext,
+): McpSdkServerConfigWithInstance {
 	return createSdkMcpServer({
 		name: MYMEMO_MCP_SERVER_NAME,
 		version: "0.1.0",
-		tools: buildMymemoTools(),
+		tools: buildMymemoTools(context),
 	});
 }

--- a/apps/sandbox-daemon/agent.test.ts
+++ b/apps/sandbox-daemon/agent.test.ts
@@ -41,6 +41,18 @@ describe("buildQueryOptions", () => {
 			"sess-1",
 		);
 	});
+
+	it("exposes the conversation docs/ dir to the agent's file tools when set", () => {
+		// docs/ is a sibling of the work/ cwd; without it in additionalDirectories
+		// the agent can't Read the localPath search_documents returns.
+		const docsDir = "/workspace/conversations/c/docs";
+		const opts = buildQueryOptions({ ...base, docsDir, runId: "run-1" });
+		expect(opts.additionalDirectories).toEqual([docsDir]);
+	});
+
+	it("omits additionalDirectories when no docsDir is wired", () => {
+		expect("additionalDirectories" in buildQueryOptions(base)).toBe(false);
+	});
 });
 
 describe("buildQueryOptions tool surface", () => {

--- a/apps/sandbox-daemon/agent.ts
+++ b/apps/sandbox-daemon/agent.ts
@@ -25,6 +25,14 @@ export interface AgentRunOptions {
 	cwd: string;
 	sessionId?: string;
 	/**
+	 * Absolute path to the conversation's `docs/` dir and the run that owns this
+	 * turn. Both feed the `search_documents` MCP tool (hydration target + manifest
+	 * attribution). When either is missing the tool is registered but reports a
+	 * recoverable "workspace not configured" error if called.
+	 */
+	docsDir?: string;
+	runId?: string;
+	/**
 	 * Mirror SDK session transcripts to durable storage so `resume` survives a
 	 * fresh or recycled sandbox. Omit to keep today's behavior (local transcript
 	 * only). Never paired with `persistSession: false` — the mirror hook fires
@@ -52,7 +60,8 @@ export interface AgentCallbacks {
  * silently widening the untrusted agent's tool surface.
  */
 export function buildQueryOptions(options: AgentRunOptions): Options {
-	const { systemPrompt, cwd, sessionId, sessionStore } = options;
+	const { systemPrompt, cwd, sessionId, sessionStore, docsDir, runId } =
+		options;
 
 	const queryOptions: Options = {
 		cwd,
@@ -66,7 +75,11 @@ export function buildQueryOptions(options: AgentRunOptions): Options {
 		tools: [...ALLOWED_BUILTIN_TOOLS],
 		allowedTools: [...PRE_APPROVED_TOOLS],
 		canUseTool: createCanUseTool(),
-		mcpServers: { [MYMEMO_MCP_SERVER_NAME]: createMymemoMcpServer() },
+		mcpServers: {
+			[MYMEMO_MCP_SERVER_NAME]: createMymemoMcpServer(
+				docsDir && runId ? { docsDir, runId } : undefined,
+			),
+		},
 		permissionMode: "default",
 		includePartialMessages: true,
 		model: "claude-sonnet-4-6",

--- a/apps/sandbox-daemon/agent.ts
+++ b/apps/sandbox-daemon/agent.ts
@@ -80,6 +80,12 @@ export function buildQueryOptions(options: AgentRunOptions): Options {
 				docsDir && runId ? { docsDir, runId } : undefined,
 			),
 		},
+		// `search_documents` hydrates into the conversation's `docs/` dir, which is
+		// a SIBLING of the agent's `work/` cwd. Claude Code scopes its file tools
+		// (Read/Glob/Grep) to the cwd plus `additionalDirectories`, so without this
+		// the agent couldn't read the very `localPath` the tool hands back. Expose
+		// the docs dir read/write so the agent can inspect hydrated documents.
+		...(docsDir ? { additionalDirectories: [docsDir] } : {}),
 		permissionMode: "default",
 		includePartialMessages: true,
 		model: "claude-sonnet-4-6",

--- a/apps/sandbox-daemon/child-spawn.ts
+++ b/apps/sandbox-daemon/child-spawn.ts
@@ -204,6 +204,15 @@ export interface SpawnAgentInput {
 	 * (createConversationWorkspace) before spawn, like cwd.
 	 */
 	claudeConfigDir: string;
+	/**
+	 * Absolute path to the conversation's docs/ dir. Forwarded (via the stdin
+	 * config) to the `search_documents` tool as its hydration target + manifest
+	 * home. The agent runs directly in the sandbox, so it reads/writes this real
+	 * directory (created by createConversationWorkspace before spawn, like cwd).
+	 */
+	docsDir?: string;
+	/** The run that owns this turn — recorded in the docs manifest by the tool. */
+	runId?: string;
 	sessionId?: string;
 	/** Trusted member code — keys the durable session-transcript store. */
 	userId?: string;
@@ -258,9 +267,10 @@ export async function spawnAgent(
 			// injects the real key. ANTHROPIC_AUTH_TOKEN is sent as a Bearer header.
 			ANTHROPIC_BASE_URL: llmBaseUrl,
 			ANTHROPIC_AUTH_TOKEN: llmToken,
-			// Document access: the `mymemo-docs` CLI (on PATH) calls the document
-			// gateway with its own (aud: "documents") token. The gateway enforces
-			// the token's signed scope, so the agent holds no document credential.
+			// Document access: the in-process `search_documents` MCP tool calls the
+			// document gateway with its own (aud: "documents") token. The gateway
+			// enforces the token's signed scope, so the agent holds no document
+			// credential.
 			MYMEMO_DOC_GATEWAY_URL: docGatewayUrl,
 			MYMEMO_DOC_TOKEN: docToken,
 			PATH: process.env.PATH ?? "",

--- a/apps/sandbox-daemon/package.json
+++ b/apps/sandbox-daemon/package.json
@@ -11,6 +11,7 @@
 	},
 	"dependencies": {
 		"hono": "^4.10.1",
-		"@anthropic-ai/claude-agent-sdk": "0.2.117"
+		"@anthropic-ai/claude-agent-sdk": "0.2.117",
+		"zod": "^4.1.12"
 	}
 }

--- a/apps/sandbox-daemon/routes/turn.ts
+++ b/apps/sandbox-daemon/routes/turn.ts
@@ -126,6 +126,10 @@ app.post("/turn", async (c) => {
 					// layout (a sibling of cwd), bound rw and set on the agent so its
 					// SDK config + transcripts stay isolated from the project `.claude`.
 					claudeConfigDir: workspace.claudeConfig,
+					// docs/ is bound rw and forwarded to the `search_documents` tool as
+					// its hydration target; run_id attributes hydration in the manifest.
+					docsDir: workspace.docs,
+					runId: run_id,
 					sessionId: agent_session_id,
 					// Identity keys the durable session-transcript store; both arrive
 					// validated from the trusted turn request.

--- a/apps/sandbox-daemon/search-documents.test.ts
+++ b/apps/sandbox-daemon/search-documents.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+	existsSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { readDocsManifest, upsertDocsManifestEntry } from "./docs-manifest";
@@ -144,6 +150,7 @@ describe("searchAndHydrate", () => {
 				source: GATEWAY_SOURCE,
 				title: "Doc One",
 				snippet: "snippet one",
+				passageId: "p1",
 				localPath: join(docsDir, "d1.md"),
 			},
 			{
@@ -151,6 +158,7 @@ describe("searchAndHydrate", () => {
 				source: GATEWAY_SOURCE,
 				title: "Doc Two",
 				snippet: "snippet two",
+				passageId: "p2",
 				localPath: join(docsDir, "d2.md"),
 			},
 		]);
@@ -185,7 +193,7 @@ describe("searchAndHydrate", () => {
 	});
 
 	it("reports already-hydrated documents as already_local without re-fetching", async () => {
-		// Pre-seed the manifest + a file as if a prior run hydrated d1.
+		// Pre-seed the manifest AND the file on disk, as a prior run would have.
 		upsertDocsManifestEntry(docsDir, {
 			documentId: "d1",
 			title: "Old Title",
@@ -194,6 +202,7 @@ describe("searchAndHydrate", () => {
 			hydratedAt: "2026-06-01T00:00:00.000Z",
 			runId: "run-0",
 		});
+		writeFileSync(join(docsDir, "d1.md"), "cached body", "utf8");
 
 		const { fetchImpl, calls } = fakeGateway({
 			search: {
@@ -219,11 +228,50 @@ describe("searchAndHydrate", () => {
 				// Title prefers the fresh search hit; localPath points at the cached file.
 				title: "Fresh Title",
 				snippet: "fresh snippet",
+				passageId: "p1",
 				localPath: join(docsDir, "d1.md"),
 			},
 		]);
 		// Never fetched — the document was already local.
 		expect(calls.some((c) => c.url.endsWith("/fetch"))).toBe(false);
+	});
+
+	it("re-fetches when a manifest entry's file is missing on disk", async () => {
+		// Manifest says d1 is hydrated, but the file is gone (deleted, or a
+		// manifest restored ahead of its blobs). The stale entry must not be
+		// trusted — re-fetch instead of handing back a path Read would fail on.
+		upsertDocsManifestEntry(docsDir, {
+			documentId: "d1",
+			title: "Stale Title",
+			localPath: "d1.md",
+			source: GATEWAY_SOURCE,
+			hydratedAt: "2026-06-01T00:00:00.000Z",
+			runId: "run-0",
+		});
+		// Note: no d1.md file written.
+
+		const { fetchImpl, calls } = fakeGateway({
+			search: {
+				body: {
+					documents: [
+						{ passageId: "p1", documentId: "d1", title: "T1", snippet: "s1" },
+					],
+				},
+			},
+			fetchByDoc: {
+				d1: { body: { documentId: "d1", title: "T1", content: "FRESH" } },
+			},
+		});
+
+		const results = await searchAndHydrate("query", deps(fetchImpl));
+
+		// Re-hydrated from the gateway, not reported already_local.
+		expect(results[0]).toMatchObject({
+			documentId: "d1",
+			source: GATEWAY_SOURCE,
+		});
+		expect(calls.some((c) => c.url.endsWith("/fetch"))).toBe(true);
+		expect(readFileSync(join(docsDir, "d1.md"), "utf8")).toBe("FRESH");
 	});
 
 	it("throws GatewayDocumentError on a non-OK search response", async () => {

--- a/apps/sandbox-daemon/search-documents.test.ts
+++ b/apps/sandbox-daemon/search-documents.test.ts
@@ -1,0 +1,273 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readDocsManifest, upsertDocsManifestEntry } from "./docs-manifest";
+import {
+	documentFilename,
+	GATEWAY_SOURCE,
+	GatewayDocumentError,
+	MAX_HYDRATED_DOCUMENTS,
+	type SearchDocumentsDeps,
+	searchAndHydrate,
+} from "./search-documents";
+
+let docsDir: string;
+
+beforeEach(() => {
+	docsDir = mkdtempSync(join(tmpdir(), "search-documents-test-"));
+});
+
+afterEach(() => {
+	rmSync(docsDir, { recursive: true, force: true });
+});
+
+const FIXED_NOW = new Date("2026-06-18T00:00:00.000Z");
+
+/**
+ * A fake gateway: routes by URL path to a queued search response and a
+ * documentId → fetch response map. Records every call so tests can assert what
+ * was (and wasn't) requested.
+ */
+function fakeGateway(opts: {
+	search?: { status?: number; body?: unknown };
+	fetchByDoc?: Record<string, { status?: number; body?: unknown }>;
+	throwOn?: "search" | "fetch";
+}): { fetchImpl: typeof fetch; calls: { url: string; body: unknown }[] } {
+	const calls: { url: string; body: unknown }[] = [];
+	const fetchImpl = (async (url: string | URL, init?: RequestInit) => {
+		const u = String(url);
+		const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+		calls.push({ url: u, body });
+		if (u.endsWith("/v1/documents/search")) {
+			if (opts.throwOn === "search") throw new Error("connection refused");
+			const r = opts.search ?? { body: { documents: [] } };
+			return new Response(JSON.stringify(r.body ?? {}), {
+				status: r.status ?? 200,
+			});
+		}
+		if (u.endsWith("/v1/documents/fetch")) {
+			if (opts.throwOn === "fetch") throw new Error("connection refused");
+			const docId = body?.documentId as string;
+			const r = opts.fetchByDoc?.[docId] ?? { status: 404, body: {} };
+			return new Response(JSON.stringify(r.body ?? {}), {
+				status: r.status ?? 200,
+			});
+		}
+		throw new Error(`unexpected url ${u}`);
+	}) as unknown as typeof fetch;
+	return { fetchImpl, calls };
+}
+
+function deps(fetchImpl: typeof fetch): SearchDocumentsDeps {
+	return {
+		gatewayUrl: "https://gateway.example",
+		token: "doc-token",
+		docsDir,
+		runId: "run-1",
+		fetchImpl,
+		now: () => FIXED_NOW,
+	};
+}
+
+describe("documentFilename", () => {
+	it("derives a .md filename and sanitizes path-unsafe characters", () => {
+		expect(documentFilename("abc-123")).toBe("abc-123.md");
+		expect(documentFilename("../../etc/passwd")).toBe("______etc_passwd.md");
+		expect(documentFilename("a/b\\c")).toBe("a_b_c.md");
+		expect(documentFilename("")).toBe("document.md");
+	});
+});
+
+describe("searchAndHydrate", () => {
+	it("returns an empty result and fetches nothing when there are no matches", async () => {
+		const { fetchImpl, calls } = fakeGateway({
+			search: { body: { documents: [] } },
+		});
+		const results = await searchAndHydrate("nothing", deps(fetchImpl));
+
+		expect(results).toEqual([]);
+		// Searched once, never fetched.
+		expect(calls.map((c) => c.url)).toEqual([
+			"https://gateway.example/v1/documents/search",
+		]);
+		// No manifest is written for an empty search.
+		expect(existsSync(join(docsDir, "manifest.json"))).toBe(false);
+	});
+
+	it("hydrates matches to disk, writes the manifest, and returns local paths", async () => {
+		const { fetchImpl, calls } = fakeGateway({
+			search: {
+				body: {
+					documents: [
+						{
+							passageId: "p1",
+							documentId: "d1",
+							title: "Doc One",
+							snippet: "snippet one",
+						},
+						{
+							passageId: "p2",
+							documentId: "d2",
+							title: "Doc Two",
+							snippet: "snippet two",
+						},
+					],
+				},
+			},
+			fetchByDoc: {
+				d1: { body: { documentId: "d1", title: "Doc One", content: "BODY1" } },
+				d2: { body: { documentId: "d2", title: "Doc Two", content: "BODY2" } },
+			},
+		});
+
+		const results = await searchAndHydrate("query", deps(fetchImpl));
+
+		expect(results).toEqual([
+			{
+				documentId: "d1",
+				source: GATEWAY_SOURCE,
+				title: "Doc One",
+				snippet: "snippet one",
+				localPath: join(docsDir, "d1.md"),
+			},
+			{
+				documentId: "d2",
+				source: GATEWAY_SOURCE,
+				title: "Doc Two",
+				snippet: "snippet two",
+				localPath: join(docsDir, "d2.md"),
+			},
+		]);
+
+		// Files were written with the fetched content...
+		expect(readFileSync(join(docsDir, "d1.md"), "utf8")).toBe("BODY1");
+		expect(readFileSync(join(docsDir, "d2.md"), "utf8")).toBe("BODY2");
+
+		// ...and the manifest records both, attributed to the run.
+		const manifest = readDocsManifest(docsDir);
+		expect(manifest.documents).toEqual([
+			{
+				documentId: "d1",
+				title: "Doc One",
+				localPath: "d1.md",
+				source: GATEWAY_SOURCE,
+				hydratedAt: FIXED_NOW.toISOString(),
+				runId: "run-1",
+			},
+			{
+				documentId: "d2",
+				title: "Doc Two",
+				localPath: "d2.md",
+				source: GATEWAY_SOURCE,
+				hydratedAt: FIXED_NOW.toISOString(),
+				runId: "run-1",
+			},
+		]);
+
+		// search + one fetch per document.
+		expect(calls.filter((c) => c.url.endsWith("/fetch")).length).toBe(2);
+	});
+
+	it("reports already-hydrated documents as already_local without re-fetching", async () => {
+		// Pre-seed the manifest + a file as if a prior run hydrated d1.
+		upsertDocsManifestEntry(docsDir, {
+			documentId: "d1",
+			title: "Old Title",
+			localPath: "d1.md",
+			source: GATEWAY_SOURCE,
+			hydratedAt: "2026-06-01T00:00:00.000Z",
+			runId: "run-0",
+		});
+
+		const { fetchImpl, calls } = fakeGateway({
+			search: {
+				body: {
+					documents: [
+						{
+							passageId: "p1",
+							documentId: "d1",
+							title: "Fresh Title",
+							snippet: "fresh snippet",
+						},
+					],
+				},
+			},
+		});
+
+		const results = await searchAndHydrate("query", deps(fetchImpl));
+
+		expect(results).toEqual([
+			{
+				documentId: "d1",
+				source: "already_local",
+				// Title prefers the fresh search hit; localPath points at the cached file.
+				title: "Fresh Title",
+				snippet: "fresh snippet",
+				localPath: join(docsDir, "d1.md"),
+			},
+		]);
+		// Never fetched — the document was already local.
+		expect(calls.some((c) => c.url.endsWith("/fetch"))).toBe(false);
+	});
+
+	it("throws GatewayDocumentError on a non-OK search response", async () => {
+		const { fetchImpl } = fakeGateway({ search: { status: 502, body: {} } });
+		await expect(searchAndHydrate("q", deps(fetchImpl))).rejects.toBeInstanceOf(
+			GatewayDocumentError,
+		);
+	});
+
+	it("throws GatewayDocumentError when the gateway is unreachable", async () => {
+		const { fetchImpl } = fakeGateway({ throwOn: "search" });
+		await expect(searchAndHydrate("q", deps(fetchImpl))).rejects.toBeInstanceOf(
+			GatewayDocumentError,
+		);
+	});
+
+	it("throws GatewayDocumentError on a non-OK fetch response", async () => {
+		const { fetchImpl } = fakeGateway({
+			search: {
+				body: { documents: [{ documentId: "d1", title: "t", snippet: "s" }] },
+			},
+			fetchByDoc: { d1: { status: 500, body: {} } },
+		});
+		await expect(searchAndHydrate("q", deps(fetchImpl))).rejects.toBeInstanceOf(
+			GatewayDocumentError,
+		);
+	});
+
+	it("dedupes passages to distinct documents and caps at MAX_HYDRATED_DOCUMENTS", async () => {
+		// Two passages for d1, then more distinct docs than the cap allows.
+		const documents = [
+			{ documentId: "d1", title: "D1", snippet: "first" },
+			{ documentId: "d1", title: "D1", snippet: "second" },
+		];
+		const fetchByDoc: Record<string, { body: unknown }> = {
+			d1: { body: { documentId: "d1", title: "D1", content: "B1" } },
+		};
+		for (let i = 0; i < MAX_HYDRATED_DOCUMENTS + 3; i++) {
+			const id = `x${i}`;
+			documents.push({ documentId: id, title: id, snippet: id });
+			fetchByDoc[id] = { body: { documentId: id, title: id, content: id } };
+		}
+
+		const { fetchImpl, calls } = fakeGateway({
+			search: { body: { documents } },
+			fetchByDoc,
+		});
+
+		const results = await searchAndHydrate("q", deps(fetchImpl));
+
+		// Capped at the limit, no document repeated.
+		expect(results.length).toBe(MAX_HYDRATED_DOCUMENTS);
+		const ids = results.map((r) => r.documentId);
+		expect(new Set(ids).size).toBe(MAX_HYDRATED_DOCUMENTS);
+		// d1 kept its first passage's snippet.
+		expect(results[0]).toMatchObject({ documentId: "d1", snippet: "first" });
+		// Never fetched more than the cap.
+		expect(calls.filter((c) => c.url.endsWith("/fetch")).length).toBe(
+			MAX_HYDRATED_DOCUMENTS,
+		);
+	});
+});

--- a/apps/sandbox-daemon/search-documents.test.ts
+++ b/apps/sandbox-daemon/search-documents.test.ts
@@ -288,6 +288,17 @@ describe("searchAndHydrate", () => {
 		);
 	});
 
+	it("throws GatewayDocumentError on a 200 with a non-JSON body", async () => {
+		// e.g. a proxy/LB returns an HTML error page with status 200.
+		const fetchImpl = (async () =>
+			new Response("<html>oops</html>", {
+				status: 200,
+			})) as unknown as typeof fetch;
+		await expect(searchAndHydrate("q", deps(fetchImpl))).rejects.toBeInstanceOf(
+			GatewayDocumentError,
+		);
+	});
+
 	it("throws GatewayDocumentError on a non-OK fetch response", async () => {
 		const { fetchImpl } = fakeGateway({
 			search: {

--- a/apps/sandbox-daemon/search-documents.test.ts
+++ b/apps/sandbox-daemon/search-documents.test.ts
@@ -71,11 +71,26 @@ function deps(fetchImpl: typeof fetch): SearchDocumentsDeps {
 }
 
 describe("documentFilename", () => {
-	it("derives a .md filename and sanitizes path-unsafe characters", () => {
+	it("keeps a clean id as a readable .md filename", () => {
 		expect(documentFilename("abc-123")).toBe("abc-123.md");
-		expect(documentFilename("../../etc/passwd")).toBe("______etc_passwd.md");
-		expect(documentFilename("a/b\\c")).toBe("a_b_c.md");
-		expect(documentFilename("")).toBe("document.md");
+		expect(documentFilename("doc-ml-intro")).toBe("doc-ml-intro.md");
+	});
+
+	it("sanitizes path-unsafe characters and disambiguates with a hash suffix", () => {
+		// A rewritten id can't keep its raw name (it would traverse / collide), so
+		// it gets `<safe>.<8-hex>.md`.
+		expect(documentFilename("../../etc/passwd")).toMatch(
+			/^______etc_passwd\.[0-9a-f]{8}\.md$/,
+		);
+		expect(documentFilename("a/b\\c")).toMatch(/^a_b_c\.[0-9a-f]{8}\.md$/);
+		expect(documentFilename("")).toMatch(/^document\.[0-9a-f]{8}\.md$/);
+	});
+
+	it("never maps two distinct ids to the same filename", () => {
+		// `a/b` and `a.b` both sanitize to `a_b`; the hash of the original id keeps
+		// their files distinct. A clean `a_b` also stays distinct from both.
+		expect(documentFilename("a/b")).not.toBe(documentFilename("a.b"));
+		expect(documentFilename("a/b")).not.toBe(documentFilename("a_b"));
 	});
 });
 

--- a/apps/sandbox-daemon/search-documents.ts
+++ b/apps/sandbox-daemon/search-documents.ts
@@ -27,7 +27,7 @@
  */
 
 import { createHash } from "node:crypto";
-import { writeFileSync } from "node:fs";
+import { existsSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { readDocsManifest, upsertDocsManifestEntry } from "./docs-manifest";
 
@@ -52,6 +52,13 @@ export interface SearchDocumentResult {
 	source: DocumentResultSource;
 	title: string;
 	snippet: string;
+	/**
+	 * The passage the snippet came from. Carried through so the agent can satisfy
+	 * the `passageId`-based citation contract (see the agent system prompt);
+	 * `""` if the gateway hit omitted it. Search returns multiple passages per
+	 * document — this is the top-ranked passage for the hydrated document.
+	 */
+	passageId: string;
 	/** Absolute path to the hydrated file (the agent can `Read` this). */
 	localPath: string;
 }
@@ -199,14 +206,21 @@ export async function searchAndHydrate(
 		// `documentId` is guaranteed by selectDocuments.
 		const documentId = hit.documentId as string;
 		const snippet = hit.snippet ?? "";
+		const passageId = hit.passageId ?? "";
 
+		// Treat a document as already-local only when both the manifest entry AND
+		// the file are present. A manifest entry whose file is gone (the agent
+		// deleted it, or a future workspace hydrate restored the manifest before
+		// the blobs) must fall through to a re-fetch — otherwise we'd hand back a
+		// path the agent's `Read` would fail on for a document that is in scope.
 		const existing = localById.get(documentId);
-		if (existing) {
+		if (existing && existsSync(join(deps.docsDir, existing.localPath))) {
 			results.push({
 				documentId,
 				source: "already_local",
 				title: hit.title || existing.title,
 				snippet,
+				passageId,
 				localPath: join(deps.docsDir, existing.localPath),
 			});
 			continue;
@@ -237,6 +251,7 @@ export async function searchAndHydrate(
 			source: GATEWAY_SOURCE,
 			title,
 			snippet,
+			passageId,
 			localPath: absolutePath,
 		});
 	}

--- a/apps/sandbox-daemon/search-documents.ts
+++ b/apps/sandbox-daemon/search-documents.ts
@@ -26,6 +26,7 @@
  * returns an empty result.
  */
 
+import { createHash } from "node:crypto";
 import { writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { readDocsManifest, upsertDocsManifestEntry } from "./docs-manifest";
@@ -126,10 +127,23 @@ async function postJson<T>(
  * Map a remote document id to a safe local filename. The id comes from the
  * gateway, but never trust a remote value as a path: collapse anything outside
  * `[A-Za-z0-9_-]` so it cannot traverse out of `docs/`.
+ *
+ * Collapsing is lossy, so two distinct ids could map to the same name (e.g.
+ * `a/b` and `a_b` both → `a_b`), which would clobber one document's file while
+ * the manifest still holds both entries — the stale entry would then point at
+ * the other document's content. A clean id (unchanged by sanitization) can't
+ * collide, so it keeps its readable name; any id that had to be rewritten gets a
+ * short hash of the *original* id appended, so distinct ids always get distinct
+ * files.
  */
 export function documentFilename(documentId: string): string {
 	const safe = documentId.replace(/[^A-Za-z0-9_-]/g, "_");
-	return `${safe || "document"}.md`;
+	if (safe.length > 0 && safe === documentId) return `${safe}.md`;
+	const hash = createHash("sha256")
+		.update(documentId)
+		.digest("hex")
+		.slice(0, 8);
+	return `${safe || "document"}.${hash}.md`;
 }
 
 /**

--- a/apps/sandbox-daemon/search-documents.ts
+++ b/apps/sandbox-daemon/search-documents.ts
@@ -127,7 +127,16 @@ async function postJson<T>(
 		// keep it short and never include the bearer token.
 		throw new GatewayDocumentError(`gateway returned ${res.status}`);
 	}
-	return res.json() as Promise<T>;
+	// A 200 with a non-JSON body (e.g. an HTML error page from a proxy/LB) would
+	// otherwise throw a bare SyntaxError; normalize it to a GatewayDocumentError
+	// so callers see one recoverable error type instead of two.
+	try {
+		return (await res.json()) as T;
+	} catch (cause) {
+		throw new GatewayDocumentError(
+			`gateway returned a non-JSON body: ${(cause as Error).message}`,
+		);
+	}
 }
 
 /**
@@ -214,16 +223,19 @@ export async function searchAndHydrate(
 		// the blobs) must fall through to a re-fetch — otherwise we'd hand back a
 		// path the agent's `Read` would fail on for a document that is in scope.
 		const existing = localById.get(documentId);
-		if (existing && existsSync(join(deps.docsDir, existing.localPath))) {
-			results.push({
-				documentId,
-				source: "already_local",
-				title: hit.title || existing.title,
-				snippet,
-				passageId,
-				localPath: join(deps.docsDir, existing.localPath),
-			});
-			continue;
+		if (existing) {
+			const existingPath = join(deps.docsDir, existing.localPath);
+			if (existsSync(existingPath)) {
+				results.push({
+					documentId,
+					source: "already_local",
+					title: hit.title || existing.title,
+					snippet,
+					passageId,
+					localPath: existingPath,
+				});
+				continue;
+			}
 		}
 
 		const doc = await postJson<GatewayFetchedDocument>(

--- a/apps/sandbox-daemon/search-documents.ts
+++ b/apps/sandbox-daemon/search-documents.ts
@@ -1,0 +1,231 @@
+/**
+ * `search_documents` — the single document operation exposed to the agent.
+ *
+ * One call does the whole working-set flow so the agent never has to chain a
+ * separate search then fetch (the old `mymemo-docs search`/`fetch` split):
+ *
+ *   1. Search the remote index through the unified gateway (`/v1/documents/search`).
+ *   2. Select the top distinct documents within the hydration cap.
+ *   3. For each, hydrate into the conversation's `docs/` dir — unless it is
+ *      already in the docs manifest, in which case it is reported as
+ *      `already_local` and re-fetched from neither the gateway nor disk.
+ *   4. Fetch full content through the gateway (`/v1/documents/fetch`), write it
+ *      to local disk, and upsert the docs manifest.
+ *   5. Return one row per document: `{ documentId, source, title, snippet,
+ *      localPath }`, where `localPath` is an absolute path the agent can `Read`.
+ *
+ * This module holds NO credential and reads NO environment: the gateway URL +
+ * bearer token and the workspace paths are injected by the caller
+ * (`agent-tools.ts`, which reads them from the per-turn env the daemon set). The
+ * `fetch` and clock are injectable so the flow is unit-testable without a live
+ * gateway.
+ *
+ * Gateway failures throw {@link GatewayDocumentError}; the MCP tool wrapper turns
+ * that into a recoverable tool error (`isError: true`) so the agent can retry or
+ * explain instead of crashing the query loop. No matches is NOT an error — it
+ * returns an empty result.
+ */
+
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { readDocsManifest, upsertDocsManifestEntry } from "./docs-manifest";
+
+/**
+ * Max distinct documents hydrated per search call. A conservative interim cap so
+ * one call can't fill the workspace; MYM-12 (Task 8) will centralize hydration
+ * limits (per-document and per-run byte ceilings) in a dedicated policy module.
+ */
+export const MAX_HYDRATED_DOCUMENTS = 5;
+
+/** Manifest `source` recorded for documents hydrated from the gateway. */
+export const GATEWAY_SOURCE = "gateway";
+
+/**
+ * Result `source`: `"gateway"` for a document hydrated by this call,
+ * `"already_local"` for one already present in the conversation workspace.
+ */
+export type DocumentResultSource = typeof GATEWAY_SOURCE | "already_local";
+
+export interface SearchDocumentResult {
+	documentId: string;
+	source: DocumentResultSource;
+	title: string;
+	snippet: string;
+	/** Absolute path to the hydrated file (the agent can `Read` this). */
+	localPath: string;
+}
+
+/** One passage hit from the gateway search endpoint. */
+interface GatewaySearchHit {
+	passageId?: string;
+	documentId?: string;
+	title?: string;
+	snippet?: string;
+}
+
+/** A fetched document from the gateway fetch endpoint. */
+interface GatewayFetchedDocument {
+	documentId?: string;
+	title?: string;
+	content?: string;
+}
+
+export interface SearchDocumentsDeps {
+	/** Document gateway base URL (from `MYMEMO_DOC_GATEWAY_URL`). */
+	gatewayUrl: string;
+	/** Document bearer token, `aud: "documents"` (from `MYMEMO_DOC_TOKEN`). */
+	token: string;
+	/** Absolute path to the conversation's `docs/` dir (hydration + manifest home). */
+	docsDir: string;
+	/** The run that caused this hydration (recorded in the manifest). */
+	runId: string;
+	/** Injectable for tests; defaults to the global `fetch`. */
+	fetchImpl?: typeof fetch;
+	/** Injectable clock for deterministic `hydratedAt`; defaults to `() => new Date()`. */
+	now?: () => Date;
+}
+
+/** Raised on any non-OK or unreachable gateway response. */
+export class GatewayDocumentError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "GatewayDocumentError";
+	}
+}
+
+async function postJson<T>(
+	doFetch: typeof fetch,
+	url: string,
+	token: string,
+	body: unknown,
+): Promise<T> {
+	let res: Response;
+	try {
+		res = await doFetch(url, {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				authorization: `Bearer ${token}`,
+			},
+			body: JSON.stringify(body),
+		});
+	} catch (cause) {
+		throw new GatewayDocumentError(
+			`gateway unreachable: ${(cause as Error).message}`,
+		);
+	}
+	if (!res.ok) {
+		// The body may carry a useful error message, but it could also echo input;
+		// keep it short and never include the bearer token.
+		throw new GatewayDocumentError(`gateway returned ${res.status}`);
+	}
+	return res.json() as Promise<T>;
+}
+
+/**
+ * Map a remote document id to a safe local filename. The id comes from the
+ * gateway, but never trust a remote value as a path: collapse anything outside
+ * `[A-Za-z0-9_-]` so it cannot traverse out of `docs/`.
+ */
+export function documentFilename(documentId: string): string {
+	const safe = documentId.replace(/[^A-Za-z0-9_-]/g, "_");
+	return `${safe || "document"}.md`;
+}
+
+/**
+ * Dedupe passage hits down to distinct documents (keeping the first hit's title
+ * and snippet for each), preserving search-rank order, capped at
+ * {@link MAX_HYDRATED_DOCUMENTS}. Hits without a `documentId` are dropped.
+ */
+function selectDocuments(hits: GatewaySearchHit[]): GatewaySearchHit[] {
+	const seen = new Set<string>();
+	const selected: GatewaySearchHit[] = [];
+	for (const hit of hits) {
+		const documentId = hit.documentId;
+		if (!documentId || seen.has(documentId)) continue;
+		seen.add(documentId);
+		selected.push(hit);
+		if (selected.length >= MAX_HYDRATED_DOCUMENTS) break;
+	}
+	return selected;
+}
+
+/**
+ * Run the full search → select → hydrate → manifest flow and return one row per
+ * selected document. Throws {@link GatewayDocumentError} on gateway failure;
+ * returns `[]` when the search has no matches.
+ */
+export async function searchAndHydrate(
+	query: string,
+	deps: SearchDocumentsDeps,
+): Promise<SearchDocumentResult[]> {
+	const doFetch = deps.fetchImpl ?? fetch;
+	const now = deps.now ?? (() => new Date());
+
+	const searchResponse = await postJson<{ documents?: unknown }>(
+		doFetch,
+		`${deps.gatewayUrl}/v1/documents/search`,
+		deps.token,
+		{ query },
+	);
+	const hits: GatewaySearchHit[] = Array.isArray(searchResponse.documents)
+		? (searchResponse.documents as GatewaySearchHit[])
+		: [];
+
+	const selected = selectDocuments(hits);
+	if (selected.length === 0) return [];
+
+	// Read the manifest once up front so repeated searches recognise documents
+	// already hydrated in this conversation workspace.
+	const manifest = readDocsManifest(deps.docsDir);
+	const localById = new Map(manifest.documents.map((d) => [d.documentId, d]));
+
+	const results: SearchDocumentResult[] = [];
+	for (const hit of selected) {
+		// `documentId` is guaranteed by selectDocuments.
+		const documentId = hit.documentId as string;
+		const snippet = hit.snippet ?? "";
+
+		const existing = localById.get(documentId);
+		if (existing) {
+			results.push({
+				documentId,
+				source: "already_local",
+				title: hit.title || existing.title,
+				snippet,
+				localPath: join(deps.docsDir, existing.localPath),
+			});
+			continue;
+		}
+
+		const doc = await postJson<GatewayFetchedDocument>(
+			doFetch,
+			`${deps.gatewayUrl}/v1/documents/fetch`,
+			deps.token,
+			{ documentId },
+		);
+
+		const filename = documentFilename(documentId);
+		const absolutePath = join(deps.docsDir, filename);
+		const title = doc.title || hit.title || "";
+		writeFileSync(absolutePath, doc.content ?? "", "utf8");
+		upsertDocsManifestEntry(deps.docsDir, {
+			documentId,
+			title,
+			localPath: filename,
+			source: GATEWAY_SOURCE,
+			hydratedAt: now().toISOString(),
+			runId: deps.runId,
+		});
+
+		results.push({
+			documentId,
+			source: GATEWAY_SOURCE,
+			title,
+			snippet,
+			localPath: absolutePath,
+		});
+	}
+
+	return results;
+}

--- a/bun.lock
+++ b/bun.lock
@@ -58,6 +58,7 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.117",
         "hono": "^4.10.1",
+        "zod": "^4.1.12",
       },
     },
     "packages/llm-token": {

--- a/e2e/compose.e2e.test.ts
+++ b/e2e/compose.e2e.test.ts
@@ -19,7 +19,7 @@
  * search_documents. It is therefore OPT-IN and never runs in the normal unit
  * suite. Enable with:
  *
- *   RUN_COMPOSE_E2E=1 bun test apps/chat-api/e2e/compose.e2e.test.ts
+ *   RUN_COMPOSE_E2E=1 bun test e2e/compose.e2e.test.ts
  *
  * Prerequisites (see README.md "Local end-to-end harness"):
  *   - The stack is up: `docker compose up --build` from the repo root, with the
@@ -54,8 +54,8 @@ const TURN_TIMEOUT_MS = Number(process.env.COMPOSE_E2E_TIMEOUT_MS) || 120_000;
 // when the suite will actually run.
 if (RUN) setDefaultTimeout(660_000);
 
-// apps/chat-api/e2e -> repo root (where compose.yaml lives).
-const REPO_ROOT = resolve(import.meta.dir, "../../..");
+// e2e/ -> repo root (where compose.yaml lives).
+const REPO_ROOT = resolve(import.meta.dir, "..");
 
 // The seeded member + documents (apps/gateway/db/init.sql). The X-Member-Code
 // header maps to the KB workspace, so document search resolves against these.

--- a/e2e/compose.e2e.test.ts
+++ b/e2e/compose.e2e.test.ts
@@ -46,7 +46,13 @@ import { resolve } from "node:path";
 const RUN = process.env.RUN_COMPOSE_E2E === "1";
 const CHAT_URL = process.env.COMPOSE_CHAT_URL ?? "http://localhost:3000";
 const AUTOSTART = process.env.COMPOSE_E2E_AUTOSTART === "1";
-const TURN_TIMEOUT_MS = Number(process.env.COMPOSE_E2E_TIMEOUT_MS) || 120_000;
+// `Number(undefined)` is NaN and `Number("0")` is 0 — both must fall back to the
+// default rather than become a 0/NaN timeout that aborts every turn instantly.
+const rawTurnTimeout = Number(process.env.COMPOSE_E2E_TIMEOUT_MS);
+const TURN_TIMEOUT_MS =
+	Number.isFinite(rawTurnTimeout) && rawTurnTimeout > 0
+		? rawTurnTimeout
+		: 120_000;
 
 // bun:test hooks take no per-call timeout argument, and bringing the stack up
 // (optionally with `--build`) can take minutes. Raise the file-wide default so
@@ -199,9 +205,16 @@ describe.skipIf(!RUN)(
 					signal: AbortSignal.timeout(TURN_TIMEOUT_MS),
 				});
 
-				expect(res.status).toBe(200);
+				// Read the body once, up front: on a non-200 (e.g. the gateway 502s or
+				// chat-api 500s) surface it in the failure message instead of a bare
+				// "expected 200, got 500" that hides the cause.
+				const bodyText = await res.text();
+				expect(
+					res.status,
+					`unexpected status; body: ${bodyText.slice(0, 500)}`,
+				).toBe(200);
 
-				const frames = parseSSE(await res.text());
+				const frames = parseSSE(bodyText);
 				const events = frames.map((f) => f.event).filter((e) => e !== "ping");
 
 				// 1. Protocol: the docker path streams the full target vocabulary and

--- a/e2e/compose.e2e.test.ts
+++ b/e2e/compose.e2e.test.ts
@@ -150,6 +150,24 @@ async function readConversationManifest(
 	return JSON.parse(stdout) as { version: number; documents: unknown[] };
 }
 
+/**
+ * Read a hydrated document's content from inside the sandbox container, by its
+ * manifest-relative `localPath`. Returns null when the file is absent — so the
+ * test can prove the blob was actually written, not just manifested.
+ */
+async function readHydratedDoc(
+	conversationId: string,
+	localPath: string,
+): Promise<string | null> {
+	const path = `/workspace/conversations/${conversationId}/docs/${localPath}`;
+	const { code, stdout } = await compose(
+		["exec", "-T", "sandbox", "sh", "-lc", `cat ${path} 2>/dev/null || true`],
+		15_000,
+	);
+	if (code !== 0 || stdout === "") return null;
+	return stdout;
+}
+
 let startedByTest = false;
 
 describe.skipIf(!RUN)(
@@ -258,6 +276,18 @@ describe.skipIf(!RUN)(
 				expect(hydrated.localPath.length).toBeGreaterThan(0);
 				expect(hydrated.source.length).toBeGreaterThan(0);
 				expect(hydrated.runId).toBe(runId);
+
+				// 3. The manifest entry must be backed by a real, non-empty file on
+				//    disk — not just a manifest row — so the agent's Read would work.
+				const docContent = await readHydratedDoc(
+					conversationId,
+					hydrated.localPath,
+				);
+				expect(
+					docContent,
+					`manifest references ${hydrated.localPath} but no file was hydrated there`,
+				).not.toBeNull();
+				expect(docContent!.trim().length).toBeGreaterThan(0);
 			},
 			TURN_TIMEOUT_MS + 30_000,
 		);

--- a/e2e/compose.e2e.test.ts
+++ b/e2e/compose.e2e.test.ts
@@ -185,12 +185,16 @@ describe.skipIf(!RUN)(
 						"x-member-code": MEMBER_CODE,
 						"x-partner-code": PARTNER_CODE,
 					},
-					// Phrased to require the document tool: the answer is only in the
-					// seeded KB, so a correct turn must call search_documents.
+					// Force the document tool explicitly. The remote-search-by-default
+					// agent prompt is MYM-13 (not yet wired), so a soft "find my doc
+					// about X" lets the model answer from its own knowledge without ever
+					// calling search_documents. Instructing it to call the tool and not
+					// answer from memory makes the hydration deterministic here.
 					body: JSON.stringify({
 						chatContent:
-							"Search my MyMemo documents for the introduction to machine " +
-							"learning and summarize it in one sentence.",
+							"Use the search_documents tool to find my MyMemo document about " +
+							"machine learning, then tell me its title. You must call " +
+							"search_documents; do not answer from your own knowledge.",
 					}),
 					signal: AbortSignal.timeout(TURN_TIMEOUT_MS),
 				});


### PR DESCRIPTION
## Summary

Implements **MYM-11 / Task 7: Replace agent-facing search/fetch**. The agent now reaches its MyMemo documents through a single in-process MCP operation — `mcp__mymemo__search_documents` — instead of the separate `mymemo-docs search` / `fetch` CLI split. The previously-scaffolded placeholder handler (MYM-32) is replaced with the real flow.

`search_documents` does the whole working-set flow in one call:
1. Search the remote index through the unified gateway (`/v1/documents/search`).
2. Dedupe passages to distinct documents within a hydration cap.
3. For each, hydrate into the conversation `docs/` dir — unless already present, in which case it is reported `already_local` and re-fetched from neither gateway nor disk.
4. Fetch full content (`/v1/documents/fetch`), write it to disk, upsert the docs manifest.
5. Return one row per document: `{ documentId, source, title, snippet, localPath }` (absolute path the agent can `Read`).

## Acceptance criteria

- [x] Agent-facing tool surface exposes one document operation: `mcp__mymemo__search_documents`.
- [x] Result includes `documentId`, `source`, `title`, `snippet`, `localPath`.
- [x] Repeated search returns `source: "already_local"` for already-hydrated docs.
- [x] Recoverable failures returned as tool errors (`isError: true`); no matches is a normal empty result.
- [x] Tests cover no results, gateway errors, hydration success, already-local, MCP tool registration/name (plus dedupe/cap, filename sanitization, handler env/context guards).

## Changes

- **`search-documents.ts`** (new): credential-free, env-free core (`searchAndHydrate`) with injectable `fetch`/clock; sanitizes remote document ids before joining into a path.
- **`agent-tools.ts`**: wire the tool to `searchAndHydrate`, reading gateway URL + `aud:"documents"` token from the per-turn env and `docsDir`/`runId` from injected context.
- **`agent.ts` / `agent-entry.ts` / `child-spawn.ts` / `routes/turn.ts`**: thread `docsDir` + `runId` from the turn route to the MCP server context, and bind `docs/` rw into bwrap (after the `/workspace` tmpfs mask) so hydrated files + manifest persist to the host.
- **`package.json`**: add `zod` (the SDK `tool()` input schema).

## Tests run

`bun test` in `apps/sandbox-daemon` — **112 pass / 0 fail**. `tsc --noEmit` and `biome check` clean. `bun run build` bundles both daemon + agent.

## Remaining risk / follow-ups

- The legacy `mymemo-docs` CLI (`search`/`fetch`) is still staged on the sandbox PATH; the agent no longer needs it. Removing it from the template and rewording the system prompt to stop instructing CLI usage is **MYM-13 (Task 9)** territory and intentionally out of scope here.
- Cross-turn `already_local` + workspace sync rely on the `docs/` bwrap bind persisting to the host; this interacts with **MYM-30** (remove nested bwrap) and **MYM-10**'s `WorkspaceStore` sync.
- Hydration limits here are a single interim `MAX_HYDRATED_DOCUMENTS` cap; per-document / per-run byte ceilings are **MYM-12 (Task 8)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)