### PR TITLE
Run E2B semantics spike (Task 4.1) and fold findings into design doc

### DIFF
--- a/apps/agent-worker/package.json
+++ b/apps/agent-worker/package.json
@@ -4,6 +4,7 @@
 		"test": "bun test",
 		"dev": "bun run --hot src/index.ts",
 		"start": "bun run src/index.ts",
+		"spike:e2b": "bun run spikes/e2b-semantics/spike.ts",
 		"format": "biome format --write",
 		"lint": "biome lint --write",
 		"check": "biome check --write"
@@ -13,6 +14,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.3.11",
-		"@types/bun": "^1.3.11"
+		"@types/bun": "^1.3.11",
+		"e2b": "^2.14.0"
 	}
 }

--- a/apps/agent-worker/spikes/e2b-semantics/NOTES.md
+++ b/apps/agent-worker/spikes/e2b-semantics/NOTES.md
@@ -1,0 +1,86 @@
+# Findings — E2B semantics gate (Task 4.1)
+
+Live run 2026-07-05 against real E2B, template `base`, SDK `e2b@2.19.0`
+(satisfies the pinned `^2.14.0`). Full log: one run of all proofs + one re-run
+of p6 after a cleanup-command bug (pkill matched its own shell wrapper; fixed
+with `pkill -x`). Verdict per proof:
+
+| id | proof | verdict |
+|----|-------|---------|
+| p1 | pause-on-timeout preserves files | **PASS** |
+| p2 | paused sandbox reconnect/resume | **PASS** |
+| p3 | active timeout can be extended | **PASS** |
+| p4 | snapshot returns reusable checkpoint id | **PASS** |
+| p5 | fresh sandbox restores from checkpoint | **PASS** |
+| p6 | timeout/cancel cleanup covers descendants | **NO — wrapper required** |
+| p7 | paused sandbox vs snapshot distinct at rest | **PASS** |
+
+## What the pinned SDK actually provides
+
+- **Lifecycle shape (design doc sketch was wrong):** the real 2.19 option is
+  `lifecycle: { onTimeout: 'pause' | 'kill', autoResume?: boolean }` — a flat
+  enum, not the guessed `{ onTimeout: { action, keepMemory } }`. There is **no
+  `keepMemory` option** in the JS SDK 2.19 surface: pause always saves
+  filesystem + memory (docs: pause ≈ 4 s/GiB RAM, resume ≈ 1 s). The design's
+  "pause mode -> filesystem-only by default" is not available.
+- **p1:** sandbox created with `timeoutMs: 20_000, lifecycle: { onTimeout: 'pause' }`
+  was observed `paused` ~1 s after the deadline (20.9 s from create). File
+  written before pause was intact after `Sandbox.connect`.
+- **p2:** explicit `sandbox.pause()` → state `paused`; `Sandbox.connect(id)`
+  auto-resumed in **256 ms**, state `running`, file intact. Connect is the
+  resume primitive — there is no separate `resume()` in the JS SDK.
+- **p3:** `setTimeout(ms)` is **absolute** — it extended 60 s → 300 s and also
+  *reduced* when given a smaller value. `Sandbox.connect(id, { timeoutMs })`
+  only extends, never shrinks (verified: connect with 30 s did not shrink a
+  300 s deadline). Worker renewal loop: `setTimeout` with monotonically
+  computed deadlines, or connect-extend.
+- **p4:** `sandbox.createSnapshot()` → `{ snapshotId: "<templateId>:default" }`
+  in **0.4 s** (tiny base sandbox). **The source sandbox was `running`
+  afterward** — any pause during snapshotting is transient and self-resolving;
+  a checkpoint does not leave the sandbox paused. Keep the worker-side barrier
+  (no snapshot while a managed command runs) anyway: the transient pause would
+  suspend in-flight commands.
+- **p5:** `Sandbox.create(snapshotId)` after killing the source produced a new
+  sandboxId with the file intact — the snapshot is durable beyond the source
+  sandbox's lifetime.
+- **p6 (the design-changing one):** a foreground `bash -c 'sleep 300 & wait'`
+  killed by `timeoutMs` raised `TimeoutError [deadline_exceeded]` but the
+  backgrounded `sleep 300` **survived, reparented to init** (`ppid 1`).
+  Explicit `commands.kill(pid)` of a background command likewise killed only
+  the managed parent; its descendant survived. **Neither timeout nor kill
+  covers the process tree — the sandbox-side process-group wrapper is required
+  before enabling Bash** (create an owned session/process group per command,
+  kill the group on timeout/cancel/stale-run recovery).
+- **p7:** a paused sandbox and a snapshot are distinct objects with distinct
+  lifetimes: the paused sandbox appears in `Sandbox.list({ state: ['paused'] })`,
+  snapshots in `Sandbox.listSnapshots({ sandboxId })`; the snapshot survived
+  `Sandbox.kill()` of its source; `Sandbox.deleteSnapshot(id)` → `true`.
+
+## Cost model (docs, not script)
+
+Per E2B billing docs and pricing pages: compute is billed per second **only
+while a sandbox is running** — billing stops on pause/kill/timeout. Paused
+state (filesystem + memory) is retained **indefinitely** with no auto-TTL, and
+the saved state accrues storage until explicitly killed; snapshots likewise
+persist until `deleteSnapshot`. E2B publishes no flat $/GB-month rate in the
+docs (they point at the pricing calculator), so the at-rest cost of a paused
+sandbox vs a snapshot is the same *kind* of cost (stored bytes), differing
+mainly in that pause includes memory state and a snapshot is filesystem-image
+shaped.
+
+**Retention decision (Task 4.1 acceptance):** bounded idle lifetime with
+snapshot restore. Paused sandboxes accumulate storage silently and forever;
+"live-forever" means unbounded per-conversation storage. Policy: keep the
+paused sandbox as the normal resume path while a conversation is warm; a
+reaper ensures a fresh snapshot exists, kills paused sandboxes idle past a
+configurable window (suggest days, not minutes — resume-from-paused is ~250 ms
+and snapshot-restore is a full sandbox create), and retains only the latest
+snapshot per conversation (`deleteSnapshot` the superseded one).
+
+Sources: e2b.dev/docs/sandbox/persistence, e2b.dev/docs/billing,
+e2b.dev/pricing.
+
+## Status
+
+Findings folded into `docs/split-runtime-fargate-e2b-design.md`. This spike
+directory can be deleted once Task 4.2+ consume the findings.

--- a/apps/agent-worker/spikes/e2b-semantics/README.md
+++ b/apps/agent-worker/spikes/e2b-semantics/README.md
@@ -1,0 +1,44 @@
+# SPIKE: E2B semantics gate (Task 4.1) — THROWAWAY CODE
+
+**Question:** does the pinned E2B SDK (`e2b ^2.14.0`, resolved 2.19.0) actually
+provide the seven behaviors `docs/split-runtime-fargate-e2b-design.md` depends
+on for user-work durability, or does the design need the sandbox-side command
+wrapper / a separate durable workspace store?
+
+This is an integration spike against **real E2B**, not a state-model prototype:
+the artifact is a sequential proof runner, not an interactive TUI, because the
+thing under test is a live external API, not our own logic.
+
+## Run
+
+```bash
+E2B_API_KEY=... bun run spike:e2b            # all proofs (from apps/agent-worker)
+E2B_API_KEY=... bun run spike:e2b p2 p6      # subset by id
+E2B_API_KEY=... bun run spike:e2b cleanup    # kill leftover spike sandboxes/snapshots
+```
+
+Proof `p1` (pause-on-timeout) idles a sandbox past its timeout and polls, so a
+full run takes a few minutes. Every sandbox/snapshot the spike creates is
+tagged with metadata `spike=e2b-semantics` and killed/deleted on the way out;
+`cleanup` sweeps anything a crashed run left behind.
+
+## The seven proofs
+
+| id | proof |
+|----|-------|
+| p1 | pause-on-timeout preserves files |
+| p2 | paused sandbox can reconnect/resume |
+| p3 | active timeout can be extended |
+| p4 | snapshot creation returns a reusable checkpoint id |
+| p5 | fresh sandbox restores from checkpoint (and snapshot survives source kill) |
+| p6 | command timeout/cancel cleanup handles descendants, or a wrapper is needed |
+| p7 | paused sandbox vs snapshot are distinct objects at rest (cost model evidence) |
+
+p7's dollar figures are a docs question, not a script question — the script
+only proves object distinctness; pricing goes in NOTES.md.
+
+## When done
+
+Findings land in `NOTES.md` here and back in
+`docs/split-runtime-fargate-e2b-design.md` (as Task 4.1 instructs). Then this
+directory gets deleted — do not import anything from it.

--- a/apps/agent-worker/spikes/e2b-semantics/spike.ts
+++ b/apps/agent-worker/spikes/e2b-semantics/spike.ts
@@ -1,0 +1,481 @@
+// SPIKE — THROWAWAY (Task 4.1: E2B semantics gate). See README.md.
+// Runs seven live proofs against real E2B with the pinned SDK. Do not import
+// from production code and do not import this from production code.
+
+import { Sandbox } from "e2b";
+
+const TEMPLATE = Bun.env.E2B_SPIKE_TEMPLATE ?? "base";
+const MARKER = { spike: "e2b-semantics" } as const;
+const FILE_PATH = "/home/user/spike-proof.txt";
+const FILE_CONTENT = `spike-proof ${crypto.randomUUID()}`;
+
+const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
+const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
+const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
+const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
+const yellow = (s: string) => `\x1b[33m${s}\x1b[0m`;
+
+type Verdict = "pass" | "fail" | "inconclusive";
+type Evidence = (line: string) => void;
+type Proof = {
+	id: string;
+	title: string;
+	run: (evidence: Evidence) => Promise<Verdict>;
+};
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function pollUntil<T>(
+	label: string,
+	evidence: Evidence,
+	intervalMs: number,
+	maxMs: number,
+	probe: () => Promise<T | undefined>,
+): Promise<{ value: T; elapsedMs: number } | undefined> {
+	const start = Date.now();
+	while (Date.now() - start < maxMs) {
+		const value = await probe();
+		if (value !== undefined) {
+			const elapsedMs = Date.now() - start;
+			evidence(`${label}: satisfied after ${(elapsedMs / 1000).toFixed(1)}s`);
+			return { value, elapsedMs };
+		}
+		await sleep(intervalMs);
+	}
+	evidence(`${label}: NOT satisfied within ${maxMs / 1000}s`);
+	return undefined;
+}
+
+async function killQuietly(sandboxId: string) {
+	try {
+		await Sandbox.kill(sandboxId);
+	} catch {
+		// already gone
+	}
+}
+
+async function psSurvivors(sandbox: Sandbox): Promise<string[]> {
+	const res = await sandbox.commands.run(
+		"ps -eo pid,ppid,stat,args | grep 'sleep 300' | grep -v grep || true",
+	);
+	return res.stdout
+		.split("\n")
+		.map((l) => l.trim())
+		.filter(Boolean);
+}
+
+// ---------------------------------------------------------------------------
+
+const p1PauseOnTimeout: Proof = {
+	id: "p1",
+	title: "pause-on-timeout preserves files",
+	async run(evidence) {
+		const sandbox = await Sandbox.create(TEMPLATE, {
+			timeoutMs: 20_000,
+			lifecycle: { onTimeout: "pause" },
+			metadata: { ...MARKER },
+		});
+		try {
+			evidence(
+				`created ${sandbox.sandboxId} timeoutMs=20000 lifecycle.onTimeout=pause`,
+			);
+			await sandbox.files.write(FILE_PATH, FILE_CONTENT);
+			const info = await Sandbox.getInfo(sandbox.sandboxId);
+			evidence(
+				`lifecycle reported by getInfo: ${JSON.stringify(info.lifecycle)}`,
+			);
+
+			const paused = await pollUntil(
+				"state becomes 'paused' after timeout",
+				evidence,
+				5_000,
+				240_000,
+				async () => {
+					const i = await Sandbox.getInfo(sandbox.sandboxId);
+					return i.state === "paused" ? i : undefined;
+				},
+			);
+			if (!paused) return "fail";
+
+			const resumed = await Sandbox.connect(sandbox.sandboxId, {
+				timeoutMs: 60_000,
+			});
+			const readBack = await resumed.files.read(FILE_PATH);
+			evidence(
+				`file after auto-pause+connect: ${readBack === FILE_CONTENT ? "intact" : `CORRUPT (${readBack})`}`,
+			);
+			return readBack === FILE_CONTENT ? "pass" : "fail";
+		} finally {
+			await killQuietly(sandbox.sandboxId);
+		}
+	},
+};
+
+const p2ExplicitPauseReconnect: Proof = {
+	id: "p2",
+	title: "paused sandbox can reconnect/resume",
+	async run(evidence) {
+		const sandbox = await Sandbox.create(TEMPLATE, {
+			timeoutMs: 120_000,
+			metadata: { ...MARKER },
+		});
+		try {
+			await sandbox.files.write(FILE_PATH, FILE_CONTENT);
+			const pausedNow = await sandbox.pause();
+			evidence(`sandbox.pause() -> ${pausedNow}`);
+			const infoPaused = await Sandbox.getInfo(sandbox.sandboxId);
+			evidence(`state after pause: ${infoPaused.state}`);
+			if (infoPaused.state !== "paused") return "fail";
+
+			const start = Date.now();
+			const resumed = await Sandbox.connect(sandbox.sandboxId, {
+				timeoutMs: 60_000,
+			});
+			evidence(`Sandbox.connect resumed in ${Date.now() - start}ms`);
+			const infoResumed = await Sandbox.getInfo(sandbox.sandboxId);
+			evidence(
+				`state after connect: ${infoResumed.state}, isRunning=${await resumed.isRunning()}`,
+			);
+			const readBack = await resumed.files.read(FILE_PATH);
+			evidence(
+				`file after pause+connect: ${readBack === FILE_CONTENT ? "intact" : "CORRUPT"}`,
+			);
+			return infoResumed.state === "running" && readBack === FILE_CONTENT
+				? "pass"
+				: "fail";
+		} finally {
+			await killQuietly(sandbox.sandboxId);
+		}
+	},
+};
+
+const p3ExtendTimeout: Proof = {
+	id: "p3",
+	title: "active timeout can be extended",
+	async run(evidence) {
+		const sandbox = await Sandbox.create(TEMPLATE, {
+			timeoutMs: 60_000,
+			metadata: { ...MARKER },
+		});
+		try {
+			const e1 = (await Sandbox.getInfo(sandbox.sandboxId)).endAt.getTime();
+			await sandbox.setTimeout(300_000);
+			const e2 = (await Sandbox.getInfo(sandbox.sandboxId)).endAt.getTime();
+			evidence(
+				`setTimeout(300000) moved endAt by ${((e2 - e1) / 1000).toFixed(1)}s (${e2 > e1 ? "extended" : "NOT extended"})`,
+			);
+
+			// connect with a SHORTER timeout must not shrink the deadline
+			await Sandbox.connect(sandbox.sandboxId, { timeoutMs: 30_000 });
+			const e3 = (await Sandbox.getInfo(sandbox.sandboxId)).endAt.getTime();
+			evidence(
+				`connect(timeoutMs=30000) after that: endAt ${e3 >= e2 ? "unchanged/longer (no shrink)" : `SHRANK by ${((e2 - e3) / 1000).toFixed(1)}s`}`,
+			);
+
+			// setTimeout CAN shrink (documented) — record it so the worker renewal loop knows
+			await sandbox.setTimeout(45_000);
+			const e4 = (await Sandbox.getInfo(sandbox.sandboxId)).endAt.getTime();
+			evidence(
+				`setTimeout(45000) after that: endAt ${e4 < e3 ? "shrank (setTimeout is absolute, can reduce)" : "did not shrink"}`,
+			);
+
+			return e2 > e1 && e3 >= e2 ? "pass" : "fail";
+		} finally {
+			await killQuietly(sandbox.sandboxId);
+		}
+	},
+};
+
+// p4/p5 share the snapshot; run() of p5 reads this
+let sharedSnapshotId: string | undefined;
+let sharedSourceSandboxId: string | undefined;
+
+const p4Snapshot: Proof = {
+	id: "p4",
+	title: "snapshot creation returns a reusable checkpoint id",
+	async run(evidence) {
+		const sandbox = await Sandbox.create(TEMPLATE, {
+			timeoutMs: 180_000,
+			metadata: { ...MARKER },
+		});
+		sharedSourceSandboxId = sandbox.sandboxId;
+		await sandbox.files.write(FILE_PATH, FILE_CONTENT);
+
+		const start = Date.now();
+		const snap = await sandbox.createSnapshot();
+		const durationMs = Date.now() - start;
+		evidence(
+			`createSnapshot() -> ${JSON.stringify(snap)} in ${(durationMs / 1000).toFixed(1)}s`,
+		);
+		sharedSnapshotId = snap.snapshotId;
+
+		// design-relevant: what state is the SOURCE sandbox in after checkpoint?
+		const infoAfter = await Sandbox.getInfo(sandbox.sandboxId);
+		evidence(`source sandbox state after createSnapshot: ${infoAfter.state}`);
+		if (infoAfter.state === "paused") {
+			const resumed = await Sandbox.connect(sandbox.sandboxId, {
+				timeoutMs: 60_000,
+			});
+			const readBack = await resumed.files.read(FILE_PATH);
+			evidence(
+				`source resumable after checkpoint: yes, file ${readBack === FILE_CONTENT ? "intact" : "CORRUPT"}`,
+			);
+		}
+		return snap.snapshotId ? "pass" : "fail";
+	},
+};
+
+const p5RestoreFromSnapshot: Proof = {
+	id: "p5",
+	title:
+		"fresh sandbox restores from checkpoint (snapshot survives source kill)",
+	async run(evidence) {
+		if (!sharedSnapshotId || !sharedSourceSandboxId) {
+			evidence("p4 did not run or failed; no snapshot to restore from");
+			return "inconclusive";
+		}
+		// kill the source FIRST so a successful restore also proves persistence
+		await killQuietly(sharedSourceSandboxId);
+		evidence(`killed source sandbox ${sharedSourceSandboxId} before restore`);
+
+		const restored = await Sandbox.create(sharedSnapshotId, {
+			timeoutMs: 60_000,
+			metadata: { ...MARKER },
+		});
+		try {
+			evidence(
+				`Sandbox.create(${sharedSnapshotId}) -> ${restored.sandboxId} (new id: ${restored.sandboxId !== sharedSourceSandboxId})`,
+			);
+			const readBack = await restored.files.read(FILE_PATH);
+			evidence(
+				`file in restored sandbox: ${readBack === FILE_CONTENT ? "intact" : "CORRUPT"}`,
+			);
+			return readBack === FILE_CONTENT &&
+				restored.sandboxId !== sharedSourceSandboxId
+				? "pass"
+				: "fail";
+		} finally {
+			await killQuietly(restored.sandboxId);
+			const deleted = await Sandbox.deleteSnapshot(sharedSnapshotId).catch(
+				() => false,
+			);
+			evidence(`deleteSnapshot(${sharedSnapshotId}) -> ${deleted}`);
+		}
+	},
+};
+
+const p6CommandTreeCleanup: Proof = {
+	id: "p6",
+	title:
+		"command timeout/cancel cleanup handles descendants (or wrapper needed)",
+	async run(evidence) {
+		const sandbox = await Sandbox.create(TEMPLATE, {
+			timeoutMs: 180_000,
+			metadata: { ...MARKER },
+		});
+		try {
+			// Case A: foreground command hits timeoutMs while a backgrounded child runs
+			try {
+				await sandbox.commands.run("bash -c 'sleep 300 & wait'", {
+					timeoutMs: 5_000,
+				});
+				evidence("case A: command unexpectedly completed within timeout");
+			} catch (err) {
+				evidence(
+					`case A: timeout raised ${err instanceof Error ? `${err.constructor.name}: ${err.message.slice(0, 120)}` : String(err)}`,
+				);
+			}
+			await sleep(1_000);
+			const survivorsA = await psSurvivors(sandbox);
+			evidence(
+				`case A survivors after timeout: ${survivorsA.length === 0 ? "none" : survivorsA.join(" | ")}`,
+			);
+			// -x matches the process name exactly, so pkill can't match its own shell wrapper
+			if (survivorsA.length > 0)
+				await sandbox.commands.run("pkill -x sleep || true");
+
+			// Case B: explicit kill of a background command with a descendant
+			const handle = await sandbox.commands.run("bash -c 'sleep 300 & wait'", {
+				background: true,
+			});
+			await sleep(1_000);
+			const killed = await sandbox.commands.kill(handle.pid);
+			evidence(`case B: commands.kill(${handle.pid}) -> ${killed}`);
+			await sleep(1_000);
+			const survivorsB = await psSurvivors(sandbox);
+			evidence(
+				`case B survivors after kill: ${survivorsB.length === 0 ? "none" : survivorsB.join(" | ")}`,
+			);
+
+			const wrapperNeeded = survivorsA.length > 0 || survivorsB.length > 0;
+			evidence(
+				`verdict: sandbox-side process-group wrapper ${wrapperNeeded ? "IS REQUIRED" : "not required"} before enabling Bash`,
+			);
+			// the proof "passes" when it produces a definite answer either way
+			return "pass";
+		} finally {
+			await killQuietly(sandbox.sandboxId);
+		}
+	},
+};
+
+const p7CostModelEvidence: Proof = {
+	id: "p7",
+	title: "paused sandbox vs snapshot are distinct objects at rest",
+	async run(evidence) {
+		const sandbox = await Sandbox.create(TEMPLATE, {
+			timeoutMs: 120_000,
+			metadata: { ...MARKER },
+		});
+		let snapshotId: string | undefined;
+		try {
+			await sandbox.files.write(FILE_PATH, FILE_CONTENT);
+			const snap = await sandbox.createSnapshot();
+			snapshotId = snap.snapshotId;
+			await Sandbox.connect(sandbox.sandboxId, { timeoutMs: 60_000 });
+			await sandbox.pause();
+
+			// both objects visible at rest, through different list surfaces
+			const paginator = Sandbox.list({ query: { state: ["paused"] } });
+			const pausedIds: string[] = [];
+			while (paginator.hasNext) {
+				for (const s of await paginator.nextItems())
+					pausedIds.push(s.sandboxId);
+			}
+			evidence(
+				`paused-sandbox list contains ours: ${pausedIds.includes(sandbox.sandboxId)}`,
+			);
+
+			const snapPaginator = Sandbox.listSnapshots({
+				sandboxId: sandbox.sandboxId,
+			});
+			const snapIds: string[] = [];
+			while (snapPaginator.hasNext) {
+				for (const s of await snapPaginator.nextItems())
+					snapIds.push(s.snapshotId);
+			}
+			evidence(`snapshot list for this sandbox: ${JSON.stringify(snapIds)}`);
+
+			// snapshot survives killing the paused sandbox — distinct lifetimes
+			await Sandbox.kill(sandbox.sandboxId);
+			const snapAfterKill = Sandbox.listSnapshots({
+				sandboxId: sandbox.sandboxId,
+			});
+			const survivingSnaps: string[] = [];
+			while (snapAfterKill.hasNext) {
+				for (const s of await snapAfterKill.nextItems())
+					survivingSnaps.push(s.snapshotId);
+			}
+			evidence(
+				`snapshots surviving sandbox kill: ${JSON.stringify(survivingSnaps)}`,
+			);
+			evidence("dollar cost at rest is a pricing-docs question -> NOTES.md");
+
+			return pausedIds.includes(sandbox.sandboxId) && survivingSnaps.length > 0
+				? "pass"
+				: "fail";
+		} finally {
+			await killQuietly(sandbox.sandboxId);
+			if (snapshotId) {
+				try {
+					const deleted = await Sandbox.deleteSnapshot(snapshotId);
+					evidence(`deleteSnapshot(${snapshotId}) -> ${deleted}`);
+				} catch (err) {
+					evidence(
+						`deleteSnapshot failed: ${err instanceof Error ? err.message : String(err)}`,
+					);
+				}
+			}
+		}
+	},
+};
+
+// ---------------------------------------------------------------------------
+
+async function cleanup() {
+	console.log(bold("cleanup: sweeping spike-tagged sandboxes and snapshots"));
+	const paginator = Sandbox.list({ query: { metadata: { ...MARKER } } });
+	let sandboxCount = 0;
+	while (paginator.hasNext) {
+		for (const s of await paginator.nextItems()) {
+			console.log(dim(`  kill ${s.sandboxId} (${s.state})`));
+			await killQuietly(s.sandboxId);
+			sandboxCount++;
+		}
+	}
+	// shared p4 snapshot survives if p5 crashed before delete
+	if (sharedSnapshotId)
+		await Sandbox.deleteSnapshot(sharedSnapshotId).catch(() => {});
+	console.log(`cleanup done: ${sandboxCount} sandbox(es) killed`);
+}
+
+const PROOFS: Proof[] = [
+	p2ExplicitPauseReconnect,
+	p3ExtendTimeout,
+	p4Snapshot,
+	p5RestoreFromSnapshot,
+	p6CommandTreeCleanup,
+	p7CostModelEvidence,
+	p1PauseOnTimeout, // slowest last: idles a sandbox past its timeout
+];
+
+async function main() {
+	if (!Bun.env.E2B_API_KEY) {
+		console.error("E2B_API_KEY is required");
+		process.exit(1);
+	}
+	const args = process.argv.slice(2);
+	if (args.includes("cleanup")) {
+		await cleanup();
+		return;
+	}
+	const selected =
+		args.length > 0 ? PROOFS.filter((p) => args.includes(p.id)) : PROOFS;
+	if (selected.length === 0) {
+		console.error(
+			`unknown proof ids: ${args.join(" ")} (known: ${PROOFS.map((p) => p.id).join(" ")})`,
+		);
+		process.exit(1);
+	}
+
+	const sdkVersion = await import("e2b/package.json")
+		.then((m) => m.default.version)
+		.catch(() => "unknown");
+	console.log(
+		bold(`E2B semantics spike — template=${TEMPLATE}, sdk=e2b@${sdkVersion}`),
+	);
+	const results: Array<{ proof: Proof; verdict: Verdict; evidence: string[] }> =
+		[];
+	for (const proof of selected) {
+		console.log(`\n${bold(`[${proof.id}] ${proof.title}`)}`);
+		const evidenceLines: string[] = [];
+		const evidence: Evidence = (line) => {
+			evidenceLines.push(line);
+			console.log(dim(`  ${line}`));
+		};
+		let verdict: Verdict;
+		try {
+			verdict = await proof.run(evidence);
+		} catch (err) {
+			evidence(
+				`threw: ${err instanceof Error ? `${err.constructor.name}: ${err.message}` : String(err)}`,
+			);
+			verdict = "fail";
+		}
+		const paint =
+			verdict === "pass" ? green : verdict === "fail" ? red : yellow;
+		console.log(`  ${paint(verdict.toUpperCase())}`);
+		results.push({ proof, verdict, evidence: evidenceLines });
+	}
+
+	console.log(`\n${bold("summary")}`);
+	for (const { proof, verdict } of results) {
+		const paint =
+			verdict === "pass" ? green : verdict === "fail" ? red : yellow;
+		console.log(`  ${paint(verdict.padEnd(12))} [${proof.id}] ${proof.title}`);
+	}
+	const failed = results.some((r) => r.verdict !== "pass");
+	process.exit(failed ? 1 : 0);
+}
+
+await main();

--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.3.11",
         "@types/bun": "^1.3.11",
+        "e2b": "^2.14.0",
       },
     },
     "apps/chat-api": {

--- a/docs/split-runtime-fargate-e2b-design.md
+++ b/docs/split-runtime-fargate-e2b-design.md
@@ -363,11 +363,11 @@ Use E2B's command APIs for remote process execution:
 - `Bash` marks the workspace dirty conservatively because even failed
   commands can mutate files
 
-E2B's JavaScript SDK documents the primary v1 executor primitives (originally
-verified against v2.6.0 docs; the repo pins `^2.14.0`, and the hoisted
-semantics spike re-verifies against the pinned version):
-`commands.run` supports `onStdout` / `onStderr` streaming callbacks and
-`timeoutMs`; background commands return a handle; running commands can be listed,
+E2B's JavaScript SDK provides the primary v1 executor primitives (verified
+live by the Task 4.1 semantics spike against `e2b@2.19.0`, which satisfies the
+pinned `^2.14.0`): `commands.run` supports `onStdout` / `onStderr` streaming
+callbacks and `timeoutMs` (expiry raises `TimeoutError [deadline_exceeded]`);
+background commands return a handle; running commands can be listed,
 reconnected with `commands.connect(pid)`, and killed with `commands.kill(pid)`.
 Use these as the default implementation path before adding any in-sandbox
 executor daemon.
@@ -380,13 +380,13 @@ feedback, but it is not a correctness boundary. Shells, package-manager
 scripts, test runners, and child processes can still create descendants that
 survive the parent process.
 
-The remaining E2B command-semantics validation is process-tree cleanup. The SDK
-reference documents `commands.kill(pid)` as killing a PID, but the design must
-not assume this also kills every descendant. Before snapshotting or emitting a
-successful terminal event, the worker must prove that timeout/cancellation
-cleanup covers child processes, or run each `Bash` command through a small
-sandbox-side wrapper that creates an owned process group/session and kills that
-group on timeout, cancellation, or stale-run recovery.
+Process-tree cleanup is resolved: the Task 4.1 spike proved that neither
+`timeoutMs` expiry nor `commands.kill(pid)` covers descendants. In both cases
+a backgrounded child (`bash -c 'sleep 300 & wait'`) survived the kill,
+reparented to init. Every `Bash` command must therefore run through a small
+sandbox-side wrapper that creates an owned process group/session and kills
+that group on timeout, cancellation, or stale-run recovery — a required v1
+component, not a contingency.
 
 Command execution requirements:
 
@@ -1196,43 +1196,50 @@ one conversation -> one persistent E2B sandbox/workspace
 E2B idle timeout -> 5 minutes while no active run owns it
 E2B active-run timeout -> renewed/extended by the owning worker
 E2B lifecycle on timeout -> pause sandbox
-E2B pause mode -> filesystem-only by default
-max lifetime -> none
+E2B pause mode -> filesystem + memory (the SDK has no filesystem-only pause)
+max paused lifetime -> bounded idle window, then snapshot + kill (see below)
 ```
 
-Create sandboxes with E2B lifecycle pause if the deployed E2B SDK/runtime
-supports an automatic pause-on-timeout contract:
+Create sandboxes with E2B lifecycle pause. The pinned SDK supports an
+automatic pause-on-timeout contract (verified live by the Task 4.1 spike):
 
 ```ts
 const sandbox = await Sandbox.create(templateOrSnapshotId, {
 	timeoutMs: 5 * 60 * 1000,
-	lifecycle: {
-		onTimeout: { action: "pause", keepMemory: false },
-		autoResume: false,
-	},
+	lifecycle: { onTimeout: "pause", autoResume: false },
 });
 ```
 
-Use `keepMemory: false` because the split runtime only needs filesystem
-persistence. The agent loop and model state live in Fargate. V1 does not preserve
-in-sandbox background processes across idle pause.
+`lifecycle.onTimeout` is a flat `"pause" | "kill"` enum; there is no
+`keepMemory` option in the JS SDK — pause always saves filesystem plus memory
+(~4 s per GiB of RAM to pause, ~1 s to resume). The split runtime only needs
+the filesystem: the agent loop and model state live in Fargate, and V1 does
+not depend on in-sandbox background processes surviving idle pause even though
+memory happens to be preserved.
 
-The exact E2B pause/snapshot API shape is a prototype gate, not an assumption to
-copy blindly into production code. Before implementation, validate the deployed
-E2B JavaScript SDK and template runtime with a spike that proves:
+The exact E2B pause/snapshot API shape was a prototype gate. The Task 4.1
+spike (run 2026-07-05 against `e2b@2.19.0`,
+`apps/agent-worker/spikes/e2b-semantics/`) validated it:
 
-- a sandbox can pause on idle timeout without losing files
-- a paused sandbox can be reconnected or resumed
-- the worker can explicitly extend or renew timeout during an active run
-- snapshot creation returns a reusable checkpoint id
-- a fresh sandbox can be created from that checkpoint id
-- timeout/cancel cleanup and snapshot creation cannot race active commands
+- pause on idle timeout preserves files — observed `paused` about 1 s after
+  the deadline; files intact after reconnect
+- a paused sandbox resumes via `Sandbox.connect(sandboxId)` (~250 ms observed);
+  connect is the resume primitive — the JS SDK has no separate `resume()`
+- `setTimeout(ms)` extends the deadline but is absolute and can also reduce
+  it, so the worker renewal loop must compute monotonically increasing
+  deadlines; `Sandbox.connect(id, { timeoutMs })` only ever extends
+- `sandbox.createSnapshot()` returns a reusable `snapshotId`
+  (`<templateId>:<tag>`) — sub-second on a small sandbox — and leaves the
+  source sandbox running afterward
+- `Sandbox.create(snapshotId)` restores a fresh sandbox with files intact,
+  even after the source sandbox is killed
+- timeout/cancel cleanup does NOT cover descendants (see the command-execution
+  section: the sandbox-side process-group wrapper is required); keep the
+  worker-side barrier that no snapshot starts while a managed command runs —
+  snapshotting transiently pauses the sandbox even though it self-resumes
 
-If automatic pause-on-timeout is not available, use explicit worker-driven
-pause/checkpoint calls where supported. If E2B cannot provide a durable
-filesystem checkpoint with the required semantics, this design must fall back to
-a separate durable workspace store instead of treating E2B as the only source of
-truth for user-created files.
+E2B provides the durable filesystem checkpoint this design requires, so the
+fallback to a separate durable workspace store is not needed for v1.
 
 The 5-minute timeout is an idle policy, not a maximum turn duration. While a run
 is active, the owning worker must renew or reconnect/extend the sandbox timeout
@@ -1255,6 +1262,19 @@ connect fails:
 
 The paused sandbox is the normal durable workspace. The snapshot is a checkpoint
 fallback, not the main per-turn resume mechanism.
+
+Cost model and retention (decided by the Task 4.1 spike, per its acceptance
+criteria): E2B bills compute per second only while a sandbox is running —
+billing stops on pause, kill, or timeout. Paused state (filesystem + memory)
+and snapshots are both retained indefinitely with no auto-TTL, accruing
+storage until explicitly deleted (`Sandbox.kill` frees a paused sandbox;
+`Sandbox.deleteSnapshot` frees a checkpoint). The retention policy is
+therefore bounded idle lifetime with snapshot restore, not live-forever:
+while a conversation is warm, the paused sandbox is the resume path; the
+cleanup loop ensures a fresh snapshot exists, kills paused sandboxes idle past
+a configurable window (days-scale — resume-from-paused is ~250 ms while
+snapshot restore is a full sandbox create), and retains only the latest
+snapshot per conversation.
 
 Sandbox replacement is an external side effect followed by a fenced database
 write. If a worker creates a replacement sandbox and then loses run ownership


### PR DESCRIPTION
## What

Executes **Task 4.1 (Prototype E2B Semantics Gate)** from `docs/split-runtime-fargate-e2b-implementation-plan.md`: a standalone throwaway spike run live against real E2B with the pinned SDK (`e2b@2.19.0`, satisfies `^2.14.0`), plus the design-doc updates the task instructs.

- `apps/agent-worker/spikes/e2b-semantics/` — the spike (README, proof runner, NOTES.md findings). Run with `bun run spike:e2b` from `apps/agent-worker`; subset via `spike:e2b p6`; leftover sweep via `spike:e2b cleanup`. All sandboxes/snapshots it creates are metadata-tagged and cleaned up (account verified clean after the run).
- `docs/split-runtime-fargate-e2b-design.md` — five targeted edits folding in the verified findings.
- `e2b ^2.14.0` added as an agent-worker devDependency.

## Findings (live-verified 2026-07-05)

| proof | verdict |
|-------|---------|
| pause-on-timeout preserves files | PASS (paused ~1s after deadline) |
| paused sandbox reconnect/resume | PASS (`Sandbox.connect`, ~250ms) |
| active timeout can be extended | PASS (`setTimeout` is absolute — can also shrink; `connect` only extends) |
| snapshot returns reusable checkpoint id | PASS (~0.4s; source stays **running**) |
| fresh sandbox restores from checkpoint | PASS (survives source kill) |
| timeout/cancel cleanup covers descendants | **NO — sandbox-side process-group wrapper required** |
| paused sandbox vs snapshot distinct at rest | PASS |

Design-changing details:

- **Wrapper is now required, not contingent**: both `timeoutMs` expiry and `commands.kill(pid)` orphan descendants (a backgrounded `sleep 300` survived both, reparented to init).
- **Design doc's API sketch was wrong**: real lifecycle option is flat `lifecycle: { onTimeout: "pause" | "kill", autoResume }`; there is no `keepMemory` / filesystem-only pause in the JS SDK (pause always saves memory + filesystem).
- **Retention decided per the task's acceptance criteria**: bounded idle lifetime with snapshot restore (paused state accrues storage indefinitely with no auto-TTL), not live-forever.

## Reviewer notes

- The spike is explicitly throwaway (marked in README and file header) and intended for deletion once Task 4.2+ consume the findings; `NOTES.md` is the durable capture.
- The one mid-spike bug was in the spike's own cleanup (`pkill -f` matching its shell wrapper), fixed and re-run; it does not affect the verdicts.
- Grilling-session convention (docs-only) doesn't apply here — this was an explicit `/prototype` invocation pointed at Task 4.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)