### PR TITLE
Add the run event projector: durable run events to client SSE frames (#176)

### DIFF
--- a/apps/chat-api/src/features/run-events/index.ts
+++ b/apps/chat-api/src/features/run-events/index.ts
@@ -1,0 +1,15 @@
+export type { ProjectedFrame, ProjectRunDeps } from "./project-run";
+export { projectRun } from "./project-run";
+export { projectRunEvent } from "./project-run-event";
+export type { RunEventReader, RunEventRow } from "./run-event-reader";
+export { DrizzleRunEventReader } from "./run-event-reader";
+export type { ClientFrame } from "./run-event-types";
+// `RunEventType` re-exports both the const values and its companion type.
+export { RunEventType, TERMINAL_RUN_EVENT_TYPES } from "./run-event-types";
+export type { RunNotifier, RunSubscription } from "./run-notifier";
+export {
+	PostgresRunNotifier,
+	parseRunNotification,
+	RUN_EVENTS_CHANNEL,
+	RunWakeupRegistry,
+} from "./run-notifier";

--- a/apps/chat-api/src/features/run-events/project-run-event.test.ts
+++ b/apps/chat-api/src/features/run-events/project-run-event.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "bun:test";
+import { projectRunEvent } from "./project-run-event";
+import { RunEventType } from "./run-event-types";
+
+describe("projectRunEvent", () => {
+	it("fans run_started out to conversation_id then run_id, in that order", () => {
+		expect(
+			projectRunEvent(RunEventType.Started, {
+				conversationId: "conv-1",
+				runId: "run-1",
+			}),
+		).toEqual([
+			{ type: "conversation_id", conversationId: "conv-1" },
+			{ type: "run_id", runId: "run-1" },
+		]);
+	});
+
+	it("maps assistant_text to a text_delta frame", () => {
+		expect(projectRunEvent(RunEventType.AssistantText, { text: "hi" })).toEqual(
+			[{ type: "text_delta", text: "hi" }],
+		);
+	});
+
+	it("maps run_done to done", () => {
+		expect(projectRunEvent(RunEventType.Done, {})).toEqual([{ type: "done" }]);
+	});
+
+	it("maps run_canceled to canceled, never error", () => {
+		expect(projectRunEvent(RunEventType.Canceled, {})).toEqual([
+			{ type: "canceled" },
+		]);
+	});
+
+	it("maps run_error to an error frame carrying the message", () => {
+		expect(projectRunEvent(RunEventType.Error, { message: "boom" })).toEqual([
+			{ type: "error", message: "boom" },
+		]);
+	});
+
+	it("still emits a terminal error frame when the payload has no message", () => {
+		expect(projectRunEvent(RunEventType.Error, {})).toEqual([
+			{ type: "error", message: "Run failed" },
+		]);
+	});
+
+	it("skips unmapped internal event types (fail-closed)", () => {
+		expect(projectRunEvent("document_search", { query: "x" })).toEqual([]);
+		expect(projectRunEvent("daemon_started", {})).toEqual([]);
+		expect(projectRunEvent("some_future_event", { secret: "leak" })).toEqual(
+			[],
+		);
+	});
+
+	it("drops frames whose payload fields are the wrong shape", () => {
+		// run_started with a non-string conversationId keeps only the valid field.
+		expect(
+			projectRunEvent(RunEventType.Started, { conversationId: 42, runId: "r" }),
+		).toEqual([{ type: "run_id", runId: "r" }]);
+		// assistant_text without a string text produces nothing.
+		expect(projectRunEvent(RunEventType.AssistantText, { text: 7 })).toEqual(
+			[],
+		);
+	});
+
+	it("tolerates a null or non-object payload without throwing", () => {
+		expect(projectRunEvent(RunEventType.AssistantText, null)).toEqual([]);
+		expect(projectRunEvent(RunEventType.Started, "nope")).toEqual([]);
+		expect(projectRunEvent(RunEventType.Done, undefined)).toEqual([
+			{ type: "done" },
+		]);
+	});
+});

--- a/apps/chat-api/src/features/run-events/project-run-event.ts
+++ b/apps/chat-api/src/features/run-events/project-run-event.ts
@@ -1,0 +1,57 @@
+import { type ClientFrame, RunEventType } from "./run-event-types";
+
+/**
+ * Derive the client SSE frame(s) for one recorded run event. This is the single
+ * authority for client exposure: an event type with no case here produces no
+ * frame (fail-closed — an unmapped internal type cannot reach the client).
+ *
+ * A single event may fan out to more than one frame (`run_started` announces
+ * both the conversation id and the run id). Payloads come from a jsonb column
+ * and are typed `unknown`; every field is read defensively and a field of the
+ * wrong shape is dropped rather than streamed as a malformed frame.
+ *
+ * Terminal events (`run_done` / `run_error` / `run_canceled`) always map to
+ * their terminal frame — even `run_error` with a missing message — so the
+ * client is never left without an outcome. The projector loop closes the stream
+ * on the terminal *type*, independent of this mapping.
+ */
+export function projectRunEvent(type: string, payload: unknown): ClientFrame[] {
+	const fields = isRecord(payload) ? payload : {};
+	switch (type) {
+		case RunEventType.Started: {
+			const out: ClientFrame[] = [];
+			if (typeof fields.conversationId === "string") {
+				out.push({
+					type: "conversation_id",
+					conversationId: fields.conversationId,
+				});
+			}
+			if (typeof fields.runId === "string") {
+				out.push({ type: "run_id", runId: fields.runId });
+			}
+			return out;
+		}
+		case RunEventType.AssistantText:
+			return typeof fields.text === "string"
+				? [{ type: "text_delta", text: fields.text }]
+				: [];
+		case RunEventType.Done:
+			return [{ type: "done" }];
+		case RunEventType.Canceled:
+			return [{ type: "canceled" }];
+		case RunEventType.Error:
+			return [
+				{
+					type: "error",
+					message:
+						typeof fields.message === "string" ? fields.message : "Run failed",
+				},
+			];
+		default:
+			return [];
+	}
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}

--- a/apps/chat-api/src/features/run-events/project-run.test.ts
+++ b/apps/chat-api/src/features/run-events/project-run.test.ts
@@ -1,0 +1,254 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import type { Database } from "@/db/client";
+import { runEvents, runs } from "@/db/schema";
+import { createTestDatabase } from "@/db/testing";
+import { type ProjectedFrame, projectRun } from "./project-run";
+import type { RunEventReader, RunEventRow } from "./run-event-reader";
+import { DrizzleRunEventReader } from "./run-event-reader";
+import { RunEventType } from "./run-event-types";
+import type { RunNotifier, RunSubscription } from "./run-notifier";
+
+/**
+ * Reader that hands out one scripted batch per `read` call, recording the
+ * `afterSeq` cursor it was called with. It models "what events are available at
+ * read time" — successive reads can reveal more, independent of the cursor — so
+ * the loop's cursor handling and its poll-then-reread behavior are observable.
+ */
+class ScriptedReader implements RunEventReader {
+	readonly cursors: number[] = [];
+	private readonly batches: RunEventRow[][];
+
+	constructor(batches: RunEventRow[][]) {
+		this.batches = [...batches];
+	}
+
+	async read(_runId: string, afterSeq: number): Promise<RunEventRow[]> {
+		this.cursors.push(afterSeq);
+		return this.batches.shift() ?? [];
+	}
+}
+
+/** Notifier whose wake-up resolves instantly — each wait models one poll cycle. */
+class InstantNotifier implements RunNotifier {
+	waits = 0;
+	closed = 0;
+
+	async subscribe(): Promise<RunSubscription> {
+		return {
+			waitForWakeup: async () => {
+				this.waits += 1;
+			},
+			close: async () => {
+				this.closed += 1;
+			},
+		};
+	}
+}
+
+async function drain(
+	gen: AsyncGenerator<ProjectedFrame>,
+): Promise<ProjectedFrame[]> {
+	const out: ProjectedFrame[] = [];
+	for await (const frame of gen) out.push(frame);
+	return out;
+}
+
+function frames(projected: ProjectedFrame[]) {
+	return projected.map((p) => p.frame);
+}
+
+describe("projectRun", () => {
+	it("replays from seq 0 as conversation_id, run_id, text deltas, then terminal, in order", async () => {
+		const reader = new ScriptedReader([
+			[
+				{
+					seq: 1,
+					type: RunEventType.Started,
+					payload: { conversationId: "conv-1", runId: "run-1" },
+				},
+				{ seq: 2, type: RunEventType.AssistantText, payload: { text: "he" } },
+				{ seq: 3, type: RunEventType.AssistantText, payload: { text: "llo" } },
+				{ seq: 4, type: RunEventType.Done, payload: {} },
+			],
+		]);
+		const notifier = new InstantNotifier();
+
+		const projected = await drain(projectRun("run-1", 0, { reader, notifier }));
+
+		expect(frames(projected)).toEqual([
+			{ type: "conversation_id", conversationId: "conv-1" },
+			{ type: "run_id", runId: "run-1" },
+			{ type: "text_delta", text: "he" },
+			{ type: "text_delta", text: "llo" },
+			{ type: "done" },
+		]);
+		// run_started's two frames share its event's seq (the reconnect cursor).
+		expect(projected.map((p) => p.seq).slice(0, 2)).toEqual([1, 1]);
+		expect(notifier.closed).toBe(1);
+	});
+
+	it("replays from a Last-Event-ID cursor, starting the read past already-seen events", async () => {
+		const reader = new ScriptedReader([
+			[
+				{ seq: 3, type: RunEventType.AssistantText, payload: { text: "tail" } },
+				{ seq: 4, type: RunEventType.Done, payload: {} },
+			],
+		]);
+
+		const projected = await drain(
+			projectRun("run-1", 2, { reader, notifier: new InstantNotifier() }),
+		);
+
+		expect(reader.cursors[0]).toBe(2);
+		expect(frames(projected)).toEqual([
+			{ type: "text_delta", text: "tail" },
+			{ type: "done" },
+		]);
+	});
+
+	it("does not lose events when no notification arrives (poll then re-read)", async () => {
+		// First read finds nothing (worker hasn't appended yet); the loop must wait
+		// and re-read rather than close. The wake-up here is the poll timeout, not a
+		// notify — proving delivery does not depend on notifications.
+		const reader = new ScriptedReader([
+			[],
+			[
+				{ seq: 1, type: RunEventType.AssistantText, payload: { text: "late" } },
+				{ seq: 2, type: RunEventType.Done, payload: {} },
+			],
+		]);
+		const notifier = new InstantNotifier();
+
+		const projected = await drain(
+			projectRun("run-1", 0, { reader, notifier, pollTimeoutMs: 5 }),
+		);
+
+		expect(notifier.waits).toBe(1); // waited once between the two reads
+		expect(reader.cursors).toEqual([0, 0]); // nothing emitted yet on the re-read
+		expect(frames(projected)).toEqual([
+			{ type: "text_delta", text: "late" },
+			{ type: "done" },
+		]);
+	});
+
+	it("maps run_canceled to canceled and closes (never error)", async () => {
+		const reader = new ScriptedReader([
+			[{ seq: 1, type: RunEventType.Canceled, payload: {} }],
+		]);
+
+		const projected = await drain(
+			projectRun("run-1", 0, { reader, notifier: new InstantNotifier() }),
+		);
+
+		expect(frames(projected)).toEqual([{ type: "canceled" }]);
+	});
+
+	it("maps run_error to a terminal error frame and closes", async () => {
+		const reader = new ScriptedReader([
+			[{ seq: 1, type: RunEventType.Error, payload: { message: "boom" } }],
+		]);
+
+		expect(
+			frames(
+				await drain(
+					projectRun("run-1", 0, { reader, notifier: new InstantNotifier() }),
+				),
+			),
+		).toEqual([{ type: "error", message: "boom" }]);
+	});
+
+	it("skips unmapped internal event types without leaking them or closing early", async () => {
+		const reader = new ScriptedReader([
+			[
+				{ seq: 1, type: "document_search", payload: { query: "secret" } },
+				{ seq: 2, type: RunEventType.AssistantText, payload: { text: "ok" } },
+				{ seq: 3, type: "daemon_started", payload: {} },
+				{ seq: 4, type: RunEventType.Done, payload: {} },
+			],
+		]);
+
+		expect(
+			frames(
+				await drain(
+					projectRun("run-1", 0, { reader, notifier: new InstantNotifier() }),
+				),
+			),
+		).toEqual([{ type: "text_delta", text: "ok" }, { type: "done" }]);
+	});
+
+	it("stops reading once a terminal event is seen (no read past the terminal)", async () => {
+		const reader = new ScriptedReader([
+			[{ seq: 1, type: RunEventType.Done, payload: {} }],
+			// A second batch exists but must never be requested.
+			[
+				{
+					seq: 2,
+					type: RunEventType.AssistantText,
+					payload: { text: "after" },
+				},
+			],
+		]);
+
+		const projected = await drain(
+			projectRun("run-1", 0, { reader, notifier: new InstantNotifier() }),
+		);
+
+		expect(frames(projected)).toEqual([{ type: "done" }]);
+		expect(reader.cursors).toEqual([0]); // exactly one read
+	});
+});
+
+describe("projectRun over the real reader", () => {
+	let db: Database;
+	let close: () => Promise<void>;
+
+	beforeEach(async () => {
+		const tdb = await createTestDatabase();
+		db = tdb.db;
+		close = tdb.close;
+		await db.insert(runs).values({
+			runId: "run-1",
+			userId: "user-1",
+			conversationId: "conv-1",
+			status: "running",
+		});
+		await db.insert(runEvents).values([
+			{
+				runId: "run-1",
+				seq: 1,
+				type: RunEventType.Started,
+				payload: { conversationId: "conv-1", runId: "run-1" },
+			},
+			{
+				runId: "run-1",
+				seq: 2,
+				type: RunEventType.AssistantText,
+				payload: { text: "hi" },
+			},
+			{ runId: "run-1", seq: 3, type: RunEventType.Done, payload: {} },
+		]);
+	});
+
+	afterEach(() => close());
+
+	it("projects durable rows end to end, honoring the reconnect cursor", async () => {
+		const reader = new DrizzleRunEventReader(db);
+		const notifier = new InstantNotifier();
+
+		const full = frames(
+			await drain(projectRun("run-1", 0, { reader, notifier })),
+		);
+		expect(full).toEqual([
+			{ type: "conversation_id", conversationId: "conv-1" },
+			{ type: "run_id", runId: "run-1" },
+			{ type: "text_delta", text: "hi" },
+			{ type: "done" },
+		]);
+
+		// Reconnect past seq 2: only the terminal remains.
+		const resumed = frames(
+			await drain(projectRun("run-1", 2, { reader, notifier })),
+		);
+		expect(resumed).toEqual([{ type: "done" }]);
+	});
+});

--- a/apps/chat-api/src/features/run-events/project-run.ts
+++ b/apps/chat-api/src/features/run-events/project-run.ts
@@ -1,0 +1,64 @@
+import { projectRunEvent } from "./project-run-event";
+import type { RunEventReader } from "./run-event-reader";
+import type { ClientFrame } from "./run-event-types";
+import { TERMINAL_RUN_EVENT_TYPES } from "./run-event-types";
+import type { RunNotifier } from "./run-notifier";
+
+/**
+ * One client SSE frame plus the sequence to use as its `id:`. All frames derived
+ * from the same run event carry that event's `seq`, so `Last-Event-ID` is a
+ * run-event cursor: reconnecting with `id = N` resumes at events with `seq > N`.
+ */
+export interface ProjectedFrame {
+	seq: number;
+	frame: ClientFrame;
+}
+
+export interface ProjectRunDeps {
+	reader: RunEventReader;
+	notifier: RunNotifier;
+	/**
+	 * Ceiling on how long a loop turn waits for a wake-up before re-reading the
+	 * table anyway. This is what makes the projector tolerant of missed
+	 * notifications; keep it short (1-2s). Default 1000ms.
+	 */
+	pollTimeoutMs?: number;
+}
+
+/**
+ * Project a run's durable event log into the client SSE stream. Run-event replay
+ * is the only SSE source: on every turn the loop reads `run_events` past the
+ * cursor, emits the mapped frames, then waits for a `LISTEN/NOTIFY` wake-up or a
+ * short poll timeout. Because it always reads before waiting, a missed
+ * notification costs latency, never an event. The loop closes as soon as it
+ * reads a terminal event — detection is by event *type*, so a terminal event
+ * with an odd payload still ends the stream after emitting its frame.
+ *
+ * The event-type→frame mapping ({@link projectRunEvent}) is the single authority
+ * for client exposure: unmapped internal event types yield no frame and cannot
+ * leak to clients.
+ */
+export async function* projectRun(
+	runId: string,
+	fromSeq: number,
+	deps: ProjectRunDeps,
+): AsyncGenerator<ProjectedFrame> {
+	const pollTimeoutMs = deps.pollTimeoutMs ?? 1000;
+	const subscription = await deps.notifier.subscribe(runId);
+	try {
+		let lastSeq = fromSeq;
+		for (;;) {
+			const rows = await deps.reader.read(runId, lastSeq);
+			for (const row of rows) {
+				lastSeq = row.seq;
+				for (const frame of projectRunEvent(row.type, row.payload)) {
+					yield { seq: row.seq, frame };
+				}
+				if (TERMINAL_RUN_EVENT_TYPES.has(row.type)) return;
+			}
+			await subscription.waitForWakeup(pollTimeoutMs);
+		}
+	} finally {
+		await subscription.close();
+	}
+}

--- a/apps/chat-api/src/features/run-events/run-event-reader.test.ts
+++ b/apps/chat-api/src/features/run-events/run-event-reader.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import type { Database } from "@/db/client";
+import { runEvents, runs } from "@/db/schema";
+import { createTestDatabase } from "@/db/testing";
+import { DrizzleRunEventReader } from "./run-event-reader";
+
+async function seedRun(db: Database, runId: string, conversationId = "conv-1") {
+	await db.insert(runs).values({
+		runId,
+		userId: "user-1",
+		conversationId,
+		status: "running",
+	});
+}
+
+async function appendEvent(
+	db: Database,
+	runId: string,
+	seq: number,
+	type: string,
+	payload: unknown,
+) {
+	await db.insert(runEvents).values({ runId, seq, type, payload });
+}
+
+describe("DrizzleRunEventReader", () => {
+	let db: Database;
+	let close: () => Promise<void>;
+	let reader: DrizzleRunEventReader;
+
+	beforeEach(async () => {
+		const tdb = await createTestDatabase();
+		db = tdb.db;
+		close = tdb.close;
+		reader = new DrizzleRunEventReader(db);
+		await seedRun(db, "run-1");
+	});
+
+	afterEach(() => close());
+
+	it("returns events with seq greater than the cursor, ordered by seq", async () => {
+		await appendEvent(db, "run-1", 2, "assistant_text", { text: "b" });
+		await appendEvent(db, "run-1", 1, "run_started", { runId: "run-1" });
+		await appendEvent(db, "run-1", 3, "run_done", {});
+
+		const rows = await reader.read("run-1", 0);
+
+		expect(rows).toEqual([
+			{ seq: 1, type: "run_started", payload: { runId: "run-1" } },
+			{ seq: 2, type: "assistant_text", payload: { text: "b" } },
+			{ seq: 3, type: "run_done", payload: {} },
+		]);
+	});
+
+	it("skips events at or below the cursor", async () => {
+		await appendEvent(db, "run-1", 1, "run_started", { runId: "run-1" });
+		await appendEvent(db, "run-1", 2, "assistant_text", { text: "a" });
+		await appendEvent(db, "run-1", 3, "run_done", {});
+
+		expect(await reader.read("run-1", 2)).toEqual([
+			{ seq: 3, type: "run_done", payload: {} },
+		]);
+	});
+
+	it("does not return events belonging to another run", async () => {
+		await seedRun(db, "run-2", "conv-2");
+		await appendEvent(db, "run-1", 1, "assistant_text", { text: "mine" });
+		await appendEvent(db, "run-2", 1, "assistant_text", { text: "theirs" });
+
+		expect(await reader.read("run-1", 0)).toEqual([
+			{ seq: 1, type: "assistant_text", payload: { text: "mine" } },
+		]);
+	});
+
+	it("returns an empty array when there are no new events", async () => {
+		expect(await reader.read("run-1", 0)).toEqual([]);
+	});
+});

--- a/apps/chat-api/src/features/run-events/run-event-reader.ts
+++ b/apps/chat-api/src/features/run-events/run-event-reader.ts
@@ -1,0 +1,39 @@
+import { and, asc, eq, gt } from "drizzle-orm";
+import type { Database } from "@/db/client";
+import { runEvents } from "@/db/schema";
+
+/** One recorded run event, as the projector reads it back from `run_events`. */
+export interface RunEventRow {
+	seq: number;
+	type: string;
+	/** The jsonb payload; shape depends on `type` and is validated on projection. */
+	payload: unknown;
+}
+
+/**
+ * Reads a run's durable events after a sequence cursor. The projector calls this
+ * on every loop turn — the durable table is the source of truth, so a replay
+ * from the `Last-Event-ID` cursor and a live tail are the same query.
+ */
+export interface RunEventReader {
+	/** Events for `runId` with `seq > afterSeq`, ordered by ascending `seq`. */
+	read(runId: string, afterSeq: number): Promise<RunEventRow[]>;
+}
+
+/** Drizzle adapter over `run_events`. The composite PK `(run_id, seq)` is the
+ * replay index this query rides. */
+export class DrizzleRunEventReader implements RunEventReader {
+	constructor(private readonly db: Database) {}
+
+	async read(runId: string, afterSeq: number): Promise<RunEventRow[]> {
+		return this.db
+			.select({
+				seq: runEvents.seq,
+				type: runEvents.type,
+				payload: runEvents.payload,
+			})
+			.from(runEvents)
+			.where(and(eq(runEvents.runId, runId), gt(runEvents.seq, afterSeq)))
+			.orderBy(asc(runEvents.seq));
+	}
+}

--- a/apps/chat-api/src/features/run-events/run-event-types.ts
+++ b/apps/chat-api/src/features/run-events/run-event-types.ts
@@ -1,0 +1,59 @@
+/**
+ * The split-runtime run-event vocabulary and the client-facing SSE frame shapes.
+ *
+ * This module is the single authority for what a client can see. Internal run
+ * events are recorded in the durable `run_events` table by the worker (and, for
+ * `run_started`, by chat-api when it queues the run); the projector derives the
+ * client SSE stream from them via {@link projectRunEvent}. The mapping is
+ * fail-closed: an internal event type without an explicit frame mapping produces
+ * no frame, so a new internal event type can never leak to clients by accident.
+ *
+ * The prototype-era `sandbox_id` / `agent_session_id` frames are deliberately
+ * absent: they are internal runtime identifiers, found in `run_events`, not in
+ * the client stream (see the design doc's client contract).
+ */
+
+/**
+ * The `run_events.type` values the projector understands. Appenders (chat-api's
+ * run queue, the worker) must import these constants rather than hard-code the
+ * strings, so this module stays the one place the vocabulary is defined.
+ */
+export const RunEventType = {
+	/** First event of a run. Payload `{ conversationId, runId }`. */
+	Started: "run_started",
+	/** A chunk of streamed assistant text. Payload `{ text }`. */
+	AssistantText: "assistant_text",
+	/** Terminal: the run finished successfully. */
+	Done: "run_done",
+	/** Terminal: the run failed. Payload `{ message }`. */
+	Error: "run_error",
+	/** Terminal: the run was canceled by the user. */
+	Canceled: "run_canceled",
+} as const;
+
+export type RunEventType = (typeof RunEventType)[keyof typeof RunEventType];
+
+/**
+ * The terminal event types. When the projector reads one of these it emits the
+ * matching terminal frame (if any) and closes the stream — detection is by
+ * event type, not by whether a frame was produced, so a terminal event with a
+ * malformed payload still ends the stream.
+ */
+export const TERMINAL_RUN_EVENT_TYPES: ReadonlySet<string> = new Set([
+	RunEventType.Done,
+	RunEventType.Error,
+	RunEventType.Canceled,
+]);
+
+/**
+ * The client-visible SSE frames. `type` is also the SSE `event:` name. This is
+ * the whole split-runtime client vocabulary — `conversation_id`, `run_id`,
+ * `text_delta`, and one terminal frame per outcome (`done | canceled | error`).
+ */
+export type ClientFrame =
+	| { type: "conversation_id"; conversationId: string }
+	| { type: "run_id"; runId: string }
+	| { type: "text_delta"; text: string }
+	| { type: "done" }
+	| { type: "canceled" }
+	| { type: "error"; message: string };

--- a/apps/chat-api/src/features/run-events/run-notifier.test.ts
+++ b/apps/chat-api/src/features/run-events/run-notifier.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "bun:test";
+import { parseRunNotification, RunWakeupRegistry } from "./run-notifier";
+
+describe("parseRunNotification", () => {
+	it("extracts a string runId", () => {
+		expect(parseRunNotification('{"runId":"run-1"}')).toBe("run-1");
+	});
+
+	it("returns null for missing, malformed, or wrong-typed payloads", () => {
+		expect(parseRunNotification(undefined)).toBeNull();
+		expect(parseRunNotification("")).toBeNull();
+		expect(parseRunNotification("not json")).toBeNull();
+		expect(parseRunNotification('{"runId":42}')).toBeNull();
+		expect(parseRunNotification('{"other":"x"}')).toBeNull();
+	});
+});
+
+describe("RunWakeupRegistry", () => {
+	it("wakes a waiting subscription immediately on signal", async () => {
+		const registry = new RunWakeupRegistry();
+		const sub = registry.subscribe("run-1");
+
+		let woke = false;
+		const wait = sub.waitForWakeup(10_000).then(() => {
+			woke = true;
+		});
+		// Let the wait register its resolver before signaling.
+		await Promise.resolve();
+		registry.signal("run-1");
+		await wait;
+
+		expect(woke).toBe(true);
+	});
+
+	it("coalesces a signal that arrives before the next wait (no lost wake-up)", async () => {
+		const registry = new RunWakeupRegistry();
+		const sub = registry.subscribe("run-1");
+
+		// Signal fires while nobody is waiting.
+		registry.signal("run-1");
+		// The next wait resolves immediately from the pending latch, not the timeout.
+		await sub.waitForWakeup(10_000);
+
+		// The latch is one-shot: a second wait now blocks until the timeout.
+		const start = performance.now();
+		await sub.waitForWakeup(20);
+		expect(performance.now() - start).toBeGreaterThanOrEqual(15);
+	});
+
+	it("falls back to the timeout when no signal arrives", async () => {
+		const registry = new RunWakeupRegistry();
+		const sub = registry.subscribe("run-1");
+		const start = performance.now();
+		await sub.waitForWakeup(20);
+		expect(performance.now() - start).toBeGreaterThanOrEqual(15);
+	});
+
+	it("only wakes subscriptions for the signaled run", async () => {
+		const registry = new RunWakeupRegistry();
+		const other = registry.subscribe("run-2");
+		let otherWoke = false;
+		other.waitForWakeup(30).then(() => {
+			otherWoke = true;
+		});
+		await Promise.resolve();
+
+		registry.signal("run-1"); // different run
+		await Promise.resolve();
+		expect(otherWoke).toBe(false);
+	});
+
+	it("does not wake a closed subscription", async () => {
+		const registry = new RunWakeupRegistry();
+		const sub = registry.subscribe("run-1");
+		await sub.close();
+		// Signaling a run with no live waiters is a no-op and must not throw.
+		expect(() => registry.signal("run-1")).not.toThrow();
+	});
+});

--- a/apps/chat-api/src/features/run-events/run-notifier.ts
+++ b/apps/chat-api/src/features/run-events/run-notifier.ts
@@ -1,0 +1,158 @@
+import { type Client, Client as PgClient } from "pg";
+
+/**
+ * A live wake-up for one run's SSE projector. `LISTEN/NOTIFY` is *only* a
+ * latency optimization: the projector re-reads the durable `run_events` table
+ * on every loop turn, so a lost or never-delivered wake-up costs latency (one
+ * poll interval) but never an event. Wake-ups that land between waits are
+ * coalesced into a single pending signal, so a notify that arrives while the
+ * projector is reading or streaming is not dropped.
+ */
+export interface RunSubscription {
+	/** Resolve when a wake-up for this run arrives, or after `timeoutMs`. */
+	waitForWakeup(timeoutMs: number): Promise<void>;
+	/** Stop listening for this run. Idempotent. */
+	close(): Promise<void>;
+}
+
+export interface RunNotifier {
+	subscribe(runId: string): Promise<RunSubscription>;
+}
+
+/** The single channel every appender notifies on; the payload carries the run id. */
+export const RUN_EVENTS_CHANNEL = "run_events";
+
+/**
+ * Extract a run id from a `run_events` notification payload. Malformed payloads
+ * yield `null` and are ignored — a bad notify can only cost a wake-up, never
+ * deliver a wrong one.
+ */
+export function parseRunNotification(
+	payload: string | undefined,
+): string | null {
+	if (!payload) return null;
+	try {
+		const parsed: unknown = JSON.parse(payload);
+		if (
+			typeof parsed === "object" &&
+			parsed !== null &&
+			typeof (parsed as { runId?: unknown }).runId === "string"
+		) {
+			return (parsed as { runId: string }).runId;
+		}
+	} catch {
+		// not JSON — ignore
+	}
+	return null;
+}
+
+interface Waiter {
+	/** True when a signal arrived while no `waitForWakeup` was outstanding. */
+	pending: boolean;
+	/** Resolver of the currently outstanding wait, if any. */
+	wake: (() => void) | null;
+}
+
+/**
+ * In-memory registry of per-run waiters. The transport (Postgres LISTEN, or a
+ * test) calls {@link signal} when a run advances; each subscription waits on its
+ * own coalescing latch. Pure and deterministic — this is where the wake-up
+ * semantics are tested, without a database.
+ *
+ * A run can have several concurrent subscriptions on purpose: the reconnect
+ * endpoint (plan Task 2.3) lets a second client tail a run while the original
+ * `user.message` stream is still open, and both must wake on each append.
+ */
+export class RunWakeupRegistry {
+	private readonly waiters = new Map<string, Set<Waiter>>();
+
+	subscribe(runId: string): RunSubscription {
+		const waiter: Waiter = { pending: false, wake: null };
+		const set = this.waiters.get(runId) ?? new Set<Waiter>();
+		set.add(waiter);
+		this.waiters.set(runId, set);
+
+		return {
+			waitForWakeup: (timeoutMs: number) =>
+				new Promise<void>((resolve) => {
+					if (waiter.pending) {
+						waiter.pending = false;
+						resolve();
+						return;
+					}
+					let settled = false;
+					const finish = () => {
+						if (settled) return;
+						settled = true;
+						clearTimeout(timer);
+						waiter.wake = null;
+						resolve();
+					};
+					const timer = setTimeout(finish, timeoutMs);
+					waiter.wake = () => {
+						waiter.pending = false;
+						finish();
+					};
+				}),
+			close: async () => {
+				const s = this.waiters.get(runId);
+				if (!s) return;
+				s.delete(waiter);
+				if (s.size === 0) this.waiters.delete(runId);
+			},
+		};
+	}
+
+	/** Wake every subscription for `runId`, coalescing if none is waiting. */
+	signal(runId: string): void {
+		const set = this.waiters.get(runId);
+		if (!set) return;
+		for (const waiter of set) {
+			if (waiter.wake) waiter.wake();
+			else waiter.pending = true;
+		}
+	}
+}
+
+/**
+ * Postgres `LISTEN/NOTIFY` notifier. Owns one dedicated `pg` connection (never a
+ * pooled/PgBouncer-multiplexed one — a listener must stay pinned to its backend)
+ * that `LISTEN`s on {@link RUN_EVENTS_CHANNEL} and fans each notification to the
+ * matching run's waiters via a {@link RunWakeupRegistry}. Every SSE stream in
+ * the process shares this one listener connection.
+ */
+export class PostgresRunNotifier implements RunNotifier {
+	private readonly registry = new RunWakeupRegistry();
+	private client: Client | null = null;
+	private connecting: Promise<void> | null = null;
+
+	constructor(private readonly connectionString: string) {}
+
+	async subscribe(runId: string): Promise<RunSubscription> {
+		await this.ensureListening();
+		return this.registry.subscribe(runId);
+	}
+
+	private ensureListening(): Promise<void> {
+		if (this.client) return Promise.resolve();
+		if (this.connecting) return this.connecting;
+		this.connecting = (async () => {
+			const client = new PgClient({ connectionString: this.connectionString });
+			client.on("notification", (msg) => {
+				const runId = parseRunNotification(msg.payload);
+				if (runId) this.registry.signal(runId);
+			});
+			await client.connect();
+			await client.query(`LISTEN ${RUN_EVENTS_CHANNEL}`);
+			this.client = client;
+		})();
+		return this.connecting;
+	}
+
+	async close(): Promise<void> {
+		const client = this.client;
+		this.client = null;
+		this.connecting = null;
+		if (client) await client.end();
+	}
+}


### PR DESCRIPTION
Implements **Task 2.2** of `docs/split-runtime-fargate-e2b-implementation-plan.md` — closes #176.

## What changed

A new `apps/chat-api/src/features/run-events/` module that turns a run's durable Postgres event log into the client SSE stream, making run-event replay the only SSE source:

- **`run-event-types.ts`** — the internal `run_events.type` vocabulary (`run_started`, `assistant_text`, `run_done`, `run_error`, `run_canceled`) and the client frame union: exactly `conversation_id`, `run_id`, `text_delta`, and one terminal frame per outcome (`done | canceled | error`). The prototype-era `sandbox_id` / `agent_session_id` frames are deliberately absent — operators find those in `run_events`, not the client stream.
- **`project-run-event.ts`** — the event-type→frame mapping, the single authority for client exposure. Fail-closed: unmapped internal event types produce no frame, so a new internal event type cannot leak to clients without an explicit mapping. `run_canceled` maps to `canceled`, never `error`. Payloads come from jsonb and are read defensively.
- **`run-event-reader.ts`** — reads `run_events` with `seq > cursor` ordered by seq, riding the composite PK; replay from `Last-Event-ID` and live tail are the same query.
- **`run-notifier.ts`** — `LISTEN/NOTIFY` as a wake-up-only optimization: a pure `RunWakeupRegistry` (coalescing per-run latches; multi-subscriber on purpose, for the Task 2.3 reconnect endpoint) plus `PostgresRunNotifier`, which owns one dedicated non-pooled `pg` connection per process (never PgBouncer-multiplexed).
- **`project-run.ts`** — the projector loop: read past the cursor, emit mapped frames (each frame carries its event's `seq` as the SSE id / reconnect cursor), wait on notify or a short poll timeout, close on terminal event *type*. It always reads before waiting, so a missed notification costs latency, never events.

## Acceptance criteria → tests

- ✅ replay from `seq = 0` emits `conversation_id`, `run_id`, text deltas, and terminal frames in order — `project-run.test.ts`
- ✅ replay from `Last-Event-ID` skips already-seen events — fake-reader cursor test + real-reader reconnect test
- ✅ missed notifications do not lose events — poll-then-reread test (wake-up is the timeout, not a notify)
- ✅ `run_canceled` maps to `canceled`, not `error` — projection + loop tests
- ✅ unmapped internal event types never reach the client — fail-closed default tested at both layers
- ✅ projector tests use a fake notifier and deterministic event rows — `ScriptedReader` / `InstantNotifier`, plus one integration pass over the real Drizzle reader against PGlite

## Notes for reviewers

- The module is standalone by design: Task 2.1 (the `user.message` hard swap) is what opens this projector from the events route; Task 2.3 adds the read-only reconnect endpoint. Issue #176 notes it is sequenced before the swap.
- `PostgresRunNotifier` (the real LISTEN transport) has no automated test — PGlite has no wire socket for `pg.Client`, and the issue's criteria call for fake-notifier tests. Its notify→wakeup path gets covered by the Task 2.1/2.3 route integration and the Milestone 3 synthetic end-to-end smoke.
- Appenders (chat-api's queue insert in Task 2.1, the worker in Milestone 3) should import `RunEventType` from this module rather than hard-code event-type strings.

Verification: `bun test` — 236 pass / 0 fail (28 in this module); `tsc` and Biome clean for the module (the 8 pre-existing `tsc` errors on `main` in unrelated files are untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)