### PR TITLE
refactor(daemon): simplify hydration limits to a single doc-count cap

### DIFF
--- a/apps/sandbox-daemon/agent-tools.ts
+++ b/apps/sandbox-daemon/agent-tools.ts
@@ -131,7 +131,7 @@ export function buildMymemoTools(context?: MymemoToolContext) {
 	return [
 		tool(
 			SEARCH_DOCUMENTS_TOOL_NAME,
-			'Search the user\'s MyMemo documents and hydrate matches into the local conversation workspace. Returns one row per document with its documentId, source, title, snippet, and localPath. A non-empty localPath is a file you can Read; if source is "skipped_too_large" or "skipped_run_budget" the document was not hydrated, localPath is empty, and the row\'s `error` says which limit was hit.',
+			"Search the user's MyMemo documents and hydrate matches into the local conversation workspace. Returns one row per document with its documentId, source, title, snippet, and localPath — a file you can Read.",
 			{
 				query: z
 					.string()

--- a/apps/sandbox-daemon/child-spawn.ts
+++ b/apps/sandbox-daemon/child-spawn.ts
@@ -286,7 +286,7 @@ export async function spawnAgent(
 			...(sessionStoreRoot
 				? { [SESSION_STORE_ROOT_ENV]: sessionStoreRoot }
 				: {}),
-			// Hydration-limit overrides for the `search_documents` tool. The child
+			// Hydration-limit override(s) for the `search_documents` tool. The child
 			// env is a fresh whitelist (not inherited), so these must be forwarded
 			// explicitly or the tool silently uses defaults. Not secrets — plain
 			// policy ints; only the ones the operator actually set are passed.

--- a/apps/sandbox-daemon/docs-manifest.ts
+++ b/apps/sandbox-daemon/docs-manifest.ts
@@ -42,14 +42,6 @@ export interface DocsManifestEntry {
 	hydratedAt: string;
 	/** The run that caused this hydration. */
 	runId: string;
-	/**
-	 * Byte length of the hydrated content as written. Recorded so the per-run
-	 * hydration budget is charged against an immutable number rather than the
-	 * on-disk file size, which a prompt-injectable agent could shrink or delete
-	 * to free budget. Optional for backward compatibility with manifests written
-	 * before this field existed.
-	 */
-	byteSize?: number;
 }
 
 export interface DocsManifest {
@@ -84,9 +76,7 @@ function isManifestEntry(value: unknown): value is DocsManifestEntry {
 		typeof e.localPath === "string" &&
 		typeof e.source === "string" &&
 		typeof e.hydratedAt === "string" &&
-		typeof e.runId === "string" &&
-		(e.byteSize === undefined ||
-			(typeof e.byteSize === "number" && Number.isFinite(e.byteSize)))
+		typeof e.runId === "string"
 	);
 }
 

--- a/apps/sandbox-daemon/hydration-policy.test.ts
+++ b/apps/sandbox-daemon/hydration-policy.test.ts
@@ -14,31 +14,26 @@ describe("loadHydrationLimits", () => {
 	it("treats an empty-string override as unset (uses the default)", () => {
 		expect(
 			loadHydrationLimits({
-				[HYDRATION_LIMIT_ENV.maxBytesPerDocument]: "",
+				[HYDRATION_LIMIT_ENV.maxDocumentsPerSearch]: "",
 			}),
 		).toEqual(DEFAULT_HYDRATION_LIMITS);
 	});
 
-	it("overrides each limit independently from the environment", () => {
-		const limits = loadHydrationLimits({
-			[HYDRATION_LIMIT_ENV.maxDocumentsPerSearch]: "2",
-			[HYDRATION_LIMIT_ENV.maxBytesPerDocument]: "1024",
-			[HYDRATION_LIMIT_ENV.maxBytesPerRun]: "4096",
-		});
-		expect(limits).toEqual({
-			maxDocumentsPerSearch: 2,
-			maxBytesPerDocument: 1024,
-			maxBytesPerRun: 4096,
-		});
+	it("overrides the limit from the environment", () => {
+		expect(
+			loadHydrationLimits({
+				[HYDRATION_LIMIT_ENV.maxDocumentsPerSearch]: "2",
+			}),
+		).toEqual({ maxDocumentsPerSearch: 2 });
 	});
 
 	it("throws on a non-positive-integer override rather than silently disabling a cap", () => {
 		for (const bad of ["0", "-1", "1.5", "abc", "ten"]) {
 			expect(() =>
 				loadHydrationLimits({
-					[HYDRATION_LIMIT_ENV.maxBytesPerRun]: bad,
+					[HYDRATION_LIMIT_ENV.maxDocumentsPerSearch]: bad,
 				}),
-			).toThrow(HYDRATION_LIMIT_ENV.maxBytesPerRun);
+			).toThrow(HYDRATION_LIMIT_ENV.maxDocumentsPerSearch);
 		}
 	});
 });
@@ -51,11 +46,10 @@ describe("hydrationLimitEnv", () => {
 	it("forwards only the limit vars that are set, omitting unset/empty ones", () => {
 		expect(
 			hydrationLimitEnv({
-				[HYDRATION_LIMIT_ENV.maxBytesPerRun]: "4096",
-				[HYDRATION_LIMIT_ENV.maxBytesPerDocument]: "",
+				[HYDRATION_LIMIT_ENV.maxDocumentsPerSearch]: "7",
 				UNRELATED: "ignored",
 			}),
-		).toEqual({ [HYDRATION_LIMIT_ENV.maxBytesPerRun]: "4096" });
+		).toEqual({ [HYDRATION_LIMIT_ENV.maxDocumentsPerSearch]: "7" });
 	});
 
 	it("passes values through verbatim (validation happens at load time, not forward time)", () => {

--- a/apps/sandbox-daemon/hydration-policy.ts
+++ b/apps/sandbox-daemon/hydration-policy.ts
@@ -1,50 +1,47 @@
 /**
- * Hydration limits — the single policy module that bounds how much
- * `search_documents` is allowed to pull into a conversation workspace.
+ * Hydration policy — bounds how much `search_documents` pulls into a conversation
+ * workspace.
  *
- * Three independent caps, enforced by {@link ./search-documents.searchAndHydrate}:
+ * One sandbox-side cap remains:
  *
- *   - `maxDocumentsPerSearch`: distinct documents hydrated per search call.
- *   - `maxBytesPerDocument`: bytes of fetched content written for one document.
- *     An oversized document is reported, NOT written to disk.
- *   - `maxBytesPerRun`: cumulative hydrated bytes attributed to one `runId`,
- *     summed across every `search_documents` call in that run.
+ *   - `maxDocumentsPerSearch`: distinct documents hydrated per search call. A
+ *     working-set / context-size knob — it bounds how many docs one search drops
+ *     into the agent's context, not a cost/abuse boundary.
  *
- * The point is to keep one prompt-injectable turn from filling the sandbox disk
- * (or running up gateway fetch cost) regardless of how the agent chains calls.
+ * The byte ceilings that used to live here are gone:
+ *   - Per-document size is bounded server-side by the gateway, which clips every
+ *     fetch to a fixed length before returning it — a sandbox-side per-document
+ *     cap was redundant.
+ *   - There is no per-run byte cap. A sandbox-side ledger is tamperable (the
+ *     prompt-injectable agent owns its filesystem), and the per-turn blast radius
+ *     is already bounded by the per-fetch clip and the agent turn timeout, so a
+ *     run-level byte budget was judged not worth the complexity. If shared-DB
+ *     fetch cost becomes a real concern, the right tool is a gateway-side fetch
+ *     rate limit, not a byte ledger here.
+ *
  * Limits are data, not behavior: this module holds no fs/network access and is
- * pure so the caps are unit-testable and the same defaults apply in tests and
- * prod. Operators override them through environment (see {@link loadHydrationLimits}).
+ * pure so the cap is unit-testable and the same default applies in tests and
+ * prod. Operators override it through environment (see {@link loadHydrationLimits}).
  */
 
-/** The three hydration caps enforced by `searchAndHydrate`. */
+/** The sandbox-side hydration cap enforced by `searchAndHydrate`. */
 export interface HydrationLimits {
 	/** Max distinct documents hydrated per `search_documents` call. */
 	maxDocumentsPerSearch: number;
-	/** Max bytes of content written to disk for a single document. */
-	maxBytesPerDocument: number;
-	/** Max cumulative hydrated bytes attributed to one run. */
-	maxBytesPerRun: number;
 }
 
 /**
- * Conservative defaults. A document over 1 MB is almost certainly not a useful
- * working-set file, and 5 MB of hydrated text per run is already a large
- * context; both are sized to be generous for real notes/docs yet still bound a
- * runaway loop. `maxDocumentsPerSearch` keeps a single search from dominating
- * the per-run byte budget with many small files.
+ * Default working set per search. Bounds how many documents one search drops
+ * into the agent's context; cumulative fetch cost across a run is bounded
+ * separately by the gateway, so this can be generous.
  */
 export const DEFAULT_HYDRATION_LIMITS: HydrationLimits = {
-	maxDocumentsPerSearch: 5,
-	maxBytesPerDocument: 1_000_000,
-	maxBytesPerRun: 5_000_000,
+	maxDocumentsPerSearch: 10,
 };
 
 /** Environment variable names that override each default limit. */
 export const HYDRATION_LIMIT_ENV = {
 	maxDocumentsPerSearch: "HYDRATION_MAX_DOCUMENTS_PER_SEARCH",
-	maxBytesPerDocument: "HYDRATION_MAX_BYTES_PER_DOCUMENT",
-	maxBytesPerRun: "HYDRATION_MAX_BYTES_PER_RUN",
 } as const satisfies Record<keyof HydrationLimits, string>;
 
 /**
@@ -101,16 +98,6 @@ export function loadHydrationLimits(
 			env,
 			HYDRATION_LIMIT_ENV.maxDocumentsPerSearch,
 			DEFAULT_HYDRATION_LIMITS.maxDocumentsPerSearch,
-		),
-		maxBytesPerDocument: parseLimit(
-			env,
-			HYDRATION_LIMIT_ENV.maxBytesPerDocument,
-			DEFAULT_HYDRATION_LIMITS.maxBytesPerDocument,
-		),
-		maxBytesPerRun: parseLimit(
-			env,
-			HYDRATION_LIMIT_ENV.maxBytesPerRun,
-			DEFAULT_HYDRATION_LIMITS.maxBytesPerRun,
 		),
 	};
 }

--- a/apps/sandbox-daemon/search-documents.test.ts
+++ b/apps/sandbox-daemon/search-documents.test.ts
@@ -181,8 +181,6 @@ describe("searchAndHydrate", () => {
 				source: GATEWAY_SOURCE,
 				hydratedAt: FIXED_NOW.toISOString(),
 				runId: "run-1",
-				// "BODY1" is 5 bytes.
-				byteSize: 5,
 			},
 			{
 				documentId: "d2",
@@ -191,7 +189,6 @@ describe("searchAndHydrate", () => {
 				source: GATEWAY_SOURCE,
 				hydratedAt: FIXED_NOW.toISOString(),
 				runId: "run-1",
-				byteSize: 5,
 			},
 		]);
 
@@ -375,13 +372,7 @@ describe("searchAndHydrate hydration limits", () => {
 		const { fetchImpl, calls } = gatewayWithSizedDocs({ a: 1, b: 1, c: 1 });
 		const results = await searchAndHydrate(
 			"q",
-			deps(fetchImpl, {
-				limits: {
-					maxDocumentsPerSearch: 2,
-					maxBytesPerDocument: 1000,
-					maxBytesPerRun: 1000,
-				},
-			}),
+			deps(fetchImpl, { limits: { maxDocumentsPerSearch: 2 } }),
 		);
 
 		expect(results.map((r) => r.documentId)).toEqual(["a", "b"]);
@@ -389,177 +380,8 @@ describe("searchAndHydrate hydration limits", () => {
 		expect(calls.filter((c) => c.url.endsWith("/fetch")).length).toBe(2);
 	});
 
-	it("skips an oversized document without writing it to disk", async () => {
-		const { fetchImpl } = gatewayWithSizedDocs({ big: 50, small: 10 });
-		const results = await searchAndHydrate(
-			"q",
-			deps(fetchImpl, {
-				limits: {
-					maxDocumentsPerSearch: 5,
-					maxBytesPerDocument: 20,
-					maxBytesPerRun: 1000,
-				},
-			}),
-		);
-
-		const big = results.find((r) => r.documentId === "big");
-		expect(big).toMatchObject({
-			documentId: "big",
-			source: "skipped_too_large",
-			localPath: "",
-		});
-		expect(big?.error).toContain("per-document limit of 20");
-
-		// Oversized doc not blindly written; the under-limit one still hydrates.
-		expect(existsSync(join(docsDir, documentFilename("big")))).toBe(false);
-		const small = results.find((r) => r.documentId === "small");
-		expect(small?.source).toBe(GATEWAY_SOURCE);
-		expect(readFileSync(small?.localPath ?? "", "utf8")).toBe("x".repeat(10));
-
-		// Only the hydrated doc is in the manifest.
-		expect(
-			readDocsManifest(docsDir).documents.map((d) => d.documentId),
-		).toEqual(["small"]);
-	});
-
-	it("enforces the per-run byte budget, still fitting a later smaller doc", async () => {
-		// a fills most of the budget; b would overflow it; c still fits.
-		const { fetchImpl } = gatewayWithSizedDocs({ a: 60, b: 60, c: 30 });
-		const results = await searchAndHydrate(
-			"q",
-			deps(fetchImpl, {
-				limits: {
-					maxDocumentsPerSearch: 5,
-					maxBytesPerDocument: 1000,
-					maxBytesPerRun: 100,
-				},
-			}),
-		);
-
-		expect(results.map((r) => [r.documentId, r.source])).toEqual([
-			["a", GATEWAY_SOURCE],
-			["b", "skipped_run_budget"],
-			["c", GATEWAY_SOURCE],
-		]);
-		const b = results.find((r) => r.documentId === "b");
-		expect(b?.localPath).toBe("");
-		expect(b?.error).toContain("per-run budget of 100");
-
-		// Only a and c reached disk and the manifest.
-		expect(existsSync(join(docsDir, documentFilename("b")))).toBe(false);
-		expect(
-			readDocsManifest(docsDir)
-				.documents.map((d) => d.documentId)
-				.sort(),
-		).toEqual(["a", "c"]);
-	});
-
-	it("carries the per-run budget across calls in the same run", async () => {
-		const limits = {
-			maxDocumentsPerSearch: 5,
-			maxBytesPerDocument: 1000,
-			maxBytesPerRun: 100,
-		};
-
-		// First call hydrates a 80-byte doc under run-1.
-		const first = gatewayWithSizedDocs({ a: 80 });
-		await searchAndHydrate("q1", deps(first.fetchImpl, { limits }));
-		expect(existsSync(join(docsDir, documentFilename("a")))).toBe(true);
-
-		// Second call in the SAME run: only 20 bytes of budget remain, so a
-		// 40-byte doc is rejected even though it is under the per-document limit.
-		const second = gatewayWithSizedDocs({ b: 40 });
-		const results = await searchAndHydrate(
-			"q2",
-			deps(second.fetchImpl, { limits }),
-		);
-		expect(results[0]).toMatchObject({
-			documentId: "b",
-			source: "skipped_run_budget",
-		});
-		expect(existsSync(join(docsDir, documentFilename("b")))).toBe(false);
-	});
-
-	it("keeps charging the run budget after the agent deletes a hydrated file", async () => {
-		// P1: budget is charged against the byte count recorded in the manifest,
-		// not the live on-disk size — so deleting/truncating a file can't free it.
-		const limits = {
-			maxDocumentsPerSearch: 5,
-			maxBytesPerDocument: 1000,
-			maxBytesPerRun: 100,
-		};
-
-		// Call 1 hydrates an 80-byte doc, then the (untrusted) agent deletes it.
-		const first = gatewayWithSizedDocs({ a: 80 });
-		await searchAndHydrate("q1", deps(first.fetchImpl, { limits }));
-		rmSync(join(docsDir, documentFilename("a")));
-
-		// Call 2 in the same run: the 80 bytes are still charged (manifest entry
-		// remains), so a 40-byte doc overflows the 100-byte budget.
-		const second = gatewayWithSizedDocs({ b: 40 });
-		const results = await searchAndHydrate(
-			"q2",
-			deps(second.fetchImpl, { limits }),
-		);
-		expect(results[0]).toMatchObject({
-			documentId: "b",
-			source: "skipped_run_budget",
-		});
-		expect(existsSync(join(docsDir, documentFilename("b")))).toBe(false);
-	});
-
-	it("does not fetch once the run budget is fully exhausted", async () => {
-		// P2: when no budget remains, candidates are skipped BEFORE the gateway
-		// fetch, so a prompt-injection loop can't keep burning fetch cost.
-		const limits = {
-			maxDocumentsPerSearch: 5,
-			maxBytesPerDocument: 1000,
-			maxBytesPerRun: 100,
-		};
-
-		// Call 1 hydrates exactly the full budget.
-		const first = gatewayWithSizedDocs({ a: 100 });
-		await searchAndHydrate("q1", deps(first.fetchImpl, { limits }));
-
-		// Call 2: budget exhausted, so the candidate is skipped without fetching.
-		const second = gatewayWithSizedDocs({ b: 40 });
-		const results = await searchAndHydrate(
-			"q2",
-			deps(second.fetchImpl, { limits }),
-		);
-		expect(results[0]).toMatchObject({
-			documentId: "b",
-			source: "skipped_run_budget",
-		});
-		// Searched, but never fetched — the short-circuit fired before /fetch.
-		expect(second.calls.some((c) => c.url.endsWith("/fetch"))).toBe(false);
-	});
-
-	it("charges a different run's budget independently", async () => {
-		const limits = {
-			maxDocumentsPerSearch: 5,
-			maxBytesPerDocument: 1000,
-			maxBytesPerRun: 100,
-		};
-
-		// run-1 hydrates 80 bytes.
-		const first = gatewayWithSizedDocs({ a: 80 });
-		await searchAndHydrate(
-			"q1",
-			deps(first.fetchImpl, { runId: "run-1", limits }),
-		);
-
-		// run-2 starts with a fresh budget, so a 40-byte doc hydrates fine even
-		// though run-1 already wrote 80 bytes into the shared docs dir.
-		const second = gatewayWithSizedDocs({ b: 40 });
-		const results = await searchAndHydrate(
-			"q2",
-			deps(second.fetchImpl, { runId: "run-2", limits }),
-		);
-		expect(results[0]).toMatchObject({
-			documentId: "b",
-			source: GATEWAY_SOURCE,
-		});
-		expect(existsSync(join(docsDir, documentFilename("b")))).toBe(true);
-	});
+	// Byte limits are intentionally NOT enforced here. Per-fetch size is bounded
+	// server-side by the gateway's content clip; there is no per-run byte cap (a
+	// sandbox-side ledger is tamperable by the agent and was judged not worth the
+	// complexity — see the gateway notes). The only remaining cap is doc count.
 });

--- a/apps/sandbox-daemon/search-documents.ts
+++ b/apps/sandbox-daemon/search-documents.ts
@@ -29,11 +29,7 @@
 import { createHash } from "node:crypto";
 import { existsSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import {
-	type DocsManifest,
-	readDocsManifest,
-	upsertDocsManifestEntry,
-} from "./docs-manifest";
+import { readDocsManifest, upsertDocsManifestEntry } from "./docs-manifest";
 import {
 	DEFAULT_HYDRATION_LIMITS,
 	type HydrationLimits,
@@ -54,19 +50,8 @@ export const GATEWAY_SOURCE = "gateway";
  * Result `source`:
  * - `"gateway"` — hydrated by this call.
  * - `"already_local"` — already present in the conversation workspace.
- * - `"skipped_too_large"` — fetched but over the per-document byte limit; NOT
- *   written to disk.
- * - `"skipped_run_budget"` — fetched but would push this run over its byte
- *   budget; NOT written to disk.
- *
- * For the two `skipped_*` sources `localPath` is `""` and `error` explains the
- * limit that was hit.
  */
-export type DocumentResultSource =
-	| typeof GATEWAY_SOURCE
-	| "already_local"
-	| "skipped_too_large"
-	| "skipped_run_budget";
+export type DocumentResultSource = typeof GATEWAY_SOURCE | "already_local";
 
 export interface SearchDocumentResult {
 	documentId: string;
@@ -80,13 +65,8 @@ export interface SearchDocumentResult {
 	 * document — this is the top-ranked passage for the hydrated document.
 	 */
 	passageId: string;
-	/**
-	 * Absolute path to the hydrated file (the agent can `Read` this), or `""` for
-	 * a `skipped_*` document that was not written to disk.
-	 */
+	/** Absolute path to the hydrated file (the agent can `Read` this). */
 	localPath: string;
-	/** Why a `skipped_*` document was not hydrated; absent on hydrated rows. */
-	error?: string;
 }
 
 /** One passage hit from the gateway search endpoint. */
@@ -114,7 +94,7 @@ export interface SearchDocumentsDeps {
 	/** The run that caused this hydration (recorded in the manifest). */
 	runId: string;
 	/**
-	 * Hydration caps (document count + byte ceilings). Defaults to
+	 * Hydration caps (max documents per search). Defaults to
 	 * {@link DEFAULT_HYDRATION_LIMITS}; the daemon passes env-derived limits.
 	 */
 	limits?: HydrationLimits;
@@ -215,23 +195,6 @@ function selectDocuments(
 }
 
 /**
- * Bytes already hydrated under `runId`, summed from the byte count RECORDED in
- * the manifest at hydration time (not the live on-disk size). This seeds the
- * per-run budget so the cap holds across multiple `search_documents` calls in
- * the same run. Using the recorded count means a prompt-injectable agent can't
- * free budget by deleting or truncating a file it already hydrated — the charge
- * stands as long as the manifest entry does. Legacy entries without a recorded
- * `byteSize` contribute 0.
- */
-function runHydratedBytes(manifest: DocsManifest, runId: string): number {
-	let total = 0;
-	for (const entry of manifest.documents) {
-		if (entry.runId === runId) total += entry.byteSize ?? 0;
-	}
-	return total;
-}
-
-/**
  * Run the full search → select → hydrate → manifest flow and return one row per
  * selected document. Throws {@link GatewayDocumentError} on gateway failure;
  * returns `[]` when the search has no matches.
@@ -262,10 +225,6 @@ export async function searchAndHydrate(
 	const manifest = readDocsManifest(deps.docsDir);
 	const localById = new Map(manifest.documents.map((d) => [d.documentId, d]));
 
-	// Seed the per-run byte budget from what this run already hydrated, so the
-	// cap holds across multiple search_documents calls in the run.
-	let runBytes = runHydratedBytes(manifest, deps.runId);
-
 	const results: SearchDocumentResult[] = [];
 	for (const hit of selected) {
 		// `documentId` is guaranteed by selectDocuments.
@@ -294,24 +253,6 @@ export async function searchAndHydrate(
 			}
 		}
 
-		// Run budget already exhausted: don't even fetch. Every remaining
-		// non-local candidate would be discarded post-fetch anyway, so fetching
-		// them just burns gateway cost — the cap is meant to bound exactly that.
-		// (A doc small enough to still fit is handled by the post-fetch check
-		// below; this short-circuits only once nothing more can fit at all.)
-		if (runBytes >= limits.maxBytesPerRun) {
-			results.push({
-				documentId,
-				source: "skipped_run_budget",
-				title: hit.title || "",
-				snippet,
-				passageId,
-				localPath: "",
-				error: `per-run hydration budget of ${limits.maxBytesPerRun} bytes is exhausted (already ${runBytes})`,
-			});
-			continue;
-		}
-
 		const doc = await postJson<GatewayFetchedDocument>(
 			doFetch,
 			`${deps.gatewayUrl}/v1/documents/fetch`,
@@ -320,42 +261,11 @@ export async function searchAndHydrate(
 		);
 
 		const content = doc.content ?? "";
-		const byteLength = Buffer.byteLength(content, "utf8");
 		const title = doc.title || hit.title || "";
-
-		// Enforce the byte caps BEFORE touching disk: an oversized or
-		// budget-busting document is reported, never written. Per-document is
-		// checked first so a single huge file is attributed to its own limit
-		// rather than the run budget it would also blow.
-		if (byteLength > limits.maxBytesPerDocument) {
-			results.push({
-				documentId,
-				source: "skipped_too_large",
-				title,
-				snippet,
-				passageId,
-				localPath: "",
-				error: `document is ${byteLength} bytes, over the per-document limit of ${limits.maxBytesPerDocument}`,
-			});
-			continue;
-		}
-		if (runBytes + byteLength > limits.maxBytesPerRun) {
-			results.push({
-				documentId,
-				source: "skipped_run_budget",
-				title,
-				snippet,
-				passageId,
-				localPath: "",
-				error: `hydrating ${byteLength} bytes would exceed the per-run budget of ${limits.maxBytesPerRun} bytes (already ${runBytes})`,
-			});
-			continue;
-		}
 
 		const filename = documentFilename(documentId);
 		const absolutePath = join(deps.docsDir, filename);
 		writeFileSync(absolutePath, content, "utf8");
-		runBytes += byteLength;
 		upsertDocsManifestEntry(deps.docsDir, {
 			documentId,
 			title,
@@ -363,7 +273,6 @@ export async function searchAndHydrate(
 			source: GATEWAY_SOURCE,
 			hydratedAt: now().toISOString(),
 			runId: deps.runId,
-			byteSize: byteLength,
 		});
 
 		results.push({


### PR DESCRIPTION
## Why

Round-2 [Codex review on the merged #142](https://github.com/X-GPT/mymemo-agent/pull/142) (MYM-12) flagged the sandbox-side **per-run byte ledger** as tamperable and incorrect: it lived in the agent-writable `docs/manifest.json`, stored one mutable entry per document, and never charged oversized / budget-rejected fetches. All five comments were variants of *"the agent controls the ledger."*

Rather than patch the ledger, this **removes it**. The sandbox agent is prompt-injectable and owns its filesystem, so any local byte ledger is enforced by the very party it's meant to restrain. The only real residual cost is fetch cost against the shared KB Postgres — already bounded by the gateway's per-fetch content clip and the agent turn timeout. (A gateway-side run budget was prototyped and dropped as not worth the complexity; if shared-DB cost ever needs bounding, the right tool is a gateway fetch **rate** limit, not a byte ledger.)

## Changes (sandbox-daemon only — gateway untouched)

- **hydration-policy**: collapse three caps to one (`maxDocumentsPerSearch`), raise default **5 → 10**.
- **search-documents**: drop `runHydratedBytes`, the per-document byte cap, the per-run ledger, and the `skipped_*` result sources. Flow is now `search → select → already-local → fetch → write → manifest`.
- **docs-manifest**: drop the now-unused `byteSize` field.
- **agent-tools**: simplify the tool description.

Net **−298 lines**.

## ⚠️ MYM-12 AC walk-back (please note)

This intentionally revises two completed [MYM-12](https://linear.app/mymemo-agent/issue/MYM-12) acceptance criteria:
- ~~"Maximum hydrated bytes per document is enforced"~~ → dropped; redundant with the gateway's server-side per-fetch content clip.
- ~~"Maximum hydrated bytes per run is enforced"~~ → dropped; tamperable in the sandbox, and the blast radius is already bounded elsewhere.
- **Doc-count default 5 → 10** — what the MYM-12 plan deferred until byte caps existed.

Rationale is captured in the `hydration-policy.ts` header.

## Test

- Daemon: **124 pass / 0 fail**, biome clean, bundle builds.
- Gateway: **34 pass / 6 skip**, unchanged from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)