### PR TITLE
feat(daemon): enforce document hydration limits (MYM-12)

### DIFF
--- a/apps/sandbox-daemon/agent-tools.ts
+++ b/apps/sandbox-daemon/agent-tools.ts
@@ -36,6 +36,7 @@ import {
 	tool,
 } from "@anthropic-ai/claude-agent-sdk";
 import { z } from "zod";
+import { loadHydrationLimits } from "./hydration-policy";
 import { searchAndHydrate } from "./search-documents";
 
 /** MCP server name; the agent sees its tools as `mcp__<server>__<tool>`. */
@@ -156,6 +157,7 @@ export function buildMymemoTools(context?: MymemoToolContext) {
 						token,
 						docsDir: context.docsDir,
 						runId: context.runId,
+						limits: loadHydrationLimits(),
 					});
 					if (documents.length === 0) {
 						return {

--- a/apps/sandbox-daemon/agent-tools.ts
+++ b/apps/sandbox-daemon/agent-tools.ts
@@ -131,7 +131,7 @@ export function buildMymemoTools(context?: MymemoToolContext) {
 	return [
 		tool(
 			SEARCH_DOCUMENTS_TOOL_NAME,
-			"Search the user's MyMemo documents and hydrate matches into the local conversation workspace. Returns one row per document with its documentId, source, title, snippet, and the local file path you can Read.",
+			'Search the user\'s MyMemo documents and hydrate matches into the local conversation workspace. Returns one row per document with its documentId, source, title, snippet, and localPath. A non-empty localPath is a file you can Read; if source is "skipped_too_large" or "skipped_run_budget" the document was not hydrated, localPath is empty, and the row\'s `error` says which limit was hit.',
 			{
 				query: z
 					.string()

--- a/apps/sandbox-daemon/child-spawn.ts
+++ b/apps/sandbox-daemon/child-spawn.ts
@@ -18,6 +18,7 @@
  */
 
 import { resolve } from "node:path";
+import { hydrationLimitEnv } from "./hydration-policy";
 import type { AgentEvent } from "./ipc-protocol";
 
 export type { AgentEvent } from "./ipc-protocol";
@@ -285,6 +286,11 @@ export async function spawnAgent(
 			...(sessionStoreRoot
 				? { [SESSION_STORE_ROOT_ENV]: sessionStoreRoot }
 				: {}),
+			// Hydration-limit overrides for the `search_documents` tool. The child
+			// env is a fresh whitelist (not inherited), so these must be forwarded
+			// explicitly or the tool silently uses defaults. Not secrets — plain
+			// policy ints; only the ones the operator actually set are passed.
+			...hydrationLimitEnv(),
 		},
 		stdout: "pipe",
 		stderr: "pipe",

--- a/apps/sandbox-daemon/docs-manifest.ts
+++ b/apps/sandbox-daemon/docs-manifest.ts
@@ -42,6 +42,14 @@ export interface DocsManifestEntry {
 	hydratedAt: string;
 	/** The run that caused this hydration. */
 	runId: string;
+	/**
+	 * Byte length of the hydrated content as written. Recorded so the per-run
+	 * hydration budget is charged against an immutable number rather than the
+	 * on-disk file size, which a prompt-injectable agent could shrink or delete
+	 * to free budget. Optional for backward compatibility with manifests written
+	 * before this field existed.
+	 */
+	byteSize?: number;
 }
 
 export interface DocsManifest {
@@ -76,7 +84,9 @@ function isManifestEntry(value: unknown): value is DocsManifestEntry {
 		typeof e.localPath === "string" &&
 		typeof e.source === "string" &&
 		typeof e.hydratedAt === "string" &&
-		typeof e.runId === "string"
+		typeof e.runId === "string" &&
+		(e.byteSize === undefined ||
+			(typeof e.byteSize === "number" && Number.isFinite(e.byteSize)))
 	);
 }
 

--- a/apps/sandbox-daemon/hydration-policy.test.ts
+++ b/apps/sandbox-daemon/hydration-policy.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import {
 	DEFAULT_HYDRATION_LIMITS,
 	HYDRATION_LIMIT_ENV,
+	hydrationLimitEnv,
 	loadHydrationLimits,
 } from "./hydration-policy";
 
@@ -39,5 +40,29 @@ describe("loadHydrationLimits", () => {
 				}),
 			).toThrow(HYDRATION_LIMIT_ENV.maxBytesPerRun);
 		}
+	});
+});
+
+describe("hydrationLimitEnv", () => {
+	it("returns an empty object when no limit vars are set", () => {
+		expect(hydrationLimitEnv({})).toEqual({});
+	});
+
+	it("forwards only the limit vars that are set, omitting unset/empty ones", () => {
+		expect(
+			hydrationLimitEnv({
+				[HYDRATION_LIMIT_ENV.maxBytesPerRun]: "4096",
+				[HYDRATION_LIMIT_ENV.maxBytesPerDocument]: "",
+				UNRELATED: "ignored",
+			}),
+		).toEqual({ [HYDRATION_LIMIT_ENV.maxBytesPerRun]: "4096" });
+	});
+
+	it("passes values through verbatim (validation happens at load time, not forward time)", () => {
+		// Forwarding is dumb on purpose: the child's loadHydrationLimits() is what
+		// validates, so an invalid value is forwarded and rejected there.
+		expect(
+			hydrationLimitEnv({ [HYDRATION_LIMIT_ENV.maxDocumentsPerSearch]: "abc" }),
+		).toEqual({ [HYDRATION_LIMIT_ENV.maxDocumentsPerSearch]: "abc" });
 	});
 });

--- a/apps/sandbox-daemon/hydration-policy.test.ts
+++ b/apps/sandbox-daemon/hydration-policy.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+import {
+	DEFAULT_HYDRATION_LIMITS,
+	HYDRATION_LIMIT_ENV,
+	loadHydrationLimits,
+} from "./hydration-policy";
+
+describe("loadHydrationLimits", () => {
+	it("returns the defaults when no env vars are set", () => {
+		expect(loadHydrationLimits({})).toEqual(DEFAULT_HYDRATION_LIMITS);
+	});
+
+	it("treats an empty-string override as unset (uses the default)", () => {
+		expect(
+			loadHydrationLimits({
+				[HYDRATION_LIMIT_ENV.maxBytesPerDocument]: "",
+			}),
+		).toEqual(DEFAULT_HYDRATION_LIMITS);
+	});
+
+	it("overrides each limit independently from the environment", () => {
+		const limits = loadHydrationLimits({
+			[HYDRATION_LIMIT_ENV.maxDocumentsPerSearch]: "2",
+			[HYDRATION_LIMIT_ENV.maxBytesPerDocument]: "1024",
+			[HYDRATION_LIMIT_ENV.maxBytesPerRun]: "4096",
+		});
+		expect(limits).toEqual({
+			maxDocumentsPerSearch: 2,
+			maxBytesPerDocument: 1024,
+			maxBytesPerRun: 4096,
+		});
+	});
+
+	it("throws on a non-positive-integer override rather than silently disabling a cap", () => {
+		for (const bad of ["0", "-1", "1.5", "abc", "ten"]) {
+			expect(() =>
+				loadHydrationLimits({
+					[HYDRATION_LIMIT_ENV.maxBytesPerRun]: bad,
+				}),
+			).toThrow(HYDRATION_LIMIT_ENV.maxBytesPerRun);
+		}
+	});
+});

--- a/apps/sandbox-daemon/hydration-policy.ts
+++ b/apps/sandbox-daemon/hydration-policy.ts
@@ -1,0 +1,98 @@
+/**
+ * Hydration limits — the single policy module that bounds how much
+ * `search_documents` is allowed to pull into a conversation workspace.
+ *
+ * Three independent caps, enforced by {@link ./search-documents.searchAndHydrate}:
+ *
+ *   - `maxDocumentsPerSearch`: distinct documents hydrated per search call.
+ *   - `maxBytesPerDocument`: bytes of fetched content written for one document.
+ *     An oversized document is reported, NOT written to disk.
+ *   - `maxBytesPerRun`: cumulative hydrated bytes attributed to one `runId`,
+ *     summed across every `search_documents` call in that run.
+ *
+ * The point is to keep one prompt-injectable turn from filling the sandbox disk
+ * (or running up gateway fetch cost) regardless of how the agent chains calls.
+ * Limits are data, not behavior: this module holds no fs/network access and is
+ * pure so the caps are unit-testable and the same defaults apply in tests and
+ * prod. Operators override them through environment (see {@link loadHydrationLimits}).
+ */
+
+/** The three hydration caps enforced by `searchAndHydrate`. */
+export interface HydrationLimits {
+	/** Max distinct documents hydrated per `search_documents` call. */
+	maxDocumentsPerSearch: number;
+	/** Max bytes of content written to disk for a single document. */
+	maxBytesPerDocument: number;
+	/** Max cumulative hydrated bytes attributed to one run. */
+	maxBytesPerRun: number;
+}
+
+/**
+ * Conservative defaults. A document over 1 MB is almost certainly not a useful
+ * working-set file, and 5 MB of hydrated text per run is already a large
+ * context; both are sized to be generous for real notes/docs yet still bound a
+ * runaway loop. `maxDocumentsPerSearch` keeps a single search from dominating
+ * the per-run byte budget with many small files.
+ */
+export const DEFAULT_HYDRATION_LIMITS: HydrationLimits = {
+	maxDocumentsPerSearch: 5,
+	maxBytesPerDocument: 1_000_000,
+	maxBytesPerRun: 5_000_000,
+};
+
+/** Environment variable names that override each default limit. */
+export const HYDRATION_LIMIT_ENV = {
+	maxDocumentsPerSearch: "HYDRATION_MAX_DOCUMENTS_PER_SEARCH",
+	maxBytesPerDocument: "HYDRATION_MAX_BYTES_PER_DOCUMENT",
+	maxBytesPerRun: "HYDRATION_MAX_BYTES_PER_RUN",
+} as const satisfies Record<keyof HydrationLimits, string>;
+
+/**
+ * Parse one limit env var: unset → the default; present → a positive integer.
+ * Anything else (non-numeric, zero, negative, fractional) is a misconfiguration
+ * that throws rather than silently falling back, so a typo can't quietly disable
+ * a cap.
+ */
+function parseLimit(
+	env: Record<string, string | undefined>,
+	name: string,
+	fallback: number,
+): number {
+	const raw = env[name];
+	if (raw === undefined || raw === "") return fallback;
+	const value = Number(raw);
+	if (!Number.isInteger(value) || value <= 0) {
+		throw new Error(
+			`${name} must be a positive integer, got ${JSON.stringify(raw)}`,
+		);
+	}
+	return value;
+}
+
+/**
+ * Build {@link HydrationLimits} from the environment, falling back to
+ * {@link DEFAULT_HYDRATION_LIMITS} for any unset var. Throws on an invalid
+ * (non-positive-integer) override. The env is injectable for tests; it defaults
+ * to `process.env`.
+ */
+export function loadHydrationLimits(
+	env: Record<string, string | undefined> = process.env,
+): HydrationLimits {
+	return {
+		maxDocumentsPerSearch: parseLimit(
+			env,
+			HYDRATION_LIMIT_ENV.maxDocumentsPerSearch,
+			DEFAULT_HYDRATION_LIMITS.maxDocumentsPerSearch,
+		),
+		maxBytesPerDocument: parseLimit(
+			env,
+			HYDRATION_LIMIT_ENV.maxBytesPerDocument,
+			DEFAULT_HYDRATION_LIMITS.maxBytesPerDocument,
+		),
+		maxBytesPerRun: parseLimit(
+			env,
+			HYDRATION_LIMIT_ENV.maxBytesPerRun,
+			DEFAULT_HYDRATION_LIMITS.maxBytesPerRun,
+		),
+	};
+}

--- a/apps/sandbox-daemon/hydration-policy.ts
+++ b/apps/sandbox-daemon/hydration-policy.ts
@@ -48,6 +48,24 @@ export const HYDRATION_LIMIT_ENV = {
 } as const satisfies Record<keyof HydrationLimits, string>;
 
 /**
+ * The hydration-limit env vars that are actually set, as a plain object suitable
+ * for forwarding into the agent child's env. `Bun.spawn` replaces (does not
+ * inherit) the child env, so without this the child's `loadHydrationLimits()`
+ * would never see operator overrides and would silently use the defaults. Unset
+ * vars are omitted so they stay genuinely unset in the child.
+ */
+export function hydrationLimitEnv(
+	env: Record<string, string | undefined> = process.env,
+): Record<string, string> {
+	const forwarded: Record<string, string> = {};
+	for (const name of Object.values(HYDRATION_LIMIT_ENV)) {
+		const value = env[name];
+		if (value !== undefined && value !== "") forwarded[name] = value;
+	}
+	return forwarded;
+}
+
+/**
  * Parse one limit env var: unset → the default; present → a positive integer.
  * Anything else (non-numeric, zero, negative, fractional) is a misconfiguration
  * that throws rather than silently falling back, so a typo can't quietly disable

--- a/apps/sandbox-daemon/search-documents.test.ts
+++ b/apps/sandbox-daemon/search-documents.test.ts
@@ -65,7 +65,10 @@ function fakeGateway(opts: {
 	return { fetchImpl, calls };
 }
 
-function deps(fetchImpl: typeof fetch): SearchDocumentsDeps {
+function deps(
+	fetchImpl: typeof fetch,
+	overrides?: Partial<SearchDocumentsDeps>,
+): SearchDocumentsDeps {
 	return {
 		gatewayUrl: "https://gateway.example",
 		token: "doc-token",
@@ -73,6 +76,7 @@ function deps(fetchImpl: typeof fetch): SearchDocumentsDeps {
 		runId: "run-1",
 		fetchImpl,
 		now: () => FIXED_NOW,
+		...overrides,
 	};
 }
 
@@ -343,5 +347,161 @@ describe("searchAndHydrate", () => {
 		expect(calls.filter((c) => c.url.endsWith("/fetch")).length).toBe(
 			MAX_HYDRATED_DOCUMENTS,
 		);
+	});
+});
+
+describe("searchAndHydrate hydration limits", () => {
+	/** Build a search body + fetch map for docs of the given byte sizes. */
+	function gatewayWithSizedDocs(sizes: Record<string, number>) {
+		const documents = Object.keys(sizes).map((id) => ({
+			passageId: `p-${id}`,
+			documentId: id,
+			title: id,
+			snippet: `snippet ${id}`,
+		}));
+		const fetchByDoc: Record<string, { body: unknown }> = {};
+		for (const [id, size] of Object.entries(sizes)) {
+			fetchByDoc[id] = {
+				body: { documentId: id, title: id, content: "x".repeat(size) },
+			};
+		}
+		return fakeGateway({ search: { body: { documents } }, fetchByDoc });
+	}
+
+	it("enforces maxDocumentsPerSearch from the injected limits", async () => {
+		const { fetchImpl, calls } = gatewayWithSizedDocs({ a: 1, b: 1, c: 1 });
+		const results = await searchAndHydrate(
+			"q",
+			deps(fetchImpl, {
+				limits: {
+					maxDocumentsPerSearch: 2,
+					maxBytesPerDocument: 1000,
+					maxBytesPerRun: 1000,
+				},
+			}),
+		);
+
+		expect(results.map((r) => r.documentId)).toEqual(["a", "b"]);
+		// Only the two selected documents were fetched.
+		expect(calls.filter((c) => c.url.endsWith("/fetch")).length).toBe(2);
+	});
+
+	it("skips an oversized document without writing it to disk", async () => {
+		const { fetchImpl } = gatewayWithSizedDocs({ big: 50, small: 10 });
+		const results = await searchAndHydrate(
+			"q",
+			deps(fetchImpl, {
+				limits: {
+					maxDocumentsPerSearch: 5,
+					maxBytesPerDocument: 20,
+					maxBytesPerRun: 1000,
+				},
+			}),
+		);
+
+		const big = results.find((r) => r.documentId === "big");
+		expect(big).toMatchObject({
+			documentId: "big",
+			source: "skipped_too_large",
+			localPath: "",
+		});
+		expect(big?.error).toContain("per-document limit of 20");
+
+		// Oversized doc not blindly written; the under-limit one still hydrates.
+		expect(existsSync(join(docsDir, documentFilename("big")))).toBe(false);
+		const small = results.find((r) => r.documentId === "small");
+		expect(small?.source).toBe(GATEWAY_SOURCE);
+		expect(readFileSync(small?.localPath ?? "", "utf8")).toBe("x".repeat(10));
+
+		// Only the hydrated doc is in the manifest.
+		expect(
+			readDocsManifest(docsDir).documents.map((d) => d.documentId),
+		).toEqual(["small"]);
+	});
+
+	it("enforces the per-run byte budget, still fitting a later smaller doc", async () => {
+		// a fills most of the budget; b would overflow it; c still fits.
+		const { fetchImpl } = gatewayWithSizedDocs({ a: 60, b: 60, c: 30 });
+		const results = await searchAndHydrate(
+			"q",
+			deps(fetchImpl, {
+				limits: {
+					maxDocumentsPerSearch: 5,
+					maxBytesPerDocument: 1000,
+					maxBytesPerRun: 100,
+				},
+			}),
+		);
+
+		expect(results.map((r) => [r.documentId, r.source])).toEqual([
+			["a", GATEWAY_SOURCE],
+			["b", "skipped_run_budget"],
+			["c", GATEWAY_SOURCE],
+		]);
+		const b = results.find((r) => r.documentId === "b");
+		expect(b?.localPath).toBe("");
+		expect(b?.error).toContain("per-run budget of 100");
+
+		// Only a and c reached disk and the manifest.
+		expect(existsSync(join(docsDir, documentFilename("b")))).toBe(false);
+		expect(
+			readDocsManifest(docsDir)
+				.documents.map((d) => d.documentId)
+				.sort(),
+		).toEqual(["a", "c"]);
+	});
+
+	it("carries the per-run budget across calls in the same run", async () => {
+		const limits = {
+			maxDocumentsPerSearch: 5,
+			maxBytesPerDocument: 1000,
+			maxBytesPerRun: 100,
+		};
+
+		// First call hydrates a 80-byte doc under run-1.
+		const first = gatewayWithSizedDocs({ a: 80 });
+		await searchAndHydrate("q1", deps(first.fetchImpl, { limits }));
+		expect(existsSync(join(docsDir, documentFilename("a")))).toBe(true);
+
+		// Second call in the SAME run: only 20 bytes of budget remain, so a
+		// 40-byte doc is rejected even though it is under the per-document limit.
+		const second = gatewayWithSizedDocs({ b: 40 });
+		const results = await searchAndHydrate(
+			"q2",
+			deps(second.fetchImpl, { limits }),
+		);
+		expect(results[0]).toMatchObject({
+			documentId: "b",
+			source: "skipped_run_budget",
+		});
+		expect(existsSync(join(docsDir, documentFilename("b")))).toBe(false);
+	});
+
+	it("charges a different run's budget independently", async () => {
+		const limits = {
+			maxDocumentsPerSearch: 5,
+			maxBytesPerDocument: 1000,
+			maxBytesPerRun: 100,
+		};
+
+		// run-1 hydrates 80 bytes.
+		const first = gatewayWithSizedDocs({ a: 80 });
+		await searchAndHydrate(
+			"q1",
+			deps(first.fetchImpl, { runId: "run-1", limits }),
+		);
+
+		// run-2 starts with a fresh budget, so a 40-byte doc hydrates fine even
+		// though run-1 already wrote 80 bytes into the shared docs dir.
+		const second = gatewayWithSizedDocs({ b: 40 });
+		const results = await searchAndHydrate(
+			"q2",
+			deps(second.fetchImpl, { runId: "run-2", limits }),
+		);
+		expect(results[0]).toMatchObject({
+			documentId: "b",
+			source: GATEWAY_SOURCE,
+		});
+		expect(existsSync(join(docsDir, documentFilename("b")))).toBe(true);
 	});
 });

--- a/apps/sandbox-daemon/search-documents.test.ts
+++ b/apps/sandbox-daemon/search-documents.test.ts
@@ -181,6 +181,8 @@ describe("searchAndHydrate", () => {
 				source: GATEWAY_SOURCE,
 				hydratedAt: FIXED_NOW.toISOString(),
 				runId: "run-1",
+				// "BODY1" is 5 bytes.
+				byteSize: 5,
 			},
 			{
 				documentId: "d2",
@@ -189,6 +191,7 @@ describe("searchAndHydrate", () => {
 				source: GATEWAY_SOURCE,
 				hydratedAt: FIXED_NOW.toISOString(),
 				runId: "run-1",
+				byteSize: 5,
 			},
 		]);
 
@@ -475,6 +478,61 @@ describe("searchAndHydrate hydration limits", () => {
 			source: "skipped_run_budget",
 		});
 		expect(existsSync(join(docsDir, documentFilename("b")))).toBe(false);
+	});
+
+	it("keeps charging the run budget after the agent deletes a hydrated file", async () => {
+		// P1: budget is charged against the byte count recorded in the manifest,
+		// not the live on-disk size — so deleting/truncating a file can't free it.
+		const limits = {
+			maxDocumentsPerSearch: 5,
+			maxBytesPerDocument: 1000,
+			maxBytesPerRun: 100,
+		};
+
+		// Call 1 hydrates an 80-byte doc, then the (untrusted) agent deletes it.
+		const first = gatewayWithSizedDocs({ a: 80 });
+		await searchAndHydrate("q1", deps(first.fetchImpl, { limits }));
+		rmSync(join(docsDir, documentFilename("a")));
+
+		// Call 2 in the same run: the 80 bytes are still charged (manifest entry
+		// remains), so a 40-byte doc overflows the 100-byte budget.
+		const second = gatewayWithSizedDocs({ b: 40 });
+		const results = await searchAndHydrate(
+			"q2",
+			deps(second.fetchImpl, { limits }),
+		);
+		expect(results[0]).toMatchObject({
+			documentId: "b",
+			source: "skipped_run_budget",
+		});
+		expect(existsSync(join(docsDir, documentFilename("b")))).toBe(false);
+	});
+
+	it("does not fetch once the run budget is fully exhausted", async () => {
+		// P2: when no budget remains, candidates are skipped BEFORE the gateway
+		// fetch, so a prompt-injection loop can't keep burning fetch cost.
+		const limits = {
+			maxDocumentsPerSearch: 5,
+			maxBytesPerDocument: 1000,
+			maxBytesPerRun: 100,
+		};
+
+		// Call 1 hydrates exactly the full budget.
+		const first = gatewayWithSizedDocs({ a: 100 });
+		await searchAndHydrate("q1", deps(first.fetchImpl, { limits }));
+
+		// Call 2: budget exhausted, so the candidate is skipped without fetching.
+		const second = gatewayWithSizedDocs({ b: 40 });
+		const results = await searchAndHydrate(
+			"q2",
+			deps(second.fetchImpl, { limits }),
+		);
+		expect(results[0]).toMatchObject({
+			documentId: "b",
+			source: "skipped_run_budget",
+		});
+		// Searched, but never fetched — the short-circuit fired before /fetch.
+		expect(second.calls.some((c) => c.url.endsWith("/fetch"))).toBe(false);
 	});
 
 	it("charges a different run's budget independently", async () => {

--- a/apps/sandbox-daemon/search-documents.ts
+++ b/apps/sandbox-daemon/search-documents.ts
@@ -27,25 +27,46 @@
  */
 
 import { createHash } from "node:crypto";
-import { existsSync, writeFileSync } from "node:fs";
+import { existsSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { readDocsManifest, upsertDocsManifestEntry } from "./docs-manifest";
+import {
+	type DocsManifest,
+	readDocsManifest,
+	upsertDocsManifestEntry,
+} from "./docs-manifest";
+import {
+	DEFAULT_HYDRATION_LIMITS,
+	type HydrationLimits,
+} from "./hydration-policy";
 
 /**
- * Max distinct documents hydrated per search call. A conservative interim cap so
- * one call can't fill the workspace; MYM-12 (Task 8) will centralize hydration
- * limits (per-document and per-run byte ceilings) in a dedicated policy module.
+ * Max distinct documents hydrated per search call. Kept as a named export for
+ * existing callers/tests; the configurable source of truth is now
+ * {@link HydrationLimits.maxDocumentsPerSearch} (see hydration-policy.ts).
  */
-export const MAX_HYDRATED_DOCUMENTS = 5;
+export const MAX_HYDRATED_DOCUMENTS =
+	DEFAULT_HYDRATION_LIMITS.maxDocumentsPerSearch;
 
 /** Manifest `source` recorded for documents hydrated from the gateway. */
 export const GATEWAY_SOURCE = "gateway";
 
 /**
- * Result `source`: `"gateway"` for a document hydrated by this call,
- * `"already_local"` for one already present in the conversation workspace.
+ * Result `source`:
+ * - `"gateway"` — hydrated by this call.
+ * - `"already_local"` — already present in the conversation workspace.
+ * - `"skipped_too_large"` — fetched but over the per-document byte limit; NOT
+ *   written to disk.
+ * - `"skipped_run_budget"` — fetched but would push this run over its byte
+ *   budget; NOT written to disk.
+ *
+ * For the two `skipped_*` sources `localPath` is `""` and `error` explains the
+ * limit that was hit.
  */
-export type DocumentResultSource = typeof GATEWAY_SOURCE | "already_local";
+export type DocumentResultSource =
+	| typeof GATEWAY_SOURCE
+	| "already_local"
+	| "skipped_too_large"
+	| "skipped_run_budget";
 
 export interface SearchDocumentResult {
 	documentId: string;
@@ -59,8 +80,13 @@ export interface SearchDocumentResult {
 	 * document — this is the top-ranked passage for the hydrated document.
 	 */
 	passageId: string;
-	/** Absolute path to the hydrated file (the agent can `Read` this). */
+	/**
+	 * Absolute path to the hydrated file (the agent can `Read` this), or `""` for
+	 * a `skipped_*` document that was not written to disk.
+	 */
 	localPath: string;
+	/** Why a `skipped_*` document was not hydrated; absent on hydrated rows. */
+	error?: string;
 }
 
 /** One passage hit from the gateway search endpoint. */
@@ -87,6 +113,11 @@ export interface SearchDocumentsDeps {
 	docsDir: string;
 	/** The run that caused this hydration (recorded in the manifest). */
 	runId: string;
+	/**
+	 * Hydration caps (document count + byte ceilings). Defaults to
+	 * {@link DEFAULT_HYDRATION_LIMITS}; the daemon passes env-derived limits.
+	 */
+	limits?: HydrationLimits;
 	/** Injectable for tests; defaults to the global `fetch`. */
 	fetchImpl?: typeof fetch;
 	/** Injectable clock for deterministic `hydratedAt`; defaults to `() => new Date()`. */
@@ -164,10 +195,13 @@ export function documentFilename(documentId: string): string {
 
 /**
  * Dedupe passage hits down to distinct documents (keeping the first hit's title
- * and snippet for each), preserving search-rank order, capped at
- * {@link MAX_HYDRATED_DOCUMENTS}. Hits without a `documentId` are dropped.
+ * and snippet for each), preserving search-rank order, capped at `maxDocuments`.
+ * Hits without a `documentId` are dropped.
  */
-function selectDocuments(hits: GatewaySearchHit[]): GatewaySearchHit[] {
+function selectDocuments(
+	hits: GatewaySearchHit[],
+	maxDocuments: number,
+): GatewaySearchHit[] {
 	const seen = new Set<string>();
 	const selected: GatewaySearchHit[] = [];
 	for (const hit of hits) {
@@ -175,9 +209,33 @@ function selectDocuments(hits: GatewaySearchHit[]): GatewaySearchHit[] {
 		if (!documentId || seen.has(documentId)) continue;
 		seen.add(documentId);
 		selected.push(hit);
-		if (selected.length >= MAX_HYDRATED_DOCUMENTS) break;
+		if (selected.length >= maxDocuments) break;
 	}
 	return selected;
+}
+
+/**
+ * Bytes already hydrated under `runId`, summed from the on-disk size of the
+ * manifest entries this run wrote. This seeds the per-run budget so the cap
+ * holds across multiple `search_documents` calls in the same run, not just
+ * within one call. Entries whose file is missing contribute 0.
+ */
+function runHydratedBytes(
+	docsDir: string,
+	manifest: DocsManifest,
+	runId: string,
+): number {
+	let total = 0;
+	for (const entry of manifest.documents) {
+		if (entry.runId !== runId) continue;
+		try {
+			total += statSync(join(docsDir, entry.localPath)).size;
+		} catch {
+			// File gone (deleted, or manifest restored ahead of its blobs) — it no
+			// longer occupies the run's byte budget.
+		}
+	}
+	return total;
 }
 
 /**
@@ -191,6 +249,7 @@ export async function searchAndHydrate(
 ): Promise<SearchDocumentResult[]> {
 	const doFetch = deps.fetchImpl ?? fetch;
 	const now = deps.now ?? (() => new Date());
+	const limits = deps.limits ?? DEFAULT_HYDRATION_LIMITS;
 
 	const searchResponse = await postJson<{ documents?: unknown }>(
 		doFetch,
@@ -202,13 +261,17 @@ export async function searchAndHydrate(
 		? (searchResponse.documents as GatewaySearchHit[])
 		: [];
 
-	const selected = selectDocuments(hits);
+	const selected = selectDocuments(hits, limits.maxDocumentsPerSearch);
 	if (selected.length === 0) return [];
 
 	// Read the manifest once up front so repeated searches recognise documents
 	// already hydrated in this conversation workspace.
 	const manifest = readDocsManifest(deps.docsDir);
 	const localById = new Map(manifest.documents.map((d) => [d.documentId, d]));
+
+	// Seed the per-run byte budget from what this run already hydrated, so the
+	// cap holds across multiple search_documents calls in the run.
+	let runBytes = runHydratedBytes(deps.docsDir, manifest, deps.runId);
 
 	const results: SearchDocumentResult[] = [];
 	for (const hit of selected) {
@@ -245,10 +308,43 @@ export async function searchAndHydrate(
 			{ documentId },
 		);
 
+		const content = doc.content ?? "";
+		const byteLength = Buffer.byteLength(content, "utf8");
+		const title = doc.title || hit.title || "";
+
+		// Enforce the byte caps BEFORE touching disk: an oversized or
+		// budget-busting document is reported, never written. Per-document is
+		// checked first so a single huge file is attributed to its own limit
+		// rather than the run budget it would also blow.
+		if (byteLength > limits.maxBytesPerDocument) {
+			results.push({
+				documentId,
+				source: "skipped_too_large",
+				title,
+				snippet,
+				passageId,
+				localPath: "",
+				error: `document is ${byteLength} bytes, over the per-document limit of ${limits.maxBytesPerDocument}`,
+			});
+			continue;
+		}
+		if (runBytes + byteLength > limits.maxBytesPerRun) {
+			results.push({
+				documentId,
+				source: "skipped_run_budget",
+				title,
+				snippet,
+				passageId,
+				localPath: "",
+				error: `hydrating ${byteLength} bytes would exceed the per-run budget of ${limits.maxBytesPerRun} bytes (already ${runBytes})`,
+			});
+			continue;
+		}
+
 		const filename = documentFilename(documentId);
 		const absolutePath = join(deps.docsDir, filename);
-		const title = doc.title || hit.title || "";
-		writeFileSync(absolutePath, doc.content ?? "", "utf8");
+		writeFileSync(absolutePath, content, "utf8");
+		runBytes += byteLength;
 		upsertDocsManifestEntry(deps.docsDir, {
 			documentId,
 			title,

--- a/apps/sandbox-daemon/search-documents.ts
+++ b/apps/sandbox-daemon/search-documents.ts
@@ -27,7 +27,7 @@
  */
 
 import { createHash } from "node:crypto";
-import { existsSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import {
 	type DocsManifest,
@@ -215,25 +215,18 @@ function selectDocuments(
 }
 
 /**
- * Bytes already hydrated under `runId`, summed from the on-disk size of the
- * manifest entries this run wrote. This seeds the per-run budget so the cap
- * holds across multiple `search_documents` calls in the same run, not just
- * within one call. Entries whose file is missing contribute 0.
+ * Bytes already hydrated under `runId`, summed from the byte count RECORDED in
+ * the manifest at hydration time (not the live on-disk size). This seeds the
+ * per-run budget so the cap holds across multiple `search_documents` calls in
+ * the same run. Using the recorded count means a prompt-injectable agent can't
+ * free budget by deleting or truncating a file it already hydrated — the charge
+ * stands as long as the manifest entry does. Legacy entries without a recorded
+ * `byteSize` contribute 0.
  */
-function runHydratedBytes(
-	docsDir: string,
-	manifest: DocsManifest,
-	runId: string,
-): number {
+function runHydratedBytes(manifest: DocsManifest, runId: string): number {
 	let total = 0;
 	for (const entry of manifest.documents) {
-		if (entry.runId !== runId) continue;
-		try {
-			total += statSync(join(docsDir, entry.localPath)).size;
-		} catch {
-			// File gone (deleted, or manifest restored ahead of its blobs) — it no
-			// longer occupies the run's byte budget.
-		}
+		if (entry.runId === runId) total += entry.byteSize ?? 0;
 	}
 	return total;
 }
@@ -271,7 +264,7 @@ export async function searchAndHydrate(
 
 	// Seed the per-run byte budget from what this run already hydrated, so the
 	// cap holds across multiple search_documents calls in the run.
-	let runBytes = runHydratedBytes(deps.docsDir, manifest, deps.runId);
+	let runBytes = runHydratedBytes(manifest, deps.runId);
 
 	const results: SearchDocumentResult[] = [];
 	for (const hit of selected) {
@@ -299,6 +292,24 @@ export async function searchAndHydrate(
 				});
 				continue;
 			}
+		}
+
+		// Run budget already exhausted: don't even fetch. Every remaining
+		// non-local candidate would be discarded post-fetch anyway, so fetching
+		// them just burns gateway cost — the cap is meant to bound exactly that.
+		// (A doc small enough to still fit is handled by the post-fetch check
+		// below; this short-circuits only once nothing more can fit at all.)
+		if (runBytes >= limits.maxBytesPerRun) {
+			results.push({
+				documentId,
+				source: "skipped_run_budget",
+				title: hit.title || "",
+				snippet,
+				passageId,
+				localPath: "",
+				error: `per-run hydration budget of ${limits.maxBytesPerRun} bytes is exhausted (already ${runBytes})`,
+			});
+			continue;
 		}
 
 		const doc = await postJson<GatewayFetchedDocument>(
@@ -352,6 +363,7 @@ export async function searchAndHydrate(
 			source: GATEWAY_SOURCE,
 			hydratedAt: now().toISOString(),
 			runId: deps.runId,
+			byteSize: byteLength,
 		});
 
 		results.push({


### PR DESCRIPTION
## Summary

Implements **MYM-12 / Task 8: Add hydration limits** (Milestone 3). Centralizes document hydration caps in one policy module and enforces them in the `search_documents` flow, so a prompt-injectable turn can't fill the sandbox disk or run up gateway fetch cost regardless of how it chains calls.

## What changed

- **`hydration-policy.ts` (new)** — the single policy module. `HydrationLimits` (count + two byte ceilings), `DEFAULT_HYDRATION_LIMITS`, and `loadHydrationLimits(env)` which reads `HYDRATION_MAX_DOCUMENTS_PER_SEARCH`, `HYDRATION_MAX_BYTES_PER_DOCUMENT`, `HYDRATION_MAX_BYTES_PER_RUN`. Invalid overrides (non-positive-integer) **throw** rather than silently disabling a cap. Pure: no fs/network.
- **`search-documents.ts`** — `searchAndHydrate` now takes `limits` and enforces:
  - max documents per search (via the existing dedupe/select step),
  - max bytes per document — fetched content is measured and an oversized doc is reported, **never written to disk**,
  - max bytes per run — cumulative bytes attributed to `runId`, **seeded from the manifest's on-disk sizes** so the cap holds across multiple `search_documents` calls in one run.
  - Skipped docs return `source: "skipped_too_large" | "skipped_run_budget"`, `localPath: ""`, and an `error` string naming the limit.
- **`agent-tools.ts`** — the tool handler now passes `loadHydrationLimits()` so the caps are env-configurable end-to-end.

## Acceptance criteria → coverage

| Criterion | Status |
|---|---|
| Max documents per search enforced | ✅ `enforces maxDocumentsPerSearch from the injected limits` |
| Max hydrated bytes per document enforced | ✅ `skips an oversized document without writing it to disk` |
| Max hydrated bytes per run enforced | ✅ `enforces the per-run byte budget...` + `carries the per-run budget across calls` + `charges a different run's budget independently` |
| Limits configurable via env/policy module | ✅ `hydration-policy.test.ts` (defaults, per-var override, invalid → throw) |
| Oversized docs not blindly written to disk | ✅ asserted `existsSync(...) === false` for skipped docs |
| Tests cover each limit + returned error shape | ✅ `source`/`localPath`/`error` asserted per skip case |

## Tests

`bun test` in `apps/sandbox-daemon`: **125 pass, 0 fail** (36 in the three affected files). Biome check clean.

## Remaining risk

- Per-run byte accounting is reconstructed from the docs manifest + on-disk file sizes each call (no shared in-memory counter); correct for the current per-turn sandbox model and verified across calls, but worth revisiting once sandbox leasing (Milestone 5) keeps a sandbox warm across runs.
- Byte size is measured from fetched content (post-fetch), so an oversized document is still fetched from the gateway once before being rejected — it is just never written. Pre-fetch size hints from the gateway are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)