### PR TITLE
feat(chat-api): rewrite agent prompt around search_documents (MYM-13)

### DIFF
--- a/apps/chat-api/src/features/sandbox-agent/sandbox-agent.prompt.test.ts
+++ b/apps/chat-api/src/features/sandbox-agent/sandbox-agent.prompt.test.ts
@@ -47,14 +47,28 @@ describe("buildSandboxAgentPrompt", () => {
 		expect(prompt).toContain("current working set");
 	});
 
-	it("permits local-only work only when the user scopes to loaded files", () => {
+	it("permits local-only work only when the user scopes to current-turn files", () => {
 		const prompt = buildSandboxAgentPrompt({
 			...baseOptions,
 			scope: "general",
 		});
 
 		expect(prompt).toContain(
-			"Local-only work is acceptable only when the user explicitly scopes",
+			"Local-only work is acceptable only when the user explicitly scopes the task to files loaded or created earlier in this same turn",
+		);
+	});
+
+	it("requires re-search for documents from a previous turn (no cross-turn local reads)", () => {
+		const prompt = buildSandboxAgentPrompt({
+			...baseOptions,
+			scope: "general",
+		});
+
+		// The working set is per-turn (fresh sandbox each turn), so prior-turn
+		// localPaths are gone — the agent must re-hydrate, not Read a stale path.
+		expect(prompt).toContain("does not carry over between turns");
+		expect(prompt).toContain(
+			"follow-up about a document from a previous message",
 		);
 	});
 

--- a/apps/chat-api/src/features/sandbox-agent/sandbox-agent.prompt.test.ts
+++ b/apps/chat-api/src/features/sandbox-agent/sandbox-agent.prompt.test.ts
@@ -19,14 +19,63 @@ describe("buildSandboxAgentPrompt", () => {
 		expect(prompt).toContain("[c1]: p_abc123");
 	});
 
-	it("instructs use of the mymemo-docs CLI", () => {
+	it("instructs use of the search_documents tool", () => {
 		const prompt = buildSandboxAgentPrompt({
 			...baseOptions,
 			scope: "general",
 		});
 
-		expect(prompt).toContain("mymemo-docs search");
-		expect(prompt).toContain("mymemo-docs fetch");
+		expect(prompt).toContain("search_documents");
+		expect(prompt).toContain("mcp__mymemo__search_documents");
+	});
+
+	it("states remote search is required by default", () => {
+		const prompt = buildSandboxAgentPrompt({
+			...baseOptions,
+			scope: "general",
+		});
+
+		expect(prompt).toContain("Remote search is required by default");
+	});
+
+	it("describes local documents as the current working set only", () => {
+		const prompt = buildSandboxAgentPrompt({
+			...baseOptions,
+			scope: "general",
+		});
+
+		expect(prompt).toContain("current working set");
+	});
+
+	it("permits local-only work only when the user scopes to loaded files", () => {
+		const prompt = buildSandboxAgentPrompt({
+			...baseOptions,
+			scope: "general",
+		});
+
+		expect(prompt).toContain(
+			"Local-only work is acceptable only when the user explicitly scopes",
+		);
+	});
+
+	it("explains hydrated documents expose a local path the agent can Read", () => {
+		const prompt = buildSandboxAgentPrompt({
+			...baseOptions,
+			scope: "general",
+		});
+
+		expect(prompt).toContain("localPath");
+		expect(prompt).toContain("Read");
+	});
+
+	it("no longer instructs separate search then fetch via mymemo-docs", () => {
+		const prompt = buildSandboxAgentPrompt({
+			...baseOptions,
+			scope: "general",
+		});
+
+		expect(prompt).not.toContain("mymemo-docs fetch");
+		expect(prompt).not.toContain("mymemo-docs search");
 	});
 
 	it("includes source restriction rules", () => {

--- a/apps/chat-api/src/features/sandbox-agent/sandbox-agent.prompt.test.ts
+++ b/apps/chat-api/src/features/sandbox-agent/sandbox-agent.prompt.test.ts
@@ -102,6 +102,17 @@ describe("buildSandboxAgentPrompt", () => {
 		expect(prompt).toContain("NEVER use outside knowledge");
 	});
 
+	it("exempts explicitly-scoped current-turn local files from the search-only rule", () => {
+		const prompt = buildSandboxAgentPrompt({
+			...baseOptions,
+			scope: "general",
+		});
+
+		// A file the agent created this turn is not a search result; the source
+		// rule must still allow reading/editing it when the user scopes the task.
+		expect(prompt).toContain("even though it is not a search result");
+	});
+
 	describe("general scope", () => {
 		it("includes general scope context", () => {
 			const prompt = buildSandboxAgentPrompt({

--- a/apps/chat-api/src/features/sandbox-agent/sandbox-agent.prompt.ts
+++ b/apps/chat-api/src/features/sandbox-agent/sandbox-agent.prompt.ts
@@ -19,8 +19,8 @@ There is no separate fetch step and no command-line document tool. Do NOT chain 
 ## Retrieval Strategy
 
 - **Remote search is required by default.** For any open question about the user's documents — anything not already scoped to files in front of you — you MUST call \`search_documents\` before answering. Do not answer from what happens to be on local disk.
-- **Local documents are only the current working set**, not the user's library: they are whatever \`search_documents\` has hydrated so far this conversation, plus files you have created. They are a cache, not the source of truth.
-- **Local-only work is acceptable only when the user explicitly scopes the task to already-loaded, current, or just-found files** (e.g. "summarize the document we just opened", "edit the file you created"). When the request is so scoped, you may \`Read\` the hydrated \`localPath\`s directly without a new search. Otherwise, search remotely.
+- **Local documents are only the current working set**, not the user's library: they are whatever \`search_documents\` has hydrated during this turn, plus files you created in it. The working set does not carry over between turns — a document hydrated for an earlier message is no longer on local disk this turn. It is a cache, not the source of truth.
+- **Local-only work is acceptable only when the user explicitly scopes the task to files loaded or created earlier in this same turn** (e.g. "summarize the file you just hydrated", "edit the file you just created"). When the request is so scoped, you may \`Read\` those \`localPath\`s directly without a new search. For anything else — including a follow-up about a document from a previous message — call \`search_documents\` to (re)hydrate before answering; do not \`Read\` a path from an earlier turn.
 
 How to use it:
 

--- a/apps/chat-api/src/features/sandbox-agent/sandbox-agent.prompt.ts
+++ b/apps/chat-api/src/features/sandbox-agent/sandbox-agent.prompt.ts
@@ -12,14 +12,22 @@ const SYSTEM_PROMPT = `You are MyMemo Document Assistant — an AI helping users
 
 ## Document Access
 
-You do NOT have the user's documents on your local filesystem. You access them with the \`mymemo-docs\` command-line tool, run via Bash. It has two subcommands, \`search\` and \`fetch\`. Run \`mymemo-docs --help\` to see their exact arguments and output format.
+The user's full document library lives remotely, not on your local filesystem. You reach it with the \`search_documents\` tool (\`mcp__mymemo__search_documents\`). A single call both searches the remote index and hydrates the matching documents into your local conversation workspace. Each result row is \`{ documentId, source, title, snippet, passageId, localPath }\`; a non-empty \`localPath\` is a file you may \`Read\`.
+
+There is no separate fetch step and no command-line document tool. Do NOT chain a search then a fetch — \`search_documents\` is the one and only document operation.
 
 ## Retrieval Strategy
 
-1. Run \`mymemo-docs search "<keywords>"\` with keywords from the user's question.
-2. Run \`mymemo-docs fetch <documentId>\` on the top 1-3 most relevant results to read them in full.
-3. Synthesize an answer using ONLY the content from documents you have fetched.
-4. If the first search returns no results, try alternative keywords or broader terms.
+- **Remote search is required by default.** For any open question about the user's documents — anything not already scoped to files in front of you — you MUST call \`search_documents\` before answering. Do not answer from what happens to be on local disk.
+- **Local documents are only the current working set**, not the user's library: they are whatever \`search_documents\` has hydrated so far this conversation, plus files you have created. They are a cache, not the source of truth.
+- **Local-only work is acceptable only when the user explicitly scopes the task to already-loaded, current, or just-found files** (e.g. "summarize the document we just opened", "edit the file you created"). When the request is so scoped, you may \`Read\` the hydrated \`localPath\`s directly without a new search. Otherwise, search remotely.
+
+How to use it:
+
+1. Call \`search_documents\` with keywords from the user's question.
+2. \`Read\` the \`localPath\` of the top 1-3 most relevant hydrated results to use their full content.
+3. Synthesize an answer using ONLY the content of documents surfaced by \`search_documents\`.
+4. If the first search returns no results, call \`search_documents\` again with alternative keywords or broader terms.
 5. If no documents match or the information is not found, state explicitly: "I cannot find this information in the available documents."
 
 ## Citations (Markdown Reference Style)
@@ -30,8 +38,8 @@ You do NOT have the user's documents on your local filesystem. You access them w
 * After the final answer, append only citation definitions at the very end of the message in plain text (no code fences). Example (each line exactly as shown, with no leading dash):
 [c1]: <passageId>
 [c2]: <passageId>
-* **Path format**: Use the \`passageId\` from the \`mymemo-docs search\` result the fact came from.
-  * Example: for a search hit \`{"passageId":"p_abc123",...}\`, emit \`[c1]: p_abc123\`
+* **Path format**: Use the \`passageId\` from the \`search_documents\` result the fact came from.
+  * Example: for a result row \`{"passageId":"p_abc123",...}\`, emit \`[c1]: p_abc123\`
 * Do not include a section heading like "References"
 * Do not wrap the citation list in code blocks
 * **Emit references only for markers used in the message**
@@ -49,7 +57,7 @@ You do NOT have the user's documents on your local filesystem. You access them w
 
 ## Rules
 
-- **ONLY use information from documents you have fetched with \`mymemo-docs\`**
+- **ONLY use information from documents surfaced by \`search_documents\`**
 - **NEVER use outside knowledge, general knowledge, or external information**
 - **NEVER hallucinate content or add facts not in the documents**
 - **NEVER expose internal IDs in the answer body** (only in citation definitions)
@@ -61,12 +69,12 @@ const GENERAL_SCOPE_CONTEXT = `
 
 ### Scope
 
-The user's question is not restricted to a particular collection. Use \`mymemo-docs search\` to find relevant documents across all of the user's documents.
+The user's question is not restricted to a particular collection. Use \`search_documents\` to find relevant documents across all of the user's documents.
 
 **CRITICAL RULES:**
-- You MUST use \`mymemo-docs search\` and \`mymemo-docs fetch\` to find and read documents before answering.
+- You MUST call \`search_documents\` to find and hydrate documents before answering.
 - If the documents do not contain the answer, explicitly state: "I cannot find this information in the available documents."
-- Always fetch documents before answering questions about their content.
+- Always search remotely before answering questions about document content.
 
 ---`;
 
@@ -76,13 +84,13 @@ function buildCollectionScopeContext(): string {
 
 ### Scope
 
-You are answering within a single collection. Search is **automatically restricted** to that collection by the gateway — just run \`mymemo-docs search "<query>"\` normally.
+You are answering within a single collection. Search is **automatically restricted** to that collection by the gateway — just call \`search_documents\` normally.
 
 **CRITICAL RULES:**
 - You must answer ONLY using documents from this collection (the gateway enforces this).
-- You MUST run \`mymemo-docs search\` and \`mymemo-docs fetch\` before answering.
+- You MUST call \`search_documents\` before answering.
 - If the collection's documents do not contain the answer, explicitly state: "I cannot find this information in the provided collection."
-- DO NOT respond that information is missing until you have searched and fetched documents.
+- DO NOT respond that information is missing until you have searched.
 
 ---`;
 }
@@ -93,7 +101,7 @@ function buildDocumentScopeContext(): string {
 
 ### Scope
 
-You are answering questions about a single specific document. Search is **automatically restricted** to that document — run \`mymemo-docs search "<query>"\` to find the relevant passages, then \`mymemo-docs fetch <documentId>\` (the documentId from a search result) to read the full content.
+You are answering questions about a single specific document. Search is **automatically restricted** to that document — call \`search_documents\` to find the relevant passages and hydrate the document, then \`Read\` the returned \`localPath\` to use its full content.
 
 **CRITICAL RULES:**
 - Answer ONLY using the content of this specific document.

--- a/apps/chat-api/src/features/sandbox-agent/sandbox-agent.prompt.ts
+++ b/apps/chat-api/src/features/sandbox-agent/sandbox-agent.prompt.ts
@@ -57,7 +57,7 @@ How to use it:
 
 ## Rules
 
-- **ONLY use information from documents surfaced by \`search_documents\`**
+- **ONLY use information from documents surfaced by \`search_documents\`** when answering questions about the user's library; its hydrated working-set files count as surfaced. The one exception is a task the user explicitly scopes to a file you loaded or created earlier this turn — you may read and edit that local file directly even though it is not a search result.
 - **NEVER use outside knowledge, general knowledge, or external information**
 - **NEVER hallucinate content or add facts not in the documents**
 - **NEVER expose internal IDs in the answer body** (only in citation definitions)


### PR DESCRIPTION
## Summary

Task 9 (MYM-13): rewrite the sandbox agent system prompt around the new single document operation `search_documents` (`mcp__mymemo__search_documents`), replacing the old `mymemo-docs search`/`fetch` CLI flow.

The prompt now:
- **Remote search is required by default** for open document questions.
- Describes **local documents as only the current working set** (a cache, not the library).
- Permits **local-only work only when the user explicitly scopes** the task to already-loaded, current, or just-found files.
- Instructs use of `search_documents` for discovery + hydration, and `Read` on the returned `localPath`s for already-hydrated documents.
- Drops the separate `search` then `fetch` chaining and all `mymemo-docs` wording.

Citations stay `passageId`-based — `passageId` is still carried on each `search_documents` result row, so the existing citation contract is unchanged.

## Files changed
- `apps/chat-api/src/features/sandbox-agent/sandbox-agent.prompt.ts` — rewritten document-access, retrieval-strategy, rules sections + all three scope contexts (general/collection/document).
- `apps/chat-api/src/features/sandbox-agent/sandbox-agent.prompt.test.ts` — updated/added acceptance tests.

## Acceptance tests
- Asserts the remote-search policy is present.
- Asserts old `mymemo-docs search`/`fetch` wording is absent.
- Asserts working-set framing, local-only-when-scoped rule, and `search_documents`/`localPath`/`Read` guidance.

## Tests run
- `bun test src/features/sandbox-agent/` → 13 pass
- Full `apps/chat-api` suite → 93 pass, 0 fail
- `biome check` on changed files → clean

## Remaining risk / blockers
None. Scope limited to the prompt string + its tests; no runtime/behavior code touched. Prompt wording is heuristic guidance to the model — effectiveness is not unit-testable beyond the asserted policy phrases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)