### PR TITLE
refactor(daemon): dependency-injected config (parity with gateway) (MYM-29)

### DIFF
--- a/apps/sandbox-daemon/child-spawn.test.ts
+++ b/apps/sandbox-daemon/child-spawn.test.ts
@@ -17,6 +17,22 @@ import {
 	buildAgentSpawnArgv,
 	spawnAgent,
 } from "./child-spawn";
+import type { AgentSpawnConfig } from "./config";
+
+// Spawn config is injected, not read from env. Default matches config.ts's
+// defaults; tests override only the field they exercise.
+const DEFAULT_SPAWN_CONFIG: AgentSpawnConfig = {
+	agentBundlePath: "/workspace/agent.js",
+	bunExecutable: "bun",
+	agentIdleTimeoutMs: 120_000,
+	agentMaxTurnMs: 600_000,
+};
+
+function makeSpawnConfig(
+	overrides: Partial<AgentSpawnConfig> = {},
+): AgentSpawnConfig {
+	return { ...DEFAULT_SPAWN_CONFIG, ...overrides };
+}
 
 describe("assertDurableStoreRoot", () => {
 	it("rejects a relative root (would resolve against the ephemeral agent cwd)", () => {
@@ -43,26 +59,19 @@ describe("buildAgentSpawnArgv", () => {
 	it("runs bun /workspace/agent.js directly, with no wrapper", () => {
 		// The sandbox/container is the isolation boundary, so the agent runs
 		// directly — there is no bwrap (or any other) wrapper around it.
-		const argv = buildAgentSpawnArgv();
+		const argv = buildAgentSpawnArgv(makeSpawnConfig());
 		expect(argv).toEqual(["bun", "/workspace/agent.js"]);
 	});
 
-	it("respects SANDBOX_BUN_PATH and SANDBOX_AGENT_PATH env overrides", () => {
-		const original = {
-			bun: process.env.SANDBOX_BUN_PATH,
-			agent: process.env.SANDBOX_AGENT_PATH,
-		};
-		process.env.SANDBOX_BUN_PATH = "/custom/bun";
-		process.env.SANDBOX_AGENT_PATH = "/custom/agent.js";
-		try {
-			expect(buildAgentSpawnArgv()).toEqual([
-				"/custom/bun",
-				"/custom/agent.js",
-			]);
-		} finally {
-			process.env.SANDBOX_BUN_PATH = original.bun;
-			process.env.SANDBOX_AGENT_PATH = original.agent;
-		}
+	it("uses the bun executable and agent bundle path from config", () => {
+		expect(
+			buildAgentSpawnArgv(
+				makeSpawnConfig({
+					bunExecutable: "/custom/bun",
+					agentBundlePath: "/custom/agent.js",
+				}),
+			),
+		).toEqual(["/custom/bun", "/custom/agent.js"]);
 	});
 });
 
@@ -108,17 +117,20 @@ describe("spawnAgent agent environment", () => {
 			fakeProc() as unknown as ReturnType<typeof Bun.spawn>,
 		);
 
-		await spawnAgent({
-			userQuery: "q",
-			systemPrompt: "s",
-			cwd,
-			claudeConfigDir,
-			llmBaseUrl: "https://gateway.example",
-			docGatewayUrl: "https://docs.example",
-			llmToken: "tok-123",
-			docToken: "doc-456",
-			onEvent: async () => {},
-		});
+		await spawnAgent(
+			{
+				userQuery: "q",
+				systemPrompt: "s",
+				cwd,
+				claudeConfigDir,
+				llmBaseUrl: "https://gateway.example",
+				docGatewayUrl: "https://docs.example",
+				llmToken: "tok-123",
+				docToken: "doc-456",
+				onEvent: async () => {},
+			},
+			makeSpawnConfig(),
+		);
 
 		const call = spawnSpy.mock.calls[0] as [
 			string[],
@@ -172,19 +184,22 @@ describe("spawnAgent agent environment", () => {
 				capturingProc() as unknown as ReturnType<typeof Bun.spawn>,
 			);
 
-			await spawnAgent({
-				userQuery: "q",
-				systemPrompt: "s",
-				cwd,
-				claudeConfigDir,
-				userId: "member-abc",
-				conversationId: "conv-1",
-				llmBaseUrl: "https://gateway.example",
-				docGatewayUrl: "https://docs.example",
-				llmToken: "tok",
-				docToken: "doc",
-				onEvent: async () => {},
-			});
+			await spawnAgent(
+				{
+					userQuery: "q",
+					systemPrompt: "s",
+					cwd,
+					claudeConfigDir,
+					userId: "member-abc",
+					conversationId: "conv-1",
+					llmBaseUrl: "https://gateway.example",
+					docGatewayUrl: "https://docs.example",
+					llmToken: "tok",
+					docToken: "doc",
+					onEvent: async () => {},
+				},
+				makeSpawnConfig(),
+			);
 
 			const call = spawnSpy.mock.calls[0] as [
 				string[],
@@ -216,18 +231,21 @@ describe("spawnAgent agent environment", () => {
 				fakeProc() as unknown as ReturnType<typeof Bun.spawn>,
 			);
 
-			await spawnAgent({
-				userQuery: "q",
-				systemPrompt: "s",
-				cwd,
-				claudeConfigDir,
-				// No userId/conversationId — mirroring must stay off.
-				llmBaseUrl: "https://gateway.example",
-				docGatewayUrl: "https://docs.example",
-				llmToken: "tok",
-				docToken: "doc",
-				onEvent: async () => {},
-			});
+			await spawnAgent(
+				{
+					userQuery: "q",
+					systemPrompt: "s",
+					cwd,
+					claudeConfigDir,
+					// No userId/conversationId — mirroring must stay off.
+					llmBaseUrl: "https://gateway.example",
+					docGatewayUrl: "https://docs.example",
+					llmToken: "tok",
+					docToken: "doc",
+					onEvent: async () => {},
+				},
+				makeSpawnConfig(),
+			);
 
 			const call = spawnSpy.mock.calls[0] as [
 				string[],
@@ -249,13 +267,6 @@ describe("spawnAgent idle timeout", () => {
 	// NDJSON + watchdog wiring rather than mocking it.
 	let tmpDir: string;
 	const fixtures: Record<string, string> = {};
-
-	const ENV_VARS = [
-		"SANDBOX_AGENT_PATH",
-		"SANDBOX_AGENT_IDLE_TIMEOUT_MS",
-		"SANDBOX_AGENT_MAX_TURN_MS",
-	];
-	const originalEnv: Record<string, string | undefined> = {};
 
 	beforeAll(() => {
 		tmpDir = mkdtempSync(join(tmpdir(), "child-spawn-"));
@@ -309,15 +320,9 @@ describe("spawnAgent idle timeout", () => {
 			fixtures.agentLinger,
 			`import { closeSync } from "node:fs";\nfor await (const _ of process.stdin) {}\nprocess.stdout.write(JSON.stringify({ type: "completed" }) + "\\n");\nawait new Promise((r) => setTimeout(r, 50));\ncloseSync(1);\nawait new Promise(() => {});\n`,
 		);
-
-		for (const key of ENV_VARS) originalEnv[key] = process.env[key];
 	});
 
 	afterAll(() => {
-		for (const key of ENV_VARS) {
-			if (originalEnv[key] === undefined) delete process.env[key];
-			else process.env[key] = originalEnv[key];
-		}
 		rmSync(tmpDir, { recursive: true, force: true });
 	});
 
@@ -336,12 +341,15 @@ describe("spawnAgent idle timeout", () => {
 	}
 
 	it("kills the child and emits failed when no events arrive", async () => {
-		process.env.SANDBOX_AGENT_PATH = fixtures.agentHang;
-		process.env.SANDBOX_AGENT_IDLE_TIMEOUT_MS = "200";
-
 		const events: AgentEvent[] = [];
 		const start = Date.now();
-		await spawnAgent(makeInput((e) => events.push(e)));
+		await spawnAgent(
+			makeInput((e) => events.push(e)),
+			makeSpawnConfig({
+				agentBundlePath: fixtures.agentHang,
+				agentIdleTimeoutMs: 200,
+			}),
+		);
 		const elapsed = Date.now() - start;
 
 		// 200ms timeout + spawn/teardown overhead. Cap at 5s to catch hangs.
@@ -355,14 +363,17 @@ describe("spawnAgent idle timeout", () => {
 	});
 
 	it("does not fire while events keep arriving (timer resets)", async () => {
-		process.env.SANDBOX_AGENT_PATH = fixtures.agentSlow;
+		const events: AgentEvent[] = [];
 		// 2s idle window: generous enough to absorb bun's cold start (~900ms
 		// observed) before the first event, while the fixture's ~2.5s total
 		// span exceeds it — so passing proves the timer resets per event.
-		process.env.SANDBOX_AGENT_IDLE_TIMEOUT_MS = "2000";
-
-		const events: AgentEvent[] = [];
-		const result = await spawnAgent(makeInput((e) => events.push(e)));
+		const result = await spawnAgent(
+			makeInput((e) => events.push(e)),
+			makeSpawnConfig({
+				agentBundlePath: fixtures.agentSlow,
+				agentIdleTimeoutMs: 2000,
+			}),
+		);
 
 		expect(result.exitCode).toBe(0);
 		expect(events.find((e) => e.type === "failed")).toBeUndefined();
@@ -371,13 +382,16 @@ describe("spawnAgent idle timeout", () => {
 	}, 15_000);
 
 	it("kills a lingering child after completed without a spurious failed", async () => {
-		process.env.SANDBOX_AGENT_PATH = fixtures.agentLinger;
-		// Same 2s window as above to absorb bun's cold start before `completed`.
-		process.env.SANDBOX_AGENT_IDLE_TIMEOUT_MS = "2000";
-
 		const events: AgentEvent[] = [];
 		const start = Date.now();
-		const result = await spawnAgent(makeInput((e) => events.push(e)));
+		// Same 2s window as above to absorb bun's cold start before `completed`.
+		const result = await spawnAgent(
+			makeInput((e) => events.push(e)),
+			makeSpawnConfig({
+				agentBundlePath: fixtures.agentLinger,
+				agentIdleTimeoutMs: 2000,
+			}),
+		);
 		const elapsed = Date.now() - start;
 
 		// The watchdog must bound the wait on the never-exiting child...
@@ -392,12 +406,15 @@ describe("spawnAgent idle timeout", () => {
 	// only by `heartbeat` events (the liveness a tool emits while executing)
 	// must NOT trip the watchdog, even though no token ever streams.
 	it("treats heartbeats as liveness: a silent-but-beating tool survives", async () => {
-		process.env.SANDBOX_AGENT_PATH = fixtures.agentHeartbeat;
-		process.env.SANDBOX_AGENT_IDLE_TIMEOUT_MS = "2000";
-		delete process.env.SANDBOX_AGENT_MAX_TURN_MS; // default ceiling, won't fire
-
 		const events: AgentEvent[] = [];
-		const result = await spawnAgent(makeInput((e) => events.push(e)));
+		// Default ceiling won't fire within the fixture's ~2.5s span.
+		const result = await spawnAgent(
+			makeInput((e) => events.push(e)),
+			makeSpawnConfig({
+				agentBundlePath: fixtures.agentHeartbeat,
+				agentIdleTimeoutMs: 2000,
+			}),
+		);
 
 		expect(result.exitCode).toBe(0);
 		expect(events.find((e) => e.type === "failed")).toBeUndefined();
@@ -410,15 +427,18 @@ describe("spawnAgent idle timeout", () => {
 	// The honest residual: a tool that hangs forever keeps heartbeating, so the
 	// idle watchdog can't see it. The absolute per-turn ceiling is the backstop.
 	it("kills a forever-beating turn via the absolute ceiling, not the idle timer", async () => {
-		process.env.SANDBOX_AGENT_PATH = fixtures.agentHeartbeatForever;
-		// Idle window large so it never fires; ceiling small so it does. The
-		// elapsed-time assertion proves the ceiling — not the idle timer — killed it.
-		process.env.SANDBOX_AGENT_IDLE_TIMEOUT_MS = "30000";
-		process.env.SANDBOX_AGENT_MAX_TURN_MS = "1500";
-
 		const events: AgentEvent[] = [];
 		const start = Date.now();
-		const result = await spawnAgent(makeInput((e) => events.push(e)));
+		// Idle window large so it never fires; ceiling small so it does. The
+		// elapsed-time assertion proves the ceiling — not the idle timer — killed it.
+		const result = await spawnAgent(
+			makeInput((e) => events.push(e)),
+			makeSpawnConfig({
+				agentBundlePath: fixtures.agentHeartbeatForever,
+				agentIdleTimeoutMs: 30000,
+				agentMaxTurnMs: 1500,
+			}),
+		);
 		const elapsed = Date.now() - start;
 
 		// Ceiling (1500ms) fired well before the idle window (30000ms).
@@ -433,22 +453,4 @@ describe("spawnAgent idle timeout", () => {
 			expect(failed.message).toContain("1500");
 		}
 	}, 15_000);
-
-	// A malformed SANDBOX_AGENT_IDLE_TIMEOUT_MS must fall back to the default,
-	// not become NaN/0 — setTimeout(fn, NaN|0) fires immediately and would
-	// SIGKILL every turn at spawn.
-	it("falls back to the default idle timeout on a malformed env value", async () => {
-		process.env.SANDBOX_AGENT_PATH = fixtures.agentSlow;
-		delete process.env.SANDBOX_AGENT_MAX_TURN_MS; // default ceiling, won't fire
-
-		for (const bad of ["abc", ""]) {
-			process.env.SANDBOX_AGENT_IDLE_TIMEOUT_MS = bad;
-			const events: AgentEvent[] = [];
-			// With the default 120s window the ~2.5s fixture finishes cleanly;
-			// an immediate (NaN/0) fire would kill it before `completed`.
-			const result = await spawnAgent(makeInput((e) => events.push(e)));
-			expect(result.exitCode).toBe(0);
-			expect(events.find((e) => e.type === "failed")).toBeUndefined();
-		}
-	}, 20_000);
 });

--- a/apps/sandbox-daemon/child-spawn.ts
+++ b/apps/sandbox-daemon/child-spawn.ts
@@ -18,53 +18,11 @@
  */
 
 import { resolve } from "node:path";
+import type { AgentSpawnConfig } from "./config";
 import { hydrationLimitEnv } from "./hydration-policy";
 import type { AgentEvent } from "./ipc-protocol";
 
 export type { AgentEvent } from "./ipc-protocol";
-
-function getAgentBundlePath(): string {
-	return process.env.SANDBOX_AGENT_PATH ?? "/workspace/agent.js";
-}
-function getBunExecutable(): string {
-	return process.env.SANDBOX_BUN_PATH ?? "bun";
-}
-
-// The agent is a streaming workload of unbounded but "chatty" duration, so a
-// wall-clock cap alone would kill healthy long turns. We bound it two ways:
-//
-//   1. An idle timeout, re-armed on every NDJSON event. Text streaming covers
-//      the model phase; a `heartbeat` (emitted by agent.ts while a tool runs —
-//      tool execution is otherwise silent on stdout) covers tool phases. So
-//      sustained silence now genuinely means a hang (a wedged model read), and
-//      a healthy long tool no longer trips this.
-//   2. A generous absolute per-turn ceiling as a backstop for the one case the
-//      idle timeout can't see: a tool that hangs forever keeps the heartbeat
-//      ticking, so without this it would never be killed and would pin the
-//      single-turn lock. Set far above any legitimate turn.
-const DEFAULT_AGENT_IDLE_TIMEOUT_MS = 120_000;
-const DEFAULT_AGENT_MAX_TURN_MS = 600_000;
-
-// Number("") -> 0 and Number("abc") -> NaN, and setTimeout(fn, 0|NaN) fires
-// immediately — a malformed env var would SIGKILL every turn at spawn. Fall
-// back to the default on any non-finite or non-positive value.
-function getPositiveMsEnv(value: string | undefined, fallback: number): number {
-	if (value === undefined) return fallback;
-	const n = Number(value);
-	return Number.isFinite(n) && n > 0 ? n : fallback;
-}
-function getAgentIdleTimeoutMs(): number {
-	return getPositiveMsEnv(
-		process.env.SANDBOX_AGENT_IDLE_TIMEOUT_MS,
-		DEFAULT_AGENT_IDLE_TIMEOUT_MS,
-	);
-}
-function getAgentMaxTurnMs(): number {
-	return getPositiveMsEnv(
-		process.env.SANDBOX_AGENT_MAX_TURN_MS,
-		DEFAULT_AGENT_MAX_TURN_MS,
-	);
-}
 
 // Durable root the agent's SessionStore mirror writes to (must match
 // SESSION_STORE_ROOT_ENV in session-store.ts, which the agent reads). Unset =
@@ -111,8 +69,8 @@ export function assertDurableStoreRoot(root: string): void {
  * sandbox/container is the isolation boundary, so there is no wrapper. Extracted
  * as a pure helper so the command is easy to inspect and unit-test.
  */
-export function buildAgentSpawnArgv(): string[] {
-	return [getBunExecutable(), getAgentBundlePath()];
+export function buildAgentSpawnArgv(config: AgentSpawnConfig): string[] {
+	return [config.bunExecutable, config.agentBundlePath];
 }
 
 function narrowAgentEvent(raw: Record<string, unknown>): AgentEvent | null {
@@ -243,6 +201,7 @@ export interface SpawnAgentResult {
 
 export async function spawnAgent(
 	input: SpawnAgentInput,
+	spawnConfig: AgentSpawnConfig,
 ): Promise<SpawnAgentResult> {
 	const {
 		onEvent,
@@ -262,7 +221,7 @@ export async function spawnAgent(
 	// Reject a root that would silently lose transcripts (relative or ephemeral)
 	// before spawning, so the misconfig fails loudly instead of breaking resume.
 	if (sessionStoreRoot) assertDurableStoreRoot(sessionStoreRoot);
-	const proc = Bun.spawn(buildAgentSpawnArgv(), {
+	const proc = Bun.spawn(buildAgentSpawnArgv(spawnConfig), {
 		env: {
 			// The agent holds no provider key — it talks to the LLM gateway, which
 			// injects the real key. ANTHROPIC_AUTH_TOKEN is sent as a Bearer header.
@@ -302,8 +261,8 @@ export async function spawnAgent(
 
 	// Idle watchdog + absolute ceiling. The SIGKILL lands on the agent process,
 	// which closes stdout and unblocks the read loop below.
-	const idleMs = getAgentIdleTimeoutMs();
-	const maxTurnMs = getAgentMaxTurnMs();
+	const idleMs = spawnConfig.agentIdleTimeoutMs;
+	const maxTurnMs = spawnConfig.agentMaxTurnMs;
 	let timedOut = false;
 	let hitMaxTurn = false;
 	let idleTimer: ReturnType<typeof setTimeout> | undefined;

--- a/apps/sandbox-daemon/config.test.ts
+++ b/apps/sandbox-daemon/config.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "bun:test";
+import { loadConfigFromEnv } from "./config";
+
+describe("loadConfigFromEnv", () => {
+	it("applies defaults when the environment is empty", () => {
+		const config = loadConfigFromEnv({});
+		expect(config).toEqual({
+			daemonPort: 8080,
+			daemonVersion: "unknown",
+			daemonAuthToken: undefined,
+			workspaceRoot: "/workspace",
+			agentSpawn: {
+				agentBundlePath: "/workspace/agent.js",
+				bunExecutable: "bun",
+				agentIdleTimeoutMs: 120_000,
+				agentMaxTurnMs: 600_000,
+			},
+		});
+	});
+
+	it("reads each setting from its environment variable", () => {
+		const config = loadConfigFromEnv({
+			DAEMON_PORT: "9090",
+			DAEMON_VERSION: "v1.2.3",
+			DAEMON_AUTH_TOKEN: "secret",
+			SANDBOX_WORKSPACE_ROOT: "/tmp/ws",
+			SANDBOX_AGENT_PATH: "/custom/agent.js",
+			SANDBOX_BUN_PATH: "/custom/bun",
+			SANDBOX_AGENT_IDLE_TIMEOUT_MS: "5000",
+			SANDBOX_AGENT_MAX_TURN_MS: "60000",
+		});
+		expect(config).toEqual({
+			daemonPort: 9090,
+			daemonVersion: "v1.2.3",
+			daemonAuthToken: "secret",
+			workspaceRoot: "/tmp/ws",
+			agentSpawn: {
+				agentBundlePath: "/custom/agent.js",
+				bunExecutable: "/custom/bun",
+				agentIdleTimeoutMs: 5000,
+				agentMaxTurnMs: 60000,
+			},
+		});
+	});
+
+	it("falls back to the default port on a malformed DAEMON_PORT", () => {
+		for (const bad of ["abc", "0", "-1", "70000", "1.5", ""]) {
+			expect(loadConfigFromEnv({ DAEMON_PORT: bad }).daemonPort).toBe(8080);
+		}
+	});
+
+	// A malformed watchdog value must fall back to the default, not become NaN/0
+	// — setTimeout(fn, NaN|0) fires immediately and would SIGKILL every turn at
+	// spawn. This is why the timeouts parse leniently (fall back) rather than throw.
+	it("falls back to the default timeouts on malformed millisecond values", () => {
+		for (const bad of ["abc", "0", "-100", ""]) {
+			const { agentSpawn } = loadConfigFromEnv({
+				SANDBOX_AGENT_IDLE_TIMEOUT_MS: bad,
+				SANDBOX_AGENT_MAX_TURN_MS: bad,
+			});
+			expect(agentSpawn.agentIdleTimeoutMs).toBe(120_000);
+			expect(agentSpawn.agentMaxTurnMs).toBe(600_000);
+		}
+	});
+});

--- a/apps/sandbox-daemon/config.ts
+++ b/apps/sandbox-daemon/config.ts
@@ -1,0 +1,125 @@
+/**
+ * Typed, validated configuration for the sandbox daemon. Built once from the
+ * environment at the entrypoint (`daemon-entry.ts`) and injected down (into
+ * `createDaemon` → routes → `spawnAgent`/`createConversationWorkspace`) so no
+ * other daemon module reads global process state. This mirrors the gateway's
+ * `loadConfigFromEnv` → `createGateway(config, db)` pattern and lets tests
+ * construct config explicitly instead of mutating `process.env`.
+ *
+ * Scope: this covers the daemon's OWN settings. The env the daemon forwards
+ * INTO the spawned agent child (PATH, CLAUDE_CODE_PATH, AGENT_SESSION_STORE_ROOT,
+ * the hydration-limit overrides) is deliberately not modeled here — that is the
+ * child's configuration surface, read where it is forwarded in `child-spawn.ts`.
+ */
+
+/** Default port for Bun.serve (the daemon's HTTP listener). */
+const DEFAULT_DAEMON_PORT = 8080;
+/** Surfaced by /health when DAEMON_VERSION is unset. */
+const DEFAULT_DAEMON_VERSION = "unknown";
+/**
+ * Root of the sandbox workspace tree. Must stay in sync with the sandbox
+ * template's setWorkdir (apps/chat-api/sandbox-template/template.ts).
+ */
+const DEFAULT_WORKSPACE_ROOT = "/workspace";
+/** Path the chat-api writes the agent bundle to inside the sandbox. */
+const DEFAULT_AGENT_BUNDLE_PATH = "/workspace/agent.js";
+/** Bun on PATH runs the agent bundle. */
+const DEFAULT_BUN_EXECUTABLE = "bun";
+
+// The agent is a streaming workload of unbounded but "chatty" duration, so a
+// wall-clock cap alone would kill healthy long turns. We bound it two ways (see
+// child-spawn.ts for the full rationale):
+//
+//   1. An idle timeout, re-armed on every NDJSON event (text or heartbeat). So
+//      sustained silence genuinely means a hang, and a healthy long tool no
+//      longer trips it.
+//   2. A generous absolute per-turn ceiling as a backstop for the one case the
+//      idle timeout can't see: a tool that hangs forever keeps heartbeating.
+const DEFAULT_AGENT_IDLE_TIMEOUT_MS = 120_000;
+const DEFAULT_AGENT_MAX_TURN_MS = 600_000;
+
+/** Subset of the process environment the daemon reads. */
+type Env = Record<string, string | undefined>;
+
+// These parsers fall back to the default on a malformed value rather than
+// throwing (unlike the gateway's `parsePort`, which fails fast). The daemon runs
+// inside the sandbox where there is no operator to read a boot error, and a
+// malformed watchdog value that became the live timeout would SIGKILL every turn
+// at spawn — so a safe default beats aborting. Required secrets are absent here
+// (the only secret, DAEMON_AUTH_TOKEN, fails closed at request time), so there
+// is nothing to fail-fast on.
+
+/** Parse a TCP port: an integer in 1..65535, else the fallback. */
+function parsePort(value: string | undefined, fallback: number): number {
+	if (!value) return fallback;
+	const n = Number(value);
+	return Number.isInteger(n) && n > 0 && n < 65536 ? n : fallback;
+}
+
+/**
+ * Parse a positive-millisecond duration. Falls back on any non-finite or
+ * non-positive value rather than throwing: `Number("")` is 0 and
+ * `Number("abc")` is NaN, and `setTimeout(fn, 0|NaN)` fires immediately — so a
+ * malformed watchdog value must NOT become the live timeout or it would SIGKILL
+ * every turn at spawn. Falling back keeps a typo from disabling the bound.
+ */
+function parsePositiveMs(value: string | undefined, fallback: number): number {
+	if (value === undefined) return fallback;
+	const n = Number(value);
+	return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+/** Spawn settings for the per-turn agent child (see `spawnAgent`). */
+export interface AgentSpawnConfig {
+	/** Path to the agent bundle (SANDBOX_AGENT_PATH). */
+	agentBundlePath: string;
+	/** Bun executable used to run the agent bundle (SANDBOX_BUN_PATH). */
+	bunExecutable: string;
+	/** Idle watchdog timeout in ms, re-armed per event (SANDBOX_AGENT_IDLE_TIMEOUT_MS). */
+	agentIdleTimeoutMs: number;
+	/** Absolute per-turn ceiling in ms, never re-armed (SANDBOX_AGENT_MAX_TURN_MS). */
+	agentMaxTurnMs: number;
+}
+
+/** Typed configuration for the sandbox daemon. */
+export interface DaemonConfig {
+	/** HTTP port for Bun.serve (DAEMON_PORT). */
+	daemonPort: number;
+	/** Surfaced by /health for the chat-api bundle check (DAEMON_VERSION). */
+	daemonVersion: string;
+	/**
+	 * Bearer secret required on /turn. When unset, every /turn is rejected with
+	 * 401 (fail-closed) — preserved as-is so behavior matches the pre-config code.
+	 */
+	daemonAuthToken: string | undefined;
+	/** Root of the sandbox workspace tree (SANDBOX_WORKSPACE_ROOT). */
+	workspaceRoot: string;
+	/** Settings for spawning the per-turn agent child. */
+	agentSpawn: AgentSpawnConfig;
+}
+
+/**
+ * Parse + validate the environment for the daemon. The single place the daemon
+ * reads ambient env for its own configuration; every other module receives the
+ * result by injection.
+ */
+export function loadConfigFromEnv(env: Env): DaemonConfig {
+	return {
+		daemonPort: parsePort(env.DAEMON_PORT, DEFAULT_DAEMON_PORT),
+		daemonVersion: env.DAEMON_VERSION ?? DEFAULT_DAEMON_VERSION,
+		daemonAuthToken: env.DAEMON_AUTH_TOKEN,
+		workspaceRoot: env.SANDBOX_WORKSPACE_ROOT ?? DEFAULT_WORKSPACE_ROOT,
+		agentSpawn: {
+			agentBundlePath: env.SANDBOX_AGENT_PATH ?? DEFAULT_AGENT_BUNDLE_PATH,
+			bunExecutable: env.SANDBOX_BUN_PATH ?? DEFAULT_BUN_EXECUTABLE,
+			agentIdleTimeoutMs: parsePositiveMs(
+				env.SANDBOX_AGENT_IDLE_TIMEOUT_MS,
+				DEFAULT_AGENT_IDLE_TIMEOUT_MS,
+			),
+			agentMaxTurnMs: parsePositiveMs(
+				env.SANDBOX_AGENT_MAX_TURN_MS,
+				DEFAULT_AGENT_MAX_TURN_MS,
+			),
+		},
+	};
+}

--- a/apps/sandbox-daemon/daemon-entry.ts
+++ b/apps/sandbox-daemon/daemon-entry.ts
@@ -3,33 +3,27 @@
  * locking, and streaming. Spawns agent.js per turn — never imports the Claude
  * Agent SDK directly, so the daemon bundle's transitive graph stays minimal.
  *
- * Env:
+ * This is the entrypoint and the ONLY place that reads the environment for
+ * daemon configuration. It parses/validates env once via `loadConfigFromEnv`
+ * and injects the typed config into `createDaemon` so no other daemon module is
+ * coupled to global process state. (The env forwarded into the spawned agent
+ * child — provider gateway URL/token, etc. — is read where it is forwarded in
+ * child-spawn.ts, not here.)
+ *
+ * Env (see config.ts):
  *   DAEMON_PORT       — HTTP port (default 8080).
  *   DAEMON_VERSION    — surfaced by /health for the chat-api bundle check.
- *   DAEMON_AUTH_TOKEN — required bearer secret for /turn.
+ *   DAEMON_AUTH_TOKEN — bearer secret for /turn (unset => every /turn is 401).
  *
  * The daemon holds no provider key: the agent's LLM gateway URL and bearer
  * token arrive per turn in the /turn body and are forwarded into agent.js's env.
  */
 
-import { Hono } from "hono";
-import currentRoutes from "./routes/current";
-import healthRoutes from "./routes/health";
-import turnRoutes from "./routes/turn";
+import { loadConfigFromEnv } from "./config";
+import { createDaemon } from "./daemon";
 
-const app = new Hono();
-
-app.route("/", healthRoutes);
-app.route("/", currentRoutes);
-app.route("/", turnRoutes);
-
-app.onError((err, c) => {
-	console.error("Hono error:", err);
-	return c.json(
-		{ error: err instanceof Error ? err.message : String(err) },
-		500,
-	);
-});
+const config = loadConfigFromEnv(Bun.env);
+const app = createDaemon(config);
 
 process.on("uncaughtException", (err) => {
 	console.error("Uncaught exception:", err);
@@ -38,16 +32,15 @@ process.on("unhandledRejection", (err) => {
 	console.error("Unhandled rejection:", err);
 });
 
-const port = Number(process.env.DAEMON_PORT) || 8080;
-
-console.log(`Sandbox daemon starting on port ${port}`);
+console.log(`Sandbox daemon starting on port ${config.daemonPort}`);
 
 export default {
-	port,
+	port: config.daemonPort,
 	fetch: app.fetch,
 	// Per-connection idle timeout (Bun caps this at 255s). Must sit above the
-	// agent idle watchdog (120s in child-spawn.ts) so that on a genuine hang the
-	// daemon emits its own `failed` event before Bun silently drops the socket.
-	// During a healthy long tool the agent's `heartbeat` events keep this armed.
+	// agent idle watchdog (120s default in config.ts) so that on a genuine hang
+	// the daemon emits its own `failed` event before Bun silently drops the
+	// socket. During a healthy long tool the agent's `heartbeat` events keep this
+	// armed.
 	idleTimeout: 240,
 };

--- a/apps/sandbox-daemon/daemon.test.ts
+++ b/apps/sandbox-daemon/daemon.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "bun:test";
+import type { DaemonConfig } from "./config";
+import { createDaemon } from "./daemon";
+
+const baseConfig: DaemonConfig = {
+	daemonPort: 8080,
+	daemonVersion: "test-1.0",
+	daemonAuthToken: "secret",
+	workspaceRoot: "/tmp/ws",
+	agentSpawn: {
+		agentBundlePath: "/workspace/agent.js",
+		bunExecutable: "bun",
+		agentIdleTimeoutMs: 120_000,
+		agentMaxTurnMs: 600_000,
+	},
+};
+
+describe("createDaemon", () => {
+	it("serves /health with the injected version", async () => {
+		const app = createDaemon(baseConfig);
+		const res = await app.request("/health");
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.status).toBe("ok");
+		expect(body.version).toBe("test-1.0");
+		expect(typeof body.uptime).toBe("number");
+	});
+
+	it("serves /current with the lock state", async () => {
+		const app = createDaemon(baseConfig);
+		const res = await app.request("/current");
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body).toHaveProperty("busy");
+	});
+
+	it("wires /turn so the injected auth token is enforced", async () => {
+		const app = createDaemon(baseConfig);
+		// No bearer header → the turn route rejects before any spawn.
+		const res = await app.request("/turn", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ message: "hi" }),
+		});
+		expect(res.status).toBe(401);
+	});
+});

--- a/apps/sandbox-daemon/daemon.ts
+++ b/apps/sandbox-daemon/daemon.ts
@@ -1,0 +1,30 @@
+/**
+ * Daemon app factory. Wires the route modules into one Hono app from an injected
+ * `DaemonConfig`, so the app is constructible without touching global env —
+ * mirrors the gateway's `createGateway(config, db)`. Pure: config in, app out.
+ * The entrypoint (`daemon-entry.ts`) is the only place that reads the env.
+ */
+
+import { Hono } from "hono";
+import type { DaemonConfig } from "./config";
+import { createCurrentRoutes } from "./routes/current";
+import { createHealthRoutes } from "./routes/health";
+import { createTurnRoutes } from "./routes/turn";
+
+export function createDaemon(config: DaemonConfig): Hono {
+	const app = new Hono();
+
+	app.route("/", createHealthRoutes(config));
+	app.route("/", createCurrentRoutes());
+	app.route("/", createTurnRoutes(config));
+
+	app.onError((err, c) => {
+		console.error("Hono error:", err);
+		return c.json(
+			{ error: err instanceof Error ? err.message : String(err) },
+			500,
+		);
+	});
+
+	return app;
+}

--- a/apps/sandbox-daemon/routes/current.ts
+++ b/apps/sandbox-daemon/routes/current.ts
@@ -1,11 +1,18 @@
 import { Hono } from "hono";
 import { getCurrentTurn } from "../turn-lock";
 
-const app = new Hono();
+/**
+ * /current route factory. Reports the daemon's single-turn lock state. Takes no
+ * config — kept a factory for parity with the other route modules so
+ * `createDaemon` wires them uniformly.
+ */
+export function createCurrentRoutes(): Hono {
+	const app = new Hono();
 
-app.get("/current", (c) => {
-	const { busy, turnId } = getCurrentTurn();
-	return c.json({ busy, turnId });
-});
+	app.get("/current", (c) => {
+		const { busy, turnId } = getCurrentTurn();
+		return c.json({ busy, turnId });
+	});
 
-export default app;
+	return app;
+}

--- a/apps/sandbox-daemon/routes/health.ts
+++ b/apps/sandbox-daemon/routes/health.ts
@@ -1,15 +1,22 @@
 import { Hono } from "hono";
+import type { DaemonConfig } from "../config";
 
-const app = new Hono();
+/**
+ * /health route factory. The version is injected from config (DAEMON_VERSION),
+ * surfaced for the chat-api bundle check. `startTime` is captured when the
+ * factory runs — once, at daemon startup — so uptime measures process lifetime.
+ */
+export function createHealthRoutes(config: DaemonConfig): Hono {
+	const app = new Hono();
+	const startTime = Date.now();
 
-const startTime = Date.now();
-
-app.get("/health", (c) => {
-	return c.json({
-		status: "ok",
-		version: process.env.DAEMON_VERSION ?? "unknown",
-		uptime: Math.floor((Date.now() - startTime) / 1000),
+	app.get("/health", (c) => {
+		return c.json({
+			status: "ok",
+			version: config.daemonVersion,
+			uptime: Math.floor((Date.now() - startTime) / 1000),
+		});
 	});
-});
 
-export default app;
+	return app;
+}

--- a/apps/sandbox-daemon/routes/turn.integration.test.ts
+++ b/apps/sandbox-daemon/routes/turn.integration.test.ts
@@ -32,16 +32,32 @@ mock.module("../child-spawn", () => ({
 // Point the workspace root at a temp dir so the turn route's directory
 // creation doesn't touch the host's /workspace.
 const testRoot = join(tmpdir(), `turn-integration-${Date.now()}`);
-process.env.SANDBOX_WORKSPACE_ROOT = testRoot;
 
 // Ensure turn-lock module is loaded
 require("../turn-lock");
 
-import turnRoutes from "./turn";
+import type { DaemonConfig } from "../config";
+import { createTurnRoutes } from "./turn";
+
+// Config is injected — no ambient env. workspaceRoot points at the temp dir and
+// the bearer secret is fixed here; agentSpawn is unused because spawnAgent is
+// mocked above.
+const config: DaemonConfig = {
+	daemonPort: 8080,
+	daemonVersion: "test",
+	daemonAuthToken: "daemon-token",
+	workspaceRoot: testRoot,
+	agentSpawn: {
+		agentBundlePath: "/workspace/agent.js",
+		bunExecutable: "bun",
+		agentIdleTimeoutMs: 120_000,
+		agentMaxTurnMs: 600_000,
+	},
+};
 
 describe("POST /turn integration", () => {
 	const app = new Hono();
-	app.route("/", turnRoutes);
+	app.route("/", createTurnRoutes(config));
 	let reqCounter = 0;
 
 	beforeAll(() => {
@@ -49,7 +65,6 @@ describe("POST /turn integration", () => {
 	});
 
 	beforeEach(() => {
-		process.env.DAEMON_AUTH_TOKEN = "daemon-token";
 		mockSpawnAgent.mockReset();
 	});
 

--- a/apps/sandbox-daemon/routes/turn.ts
+++ b/apps/sandbox-daemon/routes/turn.ts
@@ -2,13 +2,13 @@ import { timingSafeEqual } from "node:crypto";
 import { Hono } from "hono";
 import { stream } from "hono/streaming";
 import { spawnAgent } from "../child-spawn";
+import type { DaemonConfig } from "../config";
 import { acquireTurn } from "../turn-lock";
 import {
 	assertValidConversationId,
 	createConversationWorkspace,
 } from "../workspace";
 
-const app = new Hono();
 const DAEMON_AUTH_HEADER = "x-daemon-auth-token";
 
 function authTokenMatches(
@@ -43,150 +43,165 @@ function ndjsonLine(obj: Record<string, unknown>): string {
 	return `${JSON.stringify(obj)}\n`;
 }
 
-app.post("/turn", async (c) => {
-	const expectedToken = process.env.DAEMON_AUTH_TOKEN;
-	if (
-		!expectedToken ||
-		!authTokenMatches(c.req.header(DAEMON_AUTH_HEADER), expectedToken)
-	) {
-		return c.json({ error: "Unauthorized" }, 401);
-	}
+/**
+ * /turn route factory. Receives the daemon config so it reads no ambient env:
+ * the bearer secret, workspace root, and agent-spawn settings all arrive by
+ * injection from `daemon-entry.ts`.
+ */
+export function createTurnRoutes(config: DaemonConfig): Hono {
+	const app = new Hono();
 
-	const body = await c.req.json<TurnRequest>();
+	app.post("/turn", async (c) => {
+		const expectedToken = config.daemonAuthToken;
+		if (
+			!expectedToken ||
+			!authTokenMatches(c.req.header(DAEMON_AUTH_HEADER), expectedToken)
+		) {
+			return c.json({ error: "Unauthorized" }, 401);
+		}
 
-	if (
-		!body.request_id ||
-		!body.user_id ||
-		!body.conversation_id ||
-		!body.run_id ||
-		!body.message ||
-		!body.system_prompt ||
-		!body.llm_base_url ||
-		!body.doc_gateway_url ||
-		!body.llm_token ||
-		!body.doc_token
-	) {
-		return c.json({ error: "Missing required fields" }, 400);
-	}
+		const body = await c.req.json<TurnRequest>();
 
-	// conversation_id is joined into the workspace path; reject anything that
-	// could escape the conversation subtree before touching the filesystem.
-	try {
-		assertValidConversationId(body.conversation_id);
-	} catch {
-		return c.json({ error: "Invalid conversation_id" }, 400);
-	}
+		if (
+			!body.request_id ||
+			!body.user_id ||
+			!body.conversation_id ||
+			!body.run_id ||
+			!body.message ||
+			!body.system_prompt ||
+			!body.llm_base_url ||
+			!body.doc_gateway_url ||
+			!body.llm_token ||
+			!body.doc_token
+		) {
+			return c.json({ error: "Missing required fields" }, 400);
+		}
 
-	const {
-		request_id,
-		user_id,
-		conversation_id,
-		run_id,
-		message,
-		agent_session_id,
-		system_prompt,
-		llm_base_url,
-		doc_gateway_url,
-		llm_token,
-		doc_token,
-	} = body;
+		// conversation_id is joined into the workspace path; reject anything that
+		// could escape the conversation subtree before touching the filesystem.
+		try {
+			assertValidConversationId(body.conversation_id);
+		} catch {
+			return c.json({ error: "Invalid conversation_id" }, 400);
+		}
 
-	const lock = acquireTurn(request_id);
-	if (!lock) {
-		return c.json({ error: "Turn already in progress" }, 409);
-	}
+		const {
+			request_id,
+			user_id,
+			conversation_id,
+			run_id,
+			message,
+			agent_session_id,
+			system_prompt,
+			llm_base_url,
+			doc_gateway_url,
+			llm_token,
+			doc_token,
+		} = body;
 
-	return stream(
-		c,
-		async (s) => {
-			c.header("Content-Type", "application/x-ndjson");
+		const lock = acquireTurn(request_id);
+		if (!lock) {
+			return c.json({ error: "Turn already in progress" }, 409);
+		}
 
-			try {
-				await s.write(
-					ndjsonLine({
-						type: "started",
-						turn_id: request_id,
-						conversation_id,
-						run_id,
-					}),
-				);
+		return stream(
+			c,
+			async (s) => {
+				c.header("Content-Type", "application/x-ndjson");
 
-				// Materialize the conversation workspace tree and run the agent
-				// from its `work/` dir (created before spawn so the cwd exists).
-				const workspace = createConversationWorkspace(conversation_id);
-				const cwd = workspace.work;
-
-				let turnFailed = false;
-				let agentCompleted = false;
-				const agentResult = await spawnAgent({
-					userQuery: message,
-					systemPrompt: system_prompt,
-					cwd,
-					// Per-conversation CLAUDE_CONFIG_DIR — owned by the workspace
-					// layout (a sibling of cwd), bound rw and set on the agent so its
-					// SDK config + transcripts stay isolated from the project `.claude`.
-					claudeConfigDir: workspace.claudeConfig,
-					// docs/ is bound rw and forwarded to the `search_documents` tool as
-					// its hydration target; run_id attributes hydration in the manifest.
-					docsDir: workspace.docs,
-					runId: run_id,
-					sessionId: agent_session_id,
-					// Identity keys the durable session-transcript store; both arrive
-					// validated from the trusted turn request.
-					userId: user_id,
-					conversationId: conversation_id,
-					llmBaseUrl: llm_base_url,
-					docGatewayUrl: doc_gateway_url,
-					llmToken: llm_token,
-					docToken: doc_token,
-					onEvent: async (event) => {
-						if (event.type === "completed") {
-							// We emit our own `completed` below.
-							agentCompleted = true;
-							return;
-						}
-						if (event.type === "failed") {
-							turnFailed = true;
-						}
-						// Everything else (text_delta, session_id, heartbeat) is
-						// forwarded as-is. Forwarding `heartbeat` is load-bearing:
-						// it's the only traffic on this connection while a tool runs,
-						// so it keeps Bun's idleTimeout and chat-api's read alive.
-						// chat-api ignores it — it never reaches the end client.
-						await s.write(ndjsonLine(event));
-					},
-				});
-
-				// A non-zero exit after the agent already said `completed` is
-				// teardown noise (e.g. the idle watchdog killing a lingering
-				// child) — the answer fully streamed, so the turn succeeded.
-				if (agentResult.exitCode !== 0 && !turnFailed && !agentCompleted) {
-					turnFailed = true;
+				try {
 					await s.write(
 						ndjsonLine({
-							type: "failed",
-							message: `agent exited with code ${agentResult.exitCode}`,
+							type: "started",
+							turn_id: request_id,
+							conversation_id,
+							run_id,
 						}),
 					);
-				}
 
-				if (!turnFailed) {
-					await s.write(ndjsonLine({ type: "completed" }));
+					// Materialize the conversation workspace tree and run the agent
+					// from its `work/` dir (created before spawn so the cwd exists).
+					const workspace = createConversationWorkspace(
+						conversation_id,
+						config.workspaceRoot,
+					);
+					const cwd = workspace.work;
+
+					let turnFailed = false;
+					let agentCompleted = false;
+					const agentResult = await spawnAgent(
+						{
+							userQuery: message,
+							systemPrompt: system_prompt,
+							cwd,
+							// Per-conversation CLAUDE_CONFIG_DIR — owned by the workspace
+							// layout (a sibling of cwd), bound rw and set on the agent so its
+							// SDK config + transcripts stay isolated from the project `.claude`.
+							claudeConfigDir: workspace.claudeConfig,
+							// docs/ is bound rw and forwarded to the `search_documents` tool as
+							// its hydration target; run_id attributes hydration in the manifest.
+							docsDir: workspace.docs,
+							runId: run_id,
+							sessionId: agent_session_id,
+							// Identity keys the durable session-transcript store; both arrive
+							// validated from the trusted turn request.
+							userId: user_id,
+							conversationId: conversation_id,
+							llmBaseUrl: llm_base_url,
+							docGatewayUrl: doc_gateway_url,
+							llmToken: llm_token,
+							docToken: doc_token,
+							onEvent: async (event) => {
+								if (event.type === "completed") {
+									// We emit our own `completed` below.
+									agentCompleted = true;
+									return;
+								}
+								if (event.type === "failed") {
+									turnFailed = true;
+								}
+								// Everything else (text_delta, session_id, heartbeat) is
+								// forwarded as-is. Forwarding `heartbeat` is load-bearing:
+								// it's the only traffic on this connection while a tool runs,
+								// so it keeps Bun's idleTimeout and chat-api's read alive.
+								// chat-api ignores it — it never reaches the end client.
+								await s.write(ndjsonLine(event));
+							},
+						},
+						config.agentSpawn,
+					);
+
+					// A non-zero exit after the agent already said `completed` is
+					// teardown noise (e.g. the idle watchdog killing a lingering
+					// child) — the answer fully streamed, so the turn succeeded.
+					if (agentResult.exitCode !== 0 && !turnFailed && !agentCompleted) {
+						turnFailed = true;
+						await s.write(
+							ndjsonLine({
+								type: "failed",
+								message: `agent exited with code ${agentResult.exitCode}`,
+							}),
+						);
+					}
+
+					if (!turnFailed) {
+						await s.write(ndjsonLine({ type: "completed" }));
+					}
+				} catch (err) {
+					const errorMessage = err instanceof Error ? err.message : String(err);
+					await s.write(ndjsonLine({ type: "failed", message: errorMessage }));
+				} finally {
+					lock.release();
 				}
-			} catch (err) {
-				const errorMessage = err instanceof Error ? err.message : String(err);
-				await s.write(ndjsonLine({ type: "failed", message: errorMessage }));
-			} finally {
+			},
+			async (err, stream) => {
+				const message = err instanceof Error ? err.message : String(err);
+				console.error("Stream error in /turn:", message);
+				await stream.write(ndjsonLine({ type: "failed", message }));
 				lock.release();
-			}
-		},
-		async (err, stream) => {
-			const message = err instanceof Error ? err.message : String(err);
-			console.error("Stream error in /turn:", message);
-			await stream.write(ndjsonLine({ type: "failed", message }));
-			lock.release();
-		},
-	);
-});
+			},
+		);
+	});
 
-export default app;
+	return app;
+}

--- a/apps/sandbox-daemon/workspace.test.ts
+++ b/apps/sandbox-daemon/workspace.test.ts
@@ -1,41 +1,23 @@
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { existsSync, mkdirSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
 	assertValidConversationId,
 	createConversationWorkspace,
-	getWorkspaceRoot,
 	resolveConversationWorkspace,
 } from "./workspace";
 
+// Workspace root is injected, not read from env — point it at a temp dir so the
+// tests never touch the host's real /workspace.
 const testRoot = join(tmpdir(), `workspace-test-${Date.now()}`);
-const savedRoot = process.env.SANDBOX_WORKSPACE_ROOT;
 
 beforeAll(() => {
 	mkdirSync(testRoot, { recursive: true });
-	process.env.SANDBOX_WORKSPACE_ROOT = testRoot;
-});
-
-afterEach(() => {
-	process.env.SANDBOX_WORKSPACE_ROOT = testRoot;
 });
 
 afterAll(() => {
 	rmSync(testRoot, { recursive: true, force: true });
-	if (savedRoot === undefined) delete process.env.SANDBOX_WORKSPACE_ROOT;
-	else process.env.SANDBOX_WORKSPACE_ROOT = savedRoot;
-});
-
-describe("getWorkspaceRoot", () => {
-	it("honors SANDBOX_WORKSPACE_ROOT", () => {
-		expect(getWorkspaceRoot()).toBe(testRoot);
-	});
-
-	it("defaults to /workspace when unset", () => {
-		delete process.env.SANDBOX_WORKSPACE_ROOT;
-		expect(getWorkspaceRoot()).toBe("/workspace");
-	});
 });
 
 describe("assertValidConversationId", () => {
@@ -77,7 +59,7 @@ describe("assertValidConversationId", () => {
 
 describe("resolveConversationWorkspace", () => {
 	it("builds the target layout under the workspace root", () => {
-		const ws = resolveConversationWorkspace("conv-99");
+		const ws = resolveConversationWorkspace("conv-99", testRoot);
 		expect(ws).toEqual({
 			root: testRoot,
 			system: join(testRoot, "system"),
@@ -90,7 +72,7 @@ describe("resolveConversationWorkspace", () => {
 	});
 
 	it("throws on a malformed id before constructing any path", () => {
-		expect(() => resolveConversationWorkspace("../escape")).toThrow(
+		expect(() => resolveConversationWorkspace("../escape", testRoot)).toThrow(
 			/Invalid conversationId/,
 		);
 	});
@@ -98,7 +80,7 @@ describe("resolveConversationWorkspace", () => {
 
 describe("createConversationWorkspace", () => {
 	it("creates system, docs, work, output, and claude-config directories", () => {
-		const ws = createConversationWorkspace("conv-create");
+		const ws = createConversationWorkspace("conv-create", testRoot);
 		for (const dir of [
 			ws.system,
 			ws.docs,
@@ -112,15 +94,19 @@ describe("createConversationWorkspace", () => {
 	});
 
 	it("is idempotent", () => {
-		expect(() => createConversationWorkspace("conv-twice")).not.toThrow();
-		expect(() => createConversationWorkspace("conv-twice")).not.toThrow();
+		expect(() =>
+			createConversationWorkspace("conv-twice", testRoot),
+		).not.toThrow();
+		expect(() =>
+			createConversationWorkspace("conv-twice", testRoot),
+		).not.toThrow();
 		expect(
 			existsSync(join(testRoot, "conversations", "conv-twice", "work")),
 		).toBe(true);
 	});
 
 	it("refuses to create directories for a malformed id", () => {
-		expect(() => createConversationWorkspace("../../pwned")).toThrow(
+		expect(() => createConversationWorkspace("../../pwned", testRoot)).toThrow(
 			/Invalid conversationId/,
 		);
 		expect(existsSync(join(testRoot, "..", "pwned"))).toBe(false);

--- a/apps/sandbox-daemon/workspace.ts
+++ b/apps/sandbox-daemon/workspace.ts
@@ -23,16 +23,12 @@
  * into a path — a value containing `/`, `..`, or NUL could otherwise escape the
  * conversation subtree.
  *
- * The root is env-overridable (`SANDBOX_WORKSPACE_ROOT`) so tests can point it
- * at a temp dir instead of the host's real `/workspace`.
+ * The root is injected (`DaemonConfig.workspaceRoot`, default `/workspace`) so
+ * tests can point it at a temp dir instead of the host's real `/workspace`.
  */
 
 import { mkdirSync } from "node:fs";
 import { join } from "node:path";
-
-// Must stay in sync with child-spawn's WORKSPACE_ROOT and the sandbox template's
-// setWorkdir (apps/chat-api/sandbox-template/template.ts).
-const DEFAULT_WORKSPACE_ROOT = "/workspace";
 
 // conversationId is allocated by chat-api (UUID/nanoid-shaped). Restrict it to a
 // conservative charset so no value can traverse out of its conversation dir.
@@ -40,10 +36,6 @@ const DEFAULT_WORKSPACE_ROOT = "/workspace";
 // rewritten, so the path the daemon creates always matches the id chat-api uses.
 const VALID_CONVERSATION_ID = /^[A-Za-z0-9_-]+$/;
 const MAX_CONVERSATION_ID_LENGTH = 128;
-
-export function getWorkspaceRoot(): string {
-	return process.env.SANDBOX_WORKSPACE_ROOT ?? DEFAULT_WORKSPACE_ROOT;
-}
 
 /**
  * Throw if `conversationId` is missing, too long, or contains any character
@@ -83,18 +75,18 @@ export interface ConversationWorkspace {
 }
 
 /**
- * Compute the workspace paths for a conversation. Pure: validates the id and
- * joins paths, but touches no filesystem.
+ * Compute the workspace paths for a conversation under `workspaceRoot`. Pure:
+ * validates the id and joins paths, but touches no filesystem.
  */
 export function resolveConversationWorkspace(
 	conversationId: string,
+	workspaceRoot: string,
 ): ConversationWorkspace {
 	assertValidConversationId(conversationId);
-	const root = getWorkspaceRoot();
-	const conversation = join(root, "conversations", conversationId);
+	const conversation = join(workspaceRoot, "conversations", conversationId);
 	return {
-		root,
-		system: join(root, "system"),
+		root: workspaceRoot,
+		system: join(workspaceRoot, "system"),
 		conversation,
 		docs: join(conversation, "docs"),
 		work: join(conversation, "work"),
@@ -110,8 +102,9 @@ export function resolveConversationWorkspace(
  */
 export function createConversationWorkspace(
 	conversationId: string,
+	workspaceRoot: string,
 ): ConversationWorkspace {
-	const ws = resolveConversationWorkspace(conversationId);
+	const ws = resolveConversationWorkspace(conversationId, workspaceRoot);
 	mkdirSync(ws.system, { recursive: true });
 	mkdirSync(ws.docs, { recursive: true });
 	mkdirSync(ws.work, { recursive: true });


### PR DESCRIPTION
## Summary

Modularizes `sandbox-daemon` with a dependency-injected config, mirroring the gateway's `loadConfigFromEnv` → `createGateway(config, db)` pattern (MYM-26 / MYM-20). Closes [MYM-29](https://linear.app/mymemo-agent/issue/MYM-29).

Before, every daemon module read `process.env` inline (`child-spawn`, `workspace`, `routes/health`, `routes/turn`, `daemon-entry`), coupling them to global mutable state and forcing tests to set/restore `process.env`. Now `daemon-entry.ts` is the **sole reader** of ambient env for daemon configuration.

## Changes

- **`config.ts`** (new) — `loadConfigFromEnv(env): DaemonConfig` folds `DAEMON_PORT`, `DAEMON_VERSION`, `DAEMON_AUTH_TOKEN`, `SANDBOX_WORKSPACE_ROOT`, and the agent-spawn settings (`SANDBOX_AGENT_PATH`, `SANDBOX_BUN_PATH`, `SANDBOX_AGENT_IDLE_TIMEOUT_MS`, `SANDBOX_AGENT_MAX_TURN_MS`) into one typed, validated config.
- **`daemon.ts`** (new) — `createDaemon(config)` app factory wiring the route factories (parity with `gateway.ts`).
- **Routes → factories** — `createTurnRoutes(config)`, `createHealthRoutes(config)`, `createCurrentRoutes()`.
- **Injection** — config threaded into `spawnAgent`/`buildAgentSpawnArgv` and `createConversationWorkspace`/`resolveConversationWorkspace`.
- **`daemon-entry.ts`** — reads `Bun.env` once, builds config, injects into `createDaemon`.

### Scope note
Env **forwarded into the spawned agent child** (`PATH`, `CLAUDE_CODE_PATH`, `AGENT_SESSION_STORE_ROOT`, hydration-limit overrides) is intentionally left where it is forwarded in `child-spawn.ts` — that is the child's config surface, not the daemon's, and is explicitly excluded by the issue's acceptance criteria. Behavior and route semantics are unchanged.

## Acceptance criteria
- [x] `daemon-entry.ts` is the sole reader of `Bun.env`/`process.env` for daemon config (excluding env forwarded into the agent child).
- [x] Daemon behavior and route semantics unchanged.
- [x] Existing daemon tests pass without mutating `process.env` for config (they pass a config object instead).
- [x] `child-spawn`, `workspace`, `health`, and `turn` receive settings via injected config.

## Tests
- Updated `workspace.test.ts`, `child-spawn.test.ts`, `routes/turn.integration.test.ts` to construct config explicitly (no `process.env` mutation).
- New `config.test.ts` (defaults, env overrides, malformed port/timeout fallback) and `daemon.test.ts` (factory wiring: `/health` version, `/current`, `/turn` auth).
- `bun test` → **128 pass / 0 fail**; `biome check` clean; `bun run build` produces both bundles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)