### PR TITLE
feat(gateway): add OpenRouter provider adapter behind LLM_PROVIDER (MYM-21)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,7 +179,14 @@ Required:
 - `LLM_TOKEN_SECRET` — must match chat-api's
 
 Optional:
-- `UPSTREAM_BASE_URL` (default: `https://api.anthropic.com`)
+- `UPSTREAM_BASE_URL` (default: `https://api.anthropic.com`) — Anthropic upstream base (`LLM_PROVIDER=anthropic` only)
+- `LLM_PROVIDER` (default: `anthropic`) — which LLM upstream the proxy forwards to: `anthropic` injects the real `x-api-key` and talks to the Anthropic Messages API directly; `openrouter` forwards to OpenRouter's Anthropic-compatible Messages endpoint with a gateway-only bearer key. Gateway-side policy; the sandbox is unaware of it
+- `OPENROUTER_API_KEY` — gateway-only OpenRouter secret, injected as `Authorization: Bearer` on the upstream request only. **Required when `LLM_PROVIDER=openrouter`**; never minted into a token or sent to the sandbox
+- `OPENROUTER_BASE_URL` (e.g. `https://openrouter.ai/api`) — OpenRouter base (trailing slash stripped). **Required when `LLM_PROVIDER=openrouter`**
+- `OPENROUTER_DEFAULT_MODEL` — default model deployment policy picks. **Required when `LLM_PROVIDER=openrouter`** (full model allowlist/rewriting is Task 18)
+- `OPENROUTER_HTTP_REFERER`, `OPENROUTER_APP_TITLE` — optional OpenRouter attribution headers (`HTTP-Referer` / `X-Title`)
 - `DB_PASSWORD` — spliced into `DATABASE_URL` when it is passwordless (the form the platform injects)
 - `DB_SSL` (default: on; set `disable` for a local non-TLS Postgres)
 - `GATEWAY_PORT` (default: 8080)
+
+Compatibility note: the OpenRouter adapter is gated to the proven Claude-SDK-compatible surface — only `/v1/messages` forwards; `/v1/messages/count_tokens` is not part of OpenRouter's Anthropic-compatible surface and fails closed (404). `anthropic` remains the default until OpenRouter compatibility is verified end-to-end.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,7 +174,7 @@ Optional:
 ### gateway
 
 Required:
-- `ANTHROPIC_API_KEY` — the real provider key; lives **only** in this service
+- `ANTHROPIC_API_KEY` — the real Anthropic provider key; lives **only** in this service. **Required only when `LLM_PROVIDER=anthropic`** (the default); an OpenRouter-only deployment does not need it
 - `DATABASE_URL` — read-only connection to the MyMemo KB Postgres; this **read-only KB credential** lives **only** in this service (chat-api has its own, separate `DATABASE_URL` for its writable `mymemo_agent` DB — it is never the KB credential)
 - `LLM_TOKEN_SECRET` — must match chat-api's
 

--- a/apps/gateway/src/env.ts
+++ b/apps/gateway/src/env.ts
@@ -34,6 +34,70 @@ function withSsl(url: string, enabled: boolean): string {
 type Env = Record<string, string | undefined>;
 
 /**
+ * Which upstream the LLM proxy forwards to. `anthropic` (the historical default)
+ * injects `x-api-key` and talks to the Anthropic Messages API directly;
+ * `openrouter` forwards to OpenRouter's Anthropic-compatible Messages endpoint
+ * with a gateway-only bearer key. Selection is a gateway-side policy decision —
+ * the sandbox is unaware of it.
+ */
+export type LlmProviderName = "anthropic" | "openrouter";
+
+/**
+ * OpenRouter upstream settings. Present on `GatewayConfig` only when
+ * `LLM_PROVIDER=openrouter`. `apiKey` lives ONLY here, in the gateway process —
+ * it is never minted into a token or sent to the sandbox.
+ */
+export interface OpenRouterConfig {
+	/** Gateway-only secret; injected as `Authorization: Bearer` on upstream only. */
+	apiKey: string;
+	/** OpenRouter base (trailing slash stripped), e.g. `https://openrouter.ai/api`. */
+	baseUrl: string;
+	/** Default model deployment policy picks when the request leaves it to us. */
+	defaultModel: string;
+	/** Optional OpenRouter attribution header (`HTTP-Referer`). */
+	httpReferer?: string;
+	/** Optional OpenRouter attribution header (`X-Title`). */
+	appTitle?: string;
+}
+
+function parseProvider(value: string | undefined): LlmProviderName {
+	if (!value) return "anthropic";
+	invariant(
+		value === "anthropic" || value === "openrouter",
+		`LLM_PROVIDER must be "anthropic" or "openrouter", got: ${value}`,
+	);
+	return value;
+}
+
+/**
+ * Validate the OpenRouter env block. Only called when `LLM_PROVIDER=openrouter`,
+ * so the three OpenRouter vars are required exactly when the provider is selected
+ * (and ignored otherwise — no dead config to misread).
+ */
+function loadOpenRouterConfig(env: Env): OpenRouterConfig {
+	invariant(
+		env.OPENROUTER_API_KEY,
+		"OPENROUTER_API_KEY is required when LLM_PROVIDER=openrouter",
+	);
+	invariant(
+		env.OPENROUTER_BASE_URL,
+		"OPENROUTER_BASE_URL is required when LLM_PROVIDER=openrouter",
+	);
+	invariant(
+		env.OPENROUTER_DEFAULT_MODEL,
+		"OPENROUTER_DEFAULT_MODEL is required when LLM_PROVIDER=openrouter",
+	);
+	return {
+		apiKey: env.OPENROUTER_API_KEY,
+		// Trailing slash stripped so `${baseUrl}${path}` never yields a double slash.
+		baseUrl: env.OPENROUTER_BASE_URL.replace(/\/+$/, ""),
+		defaultModel: env.OPENROUTER_DEFAULT_MODEL,
+		httpReferer: env.OPENROUTER_HTTP_REFERER,
+		appTitle: env.OPENROUTER_APP_TITLE,
+	};
+}
+
+/**
  * Typed, validated configuration for the merged gateway. Built once from the
  * environment at the entrypoint and injected down (into `createGateway` /
  * `createDb`) so no other module reads global env. This decouples the app from
@@ -48,6 +112,10 @@ export interface GatewayConfig {
 	databaseUrl: string;
 	/** Anthropic upstream base; trailing slash stripped. */
 	upstreamBaseUrl: string;
+	/** Which upstream the LLM proxy forwards to (gateway-side policy). */
+	llmProvider: LlmProviderName;
+	/** OpenRouter settings; present iff `llmProvider === "openrouter"`. */
+	openRouter?: OpenRouterConfig;
 	/** Dedicated port for Bun.serve (not the generic PORT). */
 	gatewayPort: number;
 }
@@ -66,6 +134,8 @@ export function loadConfigFromEnv(env: Env): GatewayConfig {
 	invariant(env.DATABASE_URL, "DATABASE_URL is required");
 	invariant(env.LLM_TOKEN_SECRET, "LLM_TOKEN_SECRET is required");
 
+	const llmProvider = parseProvider(env.LLM_PROVIDER);
+
 	return {
 		anthropicApiKey: env.ANTHROPIC_API_KEY,
 		llmTokenSecret: env.LLM_TOKEN_SECRET,
@@ -79,6 +149,11 @@ export function loadConfigFromEnv(env: Env): GatewayConfig {
 		upstreamBaseUrl: (
 			env.UPSTREAM_BASE_URL || "https://api.anthropic.com"
 		).replace(/\/+$/, ""),
+		llmProvider,
+		// Parsed only when selected, so the OpenRouter vars are required exactly
+		// when the provider needs them.
+		openRouter:
+			llmProvider === "openrouter" ? loadOpenRouterConfig(env) : undefined,
 		gatewayPort: parsePort(env.GATEWAY_PORT, 8080),
 	};
 }

--- a/apps/gateway/src/env.ts
+++ b/apps/gateway/src/env.ts
@@ -130,14 +130,25 @@ export interface GatewayConfig {
  * another co-located service reading the same injected env.
  */
 export function loadConfigFromEnv(env: Env): GatewayConfig {
-	invariant(env.ANTHROPIC_API_KEY, "ANTHROPIC_API_KEY is required");
 	invariant(env.DATABASE_URL, "DATABASE_URL is required");
 	invariant(env.LLM_TOKEN_SECRET, "LLM_TOKEN_SECRET is required");
 
 	const llmProvider = parseProvider(env.LLM_PROVIDER);
 
+	// ANTHROPIC_API_KEY is the anthropic provider's upstream credential, so it is
+	// required only when that provider is selected — an OpenRouter-only deployment
+	// must not be forced to supply a dummy Anthropic key it never uses.
+	if (llmProvider === "anthropic") {
+		invariant(
+			env.ANTHROPIC_API_KEY,
+			"ANTHROPIC_API_KEY is required when LLM_PROVIDER=anthropic",
+		);
+	}
+
 	return {
-		anthropicApiKey: env.ANTHROPIC_API_KEY,
+		// "" when the openrouter provider is selected (the anthropic provider — the
+		// only reader — is never built in that case, so the key is never sent).
+		anthropicApiKey: env.ANTHROPIC_API_KEY ?? "",
 		llmTokenSecret: env.LLM_TOKEN_SECRET,
 		// DB_PASSWORD is spliced in when DATABASE_URL is passwordless; TLS is on by
 		// default (set DB_SSL=disable for a local non-TLS Postgres).

--- a/apps/gateway/src/llm/openrouter.live.test.ts
+++ b/apps/gateway/src/llm/openrouter.live.test.ts
@@ -1,0 +1,124 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { mintLlmToken } from "@mymemo/llm-token";
+import type { Db } from "../db/client";
+import { type GatewayConfig, loadConfigFromEnv } from "../env";
+import { createGateway } from "../server";
+
+/**
+ * LIVE OpenRouter compatibility smoke (Task 17 / MYM-21, Level A).
+ *
+ * Proves the gateway's OpenRouter adapter works against the REAL OpenRouter
+ * Anthropic-compatible Messages endpoint: a streaming `/v1/messages` request with
+ * a valid LLM token forwards upstream with the injected bearer key and a
+ * real Anthropic-shaped SSE response streams back. The unit suite
+ * (`openrouter.test.ts`) covers the same surface with a mocked fetch; this one
+ * exercises the actual provider.
+ *
+ * Gated on OPENROUTER_IT so the normal suite skips it (no network, no spend). Run:
+ *   OPENROUTER_IT=1 \
+ *   OPENROUTER_API_KEY=sk-or-... \
+ *   OPENROUTER_MODEL=anthropic/claude-3.5-haiku \
+ *   bun test apps/gateway/src/llm/openrouter.live.test.ts
+ *
+ * The model MUST be a namespaced OpenRouter id (e.g. `anthropic/claude-3.5-haiku`);
+ * this test sends it directly, sidestepping the bare-model-id rewrite that is
+ * Task 18 (MYM-22). Defaults to a cheap model if OPENROUTER_MODEL is unset.
+ */
+
+const RUN = !!Bun.env.OPENROUTER_IT && !!Bun.env.OPENROUTER_API_KEY;
+const SECRET = "test-secret";
+const MODEL = Bun.env.OPENROUTER_MODEL || "anthropic/claude-3.5-haiku";
+
+// LLM path never touches the DB; an unused fake satisfies the seam.
+const fakeDb: Db = {
+	async query() {
+		return [];
+	},
+};
+
+let app: ReturnType<typeof createGateway>;
+let apiKey = "";
+
+beforeAll(() => {
+	if (!RUN) return;
+	// Build config through the real env loader so the OpenRouter wiring
+	// (LLM_PROVIDER + OPENROUTER_*) is exercised end-to-end. The provider key is
+	// the only true secret; the rest are local stubs (we sign and verify the LLM
+	// token with the same injected SECRET, and the DB is never reached).
+	const config: GatewayConfig = loadConfigFromEnv({
+		ANTHROPIC_API_KEY: "unused-anthropic-key",
+		DATABASE_URL: "postgresql://stub@localhost/stub",
+		DB_SSL: "disable",
+		LLM_TOKEN_SECRET: SECRET,
+		LLM_PROVIDER: "openrouter",
+		OPENROUTER_API_KEY: Bun.env.OPENROUTER_API_KEY,
+		OPENROUTER_BASE_URL:
+			Bun.env.OPENROUTER_BASE_URL || "https://openrouter.ai/api",
+		OPENROUTER_DEFAULT_MODEL: MODEL,
+		OPENROUTER_HTTP_REFERER: "https://mymemo.example",
+		OPENROUTER_APP_TITLE: "MyMemo",
+	});
+	apiKey = config.openRouter?.apiKey ?? "";
+	app = createGateway(config, fakeDb);
+});
+
+function token(): string {
+	return mintLlmToken(
+		{ aud: "llm", userId: "it-user", sandboxId: "it-sbx", requestId: "it-req" },
+		SECRET,
+	);
+}
+
+describe.skipIf(!RUN)("gateway · openrouter LIVE compatibility smoke", () => {
+	it("streams a real Anthropic-shaped SSE response from OpenRouter", async () => {
+		const res = await app.request("/v1/messages", {
+			method: "POST",
+			headers: {
+				authorization: `Bearer ${token()}`,
+				"anthropic-version": "2023-06-01",
+				"content-type": "application/json",
+				accept: "text/event-stream",
+			},
+			body: JSON.stringify({
+				model: MODEL,
+				max_tokens: 16,
+				stream: true,
+				messages: [
+					{ role: "user", content: "Reply with the single word: pong" },
+				],
+			}),
+		});
+
+		expect(res.status).toBe(200);
+		const body = await res.text();
+		// Anthropic Messages streaming shape — the SDK relies on these event types.
+		expect(body).toContain("event: message_start");
+		expect(body).toContain("content_block_delta");
+		expect(body).toContain("message_stop");
+		// The injected provider key must never appear in the streamed response.
+		expect(body).not.toContain(apiKey);
+	}, 30_000);
+
+	it("returns a non-streaming Anthropic-shaped message from OpenRouter", async () => {
+		const res = await app.request("/v1/messages", {
+			method: "POST",
+			headers: {
+				authorization: `Bearer ${token()}`,
+				"anthropic-version": "2023-06-01",
+				"content-type": "application/json",
+			},
+			body: JSON.stringify({
+				model: MODEL,
+				max_tokens: 16,
+				messages: [
+					{ role: "user", content: "Reply with the single word: pong" },
+				],
+			}),
+		});
+
+		expect(res.status).toBe(200);
+		const json = (await res.json()) as { type?: string; role?: string };
+		expect(json.type).toBe("message");
+		expect(json.role).toBe("assistant");
+	}, 30_000);
+});

--- a/apps/gateway/src/llm/openrouter.live.test.ts
+++ b/apps/gateway/src/llm/openrouter.live.test.ts
@@ -25,9 +25,16 @@ import { createGateway } from "../server";
  * Task 18 (MYM-22). Defaults to a cheap model if OPENROUTER_MODEL is unset.
  */
 
-const RUN = !!Bun.env.OPENROUTER_IT && !!Bun.env.OPENROUTER_API_KEY;
+// Gate purely on the opt-in flag (matching the DOC_GATEWAY_IT convention). If
+// the flag is set but the key is missing, beforeAll fails LOUDLY via
+// loadConfigFromEnv rather than silently skipping — a skipped run must mean "not
+// asked for", never "asked for but misconfigured".
+const RUN = !!Bun.env.OPENROUTER_IT;
 const SECRET = "test-secret";
 const MODEL = Bun.env.OPENROUTER_MODEL || "anthropic/claude-haiku-4.5";
+// Read once at module load so the key-leak assertion compares against the real
+// secret without mirroring it into mutable state.
+const API_KEY = Bun.env.OPENROUTER_API_KEY ?? "";
 
 // LLM path never touches the DB; an unused fake satisfies the seam.
 const fakeDb: Db = {
@@ -37,7 +44,6 @@ const fakeDb: Db = {
 };
 
 let app: ReturnType<typeof createGateway>;
-let apiKey = "";
 
 beforeAll(() => {
 	if (!RUN) return;
@@ -58,7 +64,6 @@ beforeAll(() => {
 		OPENROUTER_HTTP_REFERER: "https://mymemo.example",
 		OPENROUTER_APP_TITLE: "MyMemo",
 	});
-	apiKey = config.openRouter?.apiKey ?? "";
 	app = createGateway(config, fakeDb);
 });
 
@@ -91,12 +96,17 @@ describe.skipIf(!RUN)("gateway · openrouter LIVE compatibility smoke", () => {
 
 		expect(res.status).toBe(200);
 		const body = await res.text();
-		// Anthropic Messages streaming shape — the SDK relies on these event types.
+		// Assert the protocol-guaranteed envelope of an Anthropic streamed message
+		// (always emitted, regardless of how the model chunks its output) plus that
+		// a content block was opened. Avoid asserting `content_block_delta`
+		// specifically — whether/how text deltas chunk is model behavior we don't
+		// control, so requiring it would make this live test flaky.
 		expect(body).toContain("event: message_start");
-		expect(body).toContain("content_block_delta");
-		expect(body).toContain("message_stop");
+		expect(body).toContain("event: content_block_start");
+		expect(body).toContain("event: message_stop");
 		// The injected provider key must never appear in the streamed response.
-		expect(body).not.toContain(apiKey);
+		expect(API_KEY.length).toBeGreaterThan(0);
+		expect(body).not.toContain(API_KEY);
 	}, 30_000);
 
 	it("returns a non-streaming Anthropic-shaped message from OpenRouter", async () => {

--- a/apps/gateway/src/llm/openrouter.live.test.ts
+++ b/apps/gateway/src/llm/openrouter.live.test.ts
@@ -17,17 +17,17 @@ import { createGateway } from "../server";
  * Gated on OPENROUTER_IT so the normal suite skips it (no network, no spend). Run:
  *   OPENROUTER_IT=1 \
  *   OPENROUTER_API_KEY=sk-or-... \
- *   OPENROUTER_MODEL=anthropic/claude-3.5-haiku \
+ *   OPENROUTER_MODEL=anthropic/claude-haiku-4.5 \
  *   bun test apps/gateway/src/llm/openrouter.live.test.ts
  *
- * The model MUST be a namespaced OpenRouter id (e.g. `anthropic/claude-3.5-haiku`);
+ * The model MUST be a namespaced OpenRouter id (e.g. `anthropic/claude-haiku-4.5`);
  * this test sends it directly, sidestepping the bare-model-id rewrite that is
  * Task 18 (MYM-22). Defaults to a cheap model if OPENROUTER_MODEL is unset.
  */
 
 const RUN = !!Bun.env.OPENROUTER_IT && !!Bun.env.OPENROUTER_API_KEY;
 const SECRET = "test-secret";
-const MODEL = Bun.env.OPENROUTER_MODEL || "anthropic/claude-3.5-haiku";
+const MODEL = Bun.env.OPENROUTER_MODEL || "anthropic/claude-haiku-4.5";
 
 // LLM path never touches the DB; an unused fake satisfies the seam.
 const fakeDb: Db = {

--- a/apps/gateway/src/llm/openrouter.test.ts
+++ b/apps/gateway/src/llm/openrouter.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
+import { mintLlmToken } from "@mymemo/llm-token";
+import type { Db } from "../db/client";
+import { type GatewayConfig, loadConfigFromEnv } from "../env";
+import { createGateway } from "../server";
+
+/**
+ * OpenRouter provider adapter (Task 17 / MYM-21). Asserts the gateway-side policy
+ * switch to OpenRouter: upstream URL construction, credential injection, streaming
+ * forwarding through the unchanged Claude-SDK compatibility surface, the
+ * compatibility gate (unsupported paths fail closed), and that the OpenRouter key
+ * never reaches the caller. The Anthropic path is covered in `server.test.ts`.
+ */
+
+const OPENROUTER_KEY = "sk-or-secret-key";
+const SECRET = "test-secret";
+
+const config: GatewayConfig = {
+	anthropicApiKey: "test-anthropic-key",
+	llmTokenSecret: SECRET,
+	databaseUrl: "postgres://test@localhost/test",
+	upstreamBaseUrl: "https://api.anthropic.com",
+	llmProvider: "openrouter",
+	openRouter: {
+		apiKey: OPENROUTER_KEY,
+		baseUrl: "https://openrouter.ai/api",
+		defaultModel: "anthropic/claude-sonnet-4.5",
+		httpReferer: "https://mymemo.example",
+		appTitle: "MyMemo",
+	},
+	gatewayPort: 8080,
+};
+
+// The document reader is not exercised here; an unused fake Db satisfies the seam.
+const fakeDb: Db = {
+	async query() {
+		return [];
+	},
+};
+const app = createGateway(config, fakeDb);
+
+function llmToken(): string {
+	return mintLlmToken(
+		{ aud: "llm", userId: "u1", sandboxId: "sbx-1", requestId: "req-1" },
+		SECRET,
+	);
+}
+
+describe("gateway · openrouter provider", () => {
+	let fetchSpy: ReturnType<typeof spyOn> | undefined;
+	afterEach(() => fetchSpy?.mockRestore());
+
+	it("forwards /v1/messages to the OpenRouter base URL", async () => {
+		fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response("{}", { status: 200 }),
+		);
+		const res = await app.request("/v1/messages", {
+			method: "POST",
+			headers: {
+				authorization: `Bearer ${llmToken()}`,
+				"content-type": "application/json",
+			},
+			body: JSON.stringify({ model: "claude-sonnet-4-6", messages: [] }),
+		});
+		expect(res.status).toBe(200);
+		const [url] = fetchSpy.mock.calls[0] as [string, RequestInit];
+		expect(url).toBe("https://openrouter.ai/api/v1/messages");
+	});
+
+	it("injects the OpenRouter bearer + attribution headers, never x-api-key", async () => {
+		fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response("{}", { status: 200 }),
+		);
+		await app.request("/v1/messages", {
+			method: "POST",
+			headers: {
+				authorization: `Bearer ${llmToken()}`,
+				"anthropic-version": "2023-06-01",
+				"content-type": "application/json",
+			},
+			body: "{}",
+		});
+		const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+		const sent = new Headers(init.headers);
+		expect(sent.get("authorization")).toBe(`Bearer ${OPENROUTER_KEY}`);
+		expect(sent.get("http-referer")).toBe("https://mymemo.example");
+		expect(sent.get("x-title")).toBe("MyMemo");
+		// The Anthropic credential header must not be set for OpenRouter.
+		expect(sent.has("x-api-key")).toBe(false);
+		// The Claude SDK's anthropic-version still forwards (compatibility surface).
+		expect(sent.get("anthropic-version")).toBe("2023-06-01");
+	});
+
+	it("streams an SSE response through unchanged (Claude SDK compatibility smoke)", async () => {
+		const chunks = [
+			'event: message_start\ndata: {"type":"message_start"}\n\n',
+			'event: content_block_delta\ndata: {"type":"content_block_delta"}\n\n',
+			"event: message_stop\ndata: {}\n\n",
+		];
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				const enc = new TextEncoder();
+				for (const c of chunks) controller.enqueue(enc.encode(c));
+				controller.close();
+			},
+		});
+		fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(stream, {
+				status: 200,
+				headers: { "content-type": "text/event-stream" },
+			}),
+		);
+		const res = await app.request("/v1/messages", {
+			method: "POST",
+			headers: {
+				authorization: `Bearer ${llmToken()}`,
+				"content-type": "application/json",
+				accept: "text/event-stream",
+			},
+			body: JSON.stringify({ model: "x", messages: [], stream: true }),
+		});
+		expect(res.status).toBe(200);
+		expect(res.headers.get("content-type")).toBe("text/event-stream");
+		expect(await res.text()).toBe(chunks.join(""));
+	});
+
+	it("fails closed (404) on count_tokens — outside the OpenRouter compat surface", async () => {
+		fetchSpy = spyOn(globalThis, "fetch").mockRejectedValue(
+			new Error("must not forward an unsupported path"),
+		);
+		const res = await app.request("/v1/messages/count_tokens", {
+			method: "POST",
+			headers: { authorization: `Bearer ${llmToken()}` },
+			body: "{}",
+		});
+		expect(res.status).toBe(404);
+		expect(fetchSpy).not.toHaveBeenCalled();
+		expect(JSON.stringify(await res.json())).toContain("openrouter");
+	});
+
+	it("rejects a documents-audience token without forwarding or leaking the key", async () => {
+		fetchSpy = spyOn(globalThis, "fetch").mockRejectedValue(
+			new Error("must not forward"),
+		);
+		const docToken = mintLlmToken(
+			{
+				aud: "documents",
+				userId: "u1",
+				sandboxId: "sbx-1",
+				requestId: "req-1",
+			},
+			SECRET,
+		);
+		const res = await app.request("/v1/messages", {
+			method: "POST",
+			headers: { authorization: `Bearer ${docToken}` },
+			body: "{}",
+		});
+		expect(res.status).toBe(401);
+		expect(fetchSpy).not.toHaveBeenCalled();
+		expect(JSON.stringify(await res.json())).not.toContain(OPENROUTER_KEY);
+	});
+
+	it("normalizes an upstream transport failure to 502 without leaking the key", async () => {
+		fetchSpy = spyOn(globalThis, "fetch").mockRejectedValue(
+			new Error(`connect failed to ${OPENROUTER_KEY}@host`),
+		);
+		const res = await app.request("/v1/messages", {
+			method: "POST",
+			headers: {
+				authorization: `Bearer ${llmToken()}`,
+				"content-type": "application/json",
+			},
+			body: "{}",
+		});
+		expect(res.status).toBe(502);
+		const body = JSON.stringify(await res.json());
+		// Normalized to a fixed message — the raw upstream error (which here carries
+		// the key) is logged, never returned to the untrusted sandbox.
+		expect(body).toContain("upstream request failed");
+		expect(body).not.toContain(OPENROUTER_KEY);
+		expect(body).not.toContain("@host");
+	});
+});
+
+describe("loadConfigFromEnv · LLM_PROVIDER", () => {
+	const base = {
+		ANTHROPIC_API_KEY: "ak",
+		DATABASE_URL: "postgres://u@h/db",
+		LLM_TOKEN_SECRET: "s",
+		DB_SSL: "disable",
+	};
+
+	it("defaults to the anthropic provider with no openRouter block", () => {
+		const cfg = loadConfigFromEnv({ ...base });
+		expect(cfg.llmProvider).toBe("anthropic");
+		expect(cfg.openRouter).toBeUndefined();
+	});
+
+	it("parses the openrouter block and strips a trailing slash from the base URL", () => {
+		const cfg = loadConfigFromEnv({
+			...base,
+			LLM_PROVIDER: "openrouter",
+			OPENROUTER_API_KEY: "sk-or",
+			OPENROUTER_BASE_URL: "https://openrouter.ai/api/",
+			OPENROUTER_DEFAULT_MODEL: "anthropic/claude-sonnet-4.5",
+			OPENROUTER_HTTP_REFERER: "https://mymemo.example",
+			OPENROUTER_APP_TITLE: "MyMemo",
+		});
+		expect(cfg.llmProvider).toBe("openrouter");
+		expect(cfg.openRouter).toEqual({
+			apiKey: "sk-or",
+			baseUrl: "https://openrouter.ai/api",
+			defaultModel: "anthropic/claude-sonnet-4.5",
+			httpReferer: "https://mymemo.example",
+			appTitle: "MyMemo",
+		});
+	});
+
+	it("rejects an unknown provider", () => {
+		expect(() =>
+			loadConfigFromEnv({ ...base, LLM_PROVIDER: "bedrock" }),
+		).toThrow(/LLM_PROVIDER/);
+	});
+
+	it("requires the OpenRouter vars when the provider is selected", () => {
+		expect(() =>
+			loadConfigFromEnv({ ...base, LLM_PROVIDER: "openrouter" }),
+		).toThrow(/OPENROUTER_API_KEY/);
+		expect(() =>
+			loadConfigFromEnv({
+				...base,
+				LLM_PROVIDER: "openrouter",
+				OPENROUTER_API_KEY: "sk-or",
+			}),
+		).toThrow(/OPENROUTER_BASE_URL/);
+		expect(() =>
+			loadConfigFromEnv({
+				...base,
+				LLM_PROVIDER: "openrouter",
+				OPENROUTER_API_KEY: "sk-or",
+				OPENROUTER_BASE_URL: "https://openrouter.ai/api",
+			}),
+		).toThrow(/OPENROUTER_DEFAULT_MODEL/);
+	});
+});

--- a/apps/gateway/src/llm/openrouter.test.ts
+++ b/apps/gateway/src/llm/openrouter.test.ts
@@ -223,6 +223,25 @@ describe("loadConfigFromEnv · LLM_PROVIDER", () => {
 		).toThrow(/LLM_PROVIDER/);
 	});
 
+	it("requires ANTHROPIC_API_KEY for the anthropic provider", () => {
+		const { ANTHROPIC_API_KEY: _omit, ...noKey } = base;
+		expect(() => loadConfigFromEnv(noKey)).toThrow(/ANTHROPIC_API_KEY/);
+	});
+
+	it("does NOT require ANTHROPIC_API_KEY for the openrouter provider", () => {
+		const { ANTHROPIC_API_KEY: _omit, ...noKey } = base;
+		const cfg = loadConfigFromEnv({
+			...noKey,
+			LLM_PROVIDER: "openrouter",
+			OPENROUTER_API_KEY: "sk-or",
+			OPENROUTER_BASE_URL: "https://openrouter.ai/api",
+			OPENROUTER_DEFAULT_MODEL: "anthropic/claude-sonnet-4.5",
+		});
+		expect(cfg.llmProvider).toBe("openrouter");
+		expect(cfg.anthropicApiKey).toBe("");
+		expect(cfg.openRouter?.apiKey).toBe("sk-or");
+	});
+
 	it("requires the OpenRouter vars when the provider is selected", () => {
 		expect(() =>
 			loadConfigFromEnv({ ...base, LLM_PROVIDER: "openrouter" }),

--- a/apps/gateway/src/llm/providers/anthropic.ts
+++ b/apps/gateway/src/llm/providers/anthropic.ts
@@ -1,0 +1,22 @@
+import type { GatewayConfig } from "../../env";
+import type { LlmProvider } from "./types";
+
+// Anthropic Messages endpoints the proxy will forward. count_tokens is part of
+// Anthropic's compatibility surface (and used by the Claude SDK), so it is
+// allowed here.
+const ANTHROPIC_PATHS = new Set(["/v1/messages", "/v1/messages/count_tokens"]);
+
+/**
+ * The historical default upstream: talk to the Anthropic Messages API directly,
+ * authenticating with the real `x-api-key`. This preserves the exact behavior the
+ * gateway had before provider selection existed.
+ */
+export function anthropicProvider(config: GatewayConfig): LlmProvider {
+	return {
+		name: "anthropic",
+		supportsPath: (path) => ANTHROPIC_PATHS.has(path),
+		upstreamUrl: (path, search) => `${config.upstreamBaseUrl}${path}${search}`,
+		authorizeUpstream: (headers) =>
+			headers.set("x-api-key", config.anthropicApiKey),
+	};
+}

--- a/apps/gateway/src/llm/providers/index.ts
+++ b/apps/gateway/src/llm/providers/index.ts
@@ -1,0 +1,26 @@
+import invariant from "tiny-invariant";
+import type { GatewayConfig } from "../../env";
+import { anthropicProvider } from "./anthropic";
+import { openRouterProvider } from "./openrouter";
+import type { LlmProvider } from "./types";
+
+export type { LlmProvider } from "./types";
+
+/**
+ * Pick the LLM upstream provider from gateway config. Built once at route
+ * registration and closed over by the proxy handler, so provider selection is a
+ * single startup decision rather than a per-request branch.
+ */
+export function selectLlmProvider(config: GatewayConfig): LlmProvider {
+	if (config.llmProvider === "openrouter") {
+		// loadConfigFromEnv guarantees this is present when the provider is
+		// openrouter; the invariant keeps the type narrow and fails loudly if a
+		// hand-built config skips it.
+		invariant(
+			config.openRouter,
+			"openRouter config is required when LLM_PROVIDER=openrouter",
+		);
+		return openRouterProvider(config.openRouter);
+	}
+	return anthropicProvider(config);
+}

--- a/apps/gateway/src/llm/providers/openrouter.ts
+++ b/apps/gateway/src/llm/providers/openrouter.ts
@@ -1,0 +1,29 @@
+import type { OpenRouterConfig } from "../../env";
+import type { LlmProvider } from "./types";
+
+// OpenRouter exposes an Anthropic-compatible Messages endpoint, so the Claude
+// SDK's `/v1/messages` path forwards through unchanged. `count_tokens` is NOT
+// part of that compatibility surface — it fails closed here (a clear 404) rather
+// than being forwarded and erroring opaquely upstream. This is the explicit
+// Claude-SDK compatibility gate: only the proven-compatible path is forwarded.
+const OPENROUTER_PATHS = new Set(["/v1/messages"]);
+
+/**
+ * OpenRouter upstream. The gateway-only `apiKey` is injected as a bearer token on
+ * the upstream request only; the sandbox's own bearer token was already consumed
+ * by token verification and is never forwarded. Optional attribution headers
+ * (`HTTP-Referer` / `X-Title`) are OpenRouter's mechanism for app identification.
+ */
+export function openRouterProvider(config: OpenRouterConfig): LlmProvider {
+	return {
+		name: "openrouter",
+		supportsPath: (path) => OPENROUTER_PATHS.has(path),
+		upstreamUrl: (path, search) => `${config.baseUrl}${path}${search}`,
+		authorizeUpstream: (headers) => {
+			// Bearer auth replaces Anthropic's x-api-key.
+			headers.set("authorization", `Bearer ${config.apiKey}`);
+			if (config.httpReferer) headers.set("http-referer", config.httpReferer);
+			if (config.appTitle) headers.set("x-title", config.appTitle);
+		},
+	};
+}

--- a/apps/gateway/src/llm/providers/types.ts
+++ b/apps/gateway/src/llm/providers/types.ts
@@ -1,0 +1,28 @@
+import type { LlmProviderName } from "../../env";
+
+/**
+ * A provider abstraction over the LLM upstream. The proxy stays provider-agnostic:
+ * it verifies the token and normalizes the path, then asks the provider whether
+ * the path is on its compatibility surface, how to build the upstream URL, and
+ * which credentials/headers to inject. Only the provider knows its own auth
+ * scheme and supported paths, so the upstream secret is set in exactly one place
+ * (`authorizeUpstream`) and never leaks into the proxy or the response.
+ */
+export interface LlmProvider {
+	/** Provider name, for logging and clear error messages. */
+	readonly name: LlmProviderName;
+	/**
+	 * Whether this provider's Claude-SDK-compatibility surface supports the given
+	 * normalized request path. Paths it cannot honor fail closed in the proxy
+	 * (a clear 404) rather than being forwarded and erroring opaquely upstream.
+	 */
+	supportsPath(path: string): boolean;
+	/** Build the upstream URL for a normalized path + raw query string. */
+	upstreamUrl(path: string, search: string): string;
+	/**
+	 * Inject upstream credentials and provider-required headers onto the outgoing
+	 * request, mutating `headers` in place. The upstream secret is only ever set
+	 * here, on the request to the provider — never echoed back to the caller.
+	 */
+	authorizeUpstream(headers: Headers): void;
+}

--- a/apps/gateway/src/llm/proxy.ts
+++ b/apps/gateway/src/llm/proxy.ts
@@ -1,24 +1,27 @@
 import type { Context } from "hono";
 import { bearerClaims } from "../auth/bearer";
 import type { GatewayConfig } from "../env";
+import type { LlmProvider } from "./providers";
 
 /**
  * LLM proxy. Sandboxed agents point the Claude binary at the gateway via
  * ANTHROPIC_BASE_URL and authenticate with a short-lived bearer token. The agent
- * holds no provider key: we validate the token, inject the real `x-api-key`, and
- * stream the upstream response back. Scope is narrow — only the Anthropic
- * Messages endpoints are proxied and only an allowlist of request headers is
- * forwarded, so a leaked token cannot reach files/batches/admin endpoints and no
- * client headers leak upstream.
+ * holds no provider key: we validate the token, hand the request to the selected
+ * provider (which injects the real upstream credential), and stream the upstream
+ * response back. Scope is narrow — only the provider's compatibility surface is
+ * forwarded and only an allowlist of request headers is sent, so a leaked token
+ * cannot reach files/batches/admin endpoints and no client headers leak upstream.
+ *
+ * The upstream provider (Anthropic direct vs. OpenRouter's Anthropic-compatible
+ * endpoint) is a gateway-side policy decision; the sandbox is unaware of it. Both
+ * speak the Anthropic Messages wire format, so the SDK compatibility surface is
+ * unchanged and the streamed response forwards through verbatim.
  */
 
-// Paths the LLM proxy will forward (after slash-normalization). Everything else
-// 404s even with a valid token.
-const ALLOWED_PATHS = new Set(["/v1/messages", "/v1/messages/count_tokens"]);
-
-// The only request headers forwarded upstream. Authorization is replaced by
-// x-api-key; everything else (host, content-length, accept-encoding, cookie, …)
-// is dropped so fetch controls compression and nothing leaks to Anthropic.
+// The only request headers forwarded upstream. The provider replaces auth
+// (x-api-key or Authorization); everything else (host, content-length,
+// accept-encoding, cookie, …) is dropped so fetch controls compression and
+// nothing leaks upstream.
 const FORWARD_REQUEST_HEADERS = [
 	"anthropic-version",
 	"anthropic-beta",
@@ -36,7 +39,11 @@ const RESPONSE_DROP_HEADERS = new Set([
 	"connection",
 ]);
 
-export async function proxyToAnthropic(c: Context, config: GatewayConfig) {
+export async function proxyLlm(
+	c: Context,
+	config: GatewayConfig,
+	provider: LlmProvider,
+) {
 	const claims = bearerClaims(c, config.llmTokenSecret, "llm");
 	if (!claims) {
 		return c.json(
@@ -57,13 +64,16 @@ export async function proxyToAnthropic(c: Context, config: GatewayConfig) {
 	const url = new URL(c.req.url);
 	let path = url.pathname.replace(/\/{2,}/g, "/");
 	if (path.length > 1 && path.endsWith("/")) path = path.slice(0, -1);
-	if (!ALLOWED_PATHS.has(path)) {
+	// The provider gates its own compatibility surface: a path the upstream cannot
+	// honor (e.g. count_tokens on OpenRouter) fails closed here with a clear 404
+	// instead of forwarding and erroring opaquely upstream.
+	if (!provider.supportsPath(path)) {
 		return c.json(
 			{
 				type: "error",
 				error: {
 					type: "not_found_error",
-					message: `unsupported path: ${path}`,
+					message: `unsupported path for provider ${provider.name}: ${path}`,
 				},
 			},
 			404,
@@ -78,9 +88,9 @@ export async function proxyToAnthropic(c: Context, config: GatewayConfig) {
 		const value = c.req.header(name);
 		if (value) headers.set(name, value);
 	}
-	headers.set("x-api-key", config.anthropicApiKey);
+	provider.authorizeUpstream(headers);
 
-	const target = `${config.upstreamBaseUrl}${path}${url.search}`;
+	const target = provider.upstreamUrl(path, url.search);
 	const method = c.req.method;
 	const hasBody = method !== "GET" && method !== "HEAD";
 	const init: RequestInit & { duplex?: "half" } = { method, headers };
@@ -95,14 +105,15 @@ export async function proxyToAnthropic(c: Context, config: GatewayConfig) {
 	try {
 		upstream = await fetch(target, init);
 	} catch (err) {
-		const message = err instanceof Error ? err.message : String(err);
+		// Normalize to a fixed, non-secret-bearing message. The raw transport error
+		// is logged for operators but never echoed to the untrusted sandbox agent —
+		// it can carry upstream URLs/hosts (and, defensively, must never carry the
+		// injected provider credential).
+		console.error(`[gateway] ${provider.name} upstream request failed:`, err);
 		return c.json(
 			{
 				type: "error",
-				error: {
-					type: "api_error",
-					message: `upstream request failed: ${message}`,
-				},
+				error: { type: "api_error", message: "upstream request failed" },
 			},
 			502,
 		);

--- a/apps/gateway/src/llm/routes.ts
+++ b/apps/gateway/src/llm/routes.ts
@@ -1,6 +1,7 @@
 import type { Hono } from "hono";
 import type { GatewayConfig } from "../env";
-import { proxyToAnthropic } from "./proxy";
+import { selectLlmProvider } from "./providers";
+import { proxyLlm } from "./proxy";
 
 /**
  * Register the LLM proxy as the catch-all. MUST be registered last (after the
@@ -8,7 +9,10 @@ import { proxyToAnthropic } from "./proxy";
  * every path; see `server.ts`.
  */
 export function registerLlmRoutes(app: Hono, config: GatewayConfig): void {
+	// Provider selection is a single startup decision; the proxy handler closes
+	// over it rather than re-resolving per request.
+	const provider = selectLlmProvider(config);
 	// A trailing-slash base URL (`…//v1/messages`) still routes here and gets
 	// normalized inside the proxy.
-	app.all("*", (c) => proxyToAnthropic(c, config));
+	app.all("*", (c) => proxyLlm(c, config, provider));
 }

--- a/apps/gateway/src/server.test.ts
+++ b/apps/gateway/src/server.test.ts
@@ -11,6 +11,7 @@ const config: GatewayConfig = {
 	llmTokenSecret: "test-secret",
 	databaseUrl: "postgres://test@localhost/test",
 	upstreamBaseUrl: "https://api.anthropic.com",
+	llmProvider: "anthropic",
 	gatewayPort: 8080,
 };
 const SECRET = config.llmTokenSecret;


### PR DESCRIPTION
## Summary

Task 17 (MYM-21, Milestone 6). Adds OpenRouter as a selectable LLM upstream owned by the gateway, behind an explicit Claude-SDK compatibility gate. Provider selection is a gateway-side policy decision — **the sandbox is unaware of it and never holds the OpenRouter key**.

- `LLM_PROVIDER=anthropic` (default) — unchanged behavior: inject the real `x-api-key`, talk to the Anthropic Messages API.
- `LLM_PROVIDER=openrouter` — forward `/v1/messages` to OpenRouter's Anthropic-compatible endpoint with a gateway-only `Authorization: Bearer` key, plus optional `HTTP-Referer` / `X-Title` attribution headers.

Both speak the Anthropic Messages wire format, so the SDK compatibility surface and SSE streaming forward through verbatim.

## Compatibility gate

The OpenRouter adapter only forwards the proven-compatible path: `/v1/messages`. `/v1/messages/count_tokens` is **not** part of OpenRouter's Anthropic-compatible surface and fails closed (404, no upstream call) rather than erroring opaquely. `anthropic` stays the default until OpenRouter is verified end-to-end.

## Secret handling

- The injected upstream credential is set in exactly one place (`provider.authorizeUpstream`) and never echoed to the caller.
- Upstream **transport errors are now normalized** to a fixed `"upstream request failed"` message and logged for operators, rather than interpolating the raw error into the response sent to the untrusted sandbox. (Applies to both providers.)

## Design

- `env.ts` — parse/validate `LLM_PROVIDER` + `OPENROUTER_{API_KEY,BASE_URL,DEFAULT_MODEL}` (+ optional `HTTP_REFERER`/`APP_TITLE`). OpenRouter vars are required **only** when that provider is selected.
- `llm/providers/` — `LlmProvider` seam (`supportsPath` / `upstreamUrl` / `authorizeUpstream`), `anthropic` + `openrouter` adapters, and `selectLlmProvider`. Provider is resolved once at route registration and closed over by the handler.
- `llm/proxy.ts` — `proxyToAnthropic` → `proxyLlm(c, config, provider)`, now provider-driven.

> Note: full model allowlist/rewriting and usage attribution are **Task 18 (MYM-22)**, intentionally out of scope here. `OPENROUTER_DEFAULT_MODEL` is wired into config but policy lives in the next task.

## Tests (`apps/gateway/src/llm/openrouter.test.ts`, 11 new cases)

- Upstream URL construction (`https://openrouter.ai/api/v1/messages`)
- Header injection: Bearer key + `HTTP-Referer` + `X-Title`, **no** `x-api-key`, `anthropic-version` still forwarded
- SSE streaming forwards through unchanged (Claude-SDK compatibility smoke)
- count_tokens fails closed (404, no upstream call)
- Audience still enforced (documents token → 401, no forward, no key leak)
- Transport failure → normalized 502, key not leaked
- `loadConfigFromEnv`: default provider, openrouter parsing + trailing-slash strip, unknown provider rejected, required-var invariants

Existing anthropic-path tests in `server.test.ts` unchanged and green.

## Verification

- `cd apps/gateway && bun test` → 44 pass, 6 skip (integration), 0 fail
- `bunx tsc --noEmit` → clean
- `bun run check` (Biome) → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)