### PR TITLE
Capture split-runtime design decisions: 5 ADRs, glossary, doc revisions

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,76 @@
+# MyMemo Agent
+
+The MyMemo agent runtime: a chat service where a trusted agent loop works
+over a user's knowledge-base documents and workspace files, with untrusted
+code execution isolated in a per-conversation sandbox.
+
+## Language
+
+**Conversation**:
+The durable, user-visible container for a chat. Its document scope is frozen
+at creation and never changes for its lifetime.
+_Avoid_: chat, session, thread
+
+**Scope**:
+The set of documents a conversation may access — `general`, `collection`, or
+`document`. Resolved once at conversation creation, then only ever re-read.
+_Avoid_: permissions, access level
+
+**Run**:
+One backend execution attempt serving a user message. At most one run per
+conversation is active at a time, and in v1 a run executes at most once —
+never requeued or automatically retried.
+_Avoid_: job, task, attempt
+
+**Claim**:
+Taking exclusive execution ownership of a queued run. A v1 run is claimed at
+most once; a stale run is terminalized, never reclaimed.
+_Avoid_: lease (that word belongs to the decommissioned prototype path)
+
+**Run event**:
+One record in a run's durable, ordered event log — the source of truth for
+what happened during a run and the only source for anything streamed to the
+client.
+
+**Outcome**:
+The single way a run ends: `done`, `error`, or `canceled`. One word per
+outcome at every layer — status `done`, run event `run_done`, client frame
+`done`; likewise `error`/`run_error` and `canceled`/`run_canceled`.
+_Avoid_: completed, failed, finished, succeeded
+
+**Document**:
+An item in the MyMemo knowledge base: an ingested summary (immutable once
+created) or a user-created document (editable). Documents can be
+deactivated; queries only ever see active ones.
+_Avoid_: file (that word means workspace files in the sandbox)
+
+**Passage**:
+An indexed chunk of a document — the search and citation unit. A passage
+points at its document.
+_Avoid_: chunk, excerpt
+
+**Docs cache**:
+The reserved directory in a conversation's sandbox workspace where loaded
+document content is materialized. Reconstructible from the KB, persists
+across turns, never user work, dies with the conversation.
+_Avoid_: document store, workspace docs
+
+**Load**:
+Materializing a document's full content into the docs cache, disk-only, with
+a metadata-only result. Re-loading a document refreshes its cached copy.
+_Avoid_: fetch (the prototype path's word for content-into-context)
+
+**Agent session**:
+The Claude SDK transcript that carries a conversation's model-side memory
+across turns. Internal and worker-owned — never client-facing, never in the
+sandbox.
+_Avoid_: chat history (that is the user-visible record in run events)
+
+**Split runtime**:
+The target architecture: the agent loop runs in trusted Fargate workers
+while untrusted filesystem and shell execution stays in E2B.
+
+**Prototype path**:
+The superseded daemon-based architecture — agent loop inside the sandbox,
+gateway, per-turn tokens, sandbox leases. Decommissioned by hard swap; never
+a fallback.

--- a/docs/adr/0001-split-runtime-trust-boundary.md
+++ b/docs/adr/0001-split-runtime-trust-boundary.md
@@ -1,0 +1,29 @@
+# Move the agent loop into trusted Fargate (split runtime)
+
+Status: accepted
+
+The agent control loop moves out of the E2B sandbox into a trusted
+`agent-worker` Fargate service; E2B keeps only untrusted filesystem/shell
+execution on a persistent workspace. The load-bearing reason is the trust
+boundary, not upgrade mechanics: while the loop runs inside a
+prompt-injectable sandbox, every trusted capability requires external
+compensating machinery (gateway, per-turn token minting, per-token audience
+separation — and another audience + gateway route family for each future
+capability). Moving the loop deletes that machinery instead of maintaining it.
+
+## Considered Options
+
+- **Versioned agent-bundle download at sandbox hydration** — solves the
+  trigger problem (Claude Code/agent upgrades forcing E2B template rebuilds,
+  warm-sandbox drain, rehydration) without any re-architecture. Rejected: it
+  keeps the compensating machinery forever, adds hydration latency, and adds a
+  supply-chain surface inside the sandbox.
+- **Split runtime** (chosen) — accepted.
+
+## Consequences
+
+- Fallbacks must preserve the split. If a prototype gate fails (e.g. E2B
+  pause/snapshot durability), the fallback is a different persistence design
+  under the split runtime — not a return to the in-sandbox agent path.
+- The gateway/token machinery loses its reason to exist once the split path
+  is the serving path.

--- a/docs/adr/0002-hard-swap-no-coexistence-flag.md
+++ b/docs/adr/0002-hard-swap-no-coexistence-flag.md
@@ -1,0 +1,28 @@
+# Hard-swap to the split runtime; no coexistence flag
+
+Status: accepted
+
+The daemon-based prototype path and the split-runtime path enforce "one
+active turn per conversation" with different authorities — the
+`sandbox_leases` CAS lease versus the `runs` partial unique index. A
+deployment where both paths are reachable (e.g. behind a runtime-mode flag)
+has no single authority for that invariant: two turns could run concurrently
+on one conversation, each legal under its own authority. The cutover is
+therefore a hard swap of the `user.message` handler (Task 2.1), not a flag.
+This is safe because nothing deployed exercises the prototype path: Terraform
+ships only `chat-api` and `agent-worker`, the Statsig gate defaults closed,
+and the gateway/daemon exist only in the local compose harness.
+
+## Consequences
+
+- There is a short local-demo gap between the swap and Milestone 3, when the
+  synthetic worker restores a working end-to-end SSE path. The compose/e2e
+  harness is rewritten against split-runtime semantics at Milestone 3, not
+  Milestone 7.
+- Superseded components are deleted eagerly, keyed to the milestone that
+  replaces them: chat-api's `sandbox-orchestration`/`sandbox-agent` features
+  and llm-token minting die with the Task 2.1 swap; `apps/gateway`,
+  `apps/sandbox-daemon`, `apps/mymemo-docs`, `packages/llm-token`, and the
+  compose `gateway`/`sandbox` services die when Milestone 7 passes the full
+  local harness; `sandbox_leases` is dropped in the same migration that
+  creates `conversation_runtime` (Task 4.2).

--- a/docs/adr/0003-model-path-openrouter-direct.md
+++ b/docs/adr/0003-model-path-openrouter-direct.md
@@ -1,0 +1,35 @@
+# Model path: direct OpenRouter from agent-worker
+
+Status: accepted
+
+`agent-worker` sends Claude Agent SDK model traffic directly to OpenRouter's
+Anthropic-compatible Messages endpoint (`ANTHROPIC_BASE_URL` +
+`ANTHROPIC_AUTH_TOKEN`), not to Anthropic first-party and not through the
+gateway. The reason is provider flexibility: MyMemo does not want to be
+vendor-locked to Anthropic and plans to route to cheaper models later;
+OpenRouter keeps the agent harness unchanged while the underlying model can
+change.
+
+## Considered Options
+
+- **Direct Anthropic** — first-party behavior for prompt caching, token
+  counting, and streaming; no middleman fee or extra failure point. Rejected
+  as the default because it hard-couples the model path to one vendor.
+- **Direct OpenRouter** (chosen) — one API surface across providers at the
+  cost of a fee margin, a second point of failure, and a compatibility layer
+  that does not implement the full Anthropic surface (`count_tokens` is
+  absent and fails closed).
+
+## Consequences
+
+- Direct Anthropic is the named contingency, not a discarded option: the
+  worker's provider config must keep both shapes valid so a failed
+  OpenRouter smoke test (streaming, tool use, cancellation, caching,
+  token counting) is fixed by an env flip, not a code or architecture
+  change.
+- Prompt caching is the dominant cost lever for agentic loops; OpenRouter's
+  cache passthrough must be measured against first-party, because a small
+  cache regression outweighs the routing fee.
+- The harness stays the Claude Agent SDK, which is Anthropic-shaped. Each
+  future cheaper model is a per-model compatibility gate (tool-calling
+  fidelity, thinking blocks, cache semantics), not a free swap.

--- a/docs/adr/0004-documents-as-files-conversation-cache.md
+++ b/docs/adr/0004-documents-as-files-conversation-cache.md
@@ -1,0 +1,47 @@
+# Materialize loaded documents into a conversation-scoped docs cache
+
+Status: accepted
+
+The original split-runtime draft banned writing KB document content into the
+E2B workspace: search snippets and fetched documents were model context only.
+We reversed this. Full document content now reaches the agent as files:
+`LoadDocuments(documentIds)` runs in the trusted worker (the only holder of
+KB credentials), copies scope-checked, size-capped content into a reserved
+docs-cache directory in the conversation's sandbox workspace, and returns
+metadata only (`path`, `documentId`, `title`). The agent works over the files
+with its normal `Read`/`Grep`/`Bash` tools. The driver: file tools are what
+an agentic loop is best at, and disk-only delivery keeps document bodies out
+of model context, run events, and tool-result persistence entirely.
+
+## Considered Options
+
+- **Documents-as-context** (original design: snippets plus fetch-into-context)
+  — rejected: burns context tokens on large documents, poor fit for
+  grep/chunked-read workflows, and full bodies returned through tool results
+  would persist in `run_events`.
+- **Turn-scoped cache** (materialize, delete before end-of-turn checkpoint) —
+  rejected: re-copies the same content every turn, which is pure waste for
+  `document`-scope conversations that exist to work over one document. KB
+  summaries are immutable once created, which removes the staleness argument
+  for aggressive expiry.
+- **Conversation-scoped cache** (chosen).
+
+## Consequences
+
+- Retention: a KB document copy lives at most as long as the conversation
+  that loaded it. The cache persists across turns and rides pause/snapshot as
+  a side effect; conversation-deletion cleanup (which kills the sandbox and
+  snapshots) is the deletion path. A document deleted (deactivated) in the KB
+  keeps its cached copies until the conversations that loaded it are deleted.
+- Staleness: user-created documents are editable and are reachable through
+  conversation scope, so a cached copy can go stale across turns. V1 accepts
+  this; `LoadDocuments` is refresh-on-load (re-loading an id overwrites the
+  cached file), and no turn-start revalidation machinery is added.
+- The cache never marks the workspace dirty: dirty tracking decides when
+  user work needs a checkpoint, and a cache reconstructible from the KB never
+  does by itself. A restored sandbox may arrive with an empty or stale cache;
+  the agent reloads.
+- Any future "agent skill" packaging of search-and-load is prompt-layer
+  guidance over these same worker-backed tools. A sandbox-side script cannot
+  reach the KB — that would resurrect the token/gateway machinery ADR-0001
+  deletes.

--- a/docs/adr/0005-conversation-continuity-postgres-session-store.md
+++ b/docs/adr/0005-conversation-continuity-postgres-session-store.md
@@ -1,0 +1,48 @@
+# Conversation continuity via SDK SessionStore backed by Postgres
+
+Status: accepted
+
+In the split runtime the Claude Agent SDK runs in Fargate workers, its
+session transcripts are worker-local disk files, and a conversation is not
+pinned to a worker — so the prototype's implicit continuity story (SDK
+session files living on the per-conversation sandbox filesystem) silently
+broke. We restore continuity with the SDK's documented `SessionStore`
+adapter interface backed by the writable agent Postgres
+(`AGENT_DATABASE_URL`): the SDK mirrors transcript entries to Postgres
+during each run, and the next run — on any worker — resumes with
+`{ sessionStore, resume: agentSessionId }`, where `agentSessionId` is the
+per-conversation resume pointer stored in `conversation_runtime`.
+
+## Considered Options
+
+- **Stash SDK session files in the E2B sandbox** (it persists
+  per-conversation) — rejected: the transcript would become sandbox-writable
+  state fed back as trusted model context, giving prompt-injected code a
+  persistent cross-turn context-poisoning and system-prompt-exfiltration
+  vector. The split exists to prevent exactly this.
+- **Pin conversations to workers** — rejected: contradicts the claim model
+  and breaks scale-in and crash recovery.
+- **Reconstruct history from `run_events` each turn** — rejected: lossy
+  (drops tool-call context), re-implements what the SDK's documented
+  `SessionStore` interface (with a Postgres reference adapter and
+  conformance suite) already provides.
+- **SDK `SessionStore` on Postgres** (chosen).
+
+## Consequences
+
+- `conversation_runtime` regains `agent_session_id` as the resume pointer.
+  It advances only in the run's terminal-success transition, under the same
+  ownership fence as other runtime metadata — a stale worker cannot move it.
+  Stale-worker transcript appends land under that worker's own session key
+  and are harmless orphans.
+- Mirror writes are best-effort: if any `mirror_error` occurred during a
+  run, the pointer does not advance. The run still succeeds for the user;
+  the next turn resumes from the previous session and loses only that
+  turn's model-side memory (the user-visible history in `run_events` is
+  unaffected).
+- Retention is ours: conversation deletion must delete the conversation's
+  transcripts from the session store; superseded session transcripts are
+  cleaned up by the same periodic cleanup that owns snapshots.
+- The worker must run each query with a deterministic, conversation-stable
+  working directory so the store's `projectKey` is identical across workers
+  and turns.

--- a/docs/split-runtime-fargate-e2b-design.md
+++ b/docs/split-runtime-fargate-e2b-design.md
@@ -6,15 +6,32 @@ This document defines the target split-runtime architecture for moving the
 agent control loop out of the E2B sandbox and into trusted Fargate workers,
 while keeping untrusted filesystem and shell execution inside E2B.
 
-The design is motivated by one primary problem in the current E2B-template
-model:
+The primary driver is the trust boundary, not upgrade mechanics. As long as
+the agent loop executes inside a prompt-injectable sandbox, every trusted
+capability must be compensated for from outside: the gateway, per-turn token
+minting, per-token audience separation, and a new token audience plus gateway
+route family for each future capability. Moving the loop into trusted Fargate
+deletes that compensating machinery instead of maintaining it. (See
+ADR-0001.)
+
+The trigger problem that exposed the cost of the current model:
 
 > Daemon, agent, and Claude Code binary upgrades require a new E2B template,
 > warm-sandbox drain, and workspace rehydration.
 
-The split-runtime design decouples agent/runtime upgrades from E2B template
-upgrades. Fargate becomes the volatile, frequently deployed agent runtime. E2B
-becomes the persistent remote workspace and shell executor.
+A narrower fix — fetching a versioned agent bundle at sandbox-hydration time —
+would solve upgrade coupling alone, but would keep the compensating machinery
+forever, add hydration latency, and add a supply-chain surface inside the
+sandbox. It was rejected.
+
+Because the trust boundary is the driver, falling back to the in-sandbox
+agent path is not an acceptable outcome if a prototype gate fails. Fallbacks
+must preserve the split — for example, a separate durable workspace store if
+E2B pause/snapshot semantics prove insufficient.
+
+The split-runtime design also decouples agent/runtime upgrades from E2B
+template upgrades. Fargate becomes the volatile, frequently deployed agent
+runtime. E2B becomes the persistent remote workspace and shell executor.
 
 ## Decision Summary
 
@@ -180,6 +197,7 @@ Bash(command, cwd?, timeout?)
 Grep(pattern, path?, include?, maxResults?)
 Glob(pattern, path?, includeHidden?, maxResults?)
 SearchDocuments(query, maxResults?)
+LoadDocuments(documentIds)
 ```
 
 `Grep` and `Glob` are included because their inputs can stay simple and
@@ -187,8 +205,16 @@ path-scoped. They are not required for expressiveness because the model can
 achieve them through `Bash`, but dedicated tools give cleaner path enforcement,
 structured output, and better audit logs.
 
-`SearchDocuments` is a model-facing MCP tool, but the database access behind it
-is trusted worker code, not an MCP server talking directly to Postgres.
+`SearchDocuments` and `LoadDocuments` are model-facing MCP tools, but the
+database access behind them is trusted worker code, not an MCP server talking
+directly to Postgres. They split the document workflow into
+documents-as-files (ADR-0004): `SearchDocuments` is discovery — passage
+snippets returned into model context, nothing written to disk.
+`LoadDocuments` is materialization — the worker copies scope-checked,
+size-capped document content into the conversation's docs cache on the
+sandbox filesystem and returns metadata only, so the agent reads documents
+with its normal file tools and document bodies never enter model context or
+run events.
 
 Suggested schemas:
 
@@ -235,6 +261,10 @@ type SearchDocumentsInput = {
 	query: string;
 	maxResults?: number;
 };
+
+type LoadDocumentsInput = {
+	documentIds: string[];
+};
 ```
 
 Defaults:
@@ -257,6 +287,10 @@ Bash: default timeout 5 minutes, system max 15 minutes
 Grep: max 100 matches unless lowered by the model
 Glob: max 500 paths unless lowered by the model
 SearchDocuments: max bounded by worker config
+LoadDocuments: per-document and per-call byte caps bounded by worker config;
+  a truncated document is marked as truncated in the written file and in the
+  tool result. Files are written under a reserved docs-cache directory in the
+  workspace (e.g. .mymemo/docs/); loading an already-cached id overwrites it
 ```
 
 The model may ask for lower limits, but the system owns the upper bounds.
@@ -329,7 +363,9 @@ Use E2B's command APIs for remote process execution:
 - `Bash` marks the workspace dirty conservatively because even failed
   commands can mutate files
 
-E2B's JavaScript SDK v2.6.0 documents the primary v1 executor primitives:
+E2B's JavaScript SDK documents the primary v1 executor primitives (originally
+verified against v2.6.0 docs; the repo pins `^2.14.0`, and the hoisted
+semantics spike re-verifies against the pinned version):
 `commands.run` supports `onStdout` / `onStderr` streaming callbacks and
 `timeoutMs`; background commands return a handle; running commands can be listed,
 reconnected with `commands.connect(pid)`, and killed with `commands.kill(pid)`.
@@ -517,6 +553,12 @@ as a separate select followed by an update in application code; the select,
 status recheck, ownership write, and returned claimed row must be one
 transactional helper so two workers cannot race through a stale candidate.
 
+Claim wake-up: `chat-api` sends a `NOTIFY` on a fixed channel when it inserts
+a queued run; workers hold a dedicated `LISTEN` connection and claim
+immediately on wake. Polling every 1-2 seconds is the correctness fallback —
+the same durable-first pattern as the SSE projector — so the claim-poll
+interval stays out of the p95 first-token budget.
+
 Workers heartbeat every 15 seconds while a run is active.
 
 Failed runs must not retry automatically in the first version. Mark the run
@@ -572,6 +614,25 @@ Cancellation rules:
   `command_canceled`, `command_cleanup_failed`, `command_cleanup_complete`, or
   `sandbox_tainted`.
 
+### Control Loop Placement
+
+Everything that keeps run state correct runs inside every worker; the one
+loop that manipulates the fleet from outside runs outside:
+
+- claim loop: per worker; `LISTEN` wake-up plus 1-2 second poll fallback.
+- stale-run recovery: per worker, at least every 15 seconds. Idempotent
+  through CAS terminal transitions, so concurrent recovery across the fleet
+  is safe. If the whole fleet is down, recovery pauses — nothing could
+  process runs anyway, and recovery runs before claiming when the fleet
+  returns.
+- cleanup (orphan sandboxes, snapshot retention, deleted-conversation
+  sandboxes, superseded session transcripts): per worker on a minutes-scale
+  timer, single-flighted across the fleet with a Postgres advisory lock.
+- scaler: a separate scheduled job (Milestone 8), never inside the fleet it
+  scales; until then, fixed `desiredCount`.
+
+No separate scheduled recovery/cleanup jobs exist in v1.
+
 Do not introduce a generic conversation-event inbox in v1. The only mid-run
 control event in v1 is cancellation, and the `runs` row is the simplest source
 of truth for that state. If future features add tool confirmations, approvals,
@@ -597,6 +658,7 @@ Postgres:
   conversation_runtime
   runs
   run_events
+  agent_sessions
 
 Postgres LISTEN/NOTIFY:
   live wake-up for SSE streaming
@@ -712,6 +774,7 @@ conversation_runtime:
   sandboxId
   latestSnapshotId
   workspaceCheckpointStatus
+  agentSessionId (Claude SDK resume pointer; see Conversation Continuity)
   runtime metadata for the persistent E2B workspace
 
 runs:
@@ -728,6 +791,10 @@ run_events:
 
 document_access_events:
   document access audit
+
+agent_sessions:
+  Claude SDK session transcript mirror (SessionStore adapter rows),
+  worker-only, keyed by projectKey/sessionId/subpath
 ```
 
 The split runtime does not need a separate active conversation lease table if
@@ -773,7 +840,7 @@ model/content events and may only be appended while the run is `running`.
 Cancellation cleanup/audit events may be appended by the owning worker after
 `cancel_requested` so command interruption, command-tree cleanup, and sandbox
 taint decisions remain durable. Terminal helpers own `run_canceled`,
-`run_failed`, and stale-run recovery. This prevents a stale worker from
+`run_error`, and stale-run recovery. This prevents a stale worker from
 appending messages after cancellation or recovery has terminalized the run while
 still preserving the cancellation audit trail.
 
@@ -805,6 +872,59 @@ WHERE user_id = $userId
 If the fenced update affects zero rows, the worker has lost ownership. It must
 stop the run, avoid emitting success, and let stale-run recovery or the current
 owner produce the terminal event.
+
+## Conversation Continuity
+
+Turn N+1 sees turns 1..N through Claude SDK session resume backed by the
+SDK's documented `SessionStore` adapter interface, implemented on the
+writable agent Postgres (ADR-0005). The prototype's implicit mechanism — SDK
+session files persisting on the per-conversation sandbox filesystem — does
+not survive the split: the SDK now runs in Fargate, its local session files
+are worker-ephemeral, and conversations are not pinned to workers.
+
+Mechanism:
+
+```text
+run starts:
+  read conversation_runtime.agent_session_id
+  query({ prompt, options: { sessionStore, resume: agentSessionId } })
+  (no pointer -> fresh session)
+
+during the run:
+  the SDK mirrors transcript entries to the Postgres session store
+  (best-effort, retried; failures surface as mirror_error messages)
+
+run succeeds:
+  store the result message's session id into
+  conversation_runtime.agent_session_id with the same ownership-fenced
+  update as other runtime metadata
+```
+
+Rules:
+
+- The session pointer advances only in the terminal-success transition,
+  under the ownership fence. A stale worker cannot move it; its transcript
+  appends land under its own session key and are harmless orphans.
+- If any `mirror_error` occurred during the run, do not advance the pointer.
+  The run still succeeds for the user; the next turn resumes from the
+  previous session and loses only that turn's model-side memory. Monitor
+  `mirror_error` as store data loss.
+- The adapter deduplicates appends by `entry.uuid` (retried batches can
+  re-deliver).
+- The worker runs each query with a deterministic, conversation-stable
+  working directory so the store's `projectKey` is identical across workers
+  and turns.
+- Point `CLAUDE_CONFIG_DIR` at a per-run temp directory: the local JSONL is
+  a throwaway mirror source, and `sessionStore` cannot be combined with
+  `persistSession: false` or `enableFileCheckpointing`.
+- Session transcripts never touch the sandbox. Sandbox-resident session
+  state would let prompt-injected code poison future trusted model context
+  (ADR-0005).
+- Retention is ours: conversation deletion deletes the conversation's
+  transcripts; periodic cleanup prunes transcripts of superseded sessions.
+- Verify during Milestone 7 whether a resumed query continues under the same
+  session id or reports a new one; the worker always stores the id reported
+  by the run's result message.
 
 ## Response Streaming
 
@@ -897,7 +1017,7 @@ Then insert `run_events(run_id, seq, type, payload, created_at)`. Worker event
 appends must use the appropriate ownership fence for their append class. Owned
 cancellation cleanup/audit appends may use `status IN ('running',
 'cancel_requested')`; model/content appends must stay `status = 'running'`.
-Terminal helpers for `run_canceled`, `run_failed`, and stale-run recovery may
+Terminal helpers for `run_canceled`, `run_error`, and stale-run recovery may
 use a different status/ownership predicate, but they still allocate sequence
 numbers through the same transactional counter. This handles events written by
 the worker, cancellation path, and stale-run recovery without sequence races.
@@ -1190,10 +1310,11 @@ makes operational lookup, debugging, and manual recovery easier.
 
 ### Snapshot Policy
 
-Snapshots are the recovery source of truth for user-created work files. Loaded
-KB document content is run context, not durable workspace state. The v1 design
-does not require loaded documents to be recoverable after the run. Create
-snapshots at conversation checkpoints, not after every file write.
+Snapshots are the recovery source of truth for user-created work files.
+Loaded KB document content lives in the conversation's docs cache —
+reconstructible from the KB and never required to be recoverable (ADR-0004);
+search snippets are run context only. Create snapshots at conversation
+checkpoints, not after every file write.
 
 Mark the workspace dirty when:
 
@@ -1201,10 +1322,16 @@ Mark the workspace dirty when:
 - `Edit` succeeds.
 - any `Bash` command is executed, regardless of exit code.
 
-`SearchDocuments` does not mark the workspace dirty because document results are
-not written into the durable workspace by default. If a later model-controlled
-command transforms a document into user work, that transformation is captured
-through `Write`, `Edit`, or `Bash` dirty tracking.
+Neither `SearchDocuments` nor `LoadDocuments` marks the workspace dirty.
+Search writes nothing to disk. `LoadDocuments` writes only into the docs
+cache, which is reconstructible from the KB and is not user work — dirty
+tracking decides when user work needs a checkpoint, and a cache never does by
+itself. When a snapshot happens for other reasons it includes whatever is in
+the docs cache; that is an accepted side effect, not a requirement — a
+restored sandbox may equally arrive with an empty or stale cache, and the
+agent reloads. If a model-controlled command transforms a loaded document
+into user work, that transformation is captured through `Write`, `Edit`, or
+`Bash` dirty tracking.
 
 Create/update the conversation snapshot:
 
@@ -1222,7 +1349,7 @@ If `workspaceDirty = true`, the snapshot must complete and the latest
 succeeded run. If snapshot creation or metadata persistence
 fails:
 
-- append `run_failed`
+- append `run_error`
 - keep the sandbox id in `conversation_runtime` if live recovery remains possible
 - return a user-visible persistence error
 - do not emit `done`
@@ -1268,9 +1395,14 @@ recovery. The product path always restores from `latest_snapshot_id`; use
 
 Paused sandbox cleanup policy:
 
-- Paused sandboxes may live as long as their conversation exists.
+- Paused sandboxes may live as long as their conversation exists. This is
+  provisional: the hoisted E2B spike measures whether a paused sandbox is
+  billed separately from a snapshot, and the retention policy (live-forever
+  vs bounded idle lifetime with snapshot restore) is decided from that cost
+  model.
 - Conversation deletion, user deletion, or workspace deletion must explicitly
-  kill the referenced E2B sandbox and clear `conversation_runtime.sandbox_id`.
+  kill the referenced E2B sandbox, clear `conversation_runtime.sandbox_id`,
+  and delete the conversation's transcripts from the session store.
 - A periodic cleanup job should kill sandboxes referenced by runtime rows whose
   conversation/user no longer exists.
 - A periodic orphan cleanup job should kill sandbox IDs recorded in
@@ -1283,7 +1415,7 @@ Snapshot failure state:
 
 ```text
 runs.status = error
-run_events includes run_failed with persistence_error
+run_events includes run_error with persistence_error
 conversation_runtime.sandbox_id remains if live/reconnectable
 latest_snapshot_id remains the previous successful checkpoint
 workspace_checkpoint_status = dirty_uncheckpointed
@@ -1365,41 +1497,64 @@ Extract the existing gateway document query and scope-guard logic into a shared
 package or shared internal module so `agent-worker` reuses the same
 parameterized SQL and scope rules with its own `KB_DATABASE_URL`.
 
-The model-facing document tool is:
+The model-facing document tools are:
 
 ```text
 SearchDocuments(query, maxResults?)
+LoadDocuments(documentIds)
 ```
 
 Implementation path:
 
 ```text
 Claude / Agent SDK
-  -> MCP tool: SearchDocuments
+  -> MCP tool: SearchDocuments | LoadDocuments
       -> agent-worker document module
           -> KB Postgres through KB_DATABASE_URL
-          -> returns scoped snippets or bounded excerpts
+          -> SearchDocuments returns scoped passage snippets into context
+          -> LoadDocuments writes scope-checked content into the sandbox
+             docs cache through the E2B files API and returns metadata only
 ```
 
-Result shape:
+Result shapes:
 
 ```ts
 type SearchDocumentsResult = {
-	documents: Array<{
+	passages: Array<{
+		passageId: string;
 		documentId: string;
 		title: string;
 		snippet: string;
 		score?: number;
 	}>;
 };
+
+type LoadDocumentsResult = {
+	documents: Array<{
+		documentId: string;
+		title: string;
+		path: string;
+		truncated: boolean;
+	}>;
+};
 ```
 
-Do not write loaded document content into the E2B workspace by default. V1
-treats document search results as current-run model context only. Do not store
-full document content in run events, audit rows, snapshots, or durable
-conversation metadata by default. If a user explicitly asks the agent to create
-a derived file from a document, that derived file is normal workspace state and
-is included in snapshots.
+`passageId` is the citation unit: search hits stay citable and point at the
+`documentId` to load.
+
+Search results are current-run model context only. Full document content
+reaches the agent exclusively through the docs cache (ADR-0004): because
+`LoadDocuments` returns metadata only, document bodies never enter model
+context, run events, or tool-result persistence. Do not store full document
+content in run events or audit rows. The docs cache is conversation-scoped:
+it persists across turns, rides pause/snapshot as a side effect, and dies
+with the conversation — a KB document copy lives at most as long as the
+conversation that loaded it. Loading an already-cached document overwrites it
+(refresh-on-load). User-created documents are editable and in scope, so a
+cached copy can be stale across turns; v1 accepts this rather than adding
+revalidation machinery. If a user explicitly asks the agent to create a
+derived file from a document, that derived file is normal workspace state
+outside the cache and is included in snapshots.
 
 Document access audit is stored in Postgres:
 
@@ -1430,7 +1585,12 @@ Do not store full document content in audit rows by default.
 
 ## Model Provider Path
 
-The target model path is direct OpenRouter access from `agent-worker`.
+The target model path is direct OpenRouter access from `agent-worker`. The
+reason is provider flexibility — avoiding vendor lock-in and enabling later
+routing to cheaper models — not cost or capability of the proxy itself
+(ADR-0003). Direct Anthropic is the named contingency: worker provider config
+must keep both shapes valid so a failed OpenRouter smoke test is fixed by an
+env flip, not an architecture change.
 
 ```text
 Claude Code / Claude Agent SDK in agent-worker
@@ -1493,6 +1653,21 @@ smoke test with the exact Claude Code / Claude Agent SDK version:
 - Run events must record tool calls and command lifecycle events.
 - Workers must not share mutable agent state across conversations.
 - The same conversation must not run concurrently on two workers.
+
+Sandbox network posture:
+
+- Inbound: none. The split runtime has no in-sandbox daemon, so nothing needs
+  to reach the sandbox over HTTP; all file/command operations travel through
+  the E2B control plane. The prototype's per-sandbox traffic-access-token
+  edge machinery is not carried forward.
+- Outbound: open internet egress is an accepted residual risk in v1. Package
+  installs and user code need it, and E2B provides no per-sandbox egress
+  firewall. The blast radius is bounded by invariants this design already
+  enforces: the sandbox holds no credentials, and a prompt-injected turn can
+  only exfiltrate data already inside its conversation's frozen scope — its
+  own workspace files and docs cache — never another user's data, another
+  conversation's documents, or any secret. Egress allowlisting/proxying is a
+  post-v1 revisit.
 
 ## Cost Model
 
@@ -1566,14 +1741,25 @@ Costs:
 
 Use:
 
-- Drizzle for schema, migrations, and ordinary database queries.
-- `pg` for dedicated `LISTEN/NOTIFY` connections and tightly controlled
-  transactional helpers that need driver-level connection control.
+- Drizzle for schema, migrations, ordinary queries, and the raw-SQL
+  transactional helpers (`claimNextRunTx` etc.), running over the `pg`
+  (node-postgres) driver everywhere in the split-runtime services.
+- One driver, `pg`, for everything — including the dedicated unpooled
+  `LISTEN` connections (chat-api projector wake-up; worker claim/cancel
+  wake-up), which Bun.sql does not implement. Uniformity was chosen over
+  keeping the incumbent Bun.sql data layer because nothing is in production
+  and most Bun.sql consumers are prototype-path code already scheduled for
+  deletion (ADR-0002), so the surviving surface migrates in one change
+  (scheduled with Task 1.1). The gateway keeps its raw Bun.sql client: it is
+  deleted at Milestone 7 and not worth touching.
 - E2B SDK directly for files, commands, pause/resume, snapshots, and sandbox
   lifecycle.
 - Claude Agent SDK / Claude Code runtime in `agent-worker`.
 - Claude Agent SDK local tool callbacks for v1 tool integration. Do not add an
   MCP server process in v1.
+- Claude Agent SDK `SessionStore` adapter on the agent Postgres for
+  conversation continuity (start from the SDK's Postgres reference adapter;
+  run its conformance suite).
 
 Avoid for v1:
 
@@ -1703,6 +1889,8 @@ Cover:
 - `Grep`
 - `Glob`
 - `SearchDocuments` with fixture-backed document data
+- `LoadDocuments` writes fixture documents into the docs cache and returns
+  metadata only
 
 For `Bash`, cover:
 
@@ -1835,8 +2023,9 @@ Acceptance criteria:
 - a user turn streams tokens through chat-api SSE
 - exactly one worker claims the run
 - tools execute in E2B, not Fargate shell
-- `SearchDocuments` enforces frozen scope without making loaded documents
-  durable workspace state
+- `SearchDocuments` and `LoadDocuments` enforce frozen scope; loaded content
+  lands only in the conversation docs cache, and document bodies never appear
+  in run events or tool results
 - dirty workspace snapshots after successful turn
 - paused sandbox resumes with files intact
 - killed sandbox recovers from latest snapshot or returns a clear recovery
@@ -1852,10 +2041,18 @@ Acceptance criteria:
 - E2B template dependencies: keep `rg`, shell/coreutils, Git, and language
   runtimes/package managers needed for user code. Do not install Claude Code,
   agent bundles, daemon bundles, provider credentials, or document credentials.
-- Model path: direct OpenRouter from `agent-worker`; no gateway in the v1 model
-  path.
+- Model path: direct OpenRouter from `agent-worker` for provider flexibility
+  (ADR-0003); no gateway in the v1 model path. Contingency if the SDK
+  compatibility smoke test fails: direct Anthropic via worker env flip, same
+  architecture.
 - Snapshot retention: keep latest and previous successful snapshot references in
   Postgres; clean unreferenced snapshots after 7 days.
+- Document materialization: `LoadDocuments` copies scope-checked KB content
+  into a conversation-scoped docs cache on the sandbox filesystem and returns
+  metadata only; `SearchDocuments` stays context-only discovery (ADR-0004).
+- Conversation continuity: Claude SDK session resume through a Postgres
+  `SessionStore` adapter; `conversation_runtime.agent_session_id` is the
+  fenced resume pointer (ADR-0005).
 
 ## Recommendation
 

--- a/docs/split-runtime-fargate-e2b-implementation-plan.md
+++ b/docs/split-runtime-fargate-e2b-implementation-plan.md
@@ -77,11 +77,16 @@ SSE frames:
 ```text
 conversation_id
 run_id
-sandbox_id
-agent_session_id
 text_delta
 done | canceled | error
 ```
+
+The prototype-era `sandbox_id` and `agent_session_id` frames are not part of
+the split-runtime contract: both are internal runtime identifiers (the design
+doc classifies the agent session id as internal/runtime-facing), and in the
+split runtime they only exist after a worker claims the run, so they could
+never be reliable early frames. Operators find them in `run_events`, not in
+the client stream.
 
 3. Reconnect to an existing run without creating another backend attempt:
 
@@ -118,7 +123,9 @@ The first deployable environment contains:
   - IAM task-role permissions for E2B access, Secrets Manager reads, logs, and
     the existing S3/RDS resources only where needed
   - Secrets Manager entries for agent-only secrets
-  - scheduled recovery/cleanup/scaler jobs if they are separate from the worker
+  - no separate scheduled recovery/cleanup jobs: those loops are
+    worker-embedded (cleanup single-flighted via a Postgres advisory lock);
+    the Milestone 8 scaler is the only separate scheduled job
 - Postgres migration task integrated with the existing migration/deploy flow.
 - E2B template build/verification step containing only stable executor
   dependencies.
@@ -166,6 +173,30 @@ Rollback for early deployments is service-level plus exposure-level:
 - close the Statsig gate
 - keep DB migrations additive until the first public launch
 - keep E2B sandboxes and snapshots until cleanup verifies they are unreferenced
+
+## Prototype Path Decommissioning
+
+The daemon-based prototype path is replaced by a hard swap, not flag-switched
+coexistence: the two paths enforce "one active turn per conversation" with
+different authorities (`sandbox_leases` CAS vs the `runs` partial unique
+index), so a deployment where both are reachable has no single authority for
+that invariant (ADR-0002).
+
+Schedule:
+
+- Task 2.1 swaps the `user.message` handler from `runSandboxChat` to
+  queued-run insertion in one PR. chat-api's `sandbox-orchestration` and
+  `sandbox-agent` features, llm-token minting, the in-memory `run-state`
+  lifecycle module, and the WorkspaceStore-backed NDJSON run-event log are
+  deleted with the swap (the Postgres `runs`/`run_events` model replaces
+  them).
+- Milestone 3's synthetic worker restores a working end-to-end SSE demo; the
+  compose/e2e harness is rewritten against split-runtime semantics then.
+- `apps/gateway`, `apps/sandbox-daemon`, `apps/mymemo-docs`,
+  `packages/llm-token`, and the compose `gateway`/`sandbox` services are
+  deleted when Milestone 7 passes the full local harness.
+- `sandbox_leases` is dropped in the same migration that creates
+  `conversation_runtime` (Task 4.2).
 
 ## Statsig Exposure Gate
 
@@ -249,6 +280,14 @@ The database must enforce one active run per `{userId, conversationId}`.
 
 The durable, ordered event stream for audit, SSE projection, and reconnect.
 This is the source of truth for client replay.
+
+### `agent_sessions`
+
+Claude SDK session transcript mirror — the `SessionStore` adapter's backing
+table (one jsonb row per transcript entry, keyed by
+`projectKey/sessionId/subpath`, insertion-ordered). Worker-only; created at
+Milestone 7 with the continuity task. The per-conversation resume pointer
+lives in `conversation_runtime.agent_session_id`, not here.
 
 ### `document_access_events`
 
@@ -474,11 +513,14 @@ Goal: create the durable run queue and event log.
 
 Add:
 
-- `conversation_runtime`
-- `runs`
-- `run_events`
+- `runs` (landed via MYM-49)
+- `run_events` (landed via MYM-49)
 - `document_access_events`
-- `orphan_sandboxes`
+
+`conversation_runtime` and `orphan_sandboxes` are deliberately not part of
+this task: their shape is an output of the E2B semantics spike (Task 4.1,
+hoisted to run in parallel with Milestones 1-3), so they are created in
+Task 4.2 after the spike passes.
 
 Key DB invariants:
 
@@ -487,6 +529,35 @@ Key DB invariants:
 - check constraints for run statuses and checkpoint statuses
 - foreign-key or ownership-equivalent constraints where practical
 - indexes for queue claim, SSE replay, stale-run recovery, and cleanup scans
+
+`runs` carries no fencing token: a v1 run is claimed exactly once (failed runs
+do not requeue; stale runs are terminalized, never reclaimed), so
+`locked_by` + `locked_until` is the complete ownership fence. Remove the
+speculative `fencing_token` column from the landed MYM-49 schema. A token
+returns only with a future requeue feature that makes multiple holds per run
+possible — in the same PR as the requeue logic.
+
+`run_events` carries no `visibility` column: the projector's event-type→frame
+mapping is the single authority for client exposure, and unmapped types are
+skipped (fail-closed — a new internal event type cannot leak to clients
+without an explicit frame mapping). Remove the landed MYM-49 `visibility`
+column together with `fencing_token`. The design doc's append classes remain
+the write-side rule; they govern who may write, not what the client sees.
+
+Because nothing is in production, do both removals by regenerating the
+migration history as a clean baseline (erase `drizzle/`, regenerate one
+0000 migration) instead of stacking drop-migrations. Any previously migrated
+environment DB must be reset to the new baseline.
+
+This task also carries the driver decision: swap chat-api's Drizzle driver
+from `drizzle-orm/bun-sql` to `drizzle-orm/node-postgres` (`pg`) in
+`src/db/client.ts` and `src/db/migrate.ts`, adding the `pg` dependency — one
+driver everywhere, since `pg` must exist anyway for the `LISTEN` connections
+Bun.sql does not implement. Caveat found while validating: the resolved URL
+appends `sslmode=require`, which `pg` treats as verified TLS (it checks the
+server cert against the trust store) while Bun.sql is laxer — verify the
+first RDS connection after the swap, and if verification fails supply the
+RDS CA bundle or switch the URL policy to `sslmode=no-verify`.
 
 Tests first:
 
@@ -656,6 +727,13 @@ Goal: prove and wrap the E2B substrate before wiring it to the model.
 
 ### Task 4.1: Prototype E2B Semantics Gate
 
+This task is hoisted: it runs now, in parallel with Milestones 1-3, as a
+standalone script against real E2B. It depends on nothing from earlier
+milestones, it is the highest-risk unknown in the design, and
+`conversation_runtime`'s schema is its output. Validate against the pinned
+SDK (`e2b ^2.14.0`), not the design doc's older v2.6.0 citation, and update
+the design doc with the findings.
+
 Write explicit live tests or a documented spike for:
 
 - pause-on-timeout preserves files
@@ -664,13 +742,21 @@ Write explicit live tests or a documented spike for:
 - snapshot creation returns a reusable checkpoint id
 - fresh sandbox can restore from checkpoint
 - command timeout/cancel cleanup handles descendants or needs a wrapper
+- the cost/storage model: whether a paused sandbox is a distinct billed
+  object from a snapshot and what each costs at rest
 
 Acceptance:
 
 - if E2B SDK behavior is insufficient, create the sandbox-side command wrapper
   before enabling Bash.
+- the paused-sandbox retention policy (live-forever vs bounded idle lifetime
+  with snapshot restore) is decided from the measured cost model.
 
 ### Task 4.2: Add Conversation Runtime Store
+
+Create the `conversation_runtime` and `orphan_sandboxes` tables here (moved
+out of Task 1.1; their shape is confirmed by the Task 4.1 spike), and drop
+`sandbox_leases` in the same migration (ADR-0002).
 
 Implement fenced helpers for:
 
@@ -752,7 +838,7 @@ Before terminal success:
 1. verify no managed command is running
 2. snapshot if workspace is dirty
 3. persist snapshot metadata with ownership fence
-4. append `run_completed`
+4. append `run_done`
 
 Tests first:
 
@@ -796,12 +882,38 @@ Tests first:
 
 - general, collection, and document scopes produce the expected query filters.
 - `maxResults` is capped by worker config.
+- results carry `passageId` and `documentId` so hits stay citable and
+  loadable.
 - empty results are stable and model-readable.
 - document access events include run/conversation/user identifiers.
 
 Verify:
 
 - no document credential is sent to E2B.
+
+### Task 6.3: Add `LoadDocuments` Tool
+
+Materializes documents-as-files (ADR-0004): the worker copies scope-checked
+content into the conversation's reserved docs-cache directory in the sandbox
+and returns metadata only.
+
+Tests first:
+
+- the tool result contains `{documentId, title, path, truncated}` and never
+  document content; no document body appears in run events.
+- content is written under the reserved docs-cache directory; paths are
+  workspace-rooted.
+- out-of-scope, unknown, and non-active document ids produce bounded,
+  model-readable errors without leaking document existence across scopes.
+- per-document and per-call byte caps are enforced; truncation is marked in
+  the written file and the result.
+- re-loading an already-cached id overwrites the file (refresh-on-load).
+- loading does not mark the workspace dirty.
+- full-document loads are audited in `document_access_events`.
+
+Verify:
+
+- no document credential is sent to E2B; only file content lands on disk.
 
 ## Milestone 7: Claude Agent SDK Integration
 
@@ -849,6 +961,32 @@ Verify:
 
 - use a fake SDK stream for deterministic unit tests.
 
+### Task 7.3: Conversation Continuity via Postgres SessionStore
+
+Add the `agent_sessions` table, the `SessionStore` adapter (start from the
+SDK's Postgres reference implementation), and `agent_session_id` on
+`conversation_runtime` (ADR-0005).
+
+Tests first:
+
+- the adapter passes the SDK's SessionStore conformance suite.
+- `append` deduplicates by `entry.uuid` (retried batches re-deliver).
+- a run with no resume pointer starts a fresh session; a run with a pointer
+  resumes it through the store.
+- the pointer advances only in the terminal-success transition, under the
+  ownership fence; a stale worker cannot move it.
+- a run that observed `mirror_error` does not advance the pointer and still
+  terminates `done`.
+- the query working directory is deterministic per conversation, so
+  `projectKey` is stable across workers and turns.
+- conversation deletion deletes the conversation's transcripts.
+
+Verify:
+
+- live check: resume on a second worker process reproduces prior-turn
+  context; record whether a resumed query keeps or renews its session id
+  (the worker always stores the id from the result message).
+
 ## Milestone 8: Operations and Scaling
 
 Goal: keep the first deployed service safe under failure and load.
@@ -892,6 +1030,8 @@ Run against the deployed environment:
 - reconnect with `Last-Event-ID`
 - cancel a running turn
 - run a bounded shell command
+- search a scoped document, load it into the docs cache, and read it back
+  through file tools
 - create a file and verify it survives sandbox pause/reconnect
 - trigger worker restart during an active run and verify recovery
 


### PR DESCRIPTION
## What changed

Documentation only — no code. A `/grill-with-docs` session walked every branch of the split-runtime design (`docs/split-runtime-fargate-e2b-design.md` + implementation plan) and captured twelve resolved decisions where they belong:

**New ADRs (`docs/adr/`):**
- **0001** — the trust boundary, not upgrade mechanics, is the load-bearing driver for the split; fallbacks must preserve it (the in-sandbox agent path is never a fallback).
- **0002** — hard-swap cutover, no coexistence flag: the prototype and split paths enforce "one active turn per conversation" with different authorities, so both being reachable is incorrect, not just untidy. Includes the prototype decommissioning schedule.
- **0003** — OpenRouter-direct for provider flexibility, with direct Anthropic as a named env-flip contingency if the SDK-compat smoke test fails.
- **0004** — documents-as-files: `LoadDocuments` materializes scope-checked KB content into a conversation-scoped docs cache on the sandbox filesystem with metadata-only tool results, reversing the earlier "never materialize" rule.
- **0005** — conversation continuity via the Claude SDK's `SessionStore` interface backed by the agent Postgres; fenced `agent_session_id` resume pointer.

**New `CONTEXT.md`** — the project glossary (14 terms: Conversation, Scope, Run, Claim, Outcome, Document, Passage, Docs cache, Load, Agent session, …).

**Design doc + implementation plan revisions:**
- Terminal vocabulary aligned across layers: status `done`/`error`/`canceled` ↔ events `run_done`/`run_error`/`run_canceled` ↔ SSE frames.
- `runs.fencing_token` and `run_events.visibility` (landed in MYM-49) marked for removal via clean-baseline migration regeneration (Task 1.1) — a v1 run is claimed exactly once, and the projector's type→frame mapping is the single client-exposure authority.
- Prototype-era `sandbox_id`/`agent_session_id` SSE frames removed from the client contract.
- E2B semantics spike (Task 4.1) hoisted ahead of dependent schema (`conversation_runtime`, `orphan_sandboxes` move to Task 4.2) and extended with a cost-model question that decides paused-sandbox retention.
- New sections: Conversation Continuity, Control Loop Placement (recovery/cleanup worker-embedded, scaler external), sandbox network posture (no inbound; open egress as documented accepted risk).
- Single Postgres driver decision: `pg` everywhere in split-runtime services (Bun.sql lacks `LISTEN/NOTIFY`), scheduled with Task 1.1, including an RDS TLS caveat.
- New tasks: 6.3 (`LoadDocuments`), 7.3 (continuity via Postgres SessionStore).

## Why

The design had internal inconsistencies (mixed terminal vocabulary, an audit section referencing document loads no tool could perform, a client contract promising internal identifiers), silent gaps (no continuity story after the split moved SDK sessions off the per-conversation sandbox filesystem), and its riskiest unproven dependency (E2B pause/snapshot semantics) sequenced after three milestones that depend on its outcome. Each fix is recorded at the point of use so implementation sessions can work from the docs alone.

## Reviewer notes

- Everything here is spec; the two agreed schema changes are deliberately **not** applied — they're specified in Task 1.1 for the implementation PR.
- ADR-0004 is the one genuine reversal of previously written design intent (documents were "never materialized"); the retention/staleness trade-offs are spelled out in the ADR.
- Next steps after merge: run the Task 4.1 E2B spike, then split the plan into tracker issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)