### PR TITLE
chore(chat-api): drop redundant in-image test run

### DIFF
--- a/apps/chat-api/Dockerfile
+++ b/apps/chat-api/Dockerfile
@@ -21,7 +21,9 @@ RUN cd /temp/dev && bun install --frozen-lockfile
 COPY --from=manifests /usr/src/app /temp/prod
 RUN cd /temp/prod && bun install --frozen-lockfile --production
 
-# Copy source, prebuild daemon bundle, and run tests
+# Copy source and prebuild the daemon bundle (shipped into the release image).
+# Tests are NOT run here — CI (.github/workflows/ci.yml) is the test gate; the
+# image build just produces the runtime artifact.
 FROM base AS prerelease
 COPY --from=install /temp/dev/node_modules node_modules
 COPY apps/chat-api/ apps/chat-api/
@@ -32,7 +34,6 @@ COPY package.json .
 WORKDIR /usr/src/app/apps/chat-api
 ENV NODE_ENV=production
 RUN bun run build:daemon
-RUN bun test
 
 # Final release image
 FROM base AS release


### PR DESCRIPTION
Independent cleanup (not part of the MYM-45/46/47 stack).

chat-api's Dockerfile `prerelease` stage ran `bun test`, which:
- **Duplicates CI** — [`.github/workflows/ci.yml`](.github/workflows/ci.yml) already runs `bun run test` on every PR and push to `main`.
- **Couples artifact production to the suite** — the `release` stage `COPY`s from `prerelease`, so the production image couldn't be built (even for a hotfix or local debug) without the full suite passing.
- **Runs under `NODE_ENV=production`**, a different environment than CI.

This removes only the redundant `RUN bun test`; the needed `RUN bun run build:daemon` (which produces the bundle the release image ships) stays. The image builds the runtime artifact; CI remains the test gate.

Same rationale applied to the new agent-worker Dockerfile in #163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)