### PR TITLE
feat(chat-api): idle sandbox termination reaper (MYM-18)

### DIFF
--- a/apps/chat-api/src/features/lease-store/lease-store.ts
+++ b/apps/chat-api/src/features/lease-store/lease-store.ts
@@ -51,4 +51,11 @@ export interface LeaseStore {
 	get(ref: LeaseRef): Promise<LeaseRecord | null>;
 	upsert(record: LeaseRecord): Promise<void>;
 	delete(ref: LeaseRef): Promise<void>;
+	/**
+	 * Every lease whose `updated_at` is older than `idleSince` — i.e. that has had
+	 * no acquire/release activity since then. The idle reaper (Task 14) ages warm
+	 * leases by this timestamp to sync + tear them down before E2B's own timeout
+	 * would. Returns the pointers; the reaper decides which are safe to terminate.
+	 */
+	listIdleLeases(idleSince: Date): Promise<LeaseRecord[]>;
 }

--- a/apps/chat-api/src/features/lease-store/postgres-lease-store.test.ts
+++ b/apps/chat-api/src/features/lease-store/postgres-lease-store.test.ts
@@ -105,4 +105,42 @@ describe("PostgresLeaseStore", () => {
 		expect(firstCall(db).text).toContain("DELETE FROM sandbox_leases");
 		expect(firstCall(db).params).toEqual(["user-1", "conv-1"]);
 	});
+
+	it("listIdleLeases selects rows older than the cutoff and maps them", async () => {
+		const db = fakeDb([
+			{
+				user_id: "user-1",
+				conversation_id: "conv-1",
+				sandbox_id: "sbx-1",
+				agent_session_id: "sess-1",
+			},
+			{
+				user_id: "user-2",
+				conversation_id: "conv-2",
+				sandbox_id: "sbx-2",
+				agent_session_id: null,
+			},
+		]);
+		const cutoff = new Date("2026-06-20T00:00:00.000Z");
+
+		const idle = await new PostgresLeaseStore(db).listIdleLeases(cutoff);
+
+		expect(idle).toEqual([
+			record,
+			{
+				userId: "user-2",
+				conversationId: "conv-2",
+				sandboxId: "sbx-2",
+				agentSessionId: null,
+			},
+		]);
+		expect(firstCall(db).text).toContain("FROM sandbox_leases");
+		expect(firstCall(db).text).toContain("WHERE updated_at < $1");
+		expect(firstCall(db).params).toEqual([cutoff]);
+	});
+
+	it("listIdleLeases returns an empty array when nothing is idle", async () => {
+		const store = new PostgresLeaseStore(fakeDb([]));
+		expect(await store.listIdleLeases(new Date())).toEqual([]);
+	});
 });

--- a/apps/chat-api/src/features/lease-store/postgres-lease-store.ts
+++ b/apps/chat-api/src/features/lease-store/postgres-lease-store.ts
@@ -51,6 +51,16 @@ export class PostgresLeaseStore implements LeaseStore {
 			[ref.userId, ref.conversationId],
 		);
 	}
+
+	async listIdleLeases(idleSince: Date): Promise<LeaseRecord[]> {
+		const rows = await this.db.query<LeaseRow>(
+			`SELECT user_id, conversation_id, sandbox_id, agent_session_id
+			   FROM sandbox_leases
+			  WHERE updated_at < $1`,
+			[idleSince],
+		);
+		return rows.map(rowToRecord);
+	}
 }
 
 /** Raw `sandbox_leases` row as returned by the driver (snake_case columns). */

--- a/apps/chat-api/src/features/sandbox-orchestration/idle-sandbox-reaper.test.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/idle-sandbox-reaper.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, mock } from "bun:test";
+import { IdleSandboxReaper } from "./idle-sandbox-reaper";
+import type { SandboxLeaseManager } from "./sandbox-lease-manager";
+
+const silentLogger = { info: () => {}, error: () => {} };
+
+/** A manager stub exposing only the sweep the reaper drives. */
+function fakeManager(reapIdle: () => Promise<void>) {
+	return { reapIdle: mock(reapIdle) } as unknown as Pick<
+		SandboxLeaseManager,
+		"reapIdle"
+	> & { reapIdle: ReturnType<typeof mock> };
+}
+
+describe("IdleSandboxReaper", () => {
+	it("runs a sweep on tick", async () => {
+		const manager = fakeManager(async () => {});
+		const reaper = new IdleSandboxReaper(manager, silentLogger);
+
+		await reaper.tick();
+
+		expect(manager.reapIdle).toHaveBeenCalledTimes(1);
+		expect(manager.reapIdle).toHaveBeenCalledWith(silentLogger);
+	});
+
+	it("contains a sweep failure instead of throwing", async () => {
+		const errors: Record<string, unknown>[] = [];
+		const manager = fakeManager(async () => {
+			throw new Error("store down");
+		});
+		const reaper = new IdleSandboxReaper(manager, {
+			info: () => {},
+			error: (obj: Record<string, unknown>) => errors.push(obj),
+		});
+
+		await expect(reaper.tick()).resolves.toBeUndefined();
+		expect(errors.some((e) => e.msg === "Idle reaper sweep failed")).toBe(true);
+	});
+
+	it("does not overlap sweeps", async () => {
+		let release: () => void = () => {};
+		let holdOpen = true;
+		const manager = fakeManager(() => {
+			if (!holdOpen) return Promise.resolve();
+			return new Promise<void>((resolve) => {
+				release = resolve;
+			});
+		});
+		const reaper = new IdleSandboxReaper(manager, silentLogger);
+
+		const first = reaper.tick(); // starts the sweep, holds it open
+		await reaper.tick(); // in-flight → no-op, must not start a second sweep
+		expect(manager.reapIdle).toHaveBeenCalledTimes(1);
+
+		holdOpen = false;
+		release();
+		await first;
+		// Once the first settles, the next tick sweeps again.
+		await reaper.tick();
+		expect(manager.reapIdle).toHaveBeenCalledTimes(2);
+	});
+
+	it("sweeps repeatedly on start and stops cleanly", async () => {
+		const manager = fakeManager(async () => {});
+		const reaper = new IdleSandboxReaper(manager, silentLogger, 5);
+
+		reaper.start();
+		// Let a few intervals fire.
+		while (manager.reapIdle.mock.calls.length < 2) await Bun.sleep(2);
+		reaper.stop();
+
+		const afterStop = manager.reapIdle.mock.calls.length;
+		await Bun.sleep(20);
+		// No further sweeps once stopped.
+		expect(manager.reapIdle.mock.calls.length).toBe(afterStop);
+	});
+
+	it("start is idempotent and stop is safe before start", () => {
+		const manager = fakeManager(async () => {});
+		const reaper = new IdleSandboxReaper(manager, silentLogger, 1_000);
+
+		expect(() => reaper.stop()).not.toThrow();
+		reaper.start();
+		reaper.start(); // second start must not schedule a second interval
+		reaper.stop();
+	});
+});

--- a/apps/chat-api/src/features/sandbox-orchestration/idle-sandbox-reaper.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/idle-sandbox-reaper.ts
@@ -1,0 +1,73 @@
+import type { SandboxLeaseManager } from "./sandbox-lease-manager";
+import type { SyncLogger } from "./sandbox-provider";
+
+/**
+ * Periodic driver for the lease manager's idle-termination sweep (Task 14). The
+ * sweep logic — which leases are idle, syncing before kill, skipping active runs
+ * — lives in {@link SandboxLeaseManager.reapIdle}; this just calls it on an
+ * interval and keeps one sweep from overlapping the next.
+ *
+ * Kept separate from the manager so the sweep stays a pure, clock-injected
+ * function (deterministically testable without real timers) while the wall-clock
+ * scheduling lives in one small, restartable place.
+ */
+
+/**
+ * Default poll interval. Shorter than the idle window so an idle lease is reaped
+ * within roughly one interval of crossing it, not a full window later.
+ */
+export const DEFAULT_REAP_INTERVAL_MS = 60_000;
+
+/** The reaper depends only on the manager's sweep — narrowed for testability. */
+type ReapableLeaseManager = Pick<SandboxLeaseManager, "reapIdle">;
+
+export class IdleSandboxReaper {
+	private timer: ReturnType<typeof setInterval> | null = null;
+	/** True while a sweep is in flight, so a slow sweep can't overlap the next. */
+	private sweeping = false;
+
+	constructor(
+		private readonly manager: ReapableLeaseManager,
+		private readonly logger: SyncLogger,
+		private readonly intervalMs: number = DEFAULT_REAP_INTERVAL_MS,
+	) {}
+
+	/** Begin sweeping on the interval. Idempotent — a second call is a no-op. */
+	start(): void {
+		if (this.timer) return;
+		this.timer = setInterval(() => {
+			void this.tick();
+		}, this.intervalMs);
+		// The reaper is background maintenance; it must not, on its own, keep the
+		// process from exiting.
+		this.timer.unref?.();
+	}
+
+	/** Stop sweeping. Idempotent and safe before `start`. */
+	stop(): void {
+		if (this.timer) {
+			clearInterval(this.timer);
+			this.timer = null;
+		}
+	}
+
+	/**
+	 * Run one sweep. Exposed for a deterministic test kick and a manual run. A
+	 * sweep already in flight is skipped (a slow sweep must not pile up), and any
+	 * thrown error is contained so the interval keeps ticking.
+	 */
+	async tick(): Promise<void> {
+		if (this.sweeping) return;
+		this.sweeping = true;
+		try {
+			await this.manager.reapIdle(this.logger);
+		} catch (err) {
+			this.logger.error({
+				msg: "Idle reaper sweep failed",
+				error: err instanceof Error ? err.message : String(err),
+			});
+		} finally {
+			this.sweeping = false;
+		}
+	}
+}

--- a/apps/chat-api/src/features/sandbox-orchestration/index.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/index.ts
@@ -1,5 +1,9 @@
 export { ConversationBusyError, SandboxCreationError } from "./errors";
 export {
+	DEFAULT_REAP_INTERVAL_MS,
+	IdleSandboxReaper,
+} from "./idle-sandbox-reaper";
+export {
 	type AcquireOptions,
 	type SandboxLease,
 	SandboxLeaseManager,

--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-lease-manager.test.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-lease-manager.test.ts
@@ -15,23 +15,53 @@ const silentLogger = {
 	child: () => silentLogger,
 } as unknown as ChatLogger;
 
+/**
+ * Controllable clock so idle-reaping is deterministic without real timers (the
+ * codebase idiom — see run-state's `fakeClock`). The lease manager ages leases
+ * against it, and the store stamps `updatedAt` from it, so cutoff and timestamps
+ * advance together.
+ */
+function makeClock(startMs = 1_000_000) {
+	let ms = startMs;
+	return {
+		now: () => new Date(ms),
+		advance: (deltaMs: number) => {
+			ms += deltaMs;
+		},
+	};
+}
+
 /** In-memory {@link LeaseStore} keyed exactly like the Postgres composite PK. */
 class FakeLeaseStore implements LeaseStore {
-	readonly records = new Map<string, LeaseRecord>();
+	readonly records = new Map<string, LeaseRecord & { updatedAt: number }>();
 	/** Every upsert, in order — stands in for the row's `updated_at` bumps. */
 	readonly upserts: LeaseRecord[] = [];
+	/** Stamps `updatedAt` so `listIdleLeases` can age rows like Postgres' now(). */
+	constructor(private readonly now: () => Date = () => new Date()) {}
 	private key(ref: LeaseRef) {
 		return `${ref.userId}\0${ref.conversationId}`;
 	}
 	async get(ref: LeaseRef) {
-		return this.records.get(this.key(ref)) ?? null;
+		const row = this.records.get(this.key(ref));
+		if (!row) return null;
+		const { updatedAt: _updatedAt, ...record } = row;
+		return record;
 	}
 	async upsert(record: LeaseRecord) {
-		this.records.set(this.key(record), { ...record });
+		this.records.set(this.key(record), {
+			...record,
+			updatedAt: this.now().getTime(),
+		});
 		this.upserts.push({ ...record });
 	}
 	async delete(ref: LeaseRef) {
 		this.records.delete(this.key(ref));
+	}
+	async listIdleLeases(idleSince: Date) {
+		const cutoff = idleSince.getTime();
+		return [...this.records.values()]
+			.filter((row) => row.updatedAt < cutoff)
+			.map(({ updatedAt: _updatedAt, ...record }) => record);
 	}
 }
 
@@ -55,30 +85,36 @@ function makeDeps() {
 	const setSandboxTimeout = mock(async () => undefined);
 	const hydrate = mock(async () => undefined);
 	const sync = mock(async () => undefined);
-	const leaseStore = new FakeLeaseStore();
+	const clock = makeClock();
+	const leaseStore = new FakeLeaseStore(clock.now);
 
-	const manager = new SandboxLeaseManager({
-		sandboxProvider: {
-			createSandbox,
-			connectSandbox,
-			daemonEndpoint,
-			setSandboxTimeout,
-			ensureSandboxDaemon,
-			killSandbox,
-			cancelSandbox,
-			// biome-ignore lint/suspicious/noExplicitAny: partial provider mock for the lease seam.
-		} as any,
-		leaseStore,
-		workspaceStore: {
-			hydrateConversationWorkspace: hydrate,
-			syncConversationWorkspace: sync,
-			// biome-ignore lint/suspicious/noExplicitAny: only hydrate/sync are used.
-		} as any,
-	});
+	const manager = new SandboxLeaseManager(
+		{
+			sandboxProvider: {
+				createSandbox,
+				connectSandbox,
+				daemonEndpoint,
+				setSandboxTimeout,
+				ensureSandboxDaemon,
+				killSandbox,
+				cancelSandbox,
+				// biome-ignore lint/suspicious/noExplicitAny: partial provider mock for the lease seam.
+			} as any,
+			leaseStore,
+			workspaceStore: {
+				hydrateConversationWorkspace: hydrate,
+				syncConversationWorkspace: sync,
+				// biome-ignore lint/suspicious/noExplicitAny: only hydrate/sync are used.
+			} as any,
+		},
+		DEFAULT_SANDBOX_IDLE_TIMEOUT_MS,
+		clock.now,
+	);
 
 	return {
 		manager,
 		leaseStore,
+		clock,
 		createSandbox,
 		connectSandbox,
 		ensureSandboxDaemon,
@@ -526,6 +562,110 @@ describe("SandboxLeaseManager", () => {
 				d.manager.terminate(refA, silentLogger),
 			).resolves.toBeUndefined();
 			expect(await d.leaseStore.get(refA)).toBeNull();
+		});
+	});
+
+	describe("idle termination (reapIdle)", () => {
+		it("syncs and terminates a warm lease idle past the window", async () => {
+			const lease = await d.manager.acquire(refA, silentLogger);
+			await d.manager.release(lease, silentLogger);
+			d.sync.mockClear();
+
+			// Cross the idle window, then sweep.
+			d.clock.advance(DEFAULT_SANDBOX_IDLE_TIMEOUT_MS + 1);
+			await d.manager.reapIdle(silentLogger);
+
+			expect(d.sync).toHaveBeenCalledWith(refA);
+			expect(d.killSandbox).toHaveBeenCalledTimes(1);
+			expect(await d.leaseStore.get(refA)).toBeNull();
+		});
+
+		it("keeps a lease that has not been idle long enough", async () => {
+			const lease = await d.manager.acquire(refA, silentLogger);
+			await d.manager.release(lease, silentLogger);
+
+			// Still inside the window.
+			d.clock.advance(DEFAULT_SANDBOX_IDLE_TIMEOUT_MS - 1);
+			await d.manager.reapIdle(silentLogger);
+
+			expect(d.killSandbox).not.toHaveBeenCalled();
+			expect(await d.leaseStore.get(refA)).not.toBeNull();
+		});
+
+		it("does not terminate an active lease even when its row looks idle", async () => {
+			// Acquire and do NOT release: the turn is in flight (guard held), and a
+			// turn longer than the idle window leaves `updated_at` old.
+			await d.manager.acquire(refA, silentLogger);
+
+			d.clock.advance(DEFAULT_SANDBOX_IDLE_TIMEOUT_MS + 1);
+			await d.manager.reapIdle(silentLogger);
+
+			expect(d.killSandbox).not.toHaveBeenCalled();
+			expect(await d.leaseStore.get(refA)).not.toBeNull();
+		});
+
+		it("syncs the workspace before killing the sandbox", async () => {
+			const lease = await d.manager.acquire(refA, silentLogger);
+			await d.manager.release(lease, silentLogger);
+			const order: string[] = [];
+			d.sync.mockImplementation(async () => {
+				order.push("sync");
+			});
+			d.killSandbox.mockImplementation(async () => {
+				order.push("kill");
+			});
+
+			d.clock.advance(DEFAULT_SANDBOX_IDLE_TIMEOUT_MS + 1);
+			await d.manager.reapIdle(silentLogger);
+
+			expect(order).toEqual(["sync", "kill"]);
+		});
+
+		it("terminates only the idle leases, leaving warm ones alone", async () => {
+			const refB: LeaseRef = { userId: "user-1", conversationId: "conv-2" };
+			const a = await d.manager.acquire(refA, silentLogger);
+			await d.manager.release(a, silentLogger);
+
+			// conv-2 is acquired/released later, so it stays inside the window when
+			// conv-1 has aged out.
+			d.clock.advance(DEFAULT_SANDBOX_IDLE_TIMEOUT_MS - 10);
+			const b = await d.manager.acquire(refB, silentLogger);
+			await d.manager.release(b, silentLogger);
+			d.clock.advance(20);
+
+			await d.manager.reapIdle(silentLogger);
+
+			expect(await d.leaseStore.get(refA)).toBeNull();
+			expect(await d.leaseStore.get(refB)).not.toBeNull();
+			expect(d.killSandbox).toHaveBeenCalledTimes(1);
+		});
+
+		it("logs the failure and continues when one lease cannot be reaped", async () => {
+			const errors: Record<string, unknown>[] = [];
+			const recordingLogger = {
+				info: () => {},
+				error: (obj: Record<string, unknown>) => errors.push(obj),
+			};
+			const refBad: LeaseRef = { userId: "user-1", conversationId: "conv-bad" };
+			const good = await d.manager.acquire(refA, silentLogger);
+			await d.manager.release(good, silentLogger);
+			const bad = await d.manager.acquire(refBad, silentLogger);
+			await d.manager.release(bad, silentLogger);
+
+			// Make tearing down conv-bad throw (a store delete failure surfaces out of
+			// terminate); the sweep must still reap conv-1.
+			const realDelete = d.leaseStore.delete.bind(d.leaseStore);
+			d.leaseStore.delete = async (ref: LeaseRef) => {
+				if (ref.conversationId === "conv-bad") throw new Error("delete boom");
+				return realDelete(ref);
+			};
+
+			d.clock.advance(DEFAULT_SANDBOX_IDLE_TIMEOUT_MS + 1);
+			await d.manager.reapIdle(recordingLogger);
+
+			// The good lease was still reaped despite the bad one throwing.
+			expect(await d.leaseStore.get(refA)).toBeNull();
+			expect(errors.some((e) => e.msg === "Idle reap failed")).toBe(true);
 		});
 	});
 });

--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-lease-manager.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-lease-manager.ts
@@ -124,6 +124,11 @@ export class SandboxLeaseManager {
 		private readonly deps: SandboxLeaseManagerDeps,
 		/** Idle window the sandbox timeout is reset to on each acquire/release. */
 		private readonly idleTimeoutMs: number = DEFAULT_SANDBOX_IDLE_TIMEOUT_MS,
+		/**
+		 * Clock the idle reaper ages leases against. Injectable so idle-termination
+		 * tests are deterministic without real timers; defaults to wall clock.
+		 */
+		private readonly now: () => Date = () => new Date(),
 	) {}
 
 	/**
@@ -219,8 +224,18 @@ export class SandboxLeaseManager {
 	 * and recycle conditions (Task 15) drive. Idempotent and best-effort — an
 	 * unknown lease is a no-op, and a sandbox already reaped (connect throws) is
 	 * still removed from the store — so cancellation racing teardown never throws.
+	 *
+	 * With `syncBeforeKill` the durable workspace is synced *before* the sandbox is
+	 * killed (the idle reaper's sync-before-kill, capturing any state a crash left
+	 * unsynced). The sync runs while the in-flight guard is held, so it cannot race
+	 * a new turn, and a sync failure is logged — not thrown — so a down store never
+	 * strands the sandbox. Cancellation/recycle callers omit it and just tear down.
 	 */
-	async terminate(ref: LeaseRef, logger: SyncLogger): Promise<void> {
+	async terminate(
+		ref: LeaseRef,
+		logger: SyncLogger,
+		opts: { syncBeforeKill?: boolean } = {},
+	): Promise<void> {
 		// Hold the guard for the whole teardown so a racing `acquire` can't hand out
 		// a lease to the sandbox we are killing, then clear it in `finally` so the
 		// conversation is never left wedged with ConversationBusyError. (If a turn
@@ -232,6 +247,20 @@ export class SandboxLeaseManager {
 		try {
 			const record = await this.deps.leaseStore.get(ref);
 			if (!record) return;
+			if (opts.syncBeforeKill) {
+				// Capture durable state before the sandbox dies. A sync failure must
+				// not strand the sandbox (mirrors `release`), so log and tear down.
+				try {
+					await this.deps.workspaceStore.syncConversationWorkspace(ref);
+				} catch (err) {
+					logger.error({
+						msg: "Workspace sync before terminate failed",
+						userId: ref.userId,
+						conversationId: ref.conversationId,
+						error: err instanceof Error ? err.message : String(err),
+					});
+				}
+			}
 			try {
 				const handle = await this.deps.sandboxProvider.connectSandbox(
 					record.sandboxId,
@@ -254,6 +283,59 @@ export class SandboxLeaseManager {
 			await this.deps.leaseStore.delete(ref);
 		} finally {
 			this.inFlight.delete(key);
+		}
+	}
+
+	/**
+	 * Idle-termination sweep (Task 14). Finds warm leases with no acquire/release
+	 * activity for longer than the idle window — `updated_at` older than
+	 * `now - idleTimeoutMs` — syncs each one's durable workspace, then tears its
+	 * sandbox down. This reclaims sandboxes proactively (before E2B's own timeout)
+	 * and captures state a crashed turn never synced.
+	 *
+	 * Active leases are kept alive: a conversation with a turn in flight holds the
+	 * in-flight guard, so it is skipped here even when its row looks idle (a turn
+	 * longer than the idle window does not bump `updated_at`). The guard check and
+	 * `terminate`'s guard claim have no `await` between them, so an in-flight turn
+	 * can't be reaped out from under itself. Cross-replica in-flight turns aren't
+	 * visible to this per-process guard; the daemon's single-turn lock backstops
+	 * that, and health/version gating before reuse is Task 15.
+	 *
+	 * Best-effort and self-contained: a failure reaping one lease is logged and the
+	 * sweep continues, so one wedged conversation can't stall the rest.
+	 */
+	async reapIdle(logger: SyncLogger): Promise<void> {
+		const cutoff = new Date(this.now().getTime() - this.idleTimeoutMs);
+		const idle = await this.deps.leaseStore.listIdleLeases(cutoff);
+		for (const record of idle) {
+			const ref: LeaseRef = {
+				userId: record.userId,
+				conversationId: record.conversationId,
+			};
+			// Active run → keep warm, never terminate mid-run. (No await before
+			// `terminate` claims the guard, so this check stays race-free.)
+			if (this.inFlight.has(inFlightKey(ref))) {
+				logger.info({
+					msg: "Skipping idle reap of active lease",
+					userId: ref.userId,
+					conversationId: ref.conversationId,
+					sandboxId: record.sandboxId,
+				});
+				continue;
+			}
+			try {
+				await this.terminate(ref, logger, { syncBeforeKill: true });
+			} catch (err) {
+				// Surfacing per run policy: log and move on so one failure can't stall
+				// the sweep. (terminate already swallows a missing sandbox internally.)
+				logger.error({
+					msg: "Idle reap failed",
+					userId: ref.userId,
+					conversationId: ref.conversationId,
+					sandboxId: record.sandboxId,
+					error: err instanceof Error ? err.message : String(err),
+				});
+			}
 		}
 	}
 


### PR DESCRIPTION
## What

Implements **Task 14 — Add idle termination** ([MYM-18](https://linear.app/mymemo-agent/issue/MYM-18/task-14-add-idle-termination), Milestone 5: Sandbox Leasing). Adds a proactive reaper that retires warm conversation sandboxes once they go idle, syncing their durable workspace before teardown — building on the lease manager from Task 13.

## Changes

- **`LeaseStore.listIdleLeases(idleSince)`** — ages warm leases by `updated_at`. Postgres adapter selects `WHERE updated_at < $1`. Added to the interface, `PostgresLeaseStore`, and the in-memory test fake.
- **`SandboxLeaseManager.reapIdle(logger)`** — the sweep: cutoff = `now - idleTimeoutMs`, list idle leases, sync each workspace, then terminate. Active (in-flight) leases are **skipped** (in-flight guard) so a turn longer than the idle window is never reaped mid-run. Per-lease failures are logged and the sweep continues. The clock is injectable (`now: () => Date`, matching run-state's idiom) so idle-termination is tested deterministically without real timers.
- **`SandboxLeaseManager.terminate(..., { syncBeforeKill })`** — new option syncs the durable workspace **before** the sandbox is killed; a sync failure is logged, never strands the sandbox. Cancellation/recycle callers omit it.
- **`IdleSandboxReaper`** — thin `setInterval` driver calling `reapIdle`, with a non-overlap guard and an `unref`'d timer so it can't keep the process alive.

## Acceptance criteria

- ✅ Fake-clock tests verify idle termination after the configured window (and that a lease inside the window is kept).
- ✅ Active sandboxes are not terminated mid-run (in-flight lease skipped even when its row looks idle).
- ✅ Workspace sync is called before sandbox kill (order asserted).
- ✅ Termination failures are logged and the sweep continues.

## Tests

`bun test` on the changed areas — 46 pass:
- `src/features/lease-store/postgres-lease-store.test.ts` (+ `listIdleLeases` SQL/mapping + empty case)
- `src/features/sandbox-orchestration/sandbox-lease-manager.test.ts` (+ `idle termination (reapIdle)` block)
- `src/features/sandbox-orchestration/idle-sandbox-reaper.test.ts` (new)

Biome lint clean on all changed files.

## Remaining risk / notes

- **Not yet wired into process startup.** The lease manager is not on the live turn path yet (deferred Milestone 5 wiring), so the reaper isn't started anywhere in production. This PR delivers the mechanism; starting `IdleSandboxReaper` belongs with the turn-path wiring.
- **E2B keep-alive for long turns** (resetting the sandbox's own timeout during a turn that outlives the idle window) is out of scope here — `reapIdle` protects in-flight leases from *our* reaper, but the sandbox's E2B auto-timeout is a separate clock. Tracked conceptually with Task 14/15.
- **Cross-replica races** (an in-flight turn on another replica) aren't visible to the per-process in-flight guard; the daemon single-turn lock backstops it, and health/version gating before reuse is Task 15.
- Pre-existing: `e2b-sandbox-provider.test.ts` fails and `tsc --noEmit` errors in this worktree because optional deps (`e2b`, etc.) aren't installed — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)