### PR TITLE
Add run store persistence and tests

### DIFF
--- a/apps/chat-api/drizzle/0003_acoustic_dexter_bennett.sql
+++ b/apps/chat-api/drizzle/0003_acoustic_dexter_bennett.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "runs_queued_claim_order" ON "runs" USING btree ("created_at","run_id") WHERE "runs"."status" = 'queued';

--- a/apps/chat-api/drizzle/0004_organic_nebula.sql
+++ b/apps/chat-api/drizzle/0004_organic_nebula.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "runs_stale_recovery_order" ON "runs" USING btree ("locked_until") WHERE "runs"."status" in ('running', 'cancel_requested');

--- a/apps/chat-api/drizzle/0005_chunky_trauma.sql
+++ b/apps/chat-api/drizzle/0005_chunky_trauma.sql
@@ -1,0 +1,2 @@
+DROP INDEX "runs_stale_recovery_order";--> statement-breakpoint
+CREATE INDEX "runs_stale_recovery_order" ON "runs" USING btree ("locked_until","created_at","run_id") WHERE "runs"."status" in ('running', 'cancel_requested');

--- a/apps/chat-api/drizzle/meta/0003_snapshot.json
+++ b/apps/chat-api/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,382 @@
+{
+  "id": "0b9f5846-539a-42f9-9e66-249d9e6c2b30",
+  "prevId": "77264ca6-df35-44c8-aa79-cf3a35fdd140",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_id": {
+          "name": "summary_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "conversations_user_id_conversation_id_pk": {
+          "name": "conversations_user_id_conversation_id_pk",
+          "columns": [
+            "user_id",
+            "conversation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "conversations_scope_check": {
+          "name": "conversations_scope_check",
+          "value": "\"conversations\".\"scope\" in ('general', 'collection', 'document')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.run_events": {
+      "name": "run_events",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "run_events_run_id_runs_run_id_fk": {
+          "name": "run_events_run_id_runs_run_id_fk",
+          "tableFrom": "run_events",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "run_events_run_id_seq_pk": {
+          "name": "run_events_run_id_seq_pk",
+          "columns": [
+            "run_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "run_events_visibility_check": {
+          "name": "run_events_visibility_check",
+          "value": "\"run_events\".\"visibility\" in ('internal', 'client')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.runs": {
+      "name": "runs",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locked_by": {
+          "name": "locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fencing_token": {
+          "name": "fencing_token",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_event_seq": {
+          "name": "next_event_seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "runs_one_active_per_conversation": {
+          "name": "runs_one_active_per_conversation",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"runs\".\"status\" in ('queued', 'running', 'cancel_requested')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_queued_claim_order": {
+          "name": "runs_queued_claim_order",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runs\".\"status\" = 'queued'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runs_status_check": {
+          "name": "runs_status_check",
+          "value": "\"runs\".\"status\" in ('queued', 'running', 'cancel_requested', 'done', 'error', 'canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sandbox_leases": {
+      "name": "sandbox_leases",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fencing_token": {
+          "name": "fencing_token",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "sandbox_leases_user_id_conversation_id_pk": {
+          "name": "sandbox_leases_user_id_conversation_id_pk",
+          "columns": [
+            "user_id",
+            "conversation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/chat-api/drizzle/meta/0004_snapshot.json
+++ b/apps/chat-api/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,398 @@
+{
+  "id": "cf7cd128-a1a6-47c0-aae0-7251298ce7ee",
+  "prevId": "0b9f5846-539a-42f9-9e66-249d9e6c2b30",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_id": {
+          "name": "summary_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "conversations_user_id_conversation_id_pk": {
+          "name": "conversations_user_id_conversation_id_pk",
+          "columns": [
+            "user_id",
+            "conversation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "conversations_scope_check": {
+          "name": "conversations_scope_check",
+          "value": "\"conversations\".\"scope\" in ('general', 'collection', 'document')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.run_events": {
+      "name": "run_events",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "run_events_run_id_runs_run_id_fk": {
+          "name": "run_events_run_id_runs_run_id_fk",
+          "tableFrom": "run_events",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "run_events_run_id_seq_pk": {
+          "name": "run_events_run_id_seq_pk",
+          "columns": [
+            "run_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "run_events_visibility_check": {
+          "name": "run_events_visibility_check",
+          "value": "\"run_events\".\"visibility\" in ('internal', 'client')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.runs": {
+      "name": "runs",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locked_by": {
+          "name": "locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fencing_token": {
+          "name": "fencing_token",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_event_seq": {
+          "name": "next_event_seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "runs_one_active_per_conversation": {
+          "name": "runs_one_active_per_conversation",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"runs\".\"status\" in ('queued', 'running', 'cancel_requested')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_queued_claim_order": {
+          "name": "runs_queued_claim_order",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runs\".\"status\" = 'queued'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_stale_recovery_order": {
+          "name": "runs_stale_recovery_order",
+          "columns": [
+            {
+              "expression": "locked_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runs\".\"status\" in ('running', 'cancel_requested')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runs_status_check": {
+          "name": "runs_status_check",
+          "value": "\"runs\".\"status\" in ('queued', 'running', 'cancel_requested', 'done', 'error', 'canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sandbox_leases": {
+      "name": "sandbox_leases",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fencing_token": {
+          "name": "fencing_token",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "sandbox_leases_user_id_conversation_id_pk": {
+          "name": "sandbox_leases_user_id_conversation_id_pk",
+          "columns": [
+            "user_id",
+            "conversation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/chat-api/drizzle/meta/0005_snapshot.json
+++ b/apps/chat-api/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,410 @@
+{
+  "id": "ed72e7a9-8b46-4883-b53f-3b82a0648cb1",
+  "prevId": "cf7cd128-a1a6-47c0-aae0-7251298ce7ee",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_id": {
+          "name": "summary_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "conversations_user_id_conversation_id_pk": {
+          "name": "conversations_user_id_conversation_id_pk",
+          "columns": [
+            "user_id",
+            "conversation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "conversations_scope_check": {
+          "name": "conversations_scope_check",
+          "value": "\"conversations\".\"scope\" in ('general', 'collection', 'document')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.run_events": {
+      "name": "run_events",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "run_events_run_id_runs_run_id_fk": {
+          "name": "run_events_run_id_runs_run_id_fk",
+          "tableFrom": "run_events",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "run_events_run_id_seq_pk": {
+          "name": "run_events_run_id_seq_pk",
+          "columns": [
+            "run_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "run_events_visibility_check": {
+          "name": "run_events_visibility_check",
+          "value": "\"run_events\".\"visibility\" in ('internal', 'client')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.runs": {
+      "name": "runs",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locked_by": {
+          "name": "locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fencing_token": {
+          "name": "fencing_token",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_event_seq": {
+          "name": "next_event_seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "runs_one_active_per_conversation": {
+          "name": "runs_one_active_per_conversation",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"runs\".\"status\" in ('queued', 'running', 'cancel_requested')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_queued_claim_order": {
+          "name": "runs_queued_claim_order",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runs\".\"status\" = 'queued'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_stale_recovery_order": {
+          "name": "runs_stale_recovery_order",
+          "columns": [
+            {
+              "expression": "locked_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runs\".\"status\" in ('running', 'cancel_requested')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runs_status_check": {
+          "name": "runs_status_check",
+          "value": "\"runs\".\"status\" in ('queued', 'running', 'cancel_requested', 'done', 'error', 'canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sandbox_leases": {
+      "name": "sandbox_leases",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fencing_token": {
+          "name": "fencing_token",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "sandbox_leases_user_id_conversation_id_pk": {
+          "name": "sandbox_leases_user_id_conversation_id_pk",
+          "columns": [
+            "user_id",
+            "conversation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/chat-api/drizzle/meta/_journal.json
+++ b/apps/chat-api/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1783150521296,
       "tag": "0003_acoustic_dexter_bennett",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1783151471775,
+      "tag": "0004_organic_nebula",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/chat-api/drizzle/meta/_journal.json
+++ b/apps/chat-api/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1783060208776,
       "tag": "0002_brief_wolfsbane",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1783150521296,
+      "tag": "0003_acoustic_dexter_bennett",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/chat-api/drizzle/meta/_journal.json
+++ b/apps/chat-api/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1783151471775,
       "tag": "0004_organic_nebula",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1783151799756,
+      "tag": "0005_chunky_trauma",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/chat-api/src/db/schema.ts
+++ b/apps/chat-api/src/db/schema.ts
@@ -145,6 +145,9 @@ export const runs = pgTable(
 		index("runs_queued_claim_order")
 			.on(t.createdAt, t.runId)
 			.where(sql`${t.status} = 'queued'`),
+		index("runs_stale_recovery_order")
+			.on(t.lockedUntil)
+			.where(sql`${t.status} in ('running', 'cancel_requested')`),
 	],
 );
 

--- a/apps/chat-api/src/db/schema.ts
+++ b/apps/chat-api/src/db/schema.ts
@@ -146,7 +146,7 @@ export const runs = pgTable(
 			.on(t.createdAt, t.runId)
 			.where(sql`${t.status} = 'queued'`),
 		index("runs_stale_recovery_order")
-			.on(t.lockedUntil)
+			.on(t.lockedUntil, t.createdAt, t.runId)
 			.where(sql`${t.status} in ('running', 'cancel_requested')`),
 	],
 );

--- a/apps/chat-api/src/db/schema.ts
+++ b/apps/chat-api/src/db/schema.ts
@@ -2,6 +2,7 @@ import { sql } from "drizzle-orm";
 import {
 	bigint,
 	check,
+	index,
 	jsonb,
 	pgTable,
 	primaryKey,
@@ -141,6 +142,9 @@ export const runs = pgTable(
 		uniqueIndex("runs_one_active_per_conversation")
 			.on(t.userId, t.conversationId)
 			.where(sql`${t.status} in ('queued', 'running', 'cancel_requested')`),
+		index("runs_queued_claim_order")
+			.on(t.createdAt, t.runId)
+			.where(sql`${t.status} = 'queued'`),
 	],
 );
 

--- a/apps/chat-api/src/features/run-store/index.ts
+++ b/apps/chat-api/src/features/run-store/index.ts
@@ -1,0 +1,1 @@
+export * from "./run-store";

--- a/apps/chat-api/src/features/run-store/run-store.test.ts
+++ b/apps/chat-api/src/features/run-store/run-store.test.ts
@@ -155,6 +155,22 @@ describe("run-store transaction helpers", () => {
 		]);
 	});
 
+	it("appendRunEventTx rejects terminal event types", async () => {
+		await createRun("run-1", "user-1", "conv-1");
+		const claimed = await claimRun();
+
+		expect(
+			await appendRunEventTx(tdb.db, {
+				mode: { kind: "owner_running", owner: claimed },
+				type: RUN_EVENT_TYPES.runDone,
+				visibility: "client",
+				payload: {},
+			}),
+		).toEqual({ status: "not_appendable" });
+		expect((await getRun("run-1"))?.nextEventSeq).toBe(3);
+		expect(await compactEvents("run-1")).toHaveLength(2);
+	});
+
 	it("heartbeatRunTx succeeds for the matching owner token and fails for wrong owner data", async () => {
 		await createRun("run-1", "user-1", "conv-1");
 		const claimed = await claimRun();
@@ -384,6 +400,36 @@ describe("run-store transaction helpers", () => {
 			await transitionRunTerminalTx(tdb.db, {
 				...claimed,
 				transition: "cancellation",
+			}),
+		).toEqual({
+			status: "transitioned",
+			runStatus: "canceled",
+			eventSeq: 4,
+		});
+		expect(await terminalEvents("run-1")).toEqual([
+			{
+				seq: 4,
+				type: RUN_EVENT_TYPES.runCanceled,
+				visibility: "client",
+				payload: {},
+			},
+		]);
+	});
+
+	it("failure after cancel_requested maps to canceled", async () => {
+		await createRun("run-1", "user-1", "conv-1");
+		const claimed = await claimRun();
+		await requestRunCancellationTx(tdb.db, {
+			userId: "user-1",
+			conversationId: "conv-1",
+			runId: "run-1",
+		});
+
+		expect(
+			await transitionRunTerminalTx(tdb.db, {
+				...claimed,
+				transition: "failure",
+				message: "SDK interrupt failed",
 			}),
 		).toEqual({
 			status: "transitioned",

--- a/apps/chat-api/src/features/run-store/run-store.test.ts
+++ b/apps/chat-api/src/features/run-store/run-store.test.ts
@@ -1,0 +1,537 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { eq, sql } from "drizzle-orm";
+import { createTestDatabase, type TestDb } from "@/db/testing";
+import { runEvents, runs } from "@/db/schema";
+import {
+	appendRunEventTx,
+	claimNextRunTx,
+	createQueuedRunTx,
+	heartbeatRunTx,
+	recoverOneStaleRunTx,
+	requestRunCancellationTx,
+	RUN_EVENT_TYPES,
+	transitionRunTerminalTx,
+	type ClaimedRun,
+} from "./run-store";
+
+const TTL = 60_000;
+
+describe("run-store transaction helpers", () => {
+	let tdb: TestDb;
+
+	beforeEach(async () => {
+		tdb = await createTestDatabase();
+	});
+
+	afterEach(async () => {
+		await tdb.close();
+	});
+
+	it("createQueuedRunTx inserts a queued run and run_created atomically", async () => {
+		const created = await createRun("run-1", "user-1", "conv-1");
+
+		expect(created).toEqual({
+			status: "created",
+			runId: "run-1",
+			runStatus: "queued",
+			eventSeq: 1,
+		});
+		expect(await getRun("run-1")).toMatchObject({
+			runId: "run-1",
+			userId: "user-1",
+			conversationId: "conv-1",
+			status: "queued",
+			fencingToken: 0,
+			nextEventSeq: 2,
+		});
+		expect(await getEvents("run-1")).toEqual([
+			expect.objectContaining({
+				seq: 1,
+				type: RUN_EVENT_TYPES.runCreated,
+				visibility: "internal",
+				payload: {
+					userId: "user-1",
+					conversationId: "conv-1",
+					runId: "run-1",
+				},
+			}),
+		]);
+	});
+
+	it("createQueuedRunTx returns an active-run conflict for the unique index", async () => {
+		await createRun("run-1", "user-1", "conv-1");
+
+		await expect(
+			createQueuedRunTx(tdb.db, {
+				runId: "run-2",
+				userId: "user-1",
+				conversationId: "conv-1",
+			}),
+		).resolves.toEqual({ status: "active_run_exists" });
+	});
+
+	it("createQueuedRunTx does not report duplicate run ids as active-run conflicts", async () => {
+		await createRun("run-1", "user-1", "conv-1");
+
+		await expect(
+			createQueuedRunTx(tdb.db, {
+				runId: "run-1",
+				userId: "user-2",
+				conversationId: "conv-2",
+			}),
+		).rejects.toThrow();
+	});
+
+	it("claimNextRunTx claims one queued run and appends run_claimed", async () => {
+		await createRun("run-1", "user-1", "conv-1");
+
+		const claimed = await claimNextRunTx(tdb.db, {
+			workerId: "worker-1",
+			ttlMs: TTL,
+		});
+
+		expect(claimed).toMatchObject({
+			runId: "run-1",
+			userId: "user-1",
+			conversationId: "conv-1",
+			workerId: "worker-1",
+			fencingToken: 1,
+		});
+		expect(claimed?.lockedUntil).toBeInstanceOf(Date);
+		expect(await getRun("run-1")).toMatchObject({
+			status: "running",
+			lockedBy: "worker-1",
+			fencingToken: 1,
+			nextEventSeq: 3,
+		});
+		expect(await compactEvents("run-1")).toEqual([
+			{
+				seq: 1,
+				type: RUN_EVENT_TYPES.runCreated,
+				visibility: "internal",
+				payload: {
+					userId: "user-1",
+					conversationId: "conv-1",
+					runId: "run-1",
+				},
+			},
+			{
+				seq: 2,
+				type: RUN_EVENT_TYPES.runClaimed,
+				visibility: "internal",
+				payload: { workerId: "worker-1" },
+			},
+		]);
+	});
+
+	it("claimNextRunTx returns null when no queued run is claimable", async () => {
+		expect(
+			await claimNextRunTx(tdb.db, { workerId: "worker-1", ttlMs: TTL }),
+		).toBeNull();
+	});
+
+	it("appendRunEventTx allocates monotonic seq values through next_event_seq", async () => {
+		await createRun("run-1", "user-1", "conv-1");
+		const claimed = await claimRun();
+
+		const first = await appendRunEventTx(tdb.db, {
+			mode: { kind: "owner_running", owner: claimed },
+			type: "worker_note",
+			visibility: "internal",
+			payload: { step: 1 },
+		});
+		const second = await appendRunEventTx(tdb.db, {
+			mode: { kind: "owner_running", owner: claimed },
+			type: "model_note",
+			visibility: "internal",
+			payload: { step: 2 },
+		});
+
+		expect(first).toEqual({ status: "appended", seq: 3 });
+		expect(second).toEqual({ status: "appended", seq: 4 });
+		expect((await getRun("run-1"))?.nextEventSeq).toBe(5);
+		expect((await getEvents("run-1")).map((event) => event.seq)).toEqual([
+			1, 2, 3, 4,
+		]);
+	});
+
+	it("heartbeatRunTx succeeds for the matching owner token and fails for wrong owner data", async () => {
+		await createRun("run-1", "user-1", "conv-1");
+		const claimed = await claimRun();
+
+		expect(
+			await heartbeatRunTx(tdb.db, { ...claimed, ttlMs: TTL }),
+		).toMatchObject({ status: "ok" });
+		expect(
+			await heartbeatRunTx(tdb.db, {
+				...claimed,
+				workerId: "worker-2",
+				ttlMs: TTL,
+			}),
+		).toEqual({ status: "lost_ownership" });
+		expect(
+			await heartbeatRunTx(tdb.db, {
+				...claimed,
+				fencingToken: claimed.fencingToken + 1,
+				ttlMs: TTL,
+			}),
+		).toEqual({ status: "lost_ownership" });
+	});
+
+	it("heartbeatRunTx does not append durable heartbeat events", async () => {
+		await createRun("run-1", "user-1", "conv-1");
+		const claimed = await claimRun();
+
+		await heartbeatRunTx(tdb.db, { ...claimed, ttlMs: TTL });
+
+		expect(await compactEvents("run-1")).toHaveLength(2);
+		expect(
+			(await compactEvents("run-1")).map((event) => event.type),
+		).not.toContain("run_heartbeat");
+	});
+
+	it("stale owner appends fail after the fencing token changes", async () => {
+		await createRun("run-1", "user-1", "conv-1");
+		const claimed = await claimRun();
+		await tdb.db
+			.update(runs)
+			.set({ fencingToken: sql`${runs.fencingToken} + 1` })
+			.where(eq(runs.runId, claimed.runId));
+
+		expect(
+			await appendRunEventTx(tdb.db, {
+				mode: { kind: "owner_running", owner: claimed },
+				type: "worker_note",
+				visibility: "internal",
+				payload: {},
+			}),
+		).toEqual({ status: "not_appendable" });
+	});
+
+	it("stale owner appends fail after the lock expires", async () => {
+		await createRun("run-1", "user-1", "conv-1");
+		const claimed = await claimRun();
+		await expireRun(claimed.runId);
+
+		expect(
+			await appendRunEventTx(tdb.db, {
+				mode: { kind: "owner_running", owner: claimed },
+				type: "model_note",
+				visibility: "internal",
+				payload: {},
+			}),
+		).toEqual({ status: "not_appendable" });
+	});
+
+	it("queued cancellation transitions directly to canceled and appends one run_canceled", async () => {
+		await createRun("run-1", "user-1", "conv-1");
+
+		expect(
+			await requestRunCancellationTx(tdb.db, {
+				userId: "user-1",
+				conversationId: "conv-1",
+				runId: "run-1",
+			}),
+		).toEqual({ status: "canceled", eventSeq: 2 });
+		expect(await getRun("run-1")).toMatchObject({
+			status: "canceled",
+			lockedBy: null,
+			lockedUntil: null,
+		});
+		expect(await terminalEvents("run-1")).toEqual([
+			{
+				seq: 2,
+				type: RUN_EVENT_TYPES.runCanceled,
+				visibility: "client",
+				payload: {},
+			},
+		]);
+	});
+
+	it("running cancellation requests cancellation, keeps ownership, and appends run_cancel_requested", async () => {
+		await createRun("run-1", "user-1", "conv-1");
+		const claimed = await claimRun();
+
+		expect(
+			await requestRunCancellationTx(tdb.db, {
+				userId: "user-1",
+				conversationId: "conv-1",
+				runId: "run-1",
+				requestedBy: "user",
+				reason: "stop",
+			}),
+		).toEqual({ status: "requested", eventSeq: 3 });
+		expect(await getRun("run-1")).toMatchObject({
+			status: "cancel_requested",
+			lockedBy: claimed.workerId,
+			fencingToken: claimed.fencingToken,
+		});
+		expect((await compactEvents("run-1")).at(-1)).toEqual({
+			seq: 3,
+			type: RUN_EVENT_TYPES.runCancelRequested,
+			visibility: "internal",
+			payload: { requestedBy: "user", reason: "stop" },
+		});
+	});
+
+	it("repeated cancellation does not duplicate terminal or control events", async () => {
+		await createRun("run-1", "user-1", "conv-1");
+		await claimRun();
+		await requestRunCancellationTx(tdb.db, {
+			userId: "user-1",
+			conversationId: "conv-1",
+			runId: "run-1",
+		});
+
+		expect(
+			await requestRunCancellationTx(tdb.db, {
+				userId: "user-1",
+				conversationId: "conv-1",
+				runId: "run-1",
+			}),
+		).toEqual({ status: "requested", eventSeq: null });
+		expect(
+			(await compactEvents("run-1")).filter(
+				(event) => event.type === RUN_EVENT_TYPES.runCancelRequested,
+			),
+		).toHaveLength(1);
+	});
+
+	it("success after cancel_requested loses", async () => {
+		await createRun("run-1", "user-1", "conv-1");
+		const claimed = await claimRun();
+		await requestRunCancellationTx(tdb.db, {
+			userId: "user-1",
+			conversationId: "conv-1",
+			runId: "run-1",
+		});
+
+		expect(
+			await transitionRunTerminalTx(tdb.db, {
+				...claimed,
+				transition: "success",
+			}),
+		).toEqual({ status: "lost_ownership_or_not_transitionable" });
+		expect(await getRun("run-1")).toMatchObject({ status: "cancel_requested" });
+	});
+
+	it("terminal transition appends exactly one terminal event", async () => {
+		await createRun("run-1", "user-1", "conv-1");
+		const claimed = await claimRun();
+
+		expect(
+			await transitionRunTerminalTx(tdb.db, {
+				...claimed,
+				transition: "failure",
+				message: "Client-safe failure",
+			}),
+		).toEqual({
+			status: "transitioned",
+			runStatus: "error",
+			eventSeq: 3,
+		});
+		expect(await getRun("run-1")).toMatchObject({
+			status: "error",
+			lockedBy: null,
+			lockedUntil: null,
+		});
+		expect(await terminalEvents("run-1")).toEqual([
+			{
+				seq: 3,
+				type: RUN_EVENT_TYPES.runError,
+				visibility: "client",
+				payload: { message: "Client-safe failure" },
+			},
+		]);
+	});
+
+	it("concurrent or repeated terminalization produces one terminal event", async () => {
+		await createRun("run-1", "user-1", "conv-1");
+		const claimed = await claimRun();
+
+		expect(
+			await transitionRunTerminalTx(tdb.db, {
+				...claimed,
+				transition: "success",
+			}),
+		).toMatchObject({ status: "transitioned", eventSeq: 3 });
+		expect(
+			await transitionRunTerminalTx(tdb.db, {
+				...claimed,
+				transition: "success",
+			}),
+		).toEqual({ status: "lost_ownership_or_not_transitionable" });
+		expect(await terminalEvents("run-1")).toEqual([
+			{
+				seq: 3,
+				type: RUN_EVENT_TYPES.runDone,
+				visibility: "client",
+				payload: {},
+			},
+		]);
+	});
+
+	it("cancellation terminalization is allowed from cancel_requested", async () => {
+		await createRun("run-1", "user-1", "conv-1");
+		const claimed = await claimRun();
+		await requestRunCancellationTx(tdb.db, {
+			userId: "user-1",
+			conversationId: "conv-1",
+			runId: "run-1",
+		});
+
+		expect(
+			await transitionRunTerminalTx(tdb.db, {
+				...claimed,
+				transition: "cancellation",
+			}),
+		).toEqual({
+			status: "transitioned",
+			runStatus: "canceled",
+			eventSeq: 4,
+		});
+		expect(await terminalEvents("run-1")).toEqual([
+			{
+				seq: 4,
+				type: RUN_EVENT_TYPES.runCanceled,
+				visibility: "client",
+				payload: {},
+			},
+		]);
+	});
+
+	it("recoverOneStaleRunTx terminalizes at most one stale run per call", async () => {
+		await createRun("run-1", "user-1", "conv-1");
+		await createRun("run-2", "user-1", "conv-2");
+		const first = await claimRun("worker-1");
+		const second = await claimRun("worker-2");
+		await expireRun(first.runId);
+		await expireRun(second.runId);
+
+		const recovered = await recoverOneStaleRunTx(tdb.db);
+
+		expect(recovered?.runId).toBe("run-1");
+		expect(
+			(await tdb.db.select().from(runs)).filter(
+				(run) => run.status === "error" || run.status === "canceled",
+			),
+		).toHaveLength(1);
+	});
+
+	it("stale running becomes error with a client-safe run_error", async () => {
+		await createRun("run-1", "user-1", "conv-1");
+		const claimed = await claimRun();
+		await expireRun(claimed.runId);
+
+		expect(await recoverOneStaleRunTx(tdb.db)).toMatchObject({
+			runId: "run-1",
+			runStatus: "error",
+			eventSeq: 3,
+		});
+		expect(await getRun("run-1")).toMatchObject({
+			status: "error",
+			lockedBy: null,
+			lockedUntil: null,
+			fencingToken: 2,
+		});
+		expect(await terminalEvents("run-1")).toEqual([
+			{
+				seq: 3,
+				type: RUN_EVENT_TYPES.runError,
+				visibility: "client",
+				payload: {
+					message: "The run was stopped because its worker became unavailable.",
+				},
+			},
+		]);
+	});
+
+	it("stale cancel_requested becomes canceled", async () => {
+		await createRun("run-1", "user-1", "conv-1");
+		const claimed = await claimRun();
+		await requestRunCancellationTx(tdb.db, {
+			userId: "user-1",
+			conversationId: "conv-1",
+			runId: "run-1",
+		});
+		await expireRun(claimed.runId);
+
+		expect(await recoverOneStaleRunTx(tdb.db)).toMatchObject({
+			runId: "run-1",
+			runStatus: "canceled",
+			eventSeq: 4,
+		});
+		expect(await getRun("run-1")).toMatchObject({
+			status: "canceled",
+			lockedBy: null,
+			lockedUntil: null,
+			fencingToken: 2,
+		});
+		expect(await terminalEvents("run-1")).toEqual([
+			{
+				seq: 4,
+				type: RUN_EVENT_TYPES.runCanceled,
+				visibility: "client",
+				payload: {},
+			},
+		]);
+	});
+
+	async function createRun(
+		runId: string,
+		userId = "user-1",
+		conversationId = "conv-1",
+	) {
+		return createQueuedRunTx(tdb.db, { runId, userId, conversationId });
+	}
+
+	async function claimRun(workerId = "worker-1"): Promise<ClaimedRun> {
+		const claimed = await claimNextRunTx(tdb.db, { workerId, ttlMs: TTL });
+		if (!claimed) throw new Error("expected a queued run");
+		return claimed;
+	}
+
+	async function expireRun(runId: string) {
+		await tdb.db
+			.update(runs)
+			.set({ lockedUntil: sql`now() - make_interval(secs => 60)` })
+			.where(eq(runs.runId, runId));
+	}
+
+	async function getRun(runId: string) {
+		const rows = await tdb.db
+			.select()
+			.from(runs)
+			.where(eq(runs.runId, runId))
+			.limit(1);
+		return rows[0] ?? null;
+	}
+
+	async function getEvents(runId: string) {
+		return tdb.db
+			.select()
+			.from(runEvents)
+			.where(eq(runEvents.runId, runId))
+			.orderBy(runEvents.seq);
+	}
+
+	async function compactEvents(runId: string) {
+		return (await getEvents(runId)).map((event) => ({
+			seq: event.seq,
+			type: event.type,
+			visibility: event.visibility,
+			payload: event.payload,
+		}));
+	}
+
+	async function terminalEvents(runId: string) {
+		const terminalTypes = new Set<string>([
+			RUN_EVENT_TYPES.runDone,
+			RUN_EVENT_TYPES.runError,
+			RUN_EVENT_TYPES.runCanceled,
+		]);
+		return (await compactEvents(runId)).filter((event) =>
+			terminalTypes.has(event.type),
+		);
+	}
+});

--- a/apps/chat-api/src/features/run-store/run-store.test.ts
+++ b/apps/chat-api/src/features/run-store/run-store.test.ts
@@ -206,6 +206,22 @@ describe("run-store transaction helpers", () => {
 		).not.toContain("run_heartbeat");
 	});
 
+	it("heartbeatRunTx reports cancellation requests without extending ownership", async () => {
+		await createRun("run-1", "user-1", "conv-1");
+		const claimed = await claimRun();
+		const lockedUntil = (await getRun("run-1"))?.lockedUntil;
+		await requestRunCancellationTx(tdb.db, {
+			userId: "user-1",
+			conversationId: "conv-1",
+			runId: "run-1",
+		});
+
+		expect(await heartbeatRunTx(tdb.db, { ...claimed, ttlMs: TTL })).toEqual({
+			status: "cancel_requested",
+		});
+		expect((await getRun("run-1"))?.lockedUntil).toEqual(lockedUntil);
+	});
+
 	it("stale owner appends fail after the fencing token changes", async () => {
 		await createRun("run-1", "user-1", "conv-1");
 		const claimed = await claimRun();

--- a/apps/chat-api/src/features/run-store/run-store.ts
+++ b/apps/chat-api/src/features/run-store/run-store.ts
@@ -79,6 +79,7 @@ export interface HeartbeatRunInput extends OwnedRunRef {
 
 export type HeartbeatRunResult =
 	| { status: "ok"; lockedUntil: Date }
+	| { status: "cancel_requested" }
 	| { status: "lost_ownership" };
 
 export interface RequestRunCancellationInput {
@@ -265,6 +266,19 @@ export async function heartbeatRunTx(
 	input: HeartbeatRunInput,
 ): Promise<HeartbeatRunResult> {
 	return db.transaction(async (tx) => {
+		const currentRows = await tx
+			.select({ status: runs.status })
+			.from(runs)
+			.where(ownedBy(input))
+			.limit(1)
+			.for("update");
+		const current = currentRows[0];
+		if (!current) return { status: "lost_ownership" };
+		if (current.status === "cancel_requested") {
+			return { status: "cancel_requested" };
+		}
+		if (current.status !== "running") return { status: "lost_ownership" };
+
 		const rows = await tx
 			.update(runs)
 			.set({
@@ -272,7 +286,7 @@ export async function heartbeatRunTx(
 				heartbeatAt: sql`now()`,
 				updatedAt: sql`now()`,
 			})
-			.where(ownedBy(input))
+			.where(and(ownedBy(input), eq(runs.status, "running")))
 			.returning({ lockedUntil: runs.lockedUntil });
 
 		const row = rows[0];
@@ -619,17 +633,25 @@ function asDate(value: Date | string): Date {
 }
 
 function isActiveRunUniqueViolation(error: unknown): boolean {
-	if (!error || typeof error !== "object") return false;
-	const maybe = error as {
-		code?: unknown;
-		constraint?: unknown;
-		cause?: unknown;
-	};
-	return (
-		(maybe.code === "23505" &&
-			maybe.constraint === "runs_one_active_per_conversation") ||
-		isActiveRunUniqueViolation(maybe.cause)
-	);
+	const seen = new WeakSet<object>();
+	let current: unknown = error;
+	while (current && typeof current === "object" && !seen.has(current)) {
+		seen.add(current);
+		const maybe = current as {
+			code?: unknown;
+			errno?: unknown;
+			constraint?: unknown;
+			cause?: unknown;
+		};
+		if (
+			(maybe.code === "23505" || maybe.errno === "23505") &&
+			maybe.constraint === "runs_one_active_per_conversation"
+		) {
+			return true;
+		}
+		current = maybe.cause;
+	}
+	return false;
 }
 
 async function executeRows<T>(tx: RunStoreTx, query: ReturnType<typeof sql>) {

--- a/apps/chat-api/src/features/run-store/run-store.ts
+++ b/apps/chat-api/src/features/run-store/run-store.ts
@@ -1,0 +1,606 @@
+import { and, eq, inArray, lt, sql } from "drizzle-orm";
+import type { Database } from "@/db/client";
+import { runEvents, runs } from "@/db/schema";
+
+export const RUN_STATUSES = [
+	"queued",
+	"running",
+	"cancel_requested",
+	"done",
+	"error",
+	"canceled",
+] as const;
+export type RunStatus = (typeof RUN_STATUSES)[number];
+
+export const RUN_EVENT_VISIBILITIES = ["internal", "client"] as const;
+export type RunEventVisibility = (typeof RUN_EVENT_VISIBILITIES)[number];
+
+export const RUN_EVENT_TYPES = {
+	runCreated: "run_created",
+	runClaimed: "run_claimed",
+	runCancelRequested: "run_cancel_requested",
+	runDone: "run_done",
+	runError: "run_error",
+	runCanceled: "run_canceled",
+} as const;
+export type RunEventType =
+	(typeof RUN_EVENT_TYPES)[keyof typeof RUN_EVENT_TYPES];
+
+export interface OwnedRunRef {
+	runId: string;
+	workerId: string;
+	fencingToken: number;
+}
+
+export interface CreateQueuedRunInput {
+	runId: string;
+	userId: string;
+	conversationId: string;
+}
+
+export type CreateQueuedRunResult =
+	| {
+			status: "created";
+			runId: string;
+			runStatus: Extract<RunStatus, "queued">;
+			eventSeq: number;
+	  }
+	| { status: "active_run_exists" };
+
+export interface ClaimNextRunInput {
+	workerId: string;
+	ttlMs: number;
+}
+
+export interface ClaimedRun extends OwnedRunRef {
+	userId: string;
+	conversationId: string;
+	lockedUntil: Date;
+}
+
+export type AppendRunEventMode =
+	| { kind: "owner_running"; owner: OwnedRunRef }
+	| { kind: "owner_running_or_cancel_requested"; owner: OwnedRunRef };
+
+export interface AppendRunEventInput {
+	mode: AppendRunEventMode;
+	type: string;
+	visibility: RunEventVisibility;
+	payload: JsonPayload;
+}
+
+export type AppendRunEventResult =
+	| { status: "appended"; seq: number }
+	| { status: "not_appendable" };
+
+export interface HeartbeatRunInput extends OwnedRunRef {
+	ttlMs: number;
+}
+
+export type HeartbeatRunResult =
+	| { status: "ok"; lockedUntil: Date }
+	| { status: "lost_ownership" };
+
+export interface RequestRunCancellationInput {
+	userId: string;
+	conversationId: string;
+	runId: string;
+	requestedBy?: string;
+	reason?: string;
+}
+
+export type RequestRunCancellationResult =
+	| { status: "canceled"; eventSeq: number }
+	| { status: "requested"; eventSeq: number | null }
+	| { status: "already_terminal"; runStatus: ExtractTerminalStatus<RunStatus> }
+	| { status: "not_found" };
+
+export type TerminalTransitionKind = "success" | "failure" | "cancellation";
+
+export interface TransitionRunTerminalInput extends OwnedRunRef {
+	transition: TerminalTransitionKind;
+	message?: string;
+}
+
+export type TransitionRunTerminalResult =
+	| {
+			status: "transitioned";
+			runStatus: ExtractTerminalStatus<RunStatus>;
+			eventSeq: number;
+	  }
+	| { status: "lost_ownership_or_not_transitionable" };
+
+export interface RecoverOneStaleRunInput {
+	message?: string;
+}
+
+export type RecoverOneStaleRunResult = {
+	runId: string;
+	userId: string;
+	conversationId: string;
+	runStatus: Extract<RunStatus, "error" | "canceled">;
+	eventSeq: number;
+} | null;
+
+type ExtractTerminalStatus<T extends RunStatus> = Extract<
+	T,
+	"done" | "error" | "canceled"
+>;
+
+type Transaction = Parameters<Parameters<Database["transaction"]>[0]>[0];
+type RunStoreTx = Database | Transaction;
+type JsonPayload = Record<string, unknown>;
+
+const STALE_WORKER_MESSAGE =
+	"The run was stopped because its worker became unavailable.";
+const DEFAULT_ERROR_MESSAGE = "The run failed.";
+
+export async function createQueuedRunTx(
+	db: Database,
+	input: CreateQueuedRunInput,
+): Promise<CreateQueuedRunResult> {
+	return db.transaction(async (tx) => {
+		try {
+			await tx.insert(runs).values({
+				runId: input.runId,
+				userId: input.userId,
+				conversationId: input.conversationId,
+				status: "queued",
+				fencingToken: 0,
+				nextEventSeq: 1,
+			});
+		} catch (error) {
+			if (isActiveRunUniqueViolation(error)) {
+				return { status: "active_run_exists" };
+			}
+			throw error;
+		}
+
+		const event = await appendRunEventInTx(tx, {
+			runId: input.runId,
+			type: RUN_EVENT_TYPES.runCreated,
+			visibility: "internal",
+			payload: {
+				userId: input.userId,
+				conversationId: input.conversationId,
+				runId: input.runId,
+			},
+			where: eq(runs.runId, input.runId),
+		});
+		if (!event) throw new Error("created run disappeared before event append");
+
+		return {
+			status: "created",
+			runId: input.runId,
+			runStatus: "queued",
+			eventSeq: event.seq,
+		};
+	});
+}
+
+export async function claimNextRunTx(
+	db: Database,
+	input: ClaimNextRunInput,
+): Promise<ClaimedRun | null> {
+	return db.transaction(async (tx) => {
+		const rows = await executeRows<{
+			run_id: string;
+			user_id: string;
+			conversation_id: string;
+			fencing_token: number | string;
+			locked_until: Date | string;
+		}>(
+			tx,
+			sql`
+				WITH candidate AS (
+					SELECT run_id
+					FROM runs
+					WHERE status = 'queued'
+					ORDER BY created_at, run_id
+					FOR UPDATE SKIP LOCKED
+					LIMIT 1
+				)
+				UPDATE runs
+				SET status = 'running',
+					locked_by = ${input.workerId},
+					locked_until = ${expiresAt(input.ttlMs)},
+					heartbeat_at = now(),
+					fencing_token = fencing_token + 1,
+					updated_at = now()
+				FROM candidate
+				WHERE runs.run_id = candidate.run_id
+					AND runs.status = 'queued'
+				RETURNING runs.run_id, runs.user_id, runs.conversation_id, runs.fencing_token, runs.locked_until
+			`,
+		);
+		const row = rows[0];
+		if (!row) return null;
+
+		const event = await appendRunEventInTx(tx, {
+			runId: row.run_id,
+			type: RUN_EVENT_TYPES.runClaimed,
+			visibility: "internal",
+			payload: { workerId: input.workerId },
+			where: ownedBy({
+				runId: row.run_id,
+				workerId: input.workerId,
+				fencingToken: Number(row.fencing_token),
+			}),
+		});
+		if (!event)
+			throw new Error("claimed run lost ownership before event append");
+
+		return {
+			runId: row.run_id,
+			userId: row.user_id,
+			conversationId: row.conversation_id,
+			workerId: input.workerId,
+			fencingToken: Number(row.fencing_token),
+			lockedUntil: asDate(row.locked_until),
+		};
+	});
+}
+
+export async function appendRunEventTx(
+	db: Database,
+	input: AppendRunEventInput,
+): Promise<AppendRunEventResult> {
+	return db.transaction(async (tx) => {
+		const event = await appendRunEventInTx(tx, {
+			runId: input.mode.owner.runId,
+			type: input.type,
+			visibility: input.visibility,
+			payload: input.payload,
+			where: appendModeWhere(input.mode),
+		});
+		if (!event) return { status: "not_appendable" };
+		return { status: "appended", seq: event.seq };
+	});
+}
+
+export async function heartbeatRunTx(
+	db: Database,
+	input: HeartbeatRunInput,
+): Promise<HeartbeatRunResult> {
+	return db.transaction(async (tx) => {
+		const rows = await tx
+			.update(runs)
+			.set({
+				lockedUntil: expiresAt(input.ttlMs),
+				heartbeatAt: sql`now()`,
+				updatedAt: sql`now()`,
+			})
+			.where(ownedBy(input))
+			.returning({ lockedUntil: runs.lockedUntil });
+
+		const row = rows[0];
+		if (!row?.lockedUntil) return { status: "lost_ownership" };
+		return { status: "ok", lockedUntil: row.lockedUntil };
+	});
+}
+
+export async function requestRunCancellationTx(
+	db: Database,
+	input: RequestRunCancellationInput,
+): Promise<RequestRunCancellationResult> {
+	return db.transaction(async (tx) => {
+		const currentRows = await tx
+			.select({ status: runs.status })
+			.from(runs)
+			.where(runIdentity(input))
+			.limit(1)
+			.for("update");
+		const current = currentRows[0];
+		if (!current) return { status: "not_found" };
+
+		if (isTerminalStatus(current.status)) {
+			return { status: "already_terminal", runStatus: current.status };
+		}
+
+		if (current.status === "cancel_requested") {
+			return { status: "requested", eventSeq: null };
+		}
+
+		if (current.status === "queued") {
+			const updated = await tx
+				.update(runs)
+				.set({
+					status: "canceled",
+					lockedBy: null,
+					lockedUntil: null,
+					heartbeatAt: null,
+					cancelRequestedAt: sql`now()`,
+					terminalAt: sql`now()`,
+					updatedAt: sql`now()`,
+				})
+				.where(and(runIdentity(input), eq(runs.status, "queued")))
+				.returning({ runId: runs.runId });
+			if (!updated[0]) return { status: "not_found" };
+
+			const event = await appendRunEventInTx(tx, {
+				runId: input.runId,
+				type: RUN_EVENT_TYPES.runCanceled,
+				visibility: "client",
+				payload: {},
+				where: eq(runs.runId, input.runId),
+			});
+			if (!event)
+				throw new Error("canceled run disappeared before event append");
+			return { status: "canceled", eventSeq: event.seq };
+		}
+
+		const updated = await tx
+			.update(runs)
+			.set({
+				status: "cancel_requested",
+				cancelRequestedAt: sql`now()`,
+				updatedAt: sql`now()`,
+			})
+			.where(and(runIdentity(input), eq(runs.status, "running")))
+			.returning({ runId: runs.runId });
+		if (!updated[0]) return { status: "not_found" };
+
+		const payload: JsonPayload = {};
+		if (input.requestedBy !== undefined)
+			payload.requestedBy = input.requestedBy;
+		if (input.reason !== undefined) payload.reason = input.reason;
+		const event = await appendRunEventInTx(tx, {
+			runId: input.runId,
+			type: RUN_EVENT_TYPES.runCancelRequested,
+			visibility: "internal",
+			payload,
+			where: eq(runs.runId, input.runId),
+		});
+		if (!event)
+			throw new Error("cancel-requested run disappeared before event append");
+		return { status: "requested", eventSeq: event.seq };
+	});
+}
+
+export async function transitionRunTerminalTx(
+	db: Database,
+	input: TransitionRunTerminalInput,
+): Promise<TransitionRunTerminalResult> {
+	return db.transaction(async (tx) => {
+		const spec = terminalSpec(input);
+		const updated = await tx
+			.update(runs)
+			.set({
+				status: spec.status,
+				lockedBy: null,
+				lockedUntil: null,
+				heartbeatAt: null,
+				terminalAt: sql`now()`,
+				updatedAt: sql`now()`,
+			})
+			.where(and(ownedBy(input), inArray(runs.status, spec.fromStatuses)))
+			.returning({ runId: runs.runId });
+
+		if (!updated[0]) {
+			return { status: "lost_ownership_or_not_transitionable" };
+		}
+
+		const event = await appendRunEventInTx(tx, {
+			runId: input.runId,
+			type: spec.eventType,
+			visibility: "client",
+			payload: spec.payload,
+			where: eq(runs.runId, input.runId),
+		});
+		if (!event) throw new Error("terminal run disappeared before event append");
+
+		return {
+			status: "transitioned",
+			runStatus: spec.status,
+			eventSeq: event.seq,
+		};
+	});
+}
+
+export async function recoverOneStaleRunTx(
+	db: Database,
+	input: RecoverOneStaleRunInput = {},
+): Promise<RecoverOneStaleRunResult> {
+	return db.transaction(async (tx) => {
+		const candidates = await tx
+			.select({
+				runId: runs.runId,
+				userId: runs.userId,
+				conversationId: runs.conversationId,
+				status: runs.status,
+			})
+			.from(runs)
+			.where(
+				and(
+					inArray(runs.status, ["running", "cancel_requested"]),
+					lt(runs.lockedUntil, sql`now()`),
+				),
+			)
+			.orderBy(runs.lockedUntil, runs.createdAt, runs.runId)
+			.limit(1)
+			.for("update", { skipLocked: true });
+		const candidate = candidates[0];
+		if (!candidate) return null;
+
+		const staleWasCancelRequested = candidate.status === "cancel_requested";
+		const runStatus = staleWasCancelRequested ? "canceled" : "error";
+		const eventType = staleWasCancelRequested
+			? RUN_EVENT_TYPES.runCanceled
+			: RUN_EVENT_TYPES.runError;
+		const payload = staleWasCancelRequested
+			? {}
+			: { message: safeErrorMessage(input.message ?? STALE_WORKER_MESSAGE) };
+
+		const updated = await tx
+			.update(runs)
+			.set({
+				status: runStatus,
+				lockedBy: null,
+				lockedUntil: null,
+				heartbeatAt: null,
+				fencingToken: sql`${runs.fencingToken} + 1`,
+				terminalAt: sql`now()`,
+				updatedAt: sql`now()`,
+			})
+			.where(
+				and(
+					eq(runs.runId, candidate.runId),
+					eq(runs.status, candidate.status),
+					lt(runs.lockedUntil, sql`now()`),
+				),
+			)
+			.returning({ runId: runs.runId });
+		if (!updated[0]) return null;
+
+		const event = await appendRunEventInTx(tx, {
+			runId: candidate.runId,
+			type: eventType,
+			visibility: "client",
+			payload,
+			where: eq(runs.runId, candidate.runId),
+		});
+		if (!event) throw new Error("stale run disappeared before event append");
+
+		return {
+			runId: candidate.runId,
+			userId: candidate.userId,
+			conversationId: candidate.conversationId,
+			runStatus,
+			eventSeq: event.seq,
+		};
+	});
+}
+
+async function appendRunEventInTx(
+	tx: RunStoreTx,
+	input: {
+		runId: string;
+		type: string;
+		visibility: RunEventVisibility;
+		payload: JsonPayload;
+		where: ReturnType<typeof and> | ReturnType<typeof eq>;
+	},
+): Promise<{ seq: number } | null> {
+	const seqRows = await tx
+		.update(runs)
+		.set({
+			nextEventSeq: sql`${runs.nextEventSeq} + 1`,
+			updatedAt: sql`now()`,
+		})
+		.where(input.where)
+		.returning({ seq: sql<number>`${runs.nextEventSeq} - 1` });
+	const seq = seqRows[0]?.seq;
+	if (seq === undefined) return null;
+
+	await tx.insert(runEvents).values({
+		runId: input.runId,
+		seq: Number(seq),
+		type: input.type,
+		visibility: input.visibility,
+		payload: input.payload,
+	});
+
+	return { seq: Number(seq) };
+}
+
+function appendModeWhere(mode: AppendRunEventMode) {
+	const statusClause =
+		mode.kind === "owner_running"
+			? eq(runs.status, "running")
+			: inArray(runs.status, ["running", "cancel_requested"]);
+	return and(ownedBy(mode.owner), statusClause);
+}
+
+function ownedBy(ref: OwnedRunRef) {
+	return and(
+		eq(runs.runId, ref.runId),
+		eq(runs.lockedBy, ref.workerId),
+		eq(runs.fencingToken, ref.fencingToken),
+		sql`${runs.lockedUntil} > now()`,
+	);
+}
+
+function runIdentity(input: {
+	userId: string;
+	conversationId: string;
+	runId: string;
+}) {
+	return and(
+		eq(runs.userId, input.userId),
+		eq(runs.conversationId, input.conversationId),
+		eq(runs.runId, input.runId),
+	);
+}
+
+function terminalSpec(input: TransitionRunTerminalInput): {
+	status: ExtractTerminalStatus<RunStatus>;
+	fromStatuses: Array<Extract<RunStatus, "running" | "cancel_requested">>;
+	eventType: RunEventType;
+	payload: JsonPayload;
+} {
+	if (input.transition === "success") {
+		return {
+			status: "done",
+			fromStatuses: ["running"],
+			eventType: RUN_EVENT_TYPES.runDone,
+			payload: {},
+		};
+	}
+	if (input.transition === "failure") {
+		return {
+			status: "error",
+			fromStatuses: ["running", "cancel_requested"],
+			eventType: RUN_EVENT_TYPES.runError,
+			payload: { message: safeErrorMessage(input.message) },
+		};
+	}
+	return {
+		status: "canceled",
+		fromStatuses: ["running", "cancel_requested"],
+		eventType: RUN_EVENT_TYPES.runCanceled,
+		payload: {},
+	};
+}
+
+function isTerminalStatus(
+	status: string,
+): status is ExtractTerminalStatus<RunStatus> {
+	return status === "done" || status === "error" || status === "canceled";
+}
+
+function safeErrorMessage(message: unknown): string {
+	if (typeof message !== "string") return DEFAULT_ERROR_MESSAGE;
+	const trimmed = message.trim();
+	return trimmed ? trimmed : DEFAULT_ERROR_MESSAGE;
+}
+
+function expiresAt(ttlMs: number) {
+	return sql`now() + make_interval(secs => ${ttlMs / 1000})`;
+}
+
+function asDate(value: Date | string): Date {
+	return value instanceof Date ? value : new Date(value);
+}
+
+function isActiveRunUniqueViolation(error: unknown): boolean {
+	if (!error || typeof error !== "object") return false;
+	const maybe = error as {
+		code?: unknown;
+		constraint?: unknown;
+		cause?: unknown;
+	};
+	return (
+		(maybe.code === "23505" &&
+			maybe.constraint === "runs_one_active_per_conversation") ||
+		isActiveRunUniqueViolation(maybe.cause)
+	);
+}
+
+async function executeRows<T>(tx: RunStoreTx, query: ReturnType<typeof sql>) {
+	const result = await tx.execute(query);
+	if (Array.isArray(result)) return result as T[];
+	if (result && typeof result === "object" && "rows" in result) {
+		return (result as { rows: T[] }).rows;
+	}
+	return [] as T[];
+}

--- a/apps/chat-api/src/features/run-store/run-store.ts
+++ b/apps/chat-api/src/features/run-store/run-store.ts
@@ -245,6 +245,8 @@ export async function appendRunEventTx(
 	db: Database,
 	input: AppendRunEventInput,
 ): Promise<AppendRunEventResult> {
+	if (isTerminalEventType(input.type)) return { status: "not_appendable" };
+
 	return db.transaction(async (tx) => {
 		const event = await appendRunEventInTx(tx, {
 			runId: input.mode.owner.runId,
@@ -362,7 +364,22 @@ export async function transitionRunTerminalTx(
 	input: TransitionRunTerminalInput,
 ): Promise<TransitionRunTerminalResult> {
 	return db.transaction(async (tx) => {
-		const spec = terminalSpec(input);
+		const currentRows = await tx
+			.select({ status: runs.status })
+			.from(runs)
+			.where(ownedBy(input))
+			.limit(1)
+			.for("update");
+		const current = currentRows[0];
+		if (!current) {
+			return { status: "lost_ownership_or_not_transitionable" };
+		}
+
+		const spec = terminalSpec(input, current.status);
+		if (!spec) {
+			return { status: "lost_ownership_or_not_transitionable" };
+		}
+
 		const updated = await tx
 			.update(runs)
 			.set({
@@ -373,7 +390,7 @@ export async function transitionRunTerminalTx(
 				terminalAt: sql`now()`,
 				updatedAt: sql`now()`,
 			})
-			.where(and(ownedBy(input), inArray(runs.status, spec.fromStatuses)))
+			.where(and(ownedBy(input), eq(runs.status, current.status)))
 			.returning({ runId: runs.runId });
 
 		if (!updated[0]) {
@@ -532,34 +549,53 @@ function runIdentity(input: {
 	);
 }
 
-function terminalSpec(input: TransitionRunTerminalInput): {
+function terminalSpec(
+	input: TransitionRunTerminalInput,
+	currentStatus: string,
+): {
 	status: ExtractTerminalStatus<RunStatus>;
-	fromStatuses: Array<Extract<RunStatus, "running" | "cancel_requested">>;
 	eventType: RunEventType;
 	payload: JsonPayload;
-} {
+} | null {
+	if (currentStatus !== "running" && currentStatus !== "cancel_requested") {
+		return null;
+	}
+
 	if (input.transition === "success") {
+		if (currentStatus !== "running") return null;
 		return {
 			status: "done",
-			fromStatuses: ["running"],
 			eventType: RUN_EVENT_TYPES.runDone,
 			payload: {},
 		};
 	}
 	if (input.transition === "failure") {
+		if (currentStatus === "cancel_requested") {
+			return {
+				status: "canceled",
+				eventType: RUN_EVENT_TYPES.runCanceled,
+				payload: {},
+			};
+		}
 		return {
 			status: "error",
-			fromStatuses: ["running", "cancel_requested"],
 			eventType: RUN_EVENT_TYPES.runError,
 			payload: { message: safeErrorMessage(input.message) },
 		};
 	}
 	return {
 		status: "canceled",
-		fromStatuses: ["running", "cancel_requested"],
 		eventType: RUN_EVENT_TYPES.runCanceled,
 		payload: {},
 	};
+}
+
+function isTerminalEventType(type: string): boolean {
+	return (
+		type === RUN_EVENT_TYPES.runDone ||
+		type === RUN_EVENT_TYPES.runError ||
+		type === RUN_EVENT_TYPES.runCanceled
+	);
 }
 
 function isTerminalStatus(


### PR DESCRIPTION
## Summary
- Add a run store feature module for persisting and loading run records
- Cover the run store behavior with focused tests
- Wire the new feature through the chat-api feature index

## Testing
- Added unit tests for run store read/write behavior
- Validation passed for the updated run-store module and its exported entrypoint