### PR TITLE
fix(sandbox): gate daemon /turn via E2B edge token, drop DAEMON_AUTH_TOKEN (MYM-35)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,8 @@ Identity arrives via `X-*` headers, **not** the JSON body. chat-api does not aut
 
 The sandboxed agent is treated as untrusted (it runs prompt-injectable, Bash-capable code). It holds no provider key and no document credential — only a short-lived, single-user, signed bearer token whose claims include the turn's document scope. The inbound edges from a sandbox are **sandbox → gateway** (for both LLM and document calls); the gateway holds the real credentials + `LLM_TOKEN_SECRET`, should only be reachable from sandboxes, and reaches only its two upstreams (`api.anthropic.com` and the MyMemo KB Postgres). Because scope is signed into the token and enforced by the gateway's document routes, a prompt-injected agent cannot read documents outside its turn's scope. chat-api mints the token; the gateway verifies it; the daemon never sees `LLM_TOKEN_SECRET`.
 
+The **chat-api → daemon `/turn`** edge has no application-layer auth and the daemon holds no secret of its own (MYM-35). In prod each E2B sandbox is created with `allowPublicTraffic: false`, so its edge rejects any request to the daemon's public URL that lacks the per-sandbox `e2b-traffic-access-token` (held only by chat-api, sent on every daemon call); chat-api fails the sandbox create if that token is absent, so the restriction can't silently fail open. Locally the daemon container is unpublished on the compose network. The previous shared `DAEMON_AUTH_TOKEN` bearer was removed: it lived in the daemon's process env where the untrusted agent could read it via `/proc`, yet it was redundant with the edge and identical across all sandboxes.
+
 **Merge tradeoff (be aware):** the LLM proxy and the document reader used to be two separate services (`llm-gateway` + `document-gateway`), each holding exactly one credential. They are now one `gateway` process that holds BOTH `ANTHROPIC_API_KEY` and `DATABASE_URL` and has a single egress identity reaching both Anthropic and the KB Postgres. This is a wider blast radius — a compromise of the gateway now exposes both credentials at once — accepted as the cost of running one deployable control plane instead of two. The token still has no audience/capability claim, so one token is valid on both route families; that was already true when they were separate and is unchanged by the merge.
 
 ### Key Modules
@@ -155,7 +157,6 @@ The sandboxed agent is treated as untrusted (it runs prompt-injectable, Bash-cap
 
 Required:
 - `E2B_API_KEY` — required only when `SANDBOX_PROVIDER=e2b` (the default); not needed for the local provider
-- `DAEMON_AUTH_TOKEN`
 - `LLM_TOKEN_SECRET` — HMAC secret for minting per-turn tokens (shared with the gateway)
 - `GATEWAY_PUBLIC_URL` — base URL of the merged gateway; the sandbox agent points BOTH the Claude binary (→ `/v1/messages`) and the `mymemo-docs` CLI (→ `/v1/documents/*`) at it. **Must be reachable from inside the E2B sandbox**
 

--- a/README.md
+++ b/README.md
@@ -66,12 +66,10 @@ Each service reads its own `apps/<svc>/.env` (non-secret wiring stays inline in
 `compose.yaml`). Create them from the examples:
 
 ```sh
-cp apps/chat-api/.env.example       apps/chat-api/.env
-cp apps/gateway/.env.example        apps/gateway/.env
-cp apps/sandbox-daemon/.env.example apps/sandbox-daemon/.env
-# Fill in apps/gateway/.env's ANTHROPIC_API_KEY. Keep the shared values identical
-# across files: LLM_TOKEN_SECRET (chat-api + gateway), DAEMON_AUTH_TOKEN
-# (chat-api + sandbox-daemon).
+cp apps/chat-api/.env.example apps/chat-api/.env
+cp apps/gateway/.env.example  apps/gateway/.env
+# Fill in apps/gateway/.env's ANTHROPIC_API_KEY. Keep LLM_TOKEN_SECRET identical
+# across the chat-api and gateway files. The sandbox-daemon needs no secrets.
 docker compose up --build
 ```
 

--- a/apps/chat-api/.env.example
+++ b/apps/chat-api/.env.example
@@ -3,10 +3,6 @@
 # Non-secret wiring (SANDBOX_PROVIDER, GATEWAY_PUBLIC_URL, ...) is set inline in
 # compose.yaml, so only secrets go here.
 
-# Shared bearer for the daemon's /turn endpoint.
-# MUST match apps/sandbox-daemon/.env's DAEMON_AUTH_TOKEN.
-DAEMON_AUTH_TOKEN=local-dev-daemon-auth-token-change-me
-
 # HMAC secret for per-turn LLM/document tokens (chat-api mints them).
 # MUST match apps/gateway/.env's LLM_TOKEN_SECRET.
 LLM_TOKEN_SECRET=local-dev-llm-token-secret-change-me

--- a/apps/chat-api/README.md
+++ b/apps/chat-api/README.md
@@ -132,7 +132,6 @@ When running the development server, interactive API documentation is available 
 |----------|-------------|----------|
 | `OPENAI_API_KEY` | OpenAI API key for chat functionality | Yes |
 | `E2B_API_KEY` | API key for the sandbox prototype script | Yes (for prototype) |
-| `DAEMON_AUTH_TOKEN` | Shared secret presented on every daemon `/turn` request | Yes |
 | `E2B_TEMPLATE` | E2B sandbox template for the prototype script | Yes (for prototype) |
 | `PORT` | Server port (default: 3000) | No |
 | `PROTECTED_API_PREFIX` | Path prefix used when forwarding chat entities (e.g. `/beta-api` or `/api`) | No |

--- a/apps/chat-api/src/config/env.ts
+++ b/apps/chat-api/src/config/env.ts
@@ -23,8 +23,6 @@ export interface ApiConfig {
 	localSandboxDaemonUrl: string;
 	/** E2B template name (SANDBOX_PROVIDER=e2b only). */
 	e2bTemplate: string;
-	/** Shared bearer for the daemon's /turn endpoint. */
-	daemonAuthToken: string;
 	/** HMAC secret for the per-turn tokens minted into each sandbox turn (shared with the gateway). */
 	llmTokenSecret: string;
 	/** Base URL of the merged gateway, reachable from the sandbox; trailing slash stripped. */
@@ -62,7 +60,6 @@ export function loadApiConfigFromEnv(env: Env): ApiConfig {
 			"E2B_API_KEY is required when SANDBOX_PROVIDER=e2b",
 		);
 	}
-	invariant(env.DAEMON_AUTH_TOKEN, "DAEMON_AUTH_TOKEN is required");
 	invariant(env.LLM_TOKEN_SECRET, "LLM_TOKEN_SECRET is required");
 	invariant(env.GATEWAY_PUBLIC_URL, "GATEWAY_PUBLIC_URL is required");
 
@@ -85,7 +82,6 @@ export function loadApiConfigFromEnv(env: Env): ApiConfig {
 			env.LOCAL_SANDBOX_DAEMON_URL || "http://sandbox:8080"
 		).replace(/\/+$/, ""),
 		e2bTemplate: env.E2B_TEMPLATE || "sandbox-template-dev",
-		daemonAuthToken: env.DAEMON_AUTH_TOKEN,
 		llmTokenSecret: env.LLM_TOKEN_SECRET,
 		// Trailing slash stripped so the binary's `${base}/v1/messages` never
 		// produces a double slash.

--- a/apps/chat-api/src/features/chat/chat.route.test.ts
+++ b/apps/chat-api/src/features/chat/chat.route.test.ts
@@ -8,8 +8,6 @@ import { join } from "node:path";
 // tests run from `apps/chat-api`, but not when `bun test` runs from the repo
 // root, so set them here too to keep this file self-sufficient.
 Bun.env.E2B_API_KEY = Bun.env.E2B_API_KEY ?? "test-e2b-key";
-Bun.env.DAEMON_AUTH_TOKEN =
-	Bun.env.DAEMON_AUTH_TOKEN ?? "test-daemon-auth-token";
 Bun.env.LLM_TOKEN_SECRET = Bun.env.LLM_TOKEN_SECRET ?? "test-llm-token-secret";
 Bun.env.GATEWAY_PUBLIC_URL =
 	Bun.env.GATEWAY_PUBLIC_URL ?? "https://gateway.test";

--- a/apps/chat-api/src/features/sandbox-orchestration/e2b-sandbox-provider.test.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/e2b-sandbox-provider.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+
+// Mock the e2b SDK so createSandbox is exercised without leasing a real sandbox.
+// createImpl is swapped per test to drive the create result; sandboxKill records
+// the fail-closed teardown. mock.module is declared before the provider import
+// (matching the project's other module-mock tests) so the import binds the mock.
+const sandboxKill = mock(async () => {});
+let createImpl: () => Promise<unknown> = async () => ({});
+const sandboxCreate = mock(() => createImpl());
+mock.module("e2b", () => ({ Sandbox: { create: sandboxCreate } }));
+
+import type { ApiConfig } from "@/config/env";
+import { E2BSandboxProvider } from "./e2b-sandbox-provider";
+import { SandboxCreationError } from "./errors";
+import type { SyncLogger } from "./sandbox-provider";
+
+const silentLogger: SyncLogger = { info: () => {}, error: () => {} };
+// createSandbox only reads e2bTemplate; the rest of ApiConfig is irrelevant here.
+const config = { e2bTemplate: "tpl" } as unknown as ApiConfig;
+
+function fakeSandbox(overrides: Record<string, unknown> = {}) {
+	return {
+		sandboxId: "sbx-1",
+		trafficAccessToken: "traffic-token",
+		kill: sandboxKill,
+		...overrides,
+	};
+}
+
+describe("E2BSandboxProvider.createSandbox", () => {
+	afterEach(() => {
+		sandboxCreate.mockClear();
+		sandboxKill.mockClear();
+	});
+
+	it("creates the sandbox with public traffic restricted", async () => {
+		createImpl = async () => fakeSandbox();
+		await new E2BSandboxProvider(config).createSandbox("user-1", silentLogger);
+		expect(sandboxCreate).toHaveBeenCalledWith(
+			"tpl",
+			expect.objectContaining({ network: { allowPublicTraffic: false } }),
+		);
+	});
+
+	it("returns the handle when the traffic token is present", async () => {
+		createImpl = async () =>
+			fakeSandbox({ trafficAccessToken: "traffic-token" });
+		const handle = await new E2BSandboxProvider(config).createSandbox(
+			"user-1",
+			silentLogger,
+		);
+		expect(handle.sandboxId).toBe("sbx-1");
+		expect(sandboxKill).not.toHaveBeenCalled();
+	});
+
+	// The security-critical guard: a sandbox whose public-traffic restriction did
+	// not take effect (no token minted) must be killed and fail closed. The error
+	// is deliberately a plain Error, NOT SandboxCreationError, so runSandboxChat
+	// does not retry an identical, deterministic create.
+	it("fails closed (no retry) and kills the sandbox when the traffic token is absent", async () => {
+		createImpl = async () => fakeSandbox({ trafficAccessToken: undefined });
+		const err = await new E2BSandboxProvider(config)
+			.createSandbox("user-1", silentLogger)
+			.catch((e) => e);
+
+		expect(err).toBeInstanceOf(Error);
+		expect(err).not.toBeInstanceOf(SandboxCreationError);
+		expect((err as Error).message).toMatch(/did not take effect/);
+		expect(sandboxKill).toHaveBeenCalled();
+	});
+
+	it("wraps a create() failure in the retryable SandboxCreationError", async () => {
+		createImpl = async () => {
+			throw new Error("e2b unavailable");
+		};
+		const err = await new E2BSandboxProvider(config)
+			.createSandbox("user-1", silentLogger)
+			.catch((e) => e);
+
+		expect(err).toBeInstanceOf(SandboxCreationError);
+		expect(sandboxKill).not.toHaveBeenCalled();
+	});
+});

--- a/apps/chat-api/src/features/sandbox-orchestration/e2b-sandbox-provider.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/e2b-sandbox-provider.ts
@@ -168,7 +168,7 @@ export class E2BSandboxProvider implements SandboxProvider {
 	/**
 	 * Deploy the daemon + agent bundles onto the freshly created sandbox and
 	 * wait for the daemon to report healthy. Returns the daemon URL and the
-	 * fixed auth token clients must present.
+	 * per-sandbox E2B traffic access token clients must present to the edge.
 	 *
 	 * Sandboxes are created fresh per turn, so the daemon is never already
 	 * running — there is nothing to health-check or restart, only to deploy.

--- a/apps/chat-api/src/features/sandbox-orchestration/e2b-sandbox-provider.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/e2b-sandbox-provider.ts
@@ -2,11 +2,12 @@ import { resolve } from "node:path";
 import { Sandbox } from "e2b";
 import type { ApiConfig } from "@/config/env";
 import { SandboxCreationError } from "./errors";
-import type {
-	SandboxDaemonEndpoint,
-	SandboxHandle,
-	SandboxProvider,
-	SyncLogger,
+import {
+	type SandboxDaemonEndpoint,
+	type SandboxHandle,
+	type SandboxProvider,
+	type SyncLogger,
+	trafficAccessHeaders,
 } from "./sandbox-provider";
 
 const DAEMON_PORT = 8080;
@@ -80,23 +81,43 @@ export class E2BSandboxProvider implements SandboxProvider {
 	): Promise<SandboxHandle> {
 		logger.info({ msg: "Creating sandbox", userId });
 
+		let sandbox: Sandbox;
 		try {
-			const sandbox = await Sandbox.create(this.config.e2bTemplate, {
+			// allowPublicTraffic: false makes the sandbox edge reject any request to
+			// the daemon's public URL that lacks the per-sandbox traffic token (held
+			// only here). This is the sole boundary in front of /turn now that the
+			// daemon's shared bearer is gone (MYM-35).
+			sandbox = await Sandbox.create(this.config.e2bTemplate, {
 				metadata: { userId },
+				network: { allowPublicTraffic: false },
 			});
-
-			logger.info({
-				msg: "Sandbox created",
-				userId,
-				sandboxId: sandbox.sandboxId,
-			});
-
-			return sandbox;
 		} catch (err) {
+			// A create failure may be transient — SandboxCreationError is retried by
+			// runSandboxChat.
 			throw new SandboxCreationError(
 				`Failed to create sandbox for user ${userId}: ${err instanceof Error ? err.message : String(err)}`,
 			);
 		}
+
+		// The token is only minted when public traffic is restricted, so its absence
+		// means the restriction did not take effect — a daemon open to the internet.
+		// This is a deterministic invariant, not a transient failure, so throw a
+		// plain Error (NOT SandboxCreationError) so runSandboxChat fails fast instead
+		// of retrying an identical create.
+		if (!sandbox.trafficAccessToken) {
+			await sandbox.kill().catch(() => {});
+			throw new Error(
+				"E2B sandbox has no trafficAccessToken; allowPublicTraffic restriction did not take effect",
+			);
+		}
+
+		logger.info({
+			msg: "Sandbox created",
+			userId,
+			sandboxId: sandbox.sandboxId,
+		});
+
+		return sandbox;
 	}
 
 	async killSandbox(
@@ -161,7 +182,12 @@ export class E2BSandboxProvider implements SandboxProvider {
 		// Sandbox its own createSandbox returned.
 		const sandbox = handle as Sandbox;
 		const daemonUrl = this.getDaemonUrl(sandbox);
-		const endpoint = { url: daemonUrl, authToken: this.config.daemonAuthToken };
+		// trafficAccessToken is guaranteed present — createSandbox fails the create
+		// when it is missing — so the turn proxy can always authenticate to the edge.
+		const endpoint = {
+			url: daemonUrl,
+			trafficAccessToken: sandbox.trafficAccessToken,
+		};
 
 		const bundles = await getSandboxBundles();
 
@@ -181,9 +207,15 @@ export class E2BSandboxProvider implements SandboxProvider {
 
 	private async checkDaemonHealth(
 		daemonUrl: string,
+		trafficAccessToken: string | undefined,
 	): Promise<{ status: string; version: string; uptime: number } | null> {
 		try {
+			// The daemon URL is the sandbox's restricted public host, so /health is
+			// gated by the edge too — present the traffic token or the edge 403s.
+			// createSandbox guarantees the token, so an absent one would only ever
+			// surface here as a 403 → "never healthy" → loud startup failure.
 			const response = await fetch(`${daemonUrl}/health`, {
+				headers: trafficAccessHeaders(trafficAccessToken),
 				signal: AbortSignal.timeout(3_000),
 			});
 			if (!response.ok) return null;
@@ -224,7 +256,6 @@ export class E2BSandboxProvider implements SandboxProvider {
 				background: true,
 				envs: {
 					DAEMON_VERSION: expectedVersion,
-					DAEMON_AUTH_TOKEN: this.config.daemonAuthToken,
 				},
 			},
 		);
@@ -233,7 +264,10 @@ export class E2BSandboxProvider implements SandboxProvider {
 		const deadline = Date.now() + DAEMON_STARTUP_TIMEOUT_MS;
 
 		while (Date.now() < deadline) {
-			const health = await this.checkDaemonHealth(daemonUrl);
+			const health = await this.checkDaemonHealth(
+				daemonUrl,
+				sandbox.trafficAccessToken,
+			);
 			if (health && (!expectedVersion || health.version === expectedVersion)) {
 				logger.info({
 					msg: "Sandbox daemon is ready",

--- a/apps/chat-api/src/features/sandbox-orchestration/local-container-sandbox-provider.test.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/local-container-sandbox-provider.test.ts
@@ -10,7 +10,6 @@ const config: ApiConfig = {
 	sandboxProvider: "local",
 	localSandboxDaemonUrl: "http://sandbox:8080",
 	e2bTemplate: "unused",
-	daemonAuthToken: "test-daemon-token",
 	llmTokenSecret: "test-llm-secret",
 	gatewayPublicUrl: "http://gateway:8080",
 	logLevel: "info",
@@ -45,7 +44,6 @@ describe("LocalContainerSandboxProvider", () => {
 
 		expect(endpoint).toEqual({
 			url: config.localSandboxDaemonUrl,
-			authToken: config.daemonAuthToken,
 		});
 		expect(fetchSpy).toHaveBeenCalledWith(
 			`${config.localSandboxDaemonUrl}/health`,

--- a/apps/chat-api/src/features/sandbox-orchestration/local-container-sandbox-provider.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/local-container-sandbox-provider.ts
@@ -60,7 +60,9 @@ export class LocalContainerSandboxProvider implements SandboxProvider {
 		logger: SyncLogger,
 	): Promise<SandboxDaemonEndpoint> {
 		const url = this.config.localSandboxDaemonUrl;
-		const endpoint = { url, authToken: this.config.daemonAuthToken };
+		// No edge to authenticate against: the daemon container is unpublished on
+		// the compose network, so the turn proxy sends no traffic token.
+		const endpoint = { url };
 
 		// Bundles are baked into the image, so there is nothing to push — just wait
 		// for the container's daemon to accept connections.

--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-orchestration.test.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-orchestration.test.ts
@@ -34,7 +34,6 @@ const config: ApiConfig = {
 	sandboxProvider: "e2b",
 	localSandboxDaemonUrl: "http://sandbox:8080",
 	e2bTemplate: "test-template",
-	daemonAuthToken: "test-daemon-auth-token",
 	llmTokenSecret: "test-llm-token-secret",
 	gatewayPublicUrl: "https://gateway.test",
 	logLevel: "info",
@@ -77,7 +76,7 @@ describe("runSandboxChat", () => {
 		createSandbox = mock(async () => sandbox);
 		ensureSandboxDaemon = mock(async () => ({
 			url: "http://daemon:8080",
-			authToken: "test-daemon-auth-token",
+			trafficAccessToken: "test-traffic-token",
 		}));
 		killSandbox = mock(async () => undefined);
 		cancelSandbox = mock(async () => undefined);
@@ -119,7 +118,7 @@ describe("runSandboxChat", () => {
 		expect(forwardTurn).toHaveBeenCalledWith(
 			expect.objectContaining({
 				daemonUrl: "http://daemon:8080",
-				daemonAuthToken: "test-daemon-auth-token",
+				trafficAccessToken: "test-traffic-token",
 			}),
 		);
 	});
@@ -259,7 +258,10 @@ describe("runSandboxChat", () => {
 		const order: string[] = [];
 		ensureSandboxDaemon.mockImplementation(async () => {
 			order.push("ensureDaemon");
-			return { url: "http://daemon:8080", authToken: "test-daemon-auth-token" };
+			return {
+				url: "http://daemon:8080",
+				trafficAccessToken: "test-traffic-token",
+			};
 		});
 		forwardTurn.mockImplementation(async () => {
 			order.push("forward");

--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-orchestration.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-orchestration.ts
@@ -146,7 +146,7 @@ export async function runSandboxChat(
 
 			await forwardChatTurnToSandbox({
 				daemonUrl: daemon.url,
-				daemonAuthToken: daemon.authToken,
+				trafficAccessToken: daemon.trafficAccessToken,
 				turnRequest,
 				onTextDelta,
 				// The proxy surfaces the daemon's Claude SDK session id, which we

--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-provider.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-provider.ts
@@ -38,9 +38,10 @@ export interface SandboxDaemonEndpoint {
 /**
  * Header name the E2B edge checks to admit a request to a sandbox's restricted
  * public URL. Vendor-controlled — keep it the single source of truth so the two
- * daemon callers (the turn proxy and the daemon health check) can't drift.
+ * daemon callers (the turn proxy and the daemon health check) can't drift. Both
+ * go through `trafficAccessHeaders`, so this stays module-private.
  */
-export const E2B_TRAFFIC_ACCESS_TOKEN_HEADER = "e2b-traffic-access-token";
+const E2B_TRAFFIC_ACCESS_TOKEN_HEADER = "e2b-traffic-access-token";
 
 /**
  * The `e2b-traffic-access-token` header for a daemon request, or an empty object

--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-provider.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-provider.ts
@@ -22,10 +22,35 @@ export interface SandboxHandle {
 	sandboxId: string;
 }
 
-/** Where the turn proxy reaches the in-sandbox daemon, plus its auth token. */
+/** Where the turn proxy reaches the in-sandbox daemon. */
 export interface SandboxDaemonEndpoint {
 	url: string;
-	authToken: string;
+	/**
+	 * Per-sandbox E2B traffic access token (sent as `e2b-traffic-access-token`).
+	 * Present for the E2B provider, whose sandbox is created with
+	 * `allowPublicTraffic: false` so its edge gates the public URL. Absent for the
+	 * local provider, where the daemon container is unpublished on the compose
+	 * network and there is no edge to authenticate against.
+	 */
+	trafficAccessToken?: string;
+}
+
+/**
+ * Header name the E2B edge checks to admit a request to a sandbox's restricted
+ * public URL. Vendor-controlled — keep it the single source of truth so the two
+ * daemon callers (the turn proxy and the daemon health check) can't drift.
+ */
+export const E2B_TRAFFIC_ACCESS_TOKEN_HEADER = "e2b-traffic-access-token";
+
+/**
+ * The `e2b-traffic-access-token` header for a daemon request, or an empty object
+ * when there is no token (the local provider, which has no edge to authenticate
+ * against). Spread into a `fetch` headers object.
+ */
+export function trafficAccessHeaders(
+	token: string | undefined,
+): Record<string, string> {
+	return token ? { [E2B_TRAFFIC_ACCESS_TOKEN_HEADER]: token } : {};
 }
 
 export interface SandboxProvider {

--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-proxy.test.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-proxy.test.ts
@@ -29,11 +29,11 @@ describe("forwardChatTurnToSandbox", () => {
 		mock.restore();
 	});
 
-	it("sends daemon auth token header", async () => {
+	it("sends the e2b traffic access token header", async () => {
 		const originalFetch = globalThis.fetch;
 		globalThis.fetch = mock((_url, init) => {
 			const headers = new Headers((init as RequestInit).headers);
-			expect(headers.get("x-daemon-auth-token")).toBe("daemon-token");
+			expect(headers.get("e2b-traffic-access-token")).toBe("traffic-token");
 			return Promise.resolve(
 				new Response(ndjsonBody([{ type: "completed" }]), { status: 200 }),
 			);
@@ -42,7 +42,7 @@ describe("forwardChatTurnToSandbox", () => {
 		try {
 			await forwardChatTurnToSandbox({
 				daemonUrl: "http://localhost:8080",
-				daemonAuthToken: "daemon-token",
+				trafficAccessToken: "traffic-token",
 				turnRequest: makeTurnRequest(),
 				onTextDelta: async () => {},
 				onSessionId: async () => {},
@@ -62,7 +62,7 @@ describe("forwardChatTurnToSandbox", () => {
 			await expect(
 				forwardChatTurnToSandbox({
 					daemonUrl: "http://localhost:8080",
-					daemonAuthToken: "daemon-token",
+					trafficAccessToken: "traffic-token",
 					turnRequest: makeTurnRequest(),
 					onTextDelta: async () => {},
 					onSessionId: async () => {},
@@ -83,7 +83,7 @@ describe("forwardChatTurnToSandbox", () => {
 			await expect(
 				forwardChatTurnToSandbox({
 					daemonUrl: "http://localhost:8080",
-					daemonAuthToken: "daemon-token",
+					trafficAccessToken: "traffic-token",
 					turnRequest: makeTurnRequest(),
 					onTextDelta: async () => {},
 					onSessionId: async () => {},
@@ -112,7 +112,7 @@ describe("forwardChatTurnToSandbox", () => {
 		try {
 			await forwardChatTurnToSandbox({
 				daemonUrl: "http://localhost:8080",
-				daemonAuthToken: "daemon-token",
+				trafficAccessToken: "traffic-token",
 				turnRequest: makeTurnRequest(),
 				onTextDelta: async (text) => {
 					deltas.push(text);
@@ -147,7 +147,7 @@ describe("forwardChatTurnToSandbox", () => {
 		try {
 			await forwardChatTurnToSandbox({
 				daemonUrl: "http://localhost:8080",
-				daemonAuthToken: "daemon-token",
+				trafficAccessToken: "traffic-token",
 				turnRequest: makeTurnRequest(),
 				onTextDelta: async (text) => {
 					if (text === "slow") {
@@ -183,7 +183,7 @@ describe("forwardChatTurnToSandbox", () => {
 		try {
 			await forwardChatTurnToSandbox({
 				daemonUrl: "http://localhost:8080",
-				daemonAuthToken: "daemon-token",
+				trafficAccessToken: "traffic-token",
 				turnRequest: makeTurnRequest(),
 				onTextDelta: async () => {},
 				onSessionId: async (id) => {
@@ -212,7 +212,7 @@ describe("forwardChatTurnToSandbox", () => {
 			await expect(
 				forwardChatTurnToSandbox({
 					daemonUrl: "http://localhost:8080",
-					daemonAuthToken: "daemon-token",
+					trafficAccessToken: "traffic-token",
 					turnRequest: makeTurnRequest(),
 					onTextDelta: async () => {},
 					onSessionId: async () => {},
@@ -238,7 +238,7 @@ describe("forwardChatTurnToSandbox", () => {
 			await expect(
 				forwardChatTurnToSandbox({
 					daemonUrl: "http://localhost:8080",
-					daemonAuthToken: "daemon-token",
+					trafficAccessToken: "traffic-token",
 					turnRequest: makeTurnRequest(),
 					onTextDelta: async () => {},
 					onSessionId: async () => {},
@@ -269,7 +269,7 @@ describe("forwardChatTurnToSandbox", () => {
 		try {
 			await forwardChatTurnToSandbox({
 				daemonUrl: "http://localhost:8080",
-				daemonAuthToken: "daemon-token",
+				trafficAccessToken: "traffic-token",
 				turnRequest: makeTurnRequest(),
 				onTextDelta: async (text) => {
 					deltas.push(text);

--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-proxy.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-proxy.ts
@@ -1,4 +1,5 @@
 import { ConversationBusyError } from "./errors";
+import { trafficAccessHeaders } from "./sandbox-provider";
 
 export interface TurnRequest {
 	request_id: string;
@@ -32,7 +33,12 @@ export interface TurnRequest {
 
 interface ForwardOptions {
 	daemonUrl: string;
-	daemonAuthToken: string;
+	/**
+	 * Per-sandbox E2B traffic access token, sent as `e2b-traffic-access-token` so
+	 * the sandbox edge admits the request to the daemon's restricted public URL.
+	 * Undefined for the local provider (no edge), where no header is sent.
+	 */
+	trafficAccessToken?: string;
 	turnRequest: TurnRequest;
 	onTextDelta: (text: string) => Promise<void>;
 	onSessionId: (id: string) => Promise<void>;
@@ -45,8 +51,13 @@ interface ForwardOptions {
 export async function forwardChatTurnToSandbox(
 	options: ForwardOptions,
 ): Promise<void> {
-	const { daemonUrl, daemonAuthToken, turnRequest, onTextDelta, onSessionId } =
-		options;
+	const {
+		daemonUrl,
+		trafficAccessToken,
+		turnRequest,
+		onTextDelta,
+		onSessionId,
+	} = options;
 
 	// Idle-based timeout over the streamed body, re-armed on every chunk —
 	// turns are legitimately long, so an absolute timeout over the whole read
@@ -75,7 +86,7 @@ export async function forwardChatTurnToSandbox(
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
-				"x-daemon-auth-token": daemonAuthToken,
+				...trafficAccessHeaders(trafficAccessToken),
 			},
 			body: JSON.stringify(turnRequest),
 			signal: idleController.signal,

--- a/apps/chat-api/src/test-setup.ts
+++ b/apps/chat-api/src/test-setup.ts
@@ -4,8 +4,6 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 Bun.env.E2B_API_KEY = Bun.env.E2B_API_KEY ?? "test-e2b-key";
-Bun.env.DAEMON_AUTH_TOKEN =
-	Bun.env.DAEMON_AUTH_TOKEN ?? "test-daemon-auth-token";
 Bun.env.LLM_TOKEN_SECRET = Bun.env.LLM_TOKEN_SECRET ?? "test-llm-token-secret";
 Bun.env.GATEWAY_PUBLIC_URL =
 	Bun.env.GATEWAY_PUBLIC_URL ?? "https://gateway.test";

--- a/apps/sandbox-daemon/.env.example
+++ b/apps/sandbox-daemon/.env.example
@@ -1,7 +1,0 @@
-# sandbox-daemon secrets for the local E2E harness (compose.yaml). Copy to
-#   apps/sandbox-daemon/.env
-# AGENT_SESSION_STORE_ROOT is set inline in compose.yaml, so only secrets go here.
-
-# Shared bearer the daemon checks on /turn.
-# MUST match apps/chat-api/.env's DAEMON_AUTH_TOKEN.
-DAEMON_AUTH_TOKEN=local-dev-daemon-auth-token-change-me

--- a/apps/sandbox-daemon/Dockerfile
+++ b/apps/sandbox-daemon/Dockerfile
@@ -55,7 +55,9 @@ RUN chmod 0755 /usr/local/bin/mymemo-docs
 COPY --from=builder /src/apps/sandbox-daemon/dist/daemon.js /workspace/daemon.js
 COPY --from=builder /src/apps/sandbox-daemon/dist/agent.js /workspace/agent.js
 
-# DAEMON_AUTH_TOKEN + AGENT_SESSION_STORE_ROOT are supplied at runtime (compose).
+# AGENT_SESSION_STORE_ROOT is supplied at runtime (compose). The daemon holds no
+# secret: /turn has no app-layer auth (MYM-35); the container is unpublished on
+# the compose network.
 ENV DAEMON_PORT=8080 \
     DAEMON_VERSION=local
 EXPOSE 8080/tcp

--- a/apps/sandbox-daemon/config.test.ts
+++ b/apps/sandbox-daemon/config.test.ts
@@ -7,7 +7,6 @@ describe("loadConfigFromEnv", () => {
 		expect(config).toEqual({
 			daemonPort: 8080,
 			daemonVersion: "unknown",
-			daemonAuthToken: undefined,
 			workspaceRoot: "/workspace",
 			agentSpawn: {
 				agentBundlePath: "/workspace/agent.js",
@@ -22,7 +21,6 @@ describe("loadConfigFromEnv", () => {
 		const config = loadConfigFromEnv({
 			DAEMON_PORT: "9090",
 			DAEMON_VERSION: "v1.2.3",
-			DAEMON_AUTH_TOKEN: "secret",
 			SANDBOX_WORKSPACE_ROOT: "/tmp/ws",
 			SANDBOX_AGENT_PATH: "/custom/agent.js",
 			SANDBOX_BUN_PATH: "/custom/bun",
@@ -32,7 +30,6 @@ describe("loadConfigFromEnv", () => {
 		expect(config).toEqual({
 			daemonPort: 9090,
 			daemonVersion: "v1.2.3",
-			daemonAuthToken: "secret",
 			workspaceRoot: "/tmp/ws",
 			agentSpawn: {
 				agentBundlePath: "/custom/agent.js",

--- a/apps/sandbox-daemon/config.ts
+++ b/apps/sandbox-daemon/config.ts
@@ -45,9 +45,9 @@ type Env = Record<string, string | undefined>;
 // throwing (unlike the gateway's `parsePort`, which fails fast). The daemon runs
 // inside the sandbox where there is no operator to read a boot error, and a
 // malformed watchdog value that became the live timeout would SIGKILL every turn
-// at spawn — so a safe default beats aborting. Required secrets are absent here
-// (the only secret, DAEMON_AUTH_TOKEN, fails closed at request time), so there
-// is nothing to fail-fast on.
+// at spawn — so a safe default beats aborting. The daemon holds no secret of its
+// own (the /turn boundary is the sandbox edge, see routes/turn.ts), so there is
+// nothing to fail-fast on.
 
 /** Parse a TCP port: an integer in 1..65535, else the fallback. */
 function parsePort(value: string | undefined, fallback: number): number {
@@ -87,11 +87,6 @@ export interface DaemonConfig {
 	daemonPort: number;
 	/** Surfaced by /health for the chat-api bundle check (DAEMON_VERSION). */
 	daemonVersion: string;
-	/**
-	 * Bearer secret required on /turn. When unset, every /turn is rejected with
-	 * 401 (fail-closed) — preserved as-is so behavior matches the pre-config code.
-	 */
-	daemonAuthToken: string | undefined;
 	/** Root of the sandbox workspace tree (SANDBOX_WORKSPACE_ROOT). */
 	workspaceRoot: string;
 	/** Settings for spawning the per-turn agent child. */
@@ -107,7 +102,6 @@ export function loadConfigFromEnv(env: Env): DaemonConfig {
 	return {
 		daemonPort: parsePort(env.DAEMON_PORT, DEFAULT_DAEMON_PORT),
 		daemonVersion: env.DAEMON_VERSION ?? DEFAULT_DAEMON_VERSION,
-		daemonAuthToken: env.DAEMON_AUTH_TOKEN,
 		workspaceRoot: env.SANDBOX_WORKSPACE_ROOT ?? DEFAULT_WORKSPACE_ROOT,
 		agentSpawn: {
 			agentBundlePath: env.SANDBOX_AGENT_PATH ?? DEFAULT_AGENT_BUNDLE_PATH,

--- a/apps/sandbox-daemon/daemon-entry.ts
+++ b/apps/sandbox-daemon/daemon-entry.ts
@@ -13,10 +13,11 @@
  * Env (see config.ts):
  *   DAEMON_PORT       — HTTP port (default 8080).
  *   DAEMON_VERSION    — surfaced by /health for the chat-api bundle check.
- *   DAEMON_AUTH_TOKEN — bearer secret for /turn (unset => every /turn is 401).
  *
- * The daemon holds no provider key: the agent's LLM gateway URL and bearer
- * token arrive per turn in the /turn body and are forwarded into agent.js's env.
+ * The daemon holds no secret: /turn has no application-layer auth (the sandbox
+ * edge is the boundary, see routes/turn.ts). The agent's LLM gateway URL and
+ * bearer token arrive per turn in the /turn body and are forwarded into
+ * agent.js's env.
  */
 
 import { loadConfigFromEnv } from "./config";

--- a/apps/sandbox-daemon/daemon.test.ts
+++ b/apps/sandbox-daemon/daemon.test.ts
@@ -5,7 +5,6 @@ import { createDaemon } from "./daemon";
 const baseConfig: DaemonConfig = {
 	daemonPort: 8080,
 	daemonVersion: "test-1.0",
-	daemonAuthToken: "secret",
 	workspaceRoot: "/tmp/ws",
 	agentSpawn: {
 		agentBundlePath: "/workspace/agent.js",
@@ -34,14 +33,16 @@ describe("createDaemon", () => {
 		expect(body).toHaveProperty("busy");
 	});
 
-	it("wires /turn so the injected auth token is enforced", async () => {
+	it("wires /turn (no app-layer auth; the sandbox edge is the boundary)", async () => {
 		const app = createDaemon(baseConfig);
-		// No bearer header → the turn route rejects before any spawn.
+		// /turn is registered and validates the body — an incomplete body is
+		// rejected with 400, not 404. There is no bearer check (MYM-35): the
+		// sandbox edge gates the public URL upstream of the daemon.
 		const res = await app.request("/turn", {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({ message: "hi" }),
 		});
-		expect(res.status).toBe(401);
+		expect(res.status).toBe(400);
 	});
 });

--- a/apps/sandbox-daemon/routes/turn.integration.test.ts
+++ b/apps/sandbox-daemon/routes/turn.integration.test.ts
@@ -39,13 +39,11 @@ require("../turn-lock");
 import type { DaemonConfig } from "../config";
 import { createTurnRoutes } from "./turn";
 
-// Config is injected — no ambient env. workspaceRoot points at the temp dir and
-// the bearer secret is fixed here; agentSpawn is unused because spawnAgent is
-// mocked above.
+// Config is injected — no ambient env. workspaceRoot points at the temp dir;
+// agentSpawn is unused because spawnAgent is mocked above.
 const config: DaemonConfig = {
 	daemonPort: 8080,
 	daemonVersion: "test",
-	daemonAuthToken: "daemon-token",
 	workspaceRoot: testRoot,
 	agentSpawn: {
 		agentBundlePath: "/workspace/agent.js",
@@ -94,7 +92,6 @@ describe("POST /turn integration", () => {
 	function turnHeaders() {
 		return {
 			"Content-Type": "application/json",
-			"x-daemon-auth-token": "daemon-token",
 		};
 	}
 
@@ -115,48 +112,6 @@ describe("POST /turn integration", () => {
 		}
 		return { exitCode };
 	}
-
-	it("rejects requests without daemon auth token", async () => {
-		const res = await app.request("/turn", {
-			method: "POST",
-			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify(makeTurnBody()),
-		});
-
-		expect(res.status).toBe(401);
-		expect(await res.json()).toEqual({ error: "Unauthorized" });
-		expect(mockSpawnAgent).not.toHaveBeenCalled();
-	});
-
-	it("rejects requests with a wrong daemon auth token", async () => {
-		const res = await app.request("/turn", {
-			method: "POST",
-			headers: {
-				"Content-Type": "application/json",
-				"x-daemon-auth-token": "wrong-token",
-			},
-			body: JSON.stringify(makeTurnBody()),
-		});
-
-		expect(res.status).toBe(401);
-		expect(await res.json()).toEqual({ error: "Unauthorized" });
-		expect(mockSpawnAgent).not.toHaveBeenCalled();
-	});
-
-	it("rejects non-ASCII auth tokens without throwing", async () => {
-		const res = await app.request("/turn", {
-			method: "POST",
-			headers: {
-				"Content-Type": "application/json",
-				"x-daemon-auth-token": "éééééééééééé",
-			},
-			body: JSON.stringify(makeTurnBody()),
-		});
-
-		expect(res.status).toBe(401);
-		expect(await res.json()).toEqual({ error: "Unauthorized" });
-		expect(mockSpawnAgent).not.toHaveBeenCalled();
-	});
 
 	it("streams text_delta events forwarded from agent.js", async () => {
 		mockSpawnAgent.mockImplementation((input) =>

--- a/apps/sandbox-daemon/routes/turn.ts
+++ b/apps/sandbox-daemon/routes/turn.ts
@@ -1,4 +1,3 @@
-import { timingSafeEqual } from "node:crypto";
 import { Hono } from "hono";
 import { stream } from "hono/streaming";
 import { spawnAgent } from "../child-spawn";
@@ -8,19 +7,6 @@ import {
 	assertValidConversationId,
 	createConversationWorkspace,
 } from "../workspace";
-
-const DAEMON_AUTH_HEADER = "x-daemon-auth-token";
-
-function authTokenMatches(
-	presented: string | undefined,
-	expected: string,
-): boolean {
-	if (!presented) return false;
-	const presentedBuffer = Buffer.from(presented, "utf8");
-	const expectedBuffer = Buffer.from(expected, "utf8");
-	if (presentedBuffer.length !== expectedBuffer.length) return false;
-	return timingSafeEqual(presentedBuffer, expectedBuffer);
-}
 
 interface TurnRequest {
 	request_id: string;
@@ -45,21 +31,21 @@ function ndjsonLine(obj: Record<string, unknown>): string {
 
 /**
  * /turn route factory. Receives the daemon config so it reads no ambient env:
- * the bearer secret, workspace root, and agent-spawn settings all arrive by
- * injection from `daemon-entry.ts`.
+ * the workspace root and agent-spawn settings arrive by injection from
+ * `daemon-entry.ts`.
+ *
+ * No application-layer auth: the boundary in front of /turn is the sandbox edge,
+ * not a daemon-held secret. In prod the E2B sandbox is created with
+ * `allowPublicTraffic: false`, so its edge rejects any request that lacks the
+ * per-sandbox `e2b-traffic-access-token` (held only by chat-api) before it
+ * reaches the daemon. Locally the daemon container is unpublished on the compose
+ * network. A daemon-held shared bearer was removed (MYM-35): it was readable by
+ * the untrusted agent via `/proc` yet redundant with the edge.
  */
 export function createTurnRoutes(config: DaemonConfig): Hono {
 	const app = new Hono();
 
 	app.post("/turn", async (c) => {
-		const expectedToken = config.daemonAuthToken;
-		if (
-			!expectedToken ||
-			!authTokenMatches(c.req.header(DAEMON_AUTH_HEADER), expectedToken)
-		) {
-			return c.json({ error: "Unauthorized" }, 401);
-		}
-
 		const body = await c.req.json<TurnRequest>();
 
 		if (

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,10 +6,13 @@
 # Config split: non-secret wiring (provider selection, service URLs, ports, the
 # local DB connection) lives inline below, so reading a service's block shows
 # exactly what it gets. Secrets live in a per-service env file next to each app
-# (see each apps/<svc>/.env.example); copy each to .env and fill it in. Two
-# values are shared and MUST match across the files that use them:
+# (see each apps/<svc>/.env.example); copy each to .env and fill it in. One value
+# is shared and MUST match across the files that use it:
 #   LLM_TOKEN_SECRET   — chat-api (mints) + gateway (verifies)
-#   DAEMON_AUTH_TOKEN  — chat-api (calls)  + sandbox (checks)
+#
+# The daemon's /turn has no application-layer auth (MYM-35): in prod the E2B
+# sandbox edge gates its public URL; here the `sandbox` container is unpublished
+# on the compose network, so it has no secret and no env file.
 #
 # Note: the agent runs without bwrap — the sandbox container is the isolation
 # boundary (see apps/sandbox-daemon/child-spawn.ts). dev and prod share one spawn
@@ -30,7 +33,7 @@ services:
       # Same compose network — no getHost tunneling, just the service name.
       GATEWAY_PUBLIC_URL: http://gateway:8080
       LOG_LEVEL: info
-    # Secrets: DAEMON_AUTH_TOKEN, LLM_TOKEN_SECRET
+    # Secrets: LLM_TOKEN_SECRET
     env_file:
       - apps/chat-api/.env
     depends_on:
@@ -76,9 +79,8 @@ services:
       dockerfile: apps/sandbox-daemon/Dockerfile
     environment:
       AGENT_SESSION_STORE_ROOT: /session-store
-    # Secrets: DAEMON_AUTH_TOKEN (must match chat-api's)
-    env_file:
-      - apps/sandbox-daemon/.env
+    # No secrets: /turn has no app-layer auth (MYM-35); the container is
+    # unpublished on the compose network.
     volumes:
       - session-store:/session-store
     healthcheck:

--- a/docs/llm-gateway-architecture.html
+++ b/docs/llm-gateway-architecture.html
@@ -307,7 +307,7 @@
       </div></div>
       <div class="step"><div class="num"></div><div class="body">
         <div class="t">chat-api → daemon</div>
-        <div class="d"><code>POST /turn</code> (<code>x-daemon-auth-token</code>) with the system prompt, scope, message, <code class="tok">llm_base_url</code>, <code class="tok">doc_gateway_url</code>, and <code class="tok">llm_token</code>.</div>
+        <div class="d"><code>POST /turn</code> (admitted by the E2B sandbox edge via <code>e2b-traffic-access-token</code>; the daemon itself has no app-layer auth) with the system prompt, scope, message, <code class="tok">llm_base_url</code>, <code class="tok">doc_gateway_url</code>, and <code class="tok">llm_token</code>.</div>
       </div></div>
       <div class="step"><div class="num"></div><div class="body">
         <div class="t">Spawn the agent (srt)</div>


### PR DESCRIPTION
## Problem

After bwrap removal, the agent runs in the daemon's PID namespace, so a prompt-injected, Bash-capable turn could read `/proc/<daemon-pid>/environ` and recover `DAEMON_AUTH_TOKEN`. That token was **shared across every sandbox** and gated a **publicly-reachable** E2B host URL (E2B's `allowPublicTraffic` defaults to `true`) — so the only thing in front of an internet-facing `/turn` was a secret the untrusted agent could exfiltrate.

Fixes [MYM-35](https://linear.app/mymemo-agent/issue/MYM-35/daemon-bearer-token-is-readable-by-the-agent-via-proc-after-bwrap).

## Approach (Option B: remove the secret, make the E2B edge the boundary)

Rather than scrub the token from `/proc` (insufficient — same-uid `/proc/<pid>/mem`/ptrace would still expose a file/stdin-delivered secret), we remove the daemon's app-layer auth entirely:

- **chat-api creates each sandbox with `network: { allowPublicTraffic: false }`** and sends the **per-sandbox** `e2b-traffic-access-token` on every daemon call (`/turn`, `/health`). The token is held only by chat-api, **never injected into the daemon env**, so the agent can't read it via `/proc`; it's unique per sandbox, so a leak compromises only its own (already fully-controlled) sandbox.
- **Fail-fast guard:** chat-api throws + kills the sandbox if `trafficAccessToken` is absent after create (the token is only minted when public traffic is restricted). Thrown *outside* the retryable path so this deterministic invariant isn't retried.
- **`DAEMON_AUTH_TOKEN` deleted** from chat-api config, the daemon env/config, the `/turn` handler, the compose harness, `.env.example`s, and docs. The daemon now holds no secret of its own.
- **Local harness:** the `sandbox` container is unpublished on the compose network (no edge), so it relies on docker-network isolation — consistent with the README's "single-user dev tool, not a security boundary" framing.

## Tradeoff

Prod auth in front of `/turn` now rests on a single flag (`allowPublicTraffic: false`) instead of a defense-in-depth bearer. The fail-fast guard converts a regression on that flag into "no sandbox boots" rather than silent internet exposure. We chose this over keeping the redundant bearer because a leakable secret that does nothing in prod is a liability — and the E2B traffic token is strictly better on every axis (per-sandbox vs shared, edge-enforced vs in-process, never in the daemon env vs `/proc`-readable).

## Verification

- chat-api: **134 tests pass**; sandbox-daemon: **125 tests pass**; both Biome-clean; daemon + agent bundles build.
- `tsc` clean (pre-existing errors in an unrelated probe script only).

## Notes

A `/code-review` (high effort, multi-agent) pass returned no hard correctness bugs. Cleanups it surfaced are applied: shared `e2b-traffic-access-token` header helper/constant, retry-classification of the guard, and stale-doc fixes (Dockerfile comment, architecture HTML).

🤖 Generated with [Claude Code](https://claude.com/claude-code)