### PR TITLE
docs(comments): trim narration from the four comment-heaviest modules

### DIFF
--- a/apps/chat-api/src/features/run-state/run-state.ts
+++ b/apps/chat-api/src/features/run-state/run-state.ts
@@ -1,26 +1,21 @@
 /**
  * Run lifecycle module. A "run" is one backend execution attempt for a chat turn
- * (identified by `runId`). This module records the run's lifecycle as an ordered
- * stream of events so a run is auditable and replayable after the fact.
+ * (`runId`), recorded as an ordered NDJSON event stream so it is auditable and
+ * replayable. Events persist through a {@link RunEventSink} (in prod the durable
+ * `WorkspaceStore.appendRunEvent`, one object per line under
+ * `users/{userId}/runs/{runId}/events.jsonl`). This module owns the event
+ * vocabulary and the state machine, not persistence.
  *
- * Events are persisted as NDJSON through a {@link RunEventSink} — in production
- * the durable `WorkspaceStore.appendRunEvent`, which writes one JSON object per
- * line to `users/{userId}/runs/{runId}/events.jsonl`. This module owns the event
- * vocabulary and the lifecycle state machine; it does not own persistence.
- *
- * A run starts in `running` and moves once to exactly one terminal state
- * (`completed`, `failed`, or `canceled`). Recording any event after a terminal
- * transition is a programming error and throws, so a run can never report two
- * outcomes or log activity after it has ended. Wiring this module into the chat
- * orchestration path (and mapping run events onto client SSE) is a later task.
+ * A run starts `running` and moves once to exactly one terminal state. Recording
+ * any event after a terminal transition throws, so a run can never report two
+ * outcomes or log activity after it ended.
  */
 
 import type { RunEvent, RunRef } from "@/features/workspace-store";
 
 /**
- * The persistence primitive this module writes through. A subset of
- * {@link WorkspaceStore} so the run module depends only on what it uses and is
- * trivial to fake in tests.
+ * Persistence primitive this module writes through — a subset of
+ * {@link WorkspaceStore}, so the run module depends only on what it uses.
  */
 export interface RunEventSink {
 	appendRunEvent(ref: RunRef, event: RunEvent): Promise<void>;
@@ -32,9 +27,9 @@ export type RunStatus = "running" | "completed" | "failed" | "canceled";
 /** Result of an idempotent {@link Run.cancel} request. */
 export interface CancelOutcome {
 	/**
-	 * True only when this call moved the run from `running` to `canceled` (and so
-	 * recorded the `run_canceled` event). False for every no-op: a repeated cancel,
-	 * or a cancel that lost the race to natural completion/failure.
+	 * True only when this call moved `running` → `canceled` (recording the event).
+	 * False for every no-op: a repeated cancel, or one that lost the race to
+	 * natural completion/failure.
 	 */
 	transitioned: boolean;
 	/** The run's status after the call. */
@@ -53,12 +48,10 @@ export const RunEventType = {
 } as const;
 
 /**
- * Lifecycle-owned event types. The start record is emitted once by `createRun`,
- * and the terminal records are emitted by the markers
- * (`markRunCompleted`/`markRunFailed`/`markRunCanceled`), which also advance the
- * state machine. The generic `appendRunEvent` primitive rejects all of them so a
- * caller cannot record a second start or an outcome out of band — replay/audit
- * consumers see exactly one start and one terminal record per run.
+ * Event types `appendRunEvent` refuses: the start is emitted once by `createRun`
+ * and outcomes by the `markRun*` markers (which also advance the state machine),
+ * so neither can be recorded out of band — replay/audit see exactly one start
+ * and one terminal record per run.
  */
 const LIFECYCLE_EVENT_TYPES: ReadonlySet<string> = new Set([
 	RunEventType.Started,
@@ -112,12 +105,11 @@ export class Run {
 
 	/**
 	 * Serializes every operation so the status guard and the durable write form
-	 * one critical section. Two lifecycle calls that are not awaited in sequence
-	 * (e.g. cancellation racing a streamed agent event once cancellation is wired)
-	 * therefore still run one-at-a-time and in enqueue order — the audit log never
-	 * records activity after the terminal event, and the guard always sees the
-	 * settled status of the previous operation. The tail is kept always-fulfilled
-	 * so a rejected operation does not stall the chain.
+	 * one critical section: lifecycle calls run one-at-a-time in enqueue order (so
+	 * a cancel racing a streamed agent event can't interleave), the guard always
+	 * sees the previous op's settled status, and the audit log never records
+	 * activity after the terminal event. The tail stays fulfilled so a rejected
+	 * operation doesn't stall the chain.
 	 */
 	private queue: Promise<void> = Promise.resolve();
 
@@ -148,12 +140,9 @@ export class Run {
 	}
 
 	/**
-	 * Append one intermediate event to the run's durable log. The primitive behind
-	 * the `record*` helpers; callers pass a non-lifecycle `type` plus any structured
-	 * fields, and a timestamp (`at`) is stamped on every event. Rejects if the run
-	 * has already reached a terminal state, or if `type` is a lifecycle-owned type
-	 * (`run_started` and the terminal types) — the start is emitted by `createRun`
-	 * and outcomes by the `markRun*` markers, so neither may be recorded out of band.
+	 * Append one intermediate event to the durable log — the primitive behind the
+	 * `record*` helpers. Stamps `at` on every event. Rejects if the run is already
+	 * terminal, or if `type` is a {@link LIFECYCLE_EVENT_TYPES lifecycle-owned} type.
 	 */
 	appendRunEvent(event: RunEvent): Promise<void> {
 		if (LIFECYCLE_EVENT_TYPES.has(event.type)) {
@@ -180,11 +169,10 @@ export class Run {
 	}
 
 	/**
-	 * Record an agent event. The `agent_event` category label is authoritative —
-	 * applied after the payload so a daemon field named `type` cannot mislabel the
-	 * event — but the daemon's own discriminator (e.g. `text_delta`, `session_id`)
-	 * is preserved under `agentEventType` so the run log can replay the original
-	 * stream rather than guessing from optional fields.
+	 * Record an agent event. The `agent_event` label is applied after the payload
+	 * so a daemon field named `type` can't mislabel it; the daemon's own
+	 * discriminator (e.g. `text_delta`) is preserved under `agentEventType` so the
+	 * run log can replay the original stream.
 	 */
 	recordAgentEvent(data: Record<string, unknown>): Promise<void> {
 		const { type: daemonType, ...rest } = data;
@@ -219,21 +207,17 @@ export class Run {
 	}
 
 	/**
-	 * Idempotent cancellation request — the entry point the cancellation contract
-	 * exposes. Unlike the strict `markRun*` terminals, `cancel` is best-effort and
-	 * safe to call repeatedly or after the run has already ended:
+	 * Idempotent, best-effort cancellation — safe to call repeatedly or after the
+	 * run has ended (unlike the strict `markRun*` terminals):
 	 *
-	 *  - `running` → records `run_canceled`, advances to `canceled`, returns
-	 *    `{ transitioned: true, status: "canceled" }`.
-	 *  - already `canceled` → no-op (no duplicate event), `transitioned: false`.
-	 *  - `completed` / `failed` → no-op; the run already reached a different
-	 *    terminal state, so cancellation lost the race. `transitioned: false`.
+	 *  - `running` → records `run_canceled`, advances, `transitioned: true`.
+	 *  - already `canceled` → no-op, no duplicate event, `transitioned: false`.
+	 *  - `completed` / `failed` → no-op; cancellation lost the race,
+	 *    `transitioned: false`.
 	 *
-	 * A cancel signal can arrive after the run has naturally finished; tolerating
-	 * the terminal states (instead of throwing like `markRunCanceled`) keeps the
-	 * single-start/single-terminal audit invariant intact. The `transitioned` flag
-	 * lets callers fire a sandbox/daemon cancellation hook only when this call
-	 * actually performed the cancellation.
+	 * Tolerating the terminal states keeps the single-start/single-terminal audit
+	 * invariant intact; `transitioned` lets callers fire the daemon cancellation
+	 * hook only when this call actually performed the cancellation.
 	 */
 	cancel(): Promise<CancelOutcome> {
 		return this.critical(async () => {
@@ -258,15 +242,11 @@ export class Run {
 					`Run ${this.ref.runId} already ${this._status}; cannot mark ${status}`,
 				);
 			}
-			// Persist the terminal event before advancing the status: if the sink
-			// rejects (e.g. ENOSPC, transient store failure) the run stays `running`
-			// so the outcome can be retried, rather than being stuck terminal with no
-			// durable record of how it ended. Note this guarantee is only as strong
-			// as the sink: a sink may deliberately resolve on a failed terminal write
-			// to decouple client signaling from audit durability (the chat SSE sink
-			// does — see `chat/run-event-sink.ts`), in which case status advances
-			// without a persisted terminal record. The default fail-closed contract
-			// holds for any sink that propagates its write failures.
+			// Persist before advancing status: if the sink rejects, the run stays
+			// `running` so the outcome can be retried rather than being stuck terminal
+			// with no record of how it ended. This guarantee is only as strong as the
+			// sink; one that resolves on a failed terminal write (the chat SSE sink
+			// does, to decouple signaling from audit durability) advances anyway.
 			await this.write(event);
 			this._status = status;
 		});

--- a/apps/chat-api/src/features/sandbox-orchestration/sandbox-lease-manager.ts
+++ b/apps/chat-api/src/features/sandbox-orchestration/sandbox-lease-manager.ts
@@ -9,42 +9,29 @@ import type {
 } from "./sandbox-provider";
 
 /**
- * Sandbox leasing for Milestone 5. Today every turn creates a fresh per-turn
- * sandbox and tears it down (`runSandboxChat`). This manager moves toward warm
- * conversation sandboxes: a sandbox is leased by `{userId, conversationId}` and
- * may be reused across turns while it stays warm.
+ * Sandbox leasing (Milestone 5). A sandbox is leased by `{userId, conversationId}`
+ * and reused across turns while warm, instead of the per-turn create/kill of
+ * `runSandboxChat`.
  *
- * The warm-sandbox pointer is persisted in the durable {@link LeaseStore}
- * (Postgres), not a per-process Map, so a restarted process or a second replica
- * finds and reuses the same sandbox. The store holds only the sandbox *id* plus
- * the daemon endpoint — a live handle is an open network client that can't be
- * serialized — so reuse reattaches through `SandboxProvider.connectSandbox`.
+ * The warm pointer lives in the durable {@link LeaseStore} (Postgres), not a
+ * per-process Map, so a restarted process or second replica finds and reuses the
+ * same sandbox. The store holds only the sandbox id + daemon endpoint (a live
+ * handle is an unserializable network client), so reuse reattaches through
+ * `SandboxProvider.connectSandbox`.
  *
- * Keeping a sandbox warm has one clock: the sandbox's own E2B auto-shutdown
- * timeout. Every acquire and release resets it to `idleTimeoutMs` via
- * `setSandboxTimeout`, so the idle window *is* the sandbox's lifetime — an idle
- * sandbox is reaped by E2B itself at expiry (no separate process needed for the
- * kill), and the next acquire for it finds a stale pointer and recreates. This is
- * why `release` can keep the sandbox warm without leaking it.
+ * Idle has one clock: the sandbox's own E2B auto-shutdown timeout, reset to
+ * `idleTimeoutMs` on every acquire/release. The idle window *is* the sandbox's
+ * lifetime — E2B reaps an idle sandbox itself and the next acquire finds a stale
+ * pointer and recreates — so `release` keeps it warm without leaking. A proactive
+ * reaper, keep-alive for long turns, and health/version-drift recycle gating are
+ * follow-ups (Tasks 14–15); `terminate` is the teardown hook they drive.
  *
- * Scope of this task (Task 13): the lease lifecycle — keyed reuse, isolation,
- * the concurrency policy, fresh create + hydrate, the idle timeout, and threading
- * `agentSessionId` for resume. Two follow-ups build on it: idle termination
- * (Task 14) adds a proactive reaper that syncs + drops the row *before* E2B's
- * timeout expires (reading `sandbox_leases.updated_at`) plus keep-alive for turns
- * longer than the idle window, and recycle conditions (Task 15) add
- * daemon-health / version-drift gating before a warm lease is reused. `terminate`
- * is the explicit teardown hook those tasks drive.
- *
- * Concurrency policy: **reject**. A second turn for a conversation whose lease is
- * already in flight throws `ConversationBusyError`. The in-flight guard is
- * per-process, so it only serializes turns landing on the same process. The
- * daemon's single-turn lock backstops two turns that reuse the *same* warm
- * sandbox (it 409s the second), but it does NOT cover a cross-replica race where
- * neither replica has a warm lease yet: both would `acquireFresh` and create
- * distinct sandboxes, and the conflicting `upsert` orphans one. A DB-level guard
- * (conditional insert / advisory lock on the lease key) closes that gap and is
- * left to the Task 14 wiring that puts this on the live multi-replica path.
+ * Concurrency policy: **reject** — a second in-flight turn for a conversation
+ * throws `ConversationBusyError`. The guard is per-process; the daemon's
+ * single-turn lock 409s two turns reusing the *same* warm sandbox, but neither
+ * covers a cross-replica race where both replicas `acquireFresh` and the
+ * conflicting upsert orphans one. A DB-level guard (conditional insert / advisory
+ * lock) would close that gap.
  */
 
 export interface AcquireOptions {
@@ -85,10 +72,9 @@ export interface SandboxLeaseManagerDeps {
 }
 
 /**
- * Default idle window: a warm sandbox with no acquire/release activity for this
- * long is auto-killed by E2B. 5 minutes matches the plan's idle policy
- * (`docs/agent-workspace-implementation-plan.md`, Task 14). Task 14's wiring will
- * source this from config; it is a constructor option so it can.
+ * Default idle window before E2B auto-kills an inactive warm sandbox. 5 minutes
+ * matches the plan's idle policy (Task 14); a constructor option so config can
+ * override it.
  */
 export const DEFAULT_SANDBOX_IDLE_TIMEOUT_MS = 5 * 60_000;
 
@@ -176,22 +162,17 @@ export class SandboxLeaseManager {
 	}
 
 	/**
-	 * End a turn's hold on a lease without tearing the sandbox down: the durable
-	 * workspace is synced, then the in-flight guard is freed, but the sandbox is
-	 * kept warm for the next turn. Idle termination of warm leases is Task 14.
-	 *
-	 * The guard is held until the sync completes (cleared in `finally`), so the
-	 * next turn for this conversation cannot start against the same workspace
-	 * before the prior turn's state is durably captured. A sync failure is logged,
-	 * not thrown — the turn already finished — but still releases the guard.
+	 * End a turn's hold without tearing the sandbox down: sync the durable
+	 * workspace, then free the in-flight guard, leaving the sandbox warm. The guard
+	 * is held until the sync completes so the next turn can't start against the
+	 * same workspace before this turn's state is durably captured. A sync failure
+	 * is logged, not thrown (the turn already finished), but still releases the guard.
 	 */
 	async release(lease: SandboxLease, logger: SyncLogger): Promise<void> {
-		// Both the idle-timeout reset and the sync run inside the try so the guard
-		// is freed in `finally` no matter what — a throw from either must not leave
-		// the conversation wedged with ConversationBusyError.
+		// Reset + sync run inside the try so the guard is freed in `finally` no
+		// matter what — a throw must not wedge the conversation as busy.
 		try {
-			// Reset the idle countdown from turn end: the sandbox now lives
-			// `idleTimeoutMs` from here, then E2B auto-kills it if no turn reuses it.
+			// Reset the idle countdown from turn end; E2B auto-kills if no turn reuses.
 			await this.deps.sandboxProvider.setSandboxTimeout(
 				lease.sandbox,
 				this.idleTimeoutMs,
@@ -214,19 +195,17 @@ export class SandboxLeaseManager {
 	}
 
 	/**
-	 * Drop a lease and tear its sandbox down: the persisted pointer is removed and
-	 * the sandbox killed. The explicit termination hook the idle reaper (Task 14)
-	 * and recycle conditions (Task 15) drive. Idempotent and best-effort — an
-	 * unknown lease is a no-op, and a sandbox already reaped (connect throws) is
-	 * still removed from the store — so cancellation racing teardown never throws.
+	 * Drop a lease and tear its sandbox down. The explicit teardown hook the idle
+	 * reaper (Task 14) and recycle conditions (Task 15) drive. Idempotent and
+	 * best-effort — an unknown lease is a no-op, and a sandbox already reaped
+	 * (connect throws) is still removed from the store — so cancellation racing
+	 * teardown never throws.
 	 */
 	async terminate(ref: LeaseRef, logger: SyncLogger): Promise<void> {
-		// Hold the guard for the whole teardown so a racing `acquire` can't hand out
-		// a lease to the sandbox we are killing, then clear it in `finally` so the
-		// conversation is never left wedged with ConversationBusyError. (If a turn
-		// was genuinely in flight, the guard was already held; clearing it here is
-		// the cancellation semantics — the reaper must not terminate in-flight
-		// leases, which is enforced where it is wired, Task 14.)
+		// Hold the guard across teardown so a racing `acquire` can't lease the
+		// sandbox we're killing; clear it in `finally` so the conversation isn't
+		// wedged. (The reaper must not terminate genuinely in-flight leases —
+		// enforced where it is wired, Task 14.)
 		const key = inFlightKey(ref);
 		this.inFlight.add(key);
 		try {
@@ -259,17 +238,13 @@ export class SandboxLeaseManager {
 
 	/**
 	 * Reattach to a persisted warm lease, or `null` when there is none / it is
-	 * stale. A stale pointer (the sandbox no longer reattaches) is deleted so the
-	 * caller falls through to a fresh create.
+	 * stale (a stale pointer is deleted so the caller falls through to a fresh
+	 * create). The daemon endpoint is recomputed from the reattached handle, never
+	 * read from the store, so it can't be stale relative to the live sandbox.
 	 *
-	 * The daemon endpoint is recomputed from the reattached handle (never read from
-	 * the store), so it cannot be stale relative to the live sandbox.
-	 *
-	 * Staleness here is only "the sandbox VM no longer reattaches" — `connectSandbox`
-	 * succeeds whenever the control plane still has the sandbox, so a VM that is up
-	 * but whose in-sandbox daemon has died (or whose bundle version drifted) is
-	 * reused and fails at `/turn`. Daemon-health / version-drift gating before reuse
-	 * is Task 15 (recycle conditions).
+	 * Staleness here is only "the VM no longer reattaches" — a VM that is up but
+	 * whose daemon died or whose bundle drifted is reused and fails at `/turn`.
+	 * Health / version-drift gating before reuse is Task 15.
 	 */
 	private async tryReuse(
 		ref: LeaseRef,
@@ -308,11 +283,10 @@ export class SandboxLeaseManager {
 		// the conversation's recorded session forward.
 		const agentSessionId = resolveAgentSessionId(opts, record.agentSessionId);
 
-		// Reuse is a use: re-persist the pointer so `updated_at` advances. The idle
-		// reaper (Task 14) ages leases by that timestamp, so without this a
-		// continuously-reused (and thus never-upserted) sandbox would look idle and
-		// be reaped mid-use. Also persists an explicit session override so the row
-		// doesn't drift from the live lease.
+		// Reuse is a use: re-persist so `updated_at` advances. The idle reaper
+		// (Task 14) ages leases by that timestamp, so without this a continuously
+		// reused sandbox would look idle and be reaped mid-use. Also persists an
+		// explicit session override so the row doesn't drift from the live lease.
 		await this.deps.leaseStore.upsert({ ...record, agentSessionId });
 
 		logger.info({
@@ -346,14 +320,12 @@ export class SandboxLeaseManager {
 		await this.deps.workspaceStore.hydrateConversationWorkspace(ref);
 		const sandbox = await this.createWithRetry(ref.userId, logger);
 
-		// The sandbox now exists; anything past this point that throws must tear it
-		// down, or a created-but-unusable sandbox leaks (the per-turn path's
-		// `finally { killSandbox }` guaranteed this — there is no caller `finally`
-		// here because no lease was handed back).
+		// The sandbox now exists; anything past this that throws must tear it down,
+		// or a created-but-unusable sandbox leaks (no caller `finally` here, since
+		// no lease was handed back).
 		try {
-			// Define the warm window explicitly rather than riding E2B's default
-			// timeout, so the lease's idle policy and the sandbox's lifetime are one
-			// clock.
+			// Set the warm window explicitly rather than riding E2B's default, so the
+			// lease's idle policy and the sandbox's lifetime are one clock.
 			await this.deps.sandboxProvider.setSandboxTimeout(
 				sandbox,
 				this.idleTimeoutMs,

--- a/apps/sandbox-daemon/agent-tools.ts
+++ b/apps/sandbox-daemon/agent-tools.ts
@@ -1,32 +1,26 @@
 /**
  * Claude Agent SDK tool surface and permission policy for the sandbox agent.
  *
- * Security boundary: the agent runs prompt-injectable, untrusted code, and the
- * real containment is the sandbox itself — the per-turn E2B sandbox in prod (the
- * daemon's container locally), with a scrubbed env holding no provider key, no
- * DB credential, and only short-lived per-turn gateway tokens (see
- * `child-spawn.ts`, covered by `child-spawn.test.ts`). Because `Bash` is on the
- * surface (below), that isolation — not this tool list — is what bounds what the
- * agent can do; Bash already subsumes file writes and network egress (`curl`).
+ * Security boundary: the agent runs prompt-injectable, untrusted code; the real
+ * containment is the sandbox itself (per-turn E2B in prod, the daemon's container
+ * locally) with a scrubbed env holding no provider key, no DB credential, only
+ * short-lived per-turn tokens (see `child-spawn.ts`). Because `Bash` is on the
+ * surface, that isolation — not this tool list — bounds the agent: Bash already
+ * subsumes file writes and network egress (`curl`).
  *
- * This module's job is therefore behavior-scoping, not the wall: pin the agent
- * to a predictable, reasoned-about set instead of the full Claude Code default,
- * and keep `permissionMode` off `bypassPermissions`.
+ * So this module is behavior-scoping, not the wall: pin the agent to a
+ * reasoned-about set instead of the full Claude Code default, and keep
+ * `permissionMode` off `bypassPermissions`.
+ *  - `tools` pins availability (not pre-approval).
+ *  - `allowedTools` pre-approves that set + the MyMemo MCP tool, so unattended
+ *    turns run without prompts.
+ *  - `canUseTool` denies anything off the list — hygiene, not containment.
  *
- * - `tools` pins the available built-ins (availability, not pre-approval).
- * - `allowedTools` pre-approves that set plus the MyMemo MCP tool, so an
- *   unattended turn runs without permission prompts.
- * - `canUseTool` denies anything off the list — hygiene so an injected prompt
- *   can't casually reach a first-class tool we never reasoned about. It is NOT
- *   a containment boundary (Bash defeats that); it just keeps behavior scoped.
- *
- * Surface rationale: `Bash` for general workspace work (running code, builds,
- * scripts); `Read`/`Grep`/`Glob` for the local working set; `Write`/`Edit` for
- * authoring files under `work/`/`output/` (more reliable than Bash heredocs, and
- * denying them buys nothing over Bash). `mcp__mymemo__search_documents` is the
- * document path. Deliberately omitted: `WebFetch`/`WebSearch` (the agent answers
- * from MyMemo documents, not the open web — a soft policy default, since
- * Bash+curl is still a hole) and `Task`/subagent orchestration (unneeded).
+ * Surface: `Bash` for workspace work; `Read`/`Grep`/`Glob` for the local set;
+ * `Write`/`Edit` for authoring under `work/`/`output/`;
+ * `mcp__mymemo__search_documents` for documents. Omitted: `WebFetch`/`WebSearch`
+ * (answer from MyMemo docs, not the web — soft default, Bash+curl is still a hole)
+ * and `Task` (unneeded).
  */
 
 import {
@@ -48,13 +42,7 @@ export const SEARCH_DOCUMENTS_TOOL_NAME = "search_documents";
 /** Fully-qualified, agent-facing name of the document tool. */
 export const SEARCH_DOCUMENTS_TOOL = `mcp__${MYMEMO_MCP_SERVER_NAME}__${SEARCH_DOCUMENTS_TOOL_NAME}`;
 
-/**
- * Built-in tools available to the agent (see the file header for the rationale
- * and what is deliberately omitted): `Bash` for general workspace work,
- * `Read`/`Grep`/`Glob` for the local working set, `Write`/`Edit` for authoring
- * files under `work/`/`output/`. Every other built-in (`WebFetch`, `WebSearch`,
- * `Task`, …) is absent by omission, and `canUseTool` denies anything off it.
- */
+/** Built-ins available to the agent (rationale + omissions in the file header). */
 export const ALLOWED_BUILTIN_TOOLS = [
 	"Bash",
 	"Read",
@@ -71,12 +59,9 @@ export const PRE_APPROVED_TOOLS = [
 ] as const;
 
 /**
- * Default-deny permission handler: allow only pre-approved tools, deny everything
- * else with a clear message. With `allowedTools` pre-approving the same set it is
- * rarely consulted; it keeps the agent's behavior scoped to the reasoned-about
- * set under `permissionMode: "default"`. This is behavior-scoping, NOT a
- * containment boundary — `Bash` can already do what a denied tool would (see the
- * file header); the sandbox/container is the boundary.
+ * Default-deny permission handler: allow only pre-approved tools, deny the rest.
+ * Rarely consulted (since `allowedTools` pre-approves the same set); it keeps
+ * behavior scoped, NOT a containment boundary — Bash defeats that (see header).
  */
 export function createCanUseTool(
 	preApproved: readonly string[] = PRE_APPROVED_TOOLS,
@@ -94,11 +79,10 @@ export function createCanUseTool(
 }
 
 /**
- * Per-turn context the document tool needs to hydrate into the right place:
- * which conversation `docs/` dir to write to, and which run to attribute the
- * hydration to in the manifest. Threaded in from the daemon (see agent.ts) so
- * this module reads no environment for paths/identity. The gateway URL + bearer
- * token are read from the per-turn env inside the handler instead.
+ * Per-turn context the document tool needs: which conversation `docs/` dir to
+ * write to, and which run to attribute hydration to. Threaded in from the daemon
+ * so this module reads no env for paths/identity (the gateway URL + token are read
+ * from per-turn env in the handler).
  */
 export interface MymemoToolContext {
 	/** Absolute path to the conversation's `docs/` dir. */
@@ -115,17 +99,14 @@ function toolError(message: string): {
 }
 
 /**
- * The MyMemo MCP tool definitions registered with the in-process server.
+ * The MyMemo MCP tool definitions for the in-process server. The single
+ * `search_documents` operation runs the search → fetch → hydrate → manifest flow
+ * (see search-documents.ts); the gateway URL + (aud: "documents") token come from
+ * per-turn env, the `docs/` dir + run id via {@link MymemoToolContext}.
  *
- * The single `search_documents` operation runs the search → fetch → hydrate →
- * manifest flow (see search-documents.ts). The gateway URL + (aud: "documents")
- * token come from the per-turn env the daemon set on the agent process; the
- * conversation `docs/` dir and run id arrive via {@link MymemoToolContext}.
- *
- * Expected failures — gateway errors, or a missing env/context (a premature call
- * before the turn is wired) — return a recoverable tool error (`isError: true`)
- * so the agent can retry or explain, rather than throwing and crashing the query
- * loop. No matches is a normal (non-error) empty result.
+ * Expected failures (gateway errors, missing env/context) return a recoverable
+ * tool error (`isError: true`) so the agent can retry instead of crashing the
+ * query loop. No matches is a normal empty result.
  */
 export function buildMymemoTools(context?: MymemoToolContext) {
 	return [

--- a/apps/sandbox-daemon/child-spawn.ts
+++ b/apps/sandbox-daemon/child-spawn.ts
@@ -1,31 +1,26 @@
 /**
  * Spawn helper for the per-turn agent.js child. The daemon never imports the
- * Claude Agent SDK itself — it lives exclusively in agent.js. The agent's LLM
- * credentials are not provider keys: it gets a gateway base URL + short-lived
- * bearer token, supplied per turn.
+ * Claude Agent SDK — it lives exclusively in agent.js. The agent gets no provider
+ * key: only a gateway base URL + short-lived bearer token, supplied per turn.
  *
- * The agent speaks NDJSON on stdout. We line-buffer, parse, and dispatch.
+ * The agent speaks NDJSON on stdout; we line-buffer, parse, and dispatch.
  *
  * Isolation: the agent runs directly (`bun /workspace/agent.js`) — the sandbox
- * itself (the per-turn E2B sandbox in prod, the daemon's container locally) is
- * the security boundary. The agent holds no provider key, runs under the SDK's
- * scoped tool surface (see agent-tools.ts), and is treated as untrusted, so dev
- * and prod share this one spawn path.
+ * (per-turn E2B in prod, the daemon's container locally) is the security boundary.
+ * It holds no provider key and runs under the SDK's scoped tool surface
+ * (agent-tools.ts), so dev and prod share this one spawn path.
  *
- * Bundle paths are env-overridable for tests; in production sandboxes the
- * chat-api writes the two bundles to /workspace/{daemon,agent}.js, and the local
- * container bakes them at the same paths.
+ * Bundle paths are env-overridable for tests; in prod chat-api writes the bundles
+ * to /workspace/{daemon,agent}.js and the local container bakes them there.
  */
 
 import { resolve } from "node:path";
 import type { AgentSpawnConfig } from "./config";
 import { hydrationLimitEnv } from "./hydration-policy";
 import type { AgentEvent } from "./ipc-protocol";
-// Single source of truth for the durable session-store root env var name; the
-// agent's SessionStore reads the same constant. Imported (not re-declared) so the
-// two sides can't drift. Unset = session mirroring disabled; the agent's
-// FileSystemSessionStore creates its own per-conversation subtree on first write,
-// so the daemon only forwards the root.
+// Single source of truth for the durable session-store root env var; the agent's
+// SessionStore reads the same constant, so the two sides can't drift. Unset =
+// mirroring disabled; the daemon only forwards the root.
 import { SESSION_STORE_ROOT_ENV } from "./session-store";
 
 export type { AgentEvent } from "./ipc-protocol";
@@ -35,19 +30,16 @@ function getSessionStoreRoot(): string | undefined {
 	return root && root.length > 0 ? root : undefined;
 }
 
-// Paths that don't survive a sandbox recycle. A store root at or under either is
-// useless for resume: transcripts written there are sandbox-local and lost when
-// the sandbox is torn down (the agent's FileSystemSessionStore silently mkdirs
-// and writes, so the misconfig surfaces as data loss, not an error).
+// Paths that don't survive a sandbox recycle. A store root at or under either
+// loses transcripts silently — FileSystemSessionStore just mkdirs and writes, so
+// the misconfig surfaces as data loss, not an error.
 const EPHEMERAL_ROOTS = ["/workspace", "/tmp"];
 
 /**
- * Fail loudly if a configured session-store root would silently lose transcripts:
- * a relative path (resolved against the agent's ephemeral cwd) or one inside an
- * ephemeral mount. This is independent of the (removed) bwrap mounts — it guards
- * the durable-mirror invariant the resume feature relies on. Throwing here, at
- * spawn time, turns an operator misconfiguration into a clear failure instead of
- * a quiet recall regression after a sandbox recycle.
+ * Fail loudly if a session-store root would silently lose transcripts: a relative
+ * path (resolved against the ephemeral cwd) or one inside an ephemeral mount.
+ * Throwing at spawn time turns an operator misconfig into a clear failure instead
+ * of a quiet recall regression after a sandbox recycle.
  */
 export function assertDurableStoreRoot(root: string): void {
 	if (!root.startsWith("/")) {
@@ -66,9 +58,8 @@ export function assertDurableStoreRoot(root: string): void {
 }
 
 /**
- * Build the argv for the agent process. The agent runs directly under bun — the
- * sandbox/container is the isolation boundary, so there is no wrapper. Extracted
- * as a pure helper so the command is easy to inspect and unit-test.
+ * Build the argv for the agent process — runs directly under bun (no wrapper; the
+ * sandbox is the boundary). Pure helper so the command is easy to test.
  */
 export function buildAgentSpawnArgv(config: AgentSpawnConfig): string[] {
 	return [config.bunExecutable, config.agentBundlePath];
@@ -213,10 +204,9 @@ export async function spawnAgent(
 		claudeConfigDir,
 		...config
 	} = input;
-	// Forward the durable transcript root only when mirroring is configured and
-	// the turn carries identity — the agent's SessionStore derives its
-	// per-{user,conversation} subtree from the root + the identity threaded
-	// through the stdin config below. Absent root/identity => mirroring disabled.
+	// Forward the durable transcript root only when mirroring is configured and the
+	// turn carries identity (the agent derives its per-{user,conversation} subtree
+	// from root + identity). Absent root/identity => mirroring disabled.
 	const sessionStoreRoot =
 		config.userId && config.conversationId ? getSessionStoreRoot() : undefined;
 	// Reject a root that would silently lose transcripts (relative or ephemeral)


### PR DESCRIPTION
## What

Comment-only **diet** on the four densest source files, where 30–41% of lines were comments:

| File | Before | After | Cut |
|---|---|---|---|
| `run-state.ts` | 309 | 289 | 20 |
| `sandbox-lease-manager.ts` | 414 | 386 | 28 |
| `child-spawn.ts` | 324 | 314 | 10 |
| `agent-tools.ts` | 200 | 181 | 19 |
| **Total** | **1,247** | **1,170** | **−77** |

## Rule applied

**Keep the security/correctness "why," cut the narration.**

- **Kept:** persist-before-advance ordering, override-after-spread (`at`/`type`), NUL-separator key injectivity, the cross-replica race gap, no-provider-key env scrubbing, the ephemeral store-root invariant.
- **Cut:** design-doc restatement, `Task-N` roadmap narration, and repeated explanations (the agent-tools "behavior-scoping not containment" point was stated three times → once).

## Verification

- `biome check` clean on all four files.
- **78 tests pass, 0 fail** (run-state 22, lease-manager 28, child-spawn + agent-tools 28).
- **No behavior change** — comment-only edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)