### PR TITLE
fix(workspace-store): atomic docs-manifest writes under concurrency (MYM-37)

### DIFF
--- a/apps/chat-api/src/features/workspace-store/docs-manifest.test.ts
+++ b/apps/chat-api/src/features/workspace-store/docs-manifest.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readDocsManifest } from "./docs-manifest";
+
+let docsDir: string;
+
+beforeEach(() => {
+	docsDir = mkdtempSync(join(tmpdir(), "chat-api-docs-manifest-test-"));
+});
+
+afterEach(() => {
+	rmSync(docsDir, { recursive: true, force: true });
+});
+
+describe("writeDocsManifest concurrency", () => {
+	// chat-api does not serialize turns per conversation, so two concurrent turns
+	// can call writeDocsManifest against the same durable `docs/` dir at once.
+	// This proves the final manifest.json is always one writer's complete output,
+	// never a torn or byte-mixed file (which a shared fixed temp name would cause).
+	it("concurrent writers never produce a torn or byte-mixed manifest", async () => {
+		const WRITERS = 8;
+		// A shared fixed temp name makes concurrent writers collide on one path:
+		// they truncate/clobber each other's in-flight bytes and their renames
+		// race (one writer renames the shared temp away, the next gets ENOENT).
+		// The payload spans several pages and each writer loops a few times to
+		// widen that window; the unique-temp fix makes every run pass regardless.
+		const ENTRIES = 800;
+		const ITERATIONS = 4;
+		const modulePath = join(import.meta.dir, "docs-manifest.ts");
+
+		const script = `
+			const { writeDocsManifest, DOCS_MANIFEST_VERSION } = await import(process.env.MODULE_PATH);
+			const id = process.env.WRITER_ID;
+			const count = Number(process.env.ENTRY_COUNT);
+			const iterations = Number(process.env.ITERATIONS);
+			const documents = Array.from({ length: count }, (_, i) => ({
+				documentId: \`doc-\${id}-\${i}\`,
+				title: \`Doc \${i} from writer \${id} \${"x".repeat(64)}\`,
+				localPath: \`doc-\${id}-\${i}.md\`,
+				source: "kb",
+				hydratedAt: "2026-06-17T00:00:00.000Z",
+				runId: \`writer-\${id}\`,
+			}));
+			const manifest = { version: DOCS_MANIFEST_VERSION, documents };
+			for (let n = 0; n < iterations; n++) {
+				writeDocsManifest(process.env.DOCS_DIR, manifest);
+			}
+		`;
+
+		const procs = Array.from({ length: WRITERS }, (_, id) =>
+			Bun.spawn(["bun", "-e", script], {
+				env: {
+					...process.env,
+					MODULE_PATH: modulePath,
+					DOCS_DIR: docsDir,
+					WRITER_ID: String(id),
+					ENTRY_COUNT: String(ENTRIES),
+					ITERATIONS: String(ITERATIONS),
+				},
+			}),
+		);
+		const codes = await Promise.all(procs.map((p) => p.exited));
+		expect(codes).toEqual(Array.from({ length: WRITERS }, () => 0));
+
+		// readDocsManifest throws on unparseable JSON, so a passing read already
+		// proves the file is valid and complete (fail-closed).
+		const manifest = readDocsManifest(docsDir);
+		expect(manifest.documents).toHaveLength(ENTRIES);
+
+		// Every entry must come from a single writer — no interleaving.
+		const writers = new Set(manifest.documents.map((d) => d.runId));
+		expect(writers.size).toBe(1);
+
+		// No writer left a temp file behind.
+		const leftovers = readdirSync(docsDir).filter((f) => f.endsWith(".tmp"));
+		expect(leftovers).toEqual([]);
+	}, 30_000);
+});

--- a/apps/chat-api/src/features/workspace-store/docs-manifest.ts
+++ b/apps/chat-api/src/features/workspace-store/docs-manifest.ts
@@ -13,13 +13,28 @@
  *     so a reader never observes a half-written `manifest.json`.
  */
 
-import { readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { randomBytes } from "node:crypto";
+import {
+	readdirSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 
 /** Current on-disk schema version. Must match the daemon's manifest version. */
 export const DOCS_MANIFEST_VERSION = 1;
 
 const MANIFEST_FILENAME = "manifest.json";
+
+/**
+ * A temp file older than this is treated as abandoned (its writer crashed before
+ * the rename) and reclaimed on the next write. Comfortably longer than any real
+ * manifest write, so a concurrent live writer's in-flight temp is never swept.
+ */
+const STALE_TEMP_MS = 60_000;
 
 export interface DocsManifestEntry {
 	/** Remote document id (stable across hydrations). */
@@ -120,16 +135,60 @@ export function readDocsManifest(docsDir: string): DocsManifest {
 }
 
 /**
+ * Best-effort removal of temp files orphaned by a writer that crashed between
+ * the write and the rename. Each write uses a unique temp name (so concurrent
+ * writers never collide), which means a hard crash leaks its temp file and
+ * nothing else would ever reclaim it. Only temps older than {@link
+ * STALE_TEMP_MS} are removed, so a concurrent live writer's fresh temp is left
+ * alone. Failures are ignored: this is opportunistic cleanup, not correctness.
+ */
+function sweepStaleTemps(docsDir: string): void {
+	const prefix = `${MANIFEST_FILENAME}.`;
+	let names: string[];
+	try {
+		names = readdirSync(docsDir);
+	} catch {
+		return;
+	}
+	const now = Date.now();
+	for (const name of names) {
+		if (!name.startsWith(prefix) || !name.endsWith(".tmp")) continue;
+		const path = join(docsDir, name);
+		try {
+			if (now - statSync(path).mtimeMs > STALE_TEMP_MS) {
+				rmSync(path, { force: true });
+			}
+		} catch {
+			// Raced with another writer renaming/removing it — ignore.
+		}
+	}
+}
+
+/**
  * Atomically write a manifest into a `docs/` directory. Writes a sibling temp
  * file and renames it into place so a partial write can never be observed as
  * `manifest.json`. The `docs/` directory must already exist.
+ *
+ * The temp file name is unique per write (pid + random token) so two writers
+ * targeting the same `docs/` dir never share a temp path: each writes its own
+ * temp file and renames it into place atomically. The final `manifest.json` is
+ * therefore never torn or a byte-mix of two writers — it is always exactly one
+ * writer's complete output. This matters because chat-api does not serialize
+ * turns per conversation, so two concurrent turns can write this durable
+ * manifest at the same time.
+ *
+ * The guarantee is corruption-freedom only: writes are last-writer-wins, not a
+ * merge. A caller that reads the manifest, mutates it, and writes it back can
+ * still drop a concurrent writer's change (a lost update) and must serialize
+ * those read-modify-write mutations itself if that matters.
  */
 export function writeDocsManifest(
 	docsDir: string,
 	manifest: DocsManifest,
 ): void {
+	sweepStaleTemps(docsDir);
 	const target = docsManifestPath(docsDir);
-	const tmp = `${target}.tmp`;
+	const tmp = `${target}.${process.pid}.${randomBytes(6).toString("hex")}.tmp`;
 	try {
 		writeFileSync(tmp, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
 		renameSync(tmp, target);

--- a/apps/sandbox-daemon/docs-manifest.test.ts
+++ b/apps/sandbox-daemon/docs-manifest.test.ts
@@ -2,8 +2,10 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import {
 	existsSync,
 	mkdtempSync,
+	readdirSync,
 	readFileSync,
 	rmSync,
+	utimesSync,
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -124,8 +126,92 @@ describe("writeDocsManifest", () => {
 
 	it("leaves no temp file behind", () => {
 		writeDocsManifest(docsDir, emptyDocsManifest());
-		expect(existsSync(`${docsManifestPath(docsDir)}.tmp`)).toBe(false);
+		const leftovers = readdirSync(docsDir).filter((f) => f.endsWith(".tmp"));
+		expect(leftovers).toEqual([]);
 	});
+
+	it("sweeps stale orphan temp files but spares fresh ones", () => {
+		const target = docsManifestPath(docsDir);
+		// A temp orphaned by a crashed writer (old) and one a concurrent live
+		// writer is mid-write on (fresh).
+		const stale = `${target}.111.deadbeef.tmp`;
+		const fresh = `${target}.222.cafef00d.tmp`;
+		writeFileSync(stale, "orphan", "utf8");
+		writeFileSync(fresh, "in-flight", "utf8");
+		const longAgo = new Date(Date.now() - 10 * 60_000);
+		utimesSync(stale, longAgo, longAgo);
+
+		writeDocsManifest(docsDir, emptyDocsManifest());
+
+		expect(existsSync(stale)).toBe(false);
+		expect(existsSync(fresh)).toBe(true);
+	});
+});
+
+describe("writeDocsManifest concurrency", () => {
+	it("concurrent writers never produce a torn or byte-mixed manifest", async () => {
+		const WRITERS = 8;
+		// A shared fixed temp name makes concurrent writers collide on one path:
+		// they truncate/clobber each other's in-flight bytes and their renames
+		// race (one writer renames the shared temp away, the next gets ENOENT).
+		// The payload spans several pages and each writer loops a few times to
+		// widen that window; the unique-temp fix makes every run pass regardless.
+		const ENTRIES = 800;
+		const ITERATIONS = 4;
+		const modulePath = join(import.meta.dir, "docs-manifest.ts");
+
+		// Each subprocess repeatedly writes a full manifest of ENTRIES entries,
+		// all tagged with its own writer id, into the SAME docs dir at once. With
+		// a unique temp name per write the final manifest.json is always one
+		// writer's complete output; a shared fixed temp name lets the writers
+		// clobber each other's temp bytes and produce a torn/byte-mixed file.
+		const script = `
+			const { writeDocsManifest, DOCS_MANIFEST_VERSION } = await import(process.env.MODULE_PATH);
+			const id = process.env.WRITER_ID;
+			const count = Number(process.env.ENTRY_COUNT);
+			const iterations = Number(process.env.ITERATIONS);
+			const documents = Array.from({ length: count }, (_, i) => ({
+				documentId: \`doc-\${id}-\${i}\`,
+				title: \`Doc \${i} from writer \${id} \${"x".repeat(64)}\`,
+				localPath: \`doc-\${id}-\${i}.md\`,
+				source: "kb",
+				hydratedAt: "2026-06-17T00:00:00.000Z",
+				runId: \`writer-\${id}\`,
+			}));
+			const manifest = { version: DOCS_MANIFEST_VERSION, documents };
+			for (let n = 0; n < iterations; n++) {
+				writeDocsManifest(process.env.DOCS_DIR, manifest);
+			}
+		`;
+
+		const procs = Array.from({ length: WRITERS }, (_, id) =>
+			Bun.spawn(["bun", "-e", script], {
+				env: {
+					...process.env,
+					MODULE_PATH: modulePath,
+					DOCS_DIR: docsDir,
+					WRITER_ID: String(id),
+					ENTRY_COUNT: String(ENTRIES),
+					ITERATIONS: String(ITERATIONS),
+				},
+			}),
+		);
+		const codes = await Promise.all(procs.map((p) => p.exited));
+		expect(codes).toEqual(Array.from({ length: WRITERS }, () => 0));
+
+		// readDocsManifest throws on unparseable JSON, so a passing read already
+		// proves the file is valid and complete (fail-closed).
+		const manifest = readDocsManifest(docsDir);
+		expect(manifest.documents).toHaveLength(ENTRIES);
+
+		// Every entry must come from a single writer — no interleaving.
+		const writers = new Set(manifest.documents.map((d) => d.runId));
+		expect(writers.size).toBe(1);
+
+		// No writer left a temp file behind.
+		const leftovers = readdirSync(docsDir).filter((f) => f.endsWith(".tmp"));
+		expect(leftovers).toEqual([]);
+	}, 30_000);
 });
 
 describe("upsertDocsManifestEntry", () => {

--- a/apps/sandbox-daemon/docs-manifest.ts
+++ b/apps/sandbox-daemon/docs-manifest.ts
@@ -21,13 +21,28 @@
  *     the bytes are not fsync'd before the rename.)
  */
 
-import { readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { randomBytes } from "node:crypto";
+import {
+	readdirSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 
 /** Current on-disk schema version. Bumped only on a breaking format change. */
 export const DOCS_MANIFEST_VERSION = 1;
 
 const MANIFEST_FILENAME = "manifest.json";
+
+/**
+ * A temp file older than this is treated as abandoned (its writer crashed before
+ * the rename) and reclaimed on the next write. Comfortably longer than any real
+ * manifest write, so a concurrent live writer's in-flight temp is never swept.
+ */
+const STALE_TEMP_MS = 60_000;
 
 export interface DocsManifestEntry {
 	/** Remote document id (stable across hydrations). */
@@ -131,16 +146,59 @@ export function readDocsManifest(docsDir: string): DocsManifest {
 }
 
 /**
+ * Best-effort removal of temp files orphaned by a writer that crashed between
+ * the write and the rename. Each write uses a unique temp name (so concurrent
+ * writers never collide), which means a hard crash leaks its temp file and
+ * nothing else would ever reclaim it. Only temps older than {@link
+ * STALE_TEMP_MS} are removed, so a concurrent live writer's fresh temp is left
+ * alone. Failures are ignored: this is opportunistic cleanup, not correctness.
+ */
+function sweepStaleTemps(docsDir: string): void {
+	const prefix = `${MANIFEST_FILENAME}.`;
+	let names: string[];
+	try {
+		names = readdirSync(docsDir);
+	} catch {
+		return;
+	}
+	const now = Date.now();
+	for (const name of names) {
+		if (!name.startsWith(prefix) || !name.endsWith(".tmp")) continue;
+		const path = join(docsDir, name);
+		try {
+			if (now - statSync(path).mtimeMs > STALE_TEMP_MS) {
+				rmSync(path, { force: true });
+			}
+		} catch {
+			// Raced with another writer renaming/removing it — ignore.
+		}
+	}
+}
+
+/**
  * Atomically write a manifest into a conversation's `docs/` directory. Writes a
  * sibling temp file and renames it into place so a partial write can never be
  * observed as `manifest.json`. The `docs/` directory must already exist.
+ *
+ * The temp file name is unique per write (pid + random token) so two writers
+ * targeting the same `docs/` dir never share a temp path: each writes its own
+ * temp file and renames it into place atomically, so the final `manifest.json`
+ * is always one writer's complete output — never a byte-mix of both. (A fixed
+ * temp name would let concurrent writers truncate and clobber each other's
+ * temp bytes before the rename.)
+ *
+ * The guarantee is corruption-freedom only: writes are last-writer-wins, not a
+ * merge. A caller that reads the manifest, mutates it, and writes it back (see
+ * {@link upsertDocsManifestEntry}) can still drop a concurrent writer's change;
+ * such read-modify-write callers must serialize themselves.
  */
 export function writeDocsManifest(
 	docsDir: string,
 	manifest: DocsManifest,
 ): void {
+	sweepStaleTemps(docsDir);
 	const target = docsManifestPath(docsDir);
-	const tmp = `${target}.tmp`;
+	const tmp = `${target}.${process.pid}.${randomBytes(6).toString("hex")}.tmp`;
 	try {
 		writeFileSync(tmp, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
 		renameSync(tmp, target);
@@ -155,6 +213,12 @@ export function writeDocsManifest(
  * Read the manifest, insert or replace the entry for `entry.documentId`, and
  * write it back atomically. Re-hydrating a document updates its existing entry
  * in place rather than appending a duplicate. Returns the updated manifest.
+ *
+ * This is a read-modify-write, so it is only safe under a single writer: the
+ * daemon's per-turn lock serializes turns within a sandbox. Two concurrent
+ * upserts would each read the same base and one would overwrite the other (a
+ * lost update); the atomic write in {@link writeDocsManifest} prevents
+ * corruption but not that.
  */
 export function upsertDocsManifestEntry(
 	docsDir: string,


### PR DESCRIPTION
## What

`writeDocsManifest()` wrote to a **fixed** sibling temp path `${target}.tmp`, then renamed it into place for atomicity. chat-api does **not** serialize turns per conversation (`chat.controller.ts` derives `conversationId` from the body; `runSandboxChat()` takes no lock), and the durable root `users/{userId}/conversations/{conversationId}/docs/` is shared across turns. Two concurrent turns for the same conversation therefore wrote the **same** `manifest.json.tmp`: `writeFileSync` truncates, so the writers clobbered each other's temp bytes and their renames raced — producing a lost update, a byte-mixed manifest, or an `ENOENT`-on-rename crash.

This PR makes the atomic-write path safe under concurrency.

## Why

The durable docs manifest is the record of a conversation's hydrated working set. A corrupted or partially-overwritten `manifest.json` is a fail-closed error (`readDocsManifest` throws on malformed input), so a torn write breaks the next turn for that conversation. MYM-9's acceptance criteria called for writes to avoid corruption; this closes the concurrency gap that slipped through.

## Changes

- **Unique temp name per write** — `${target}.${pid}.${random}.tmp`. Concurrent writers never share a temp path; each renames its own complete file in (last-writer-wins, never torn). Per-pid alone is unsafe across containers (shared PID namespaces), so the random token is required for a shared volume.
- **Orphan temp sweep** (`sweepStaleTemps`, 60s threshold) — unique names defeat the old self-healing reclamation, so a writer that crashes between write and rename would leak its temp forever. Best-effort, age-based so a concurrent live writer's fresh temp is never swept.
- **Scoped docstring** — the guarantee is corruption-freedom only (last-writer-wins, not a merge). Read-modify-write callers (`upsertDocsManifestEntry`, future hydrate→sync) can still drop a concurrent change and must serialize themselves; documented on both `writeDocsManifest` and `upsertDocsManifestEntry`.
- Mirrored across the **chat-api** and **sandbox-daemon** copies for parity (daemon is lower risk: turn-locked, one sandbox per conversation).

## Tests

- New concurrency test (both apps): 8 subprocesses write the same `docs/` dir; the final `manifest.json` must be valid JSON and exactly one writer's complete output. **Verified to fail on the old fixed-temp code** and pass on the fix.
- New stale-temp-sweep test: an orphaned (backdated) temp is reclaimed while a fresh one is spared. **Verified to fail if the sweep call is removed.**
- Full suites green: **daemon 63/63, chat-api 84/84**; lint clean on all touched files.

## Reviewer notes

- The logical **lost update** under concurrent read-modify-write is documented but intentionally not eliminated — no concurrent RMW caller exists yet in chat-api, and the daemon relies on its per-turn lock. If such a path is added later, serialize manifest mutations per conversation.

Closes MYM-37. Related: MYM-9, MYM-10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)