### PR TITLE
feat(chat-api): prepare cancellation contract (MYM-16)

### DIFF
--- a/apps/chat-api/src/features/run-state/index.ts
+++ b/apps/chat-api/src/features/run-state/index.ts
@@ -1,4 +1,5 @@
 export {
+	type CancelOutcome,
 	type CreateRunOptions,
 	createRun,
 	normalizeRunError,

--- a/apps/chat-api/src/features/run-state/run-state.test.ts
+++ b/apps/chat-api/src/features/run-state/run-state.test.ts
@@ -158,6 +158,87 @@ describe("run-state lifecycle", () => {
 	});
 });
 
+describe("run-state cancellation (idempotent)", () => {
+	// Acceptance: cancellation covers an active run, an already-completed run, an
+	// already-failed run, and an already-canceled run. Only the active case
+	// transitions; every other call is a safe no-op so a late cancel signal that
+	// races the run's natural outcome never throws or double-records.
+
+	it("cancels an active run and records exactly one run_canceled", async () => {
+		const { sink, types } = fakeSink();
+		const run = await createRun({ sink, ref, conversationId: "conv-1" });
+
+		const outcome = await run.cancel();
+
+		expect(outcome).toEqual({ transitioned: true, status: "canceled" });
+		expect(run.status).toBe("canceled");
+		expect(types()).toEqual([RunEventType.Started, RunEventType.Canceled]);
+	});
+
+	it("is idempotent: a repeated cancel is a no-op with no duplicate event", async () => {
+		const { sink, types } = fakeSink();
+		const run = await createRun({ sink, ref, conversationId: "conv-1" });
+
+		await run.cancel();
+		const second = await run.cancel();
+
+		expect(second).toEqual({ transitioned: false, status: "canceled" });
+		expect(run.status).toBe("canceled");
+		// Still exactly one canceled record — the second cancel wrote nothing.
+		expect(types()).toEqual([RunEventType.Started, RunEventType.Canceled]);
+	});
+
+	it("does not cancel an already-completed run (cancel lost the race)", async () => {
+		const { sink, types } = fakeSink();
+		const run = await createRun({ sink, ref, conversationId: "conv-1" });
+		await run.markRunCompleted();
+
+		const outcome = await run.cancel();
+
+		expect(outcome).toEqual({ transitioned: false, status: "completed" });
+		expect(run.status).toBe("completed");
+		expect(types()).toEqual([RunEventType.Started, RunEventType.Completed]);
+	});
+
+	it("does not cancel an already-failed run (cancel lost the race)", async () => {
+		const { sink, types } = fakeSink();
+		const run = await createRun({ sink, ref, conversationId: "conv-1" });
+		await run.markRunFailed(new Error("boom"));
+
+		const outcome = await run.cancel();
+
+		expect(outcome).toEqual({ transitioned: false, status: "failed" });
+		expect(run.status).toBe("failed");
+		expect(types()).toEqual([RunEventType.Started, RunEventType.Failed]);
+	});
+
+	it("stays running and is retryable when the cancel write fails", async () => {
+		let failNext = true;
+		const persisted: RunEvent[] = [];
+		const sink: RunEventSink = {
+			async appendRunEvent(_ref, event) {
+				if (failNext && event.type === RunEventType.Canceled) {
+					failNext = false;
+					throw new Error("ENOSPC");
+				}
+				persisted.push(event);
+			},
+		};
+		const run = await createRun({ sink, ref, conversationId: "conv-1" });
+
+		// First cancel write rejects; status must not advance, so a retry works.
+		await expect(run.cancel()).rejects.toThrow(/ENOSPC/);
+		expect(run.status).toBe("running");
+
+		const outcome = await run.cancel();
+		expect(outcome).toEqual({ transitioned: true, status: "canceled" });
+		expect(persisted.map((e) => e.type)).toEqual([
+			RunEventType.Started,
+			RunEventType.Canceled,
+		]);
+	});
+});
+
 describe("run-state terminal guards", () => {
 	it("rejects a second terminal transition", async () => {
 		const { sink } = fakeSink();

--- a/apps/chat-api/src/features/run-state/run-state.ts
+++ b/apps/chat-api/src/features/run-state/run-state.ts
@@ -29,6 +29,18 @@ export interface RunEventSink {
 /** Lifecycle state of a run. */
 export type RunStatus = "running" | "completed" | "failed" | "canceled";
 
+/** Result of an idempotent {@link Run.cancel} request. */
+export interface CancelOutcome {
+	/**
+	 * True only when this call moved the run from `running` to `canceled` (and so
+	 * recorded the `run_canceled` event). False for every no-op: a repeated cancel,
+	 * or a cancel that lost the race to natural completion/failure.
+	 */
+	transitioned: boolean;
+	/** The run's status after the call. */
+	status: RunStatus;
+}
+
 /** Canonical run-event type names recorded by this module. */
 export const RunEventType = {
 	Started: "run_started",
@@ -212,6 +224,36 @@ export class Run {
 		return this.terminate("canceled", { type: RunEventType.Canceled });
 	}
 
+	/**
+	 * Idempotent cancellation request — the entry point the cancellation contract
+	 * exposes. Unlike the strict `markRun*` terminals, `cancel` is best-effort and
+	 * safe to call repeatedly or after the run has already ended:
+	 *
+	 *  - `running` → records `run_canceled`, advances to `canceled`, returns
+	 *    `{ transitioned: true, status: "canceled" }`.
+	 *  - already `canceled` → no-op (no duplicate event), `transitioned: false`.
+	 *  - `completed` / `failed` → no-op; the run already reached a different
+	 *    terminal state, so cancellation lost the race. `transitioned: false`.
+	 *
+	 * A cancel signal can arrive after the run has naturally finished; tolerating
+	 * the terminal states (instead of throwing like `markRunCanceled`) keeps the
+	 * single-start/single-terminal audit invariant intact. The `transitioned` flag
+	 * lets callers fire a sandbox/daemon cancellation hook only when this call
+	 * actually performed the cancellation.
+	 */
+	cancel(): Promise<CancelOutcome> {
+		return this.critical(async () => {
+			if (this._status !== "running") {
+				return { transitioned: false, status: this._status };
+			}
+			// Persist before advancing, same ordering rule as terminate(): a failed
+			// write leaves the run running so the cancel can be retried.
+			await this.write({ type: RunEventType.Canceled });
+			this._status = "canceled";
+			return { transitioned: true, status: "canceled" };
+		});
+	}
+
 	private terminate(
 		status: Exclude<RunStatus, "running">,
 		event: RunEvent,
@@ -250,7 +292,7 @@ export class Run {
 	 * caller observes `fn`'s own outcome; the internal tail swallows rejections so
 	 * one failed operation does not block the next.
 	 */
-	private critical(fn: () => Promise<void>): Promise<void> {
+	private critical<T>(fn: () => Promise<T>): Promise<T> {
 		const result = this.queue.then(fn);
 		this.queue = result.then(
 			() => {},

--- a/apps/chat-api/src/features/sandbox-orchestration/e2b-sandbox-provider.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/e2b-sandbox-provider.ts
@@ -127,6 +127,24 @@ export class E2BSandboxProvider implements SandboxProvider {
 	}
 
 	/**
+	 * Cancel an in-flight turn. A per-turn E2B sandbox has no in-place turn abort,
+	 * so killing the sandbox is the cancellation. `killSandbox` already swallows
+	 * errors, so this is idempotent and safe whether or not a turn is in flight.
+	 */
+	async cancelSandbox(
+		userId: string,
+		handle: SandboxHandle,
+		logger: SyncLogger,
+	): Promise<void> {
+		logger.info({
+			msg: "Canceling sandbox turn",
+			userId,
+			sandboxId: handle.sandboxId,
+		});
+		await this.killSandbox(userId, handle, logger);
+	}
+
+	/**
 	 * Deploy the daemon + agent bundles onto the freshly created sandbox and
 	 * wait for the daemon to report healthy. Returns the daemon URL and the
 	 * fixed auth token clients must present.

--- a/apps/chat-api/src/features/sandbox-orchestration/local-container-sandbox-provider.test.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/local-container-sandbox-provider.test.ts
@@ -98,4 +98,15 @@ describe("LocalContainerSandboxProvider", () => {
 		const provider = new LocalContainerSandboxProvider(config);
 		await expect(provider.killSandbox()).resolves.toBeUndefined();
 	});
+
+	it("cancelSandbox is a best-effort no-op (no per-turn abort on the shared container)", async () => {
+		const provider = new LocalContainerSandboxProvider(config);
+		await expect(
+			provider.cancelSandbox(
+				"user-1",
+				{ sandboxId: "local-sandbox" },
+				silentLogger,
+			),
+		).resolves.toBeUndefined();
+	});
 });

--- a/apps/chat-api/src/features/sandbox-orchestration/local-container-sandbox-provider.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/local-container-sandbox-provider.ts
@@ -85,6 +85,21 @@ export class LocalContainerSandboxProvider implements SandboxProvider {
 		// The local container is long-lived — nothing to tear down per turn.
 	}
 
+	async cancelSandbox(
+		userId: string,
+		handle: SandboxHandle,
+		logger: SyncLogger,
+	): Promise<void> {
+		// The shared container is long-lived and has no per-turn abort hook, so
+		// cancellation is a best-effort no-op here; the daemon's turn lock frees
+		// when the turn ends. Mirrors killSandbox.
+		logger.info({
+			msg: "Local sandbox cancel is a no-op",
+			userId,
+			sandboxId: handle.sandboxId,
+		});
+	}
+
 	private async isHealthy(url: string): Promise<boolean> {
 		try {
 			const response = await fetch(`${url}/health`, {

--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-orchestration.test.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-orchestration.test.ts
@@ -66,6 +66,7 @@ describe("runSandboxChat", () => {
 	let createSandbox: ReturnType<typeof mock>;
 	let ensureSandboxDaemon: ReturnType<typeof mock>;
 	let killSandbox: ReturnType<typeof mock>;
+	let cancelSandbox: ReturnType<typeof mock>;
 	let hydrate: ReturnType<typeof mock>;
 	let sync: ReturnType<typeof mock>;
 	let forwardTurn: ReturnType<typeof spyOn>;
@@ -79,12 +80,18 @@ describe("runSandboxChat", () => {
 			authToken: "test-daemon-auth-token",
 		}));
 		killSandbox = mock(async () => undefined);
+		cancelSandbox = mock(async () => undefined);
 		hydrate = mock(async () => undefined);
 		sync = mock(async () => undefined);
 
 		deps = {
 			config,
-			sandboxProvider: { createSandbox, ensureSandboxDaemon, killSandbox },
+			sandboxProvider: {
+				createSandbox,
+				ensureSandboxDaemon,
+				killSandbox,
+				cancelSandbox,
+			},
 			workspaceStore: {
 				hydrateConversationWorkspace: hydrate,
 				syncConversationWorkspace: sync,

--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-provider.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-provider.ts
@@ -40,4 +40,17 @@ export interface SandboxProvider {
 		handle: SandboxHandle,
 		logger: SyncLogger,
 	): Promise<void>;
+	/**
+	 * Best-effort cancellation hook for an in-flight turn. Idempotent and safe to
+	 * call whether or not a turn is active, so a cancel signal that races a turn's
+	 * completion never throws. The run-state cancellation contract ({@link Run.cancel})
+	 * drives this; SSE wiring (Task 11) and leasing (Milestone 5) will invoke it.
+	 * The per-turn providers have no in-place abort, so they honor it by tearing
+	 * the sandbox down — which aborts the daemon turn.
+	 */
+	cancelSandbox(
+		userId: string,
+		handle: SandboxHandle,
+		logger: SyncLogger,
+	): Promise<void>;
 }


### PR DESCRIPTION
## Task 12: Prepare cancellation contract ([MYM-16](https://linear.app/mymemo-agent/issue/MYM-16/task-12-prepare-cancellation-contract))

Milestone 4: Run Lifecycle And Event Persistence.

Adds the backend cancellation **contract** — an idempotent cancellation entry point on the run lifecycle plus a cancellation hook on the sandbox abstraction — so the later SSE wiring (Task 11) and sandbox leasing (Milestone 5) have something to call. No cancellation *trigger* is wired yet; that is out of scope for this task.

### Changes
- **`run-state.ts` — `Run.cancel()`**: idempotent, best-effort, terminal-tolerant cancellation request, distinct from the strict `markRunCanceled` terminal marker (which still throws after a terminal state, as its existing tests require).
  - `running` → records `run_canceled`, advances to `canceled`, returns `{ transitioned: true, status: "canceled" }`.
  - already `canceled` → no-op, no duplicate event, `transitioned: false`.
  - `completed` / `failed` → no-op (cancel lost the race), `transitioned: false`.
  - A failed cancel write leaves the run `running` and retryable (same ordering rule as `terminate()`).
  - `transitioned` lets callers fire the sandbox hook only when this call actually performed the cancellation. `critical()` is generalized to carry a return value.
- **`SandboxProvider.cancelSandbox()`**: cancellation method on the sandbox/daemon abstraction. E2B (per-turn) honors it by tearing the sandbox down (aborts the daemon turn, idempotent via `killSandbox`); the shared local container treats it as a best-effort no-op.

### Acceptance criteria
- [x] Run state model includes `canceled` (present since Task 10).
- [x] Sandbox/daemon abstraction exposes a cancellation method (`cancelSandbox`).
- [x] Cancellation state transition is idempotent.
- [x] Tests cover canceling active, completed, failed, and already-canceled runs.

### Tests
- `bun test src/features/run-state src/features/sandbox-orchestration` → 56 pass
- `bun test` (full chat-api) → 118 pass, 0 fail
- `biome check` on changed dirs → clean; `tsc --noEmit` → no new errors (only pre-existing unrelated errors in `scripts/probe-agent-tools.ts`)

### Risk / blockers
- Cancellation is defined but not yet *triggered* anywhere — intentional; wiring is Task 11 (SSE) and Milestone 5 (leasing).
- For per-turn E2B sandboxes, cancel == kill; Milestone 5 may want a softer in-place daemon abort that keeps a warm sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)