### PR TITLE
feat(chat-api): split-runtime config + env ownership (MYM-45)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ The chat surface is **two endpoints** under `/v1` (mounted in `src/routes/v1.ts`
 1. `POST /v1/conversations` — create a conversation. With:
    - **JSON body** (`CreateConversationBody`, `.strict()`): optional `collectionId` / `summaryId`. Scope is **resolved once from these ids and frozen** onto the conversation record; it is never re-derived per turn.
    - **Identity headers** (`InternalIdentity`): `X-Member-Code` (required), `X-Partner-Code` (required), `X-Team-Code`, `X-Member-Name`, `X-Partner-Name` (all optional). `memberCode` is the conversation owner (`user_id`).
-   - Returns `201 { conversationId, scope }`. `conversationId` is **server-generated** (a UUID, path-safe by construction). Persisted via `conversationStore` to chat-api's writable `mymemo_agent` DB. `DATABASE_URL` is **required** — validated at config load, so a misconfigured deploy fails fast at startup rather than 503-ing per request.
+   - Returns `201 { conversationId, scope }`. `conversationId` is **server-generated** (a UUID, path-safe by construction). Persisted via `conversationStore` to chat-api's writable `mymemo_agent` DB. `AGENT_DATABASE_URL` is **required** — validated at config load, so a misconfigured deploy fails fast at startup rather than 503-ing per request.
 2. `POST /v1/conversations/:conversationId/events` — append an event and stream the turn. With:
    - **JSON body** (`ConversationEventBody`): a discriminated union over `type`. Today only `{ type: "user.message", text }`; extensible to `user.interrupt` / `user.tool_confirmation` without a contract rename. Unknown types → `400`.
    - Same identity headers. The `:conversationId` path param is re-validated as path-safe.
@@ -172,16 +172,18 @@ Required:
 - `E2B_API_KEY` — required only when `SANDBOX_PROVIDER=e2b` (the default); not needed for the local provider
 - `LLM_TOKEN_SECRET` — HMAC secret for minting per-turn tokens (shared with the gateway)
 - `GATEWAY_PUBLIC_URL` — base URL of the merged gateway; the sandbox agent points BOTH the Claude binary (→ `/v1/messages`) and the `mymemo-docs` CLI (→ `/v1/documents/*`) at it. **Must be reachable from inside the E2B sandbox**
-- `DATABASE_URL` — connection to chat-api's **own writable** Postgres (`mymemo_agent`), which backs the conversation registry (frozen scope) and the sandbox-lease registry. A **separate database and credential** from the gateway's read-only KB (`mymemo_kb`), even when co-located — chat-api never touches KB tables. **Required**: the conversation endpoints are the primary surface and cannot work without it, so it is validated at config load. The `conversations`/`sandbox_leases` tables are owned by Drizzle migrations (`src/db/schema.ts` → `drizzle/`); run `bun run db:migrate` (the compose `migrate` one-shot does this locally)
+- `AGENT_DATABASE_URL` — connection to chat-api's **own writable** Postgres (`mymemo_agent`), which backs the conversation registry (frozen scope) and the sandbox-lease registry. A **separate database and credential** from the gateway's read-only KB (`mymemo_kb`), even when co-located — chat-api never touches KB tables. Named `AGENT_DATABASE_URL` (not the generic `DATABASE_URL`, which names the read-only KB credential elsewhere) so the two trust domains never collide. **Required**: the conversation endpoints are the primary surface and cannot work without it, so it is validated at config load. The `conversations`/`sandbox_leases` tables are owned by Drizzle migrations (`src/db/schema.ts` → `drizzle/`); run `bun run db:migrate` (the compose `migrate` one-shot does this locally)
+- `STATSIG_SERVER_SECRET` — backs the production agent exposure gate (`mymemo_agent_split_runtime_enabled`). **Required unless `AGENT_EXPOSURE_BREAK_GLASS=true`** (the gate then opens without Statsig). Never sent to the sandbox or logged
 
 Optional:
 - `LOG_LEVEL` (default: `info`)
 - `PORT` (default: 3000)
+- `AGENT_EXPOSURE_BREAK_GLASS` (default: off) — operator break-glass for the agent exposure gate. When `true`, new agent work is allowed without Statsig (local dev, or an incident where Statsig is unavailable) and `STATSIG_SERVER_SECRET` is not required. When off (production default), the gate fails closed
 - `SANDBOX_PROVIDER` (default: `e2b`) — `e2b` leases sandboxes from E2B; `local` targets a long-lived daemon container for the docker-compose E2E harness (`compose.yaml`). Selected in `sandbox-orchestration/singleton.ts`
 - `LOCAL_SANDBOX_DAEMON_URL` (default: `http://sandbox:8080`) — base URL of the local daemon container (`SANDBOX_PROVIDER=local` only)
 - `E2B_TEMPLATE` (default: `sandbox-template-dev`)
 - `WORKSPACE_STORE_ROOT` — root dir of the durable workspace store (local filesystem `WorkspaceStore` adapter). Holds per-user/per-conversation work, output, and the docs manifest, plus per-run event logs, following the path model `users/{userId}/conversations/{conversationId}/…` and `users/{userId}/runs/{runId}/events.jsonl`. Defaults to `.workspace-store` under the process cwd (writable in the container). **For durability across container recycles, point this at a mounted persistent volume in production**
-- `DB_PASSWORD` — spliced into `DATABASE_URL` when it is passwordless (the form the platform injects)
+- `DB_PASSWORD` — spliced into `AGENT_DATABASE_URL` when it is passwordless (the form the platform injects)
 - `DB_SSL` (default: on; set `disable` for a local non-TLS Postgres)
 
 ### gateway

--- a/apps/chat-api/.env.example
+++ b/apps/chat-api/.env.example
@@ -1,8 +1,77 @@
-# chat-api secrets for the local E2E harness (compose.yaml). Copy to
-#   apps/chat-api/.env
-# Non-secret wiring (SANDBOX_PROVIDER, GATEWAY_PUBLIC_URL, ...) is set inline in
-# compose.yaml, so only secrets go here.
+# chat-api environment template — copy to apps/chat-api/.env and fill in.
+#
+# This lists EVERY variable chat-api reads (src/config/env.ts), so it doubles as
+# deployment documentation. Legend: [required] must be set (prod); [secret] must
+# come from a secret store, never source control; [optional] has a default.
+#
+# Local docker-compose harness: compose.yaml sets the non-secret wiring inline
+# under `environment:`, and inline values OVERRIDE this file — so for `docker
+# compose up` you only need LLM_TOKEN_SECRET below. The other vars are shown
+# (commented) for documentation and for running chat-api directly (`bun run
+# dev`) outside compose. In production, supply every [required] var via your
+# platform / Secrets Manager.
 
-# HMAC secret for per-turn LLM/document tokens (chat-api mints them).
-# MUST match apps/gateway/.env's LLM_TOKEN_SECRET.
+# ── Required ──────────────────────────────────────────────────────────────────
+
+# [required][secret] HMAC secret for per-turn LLM/document tokens (chat-api mints
+# them). MUST match apps/gateway/.env's LLM_TOKEN_SECRET. The one value the local
+# harness actually needs here.
 LLM_TOKEN_SECRET=local-dev-llm-token-secret-change-me
+
+# [required] Writable mymemo_agent Postgres: conversation registry (frozen
+# scope), sandbox-lease registry, run state. A DIFFERENT database/credential from
+# the gateway's read-only KB — never the KB URL. Local harness: set inline in
+# compose.yaml. Prod: from Secrets Manager.
+# AGENT_DATABASE_URL=postgresql://user:password@host:5432/mymemo_agent
+
+# [required] Base URL of the merged gateway, reachable from inside the sandbox.
+# Local harness: set inline in compose.yaml (http://gateway:8080).
+# GATEWAY_PUBLIC_URL=https://gateway.example.com
+
+# [required unless break-glass][secret] Statsig server secret backing the agent
+# exposure gate (mymemo_agent_split_runtime_enabled). NOT needed locally: the
+# harness sets AGENT_EXPOSURE_BREAK_GLASS=true, which opens the gate without
+# Statsig. Required in production, where break-glass is off and the gate fails
+# closed. Never sent to the sandbox or logged.
+# STATSIG_SERVER_SECRET=secret-...
+
+# [required when SANDBOX_PROVIDER=e2b][secret] E2B API key. Not needed for the
+# local provider (the harness uses SANDBOX_PROVIDER=local). Read directly by the
+# E2B SDK from the environment.
+# E2B_API_KEY=e2b_...
+
+# ── Optional (defaults shown) ───────────────────────────────────────────────────
+
+# Operator break-glass for the exposure gate: when "true", new agent work is
+# allowed without Statsig (local dev, or a Statsig outage). Default off — the
+# gate fails closed. The local harness sets this true inline in compose.yaml.
+# AGENT_EXPOSURE_BREAK_GLASS=false
+
+# Sandbox provider: "e2b" leases a sandbox per turn; "local" targets the harness
+# daemon container.
+# SANDBOX_PROVIDER=e2b
+
+# Base URL of the local daemon container (SANDBOX_PROVIDER=local only).
+# LOCAL_SANDBOX_DAEMON_URL=http://sandbox:8080
+
+# E2B template name (SANDBOX_PROVIDER=e2b only).
+# E2B_TEMPLATE=sandbox-template-dev
+
+# Durable workspace store root (local filesystem adapter). Defaults to
+# .workspace-store under the process cwd; point at a mounted persistent volume in
+# production for durability across container recycles.
+# WORKSPACE_STORE_ROOT=.workspace-store
+
+# Spliced into AGENT_DATABASE_URL when it is passwordless (the platform-injected
+# form). Leave unset when AGENT_DATABASE_URL already carries its password.
+# DB_PASSWORD=
+
+# Postgres TLS. On by default (appends sslmode=require); set "disable" for a
+# local non-TLS Postgres.
+# DB_SSL=disable
+
+# pino log level.
+# LOG_LEVEL=info
+
+# HTTP listen port (Bun server).
+# PORT=3000

--- a/apps/chat-api/drizzle.config.ts
+++ b/apps/chat-api/drizzle.config.ts
@@ -3,12 +3,12 @@ import { defineConfig } from "drizzle-kit";
 /**
  * drizzle-kit config for chat-api's writable DB (`mymemo_agent`). `src/db/schema.ts`
  * is the source of truth; `bun run db:generate` emits SQL migrations into
- * `drizzle/`, and `bun run db:migrate` applies them. `DATABASE_URL` is only read
- * by drizzle-kit's introspection/push commands, not by `generate`.
+ * `drizzle/`, and `bun run db:migrate` applies them. `AGENT_DATABASE_URL` is only
+ * read by drizzle-kit's introspection/push commands, not by `generate`.
  */
 export default defineConfig({
 	dialect: "postgresql",
 	schema: "./src/db/schema.ts",
 	out: "./drizzle",
-	dbCredentials: { url: process.env.DATABASE_URL ?? "" },
+	dbCredentials: { url: process.env.AGENT_DATABASE_URL ?? "" },
 });

--- a/apps/chat-api/package.json
+++ b/apps/chat-api/package.json
@@ -23,7 +23,6 @@
 		"hono-openapi": "^1.1.0",
 		"hono-pino": "^0.10.3",
 		"pino": "^9.14.0",
-		"tiny-invariant": "^1.3.3",
 		"zod": "^4.1.12"
 	},
 	"devDependencies": {

--- a/apps/chat-api/src/config/env.test.ts
+++ b/apps/chat-api/src/config/env.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "bun:test";
+import { type ApiConfig, loadApiConfigFromEnv } from "./env";
+
+/**
+ * Split-runtime env ownership (MYM-45). `chat-api` owns the writable agent DB
+ * and the Statsig exposure config; it must NOT require or read the worker-only
+ * secrets (OpenRouter, KB). These tests pin that boundary.
+ */
+
+/** A minimal env that loads cleanly: the local provider needs no E2B key. */
+function baseEnv(): Record<string, string | undefined> {
+	return {
+		SANDBOX_PROVIDER: "local",
+		LLM_TOKEN_SECRET: "test-secret",
+		GATEWAY_PUBLIC_URL: "https://gateway.test",
+		AGENT_DATABASE_URL: "postgresql://u:p@localhost:5432/mymemo_agent",
+		STATSIG_SERVER_SECRET: "secret-statsig",
+		DB_SSL: "disable",
+	};
+}
+
+describe("loadApiConfigFromEnv — agent DB ownership", () => {
+	it("refuses to boot without AGENT_DATABASE_URL", () => {
+		const env = baseEnv();
+		delete env.AGENT_DATABASE_URL;
+		expect(() => loadApiConfigFromEnv(env)).toThrow(/AGENT_DATABASE_URL/);
+	});
+
+	it("reads the writable agent DB from AGENT_DATABASE_URL, not DATABASE_URL", () => {
+		const env = baseEnv();
+		// A stray DATABASE_URL (the gateway's KB var name) must be ignored.
+		env.DATABASE_URL = "postgresql://kb:kb@localhost:5432/mymemo_kb";
+		const config = loadApiConfigFromEnv(env);
+		expect(config.databaseUrl).toContain("mymemo_agent");
+		expect(config.databaseUrl).not.toContain("mymemo_kb");
+	});
+});
+
+describe("loadApiConfigFromEnv — worker-secret boundary", () => {
+	it("boots without any worker-only secret present", () => {
+		const env = baseEnv();
+		// None of these are set; chat-api must not require them.
+		expect(env.OPENROUTER_API_KEY).toBeUndefined();
+		expect(env.KB_DATABASE_URL).toBeUndefined();
+		expect(() => loadApiConfigFromEnv(env)).not.toThrow();
+	});
+
+	it("never surfaces worker-only secrets on the config object", () => {
+		const env = baseEnv();
+		env.OPENROUTER_API_KEY = "sk-or-should-be-ignored";
+		env.OPENROUTER_BASE_URL = "https://openrouter.test";
+		env.OPENROUTER_DEFAULT_MODEL = "anthropic/claude";
+		env.KB_DATABASE_URL = "postgresql://kb:kb@localhost:5432/mymemo_kb";
+		const config = loadApiConfigFromEnv(env);
+		const serialized = JSON.stringify(config);
+		expect(serialized).not.toContain("sk-or-should-be-ignored");
+		expect(serialized).not.toContain("openrouter.test");
+		expect(serialized).not.toContain("mymemo_kb");
+		// And there is no openrouter/kb field by name.
+		expect(config as Record<string, unknown>).not.toHaveProperty(
+			"openrouterApiKey",
+		);
+		expect(config as Record<string, unknown>).not.toHaveProperty(
+			"kbDatabaseUrl",
+		);
+	});
+});
+
+describe("loadApiConfigFromEnv — Statsig exposure config", () => {
+	it("requires STATSIG_SERVER_SECRET when break-glass is off", () => {
+		const env = baseEnv();
+		delete env.STATSIG_SERVER_SECRET;
+		expect(() => loadApiConfigFromEnv(env)).toThrow(/STATSIG_SERVER_SECRET/);
+	});
+
+	it("allows boot without the Statsig secret under operator break-glass", () => {
+		const env = baseEnv();
+		delete env.STATSIG_SERVER_SECRET;
+		env.AGENT_EXPOSURE_BREAK_GLASS = "true";
+		const config = loadApiConfigFromEnv(env);
+		expect(config.agentExposureBreakGlass).toBe(true);
+		expect(config.statsigServerSecret).toBeUndefined();
+	});
+
+	it("carries the Statsig secret when configured normally", () => {
+		const config = loadApiConfigFromEnv(baseEnv());
+		expect(config.agentExposureBreakGlass).toBe(false);
+		expect(config.statsigServerSecret).toBe("secret-statsig");
+	});
+});
+
+describe("loadApiConfigFromEnv — prototype provider path unchanged", () => {
+	it("still requires E2B_API_KEY when SANDBOX_PROVIDER=e2b", () => {
+		const env = baseEnv();
+		env.SANDBOX_PROVIDER = "e2b";
+		delete env.E2B_API_KEY;
+		expect(() => loadApiConfigFromEnv(env)).toThrow(/E2B_API_KEY/);
+	});
+
+	it("returns a config typed as ApiConfig with the expected core fields", () => {
+		const config: ApiConfig = loadApiConfigFromEnv(baseEnv());
+		expect(config.sandboxProvider).toBe("local");
+		expect(config.gatewayPublicUrl).toBe("https://gateway.test");
+	});
+});

--- a/apps/chat-api/src/config/env.ts
+++ b/apps/chat-api/src/config/env.ts
@@ -1,5 +1,4 @@
 import { join } from "node:path";
-import invariant from "tiny-invariant";
 
 export type ChatMessagesScope = "general" | "collection" | "document";
 
@@ -7,6 +6,16 @@ export type SandboxProviderKind = "e2b" | "local";
 
 /** Subset of the process environment the API reads. */
 type Env = Record<string, string | undefined>;
+
+/**
+ * Assert a config invariant, throwing an Error whose message survives
+ * production builds. Deliberately NOT tiny-invariant: that strips the message
+ * when NODE_ENV=production, which would turn a misconfigured prod boot into an
+ * opaque "Invariant failed" instead of naming the missing variable.
+ */
+function assert(condition: unknown, message: string): asserts condition {
+	if (!condition) throw new Error(message);
+}
 
 /**
  * Typed, validated configuration for the chat-api. Built once from the
@@ -33,19 +42,34 @@ export interface ApiConfig {
 	workspaceStoreRoot: string;
 	/**
 	 * Writable connection to chat-api's own Postgres (`mymemo_agent`), distinct
-	 * from the gateway's read-only KB. Backs the conversation registry (frozen
-	 * scope) and the sandbox-lease registry. **Required** — the conversation
-	 * endpoints are the primary surface and cannot work without it, so it is
-	 * validated at config load rather than failing per-request.
-	 * DB_PASSWORD spliced in when passwordless; TLS applied (DB_SSL=disable to
-	 * turn off for a local non-TLS Postgres).
+	 * from the gateway's/worker's read-only KB. Backs the conversation registry
+	 * (frozen scope), the sandbox-lease registry, and (in the split runtime) the
+	 * run queue and event log. Sourced from `AGENT_DATABASE_URL` — never the
+	 * generic `DATABASE_URL`, which names the read-only KB elsewhere in the repo.
+	 * **Required** — the conversation endpoints are the primary surface and cannot
+	 * work without it, so it is validated at config load rather than failing
+	 * per-request. DB_PASSWORD spliced in when passwordless; TLS applied
+	 * (DB_SSL=disable to turn off for a local non-TLS Postgres).
 	 */
 	databaseUrl: string;
+	/**
+	 * Statsig server secret backing the production agent exposure gate (MYM-46).
+	 * Required unless operator break-glass is on; undefined only in that case.
+	 * Never sent to the sandbox or logged.
+	 */
+	statsigServerSecret: string | undefined;
+	/**
+	 * Operator break-glass for the agent exposure gate. When true, new agent work
+	 * is allowed without Statsig (local dev, or an incident where Statsig is
+	 * unavailable). When false (production default), the gate fails closed and a
+	 * Statsig secret is required. Identity-independent and explicit.
+	 */
+	agentExposureBreakGlass: boolean;
 }
 
 /**
- * If DATABASE_URL is passwordless (the form the platform injects) and
- * DB_PASSWORD is set, splice the password in. Mirrors the gateway's helper.
+ * If the DB URL is passwordless (the form the platform injects) and DB_PASSWORD
+ * is set, splice the password in. Mirrors the gateway's helper.
  */
 function withPassword(url: string, password: string | undefined): string {
 	if (!password) return url;
@@ -87,7 +111,7 @@ export function loadApiConfigFromEnv(env: Env): ApiConfig {
 	// rather than silently falling back to e2b (a typo like `locl` would
 	// otherwise surface as a confusing "E2B_API_KEY required").
 	const rawSandboxProvider = env.SANDBOX_PROVIDER;
-	invariant(
+	assert(
 		rawSandboxProvider === undefined ||
 			rawSandboxProvider === "e2b" ||
 			rawSandboxProvider === "local",
@@ -99,23 +123,38 @@ export function loadApiConfigFromEnv(env: Env): ApiConfig {
 	// E2B credentials are only needed for the E2B provider; the local provider
 	// reaches a container it does not create, so don't hard-require them there.
 	if (sandboxProvider === "e2b") {
-		invariant(
+		assert(
 			env.E2B_API_KEY,
 			"E2B_API_KEY is required when SANDBOX_PROVIDER=e2b",
 		);
 	}
-	invariant(env.LLM_TOKEN_SECRET, "LLM_TOKEN_SECRET is required");
-	invariant(env.GATEWAY_PUBLIC_URL, "GATEWAY_PUBLIC_URL is required");
+	assert(env.LLM_TOKEN_SECRET, "LLM_TOKEN_SECRET is required");
+	assert(env.GATEWAY_PUBLIC_URL, "GATEWAY_PUBLIC_URL is required");
 
 	// The conversation registry is the primary surface and cannot work without a
 	// writable DB; require it at load so a misconfigured deploy fails fast instead
-	// of booting green and 503-ing every request.
+	// of booting green and 503-ing every request. Sourced from AGENT_DATABASE_URL
+	// (the writable mymemo_agent DB), never the generic DATABASE_URL — that name
+	// is the read-only KB credential elsewhere in the repo, and conflating them
+	// would point chat-api at the wrong trust domain.
 	const databaseUrl = resolveDatabaseUrl(
-		env.DATABASE_URL,
+		env.AGENT_DATABASE_URL,
 		env.DB_PASSWORD,
 		env.DB_SSL,
 	);
-	invariant(databaseUrl, "DATABASE_URL is required");
+	assert(databaseUrl, "AGENT_DATABASE_URL is required");
+
+	// Agent exposure (MYM-46) fails closed in production: a Statsig secret is
+	// required unless an operator explicitly enables break-glass (local dev, or an
+	// incident where Statsig is unavailable). The worker-only secrets (OpenRouter,
+	// KB) are intentionally NOT read here — chat-api must not hold them.
+	const agentExposureBreakGlass = env.AGENT_EXPOSURE_BREAK_GLASS === "true";
+	if (!agentExposureBreakGlass) {
+		assert(
+			env.STATSIG_SERVER_SECRET,
+			"STATSIG_SERVER_SECRET is required (or set AGENT_EXPOSURE_BREAK_GLASS=true to open the gate without Statsig)",
+		);
+	}
 
 	// Durable workspace store root. Optional with a writable fallback so it works
 	// out of the box, but the fallback is process-local and lost on container
@@ -143,5 +182,7 @@ export function loadApiConfigFromEnv(env: Env): ApiConfig {
 		logLevel: env.LOG_LEVEL || "info",
 		workspaceStoreRoot,
 		databaseUrl,
+		statsigServerSecret: env.STATSIG_SERVER_SECRET,
+		agentExposureBreakGlass,
 	};
 }

--- a/apps/chat-api/src/db/migrate.ts
+++ b/apps/chat-api/src/db/migrate.ts
@@ -11,12 +11,12 @@ import { resolveDatabaseUrl } from "@/config/env";
  * same way the app does (DB_PASSWORD splice + DB_SSL) so both connect identically.
  */
 const databaseUrl = resolveDatabaseUrl(
-	Bun.env.DATABASE_URL,
+	Bun.env.AGENT_DATABASE_URL,
 	Bun.env.DB_PASSWORD,
 	Bun.env.DB_SSL,
 );
 if (!databaseUrl) {
-	console.error("DATABASE_URL is required to run migrations");
+	console.error("AGENT_DATABASE_URL is required to run migrations");
 	process.exit(1);
 }
 

--- a/apps/chat-api/src/test-setup.ts
+++ b/apps/chat-api/src/test-setup.ts
@@ -7,10 +7,15 @@ Bun.env.E2B_API_KEY = Bun.env.E2B_API_KEY ?? "test-e2b-key";
 Bun.env.LLM_TOKEN_SECRET = Bun.env.LLM_TOKEN_SECRET ?? "test-llm-token-secret";
 Bun.env.GATEWAY_PUBLIC_URL =
 	Bun.env.GATEWAY_PUBLIC_URL ?? "https://gateway.test";
-// DATABASE_URL is required at config load; tests inject fake stores, and the
-// Drizzle client connects lazily, so a non-connecting placeholder is enough.
-Bun.env.DATABASE_URL =
-	Bun.env.DATABASE_URL ?? "postgresql://test:test@localhost:5432/test";
+// AGENT_DATABASE_URL is required at config load; tests inject fake stores, and
+// the Drizzle client connects lazily, so a non-connecting placeholder is enough.
+Bun.env.AGENT_DATABASE_URL =
+	Bun.env.AGENT_DATABASE_URL ?? "postgresql://test:test@localhost:5432/test";
+// The agent exposure gate requires a Statsig secret unless break-glass is on.
+// Tests that exercise the gate use Statsig local mode / overrides; this default
+// just lets unrelated app/route tests load config without wiring Statsig.
+Bun.env.STATSIG_SERVER_SECRET =
+	Bun.env.STATSIG_SERVER_SECRET ?? "secret-statsig-test";
 // Keep the durable workspace store off the host's real root during tests.
 Bun.env.WORKSPACE_STORE_ROOT =
 	Bun.env.WORKSPACE_STORE_ROOT ??

--- a/bun.lock
+++ b/bun.lock
@@ -23,7 +23,6 @@
         "hono-openapi": "^1.1.0",
         "hono-pino": "^0.10.3",
         "pino": "^9.14.0",
-        "tiny-invariant": "^1.3.3",
         "zod": "^4.1.12",
       },
       "devDependencies": {

--- a/compose.yaml
+++ b/compose.yaml
@@ -34,10 +34,13 @@ services:
       GATEWAY_PUBLIC_URL: http://gateway:8080
       # chat-api's OWN writable database (mymemo_agent), separate from the
       # gateway's read-only KB (mymemo_kb) on the same postgres instance. Holds
-      # the sandbox-lease registry. Local-only dev credential, so inline.
-      DATABASE_URL: postgresql://mymemo:mymemo@postgres:5432/mymemo_agent
+      # the sandbox-lease registry. Local-only dev credential, so inline. Named
+      # AGENT_DATABASE_URL so it never collides with the KB's DATABASE_URL.
+      AGENT_DATABASE_URL: postgresql://mymemo:mymemo@postgres:5432/mymemo_agent
       DB_SSL: disable
       LOG_LEVEL: info
+      # Open the agent exposure gate locally without wiring Statsig (break-glass).
+      AGENT_EXPOSURE_BREAK_GLASS: "true"
     # Secrets: LLM_TOKEN_SECRET
     env_file:
       - apps/chat-api/.env
@@ -67,7 +70,7 @@ services:
     # image sets no CMD, so a `command:` would append to the entrypoint instead.
     entrypoint: ["bun", "run", "db:migrate"]
     environment:
-      DATABASE_URL: postgresql://mymemo:mymemo@postgres:5432/mymemo_agent
+      AGENT_DATABASE_URL: postgresql://mymemo:mymemo@postgres:5432/mymemo_agent
       DB_SSL: disable
     depends_on:
       postgres:


### PR DESCRIPTION
Milestone 0 of the **Split Runtime Fargate/E2B** project. Part 1 of a 3-PR stack.

Closes MYM-45.

## What
- Clean-rename chat-api's writable DB env `DATABASE_URL` → `AGENT_DATABASE_URL` so it never collides with the read-only KB `DATABASE_URL` used elsewhere (config, migrate runner, drizzle config, test-setup, compose).
- Add Statsig exposure config to `ApiConfig`: `STATSIG_SERVER_SECRET` (required unless `AGENT_EXPOSURE_BREAK_GLASS=true`) + the break-glass flag, validated **fail-closed** at boot.
- Env validation uses a local `assert` helper instead of tiny-invariant so a misconfigured **production** boot logs the missing var name rather than an opaque `Invariant failed`.
- Pin the worker-secret boundary by test: chat-api never requires or surfaces OpenRouter/KB secrets.
- Rewrite `.env.example` as a comprehensive, self-documenting deployment template.

## Tests
9 new config tests; full chat-api suite green (193) in both normal and `NODE_ENV=production` mode.

## Stack (review/merge in order)
1. **MYM-45 (this PR)** → `main`
2. MYM-46 (exposure gate) → MYM-45
3. MYM-47 (agent-worker) → MYM-46

🤖 Generated with [Claude Code](https://claude.com/claude-code)