### PR TITLE
Implement run-store transaction helpers with DB-owned ordering and ownership fences (plan 1.2)

### DIFF
--- a/apps/chat-api/src/features/run-store/index.ts
+++ b/apps/chat-api/src/features/run-store/index.ts
@@ -1,0 +1,19 @@
+export type {
+	RunCancellationResult,
+	RunEventAppendClass,
+	RunEventPayload,
+	RunRecord,
+	RunStatus,
+	TerminalRunStatus,
+} from "./run-store";
+export {
+	ActiveRunConflictError,
+	appendRunEventTx,
+	claimNextRunTx,
+	createQueuedRunTx,
+	heartbeatRunTx,
+	markStaleRunsTx,
+	RunFenceError,
+	requestRunCancellationTx,
+	transitionRunTerminalTx,
+} from "./run-store";

--- a/apps/chat-api/src/features/run-store/run-store.test.ts
+++ b/apps/chat-api/src/features/run-store/run-store.test.ts
@@ -1,0 +1,689 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { eq, sql } from "drizzle-orm";
+import { runEvents, runs } from "@/db/schema";
+import { createTestDatabase, type TestDb } from "@/db/testing";
+import {
+	ActiveRunConflictError,
+	appendRunEventTx,
+	claimNextRunTx,
+	createQueuedRunTx,
+	heartbeatRunTx,
+	markStaleRunsTx,
+	RunFenceError,
+	requestRunCancellationTx,
+	transitionRunTerminalTx,
+} from "./run-store";
+
+let tdb: TestDb;
+
+beforeEach(async () => {
+	tdb = await createTestDatabase();
+});
+
+afterEach(async () => {
+	await tdb.close();
+});
+
+describe("createQueuedRunTx", () => {
+	it("creates a queued run with queue defaults", async () => {
+		const run = await createQueuedRunTx(tdb.db, {
+			runId: "run-1",
+			userId: "user-1",
+			conversationId: "conv-1",
+		});
+
+		expect(run).toMatchObject({
+			runId: "run-1",
+			userId: "user-1",
+			conversationId: "conv-1",
+			status: "queued",
+			lockedBy: null,
+			lockedUntil: null,
+			heartbeatAt: null,
+			cancelRequestedAt: null,
+			nextEventSeq: 1,
+			terminalAt: null,
+		});
+	});
+
+	it("rejects a second active run for the same conversation", async () => {
+		await createQueuedRunTx(tdb.db, {
+			runId: "run-1",
+			userId: "user-1",
+			conversationId: "conv-1",
+		});
+
+		await expect(
+			createQueuedRunTx(tdb.db, {
+				runId: "run-2",
+				userId: "user-1",
+				conversationId: "conv-1",
+			}),
+		).rejects.toBeInstanceOf(ActiveRunConflictError);
+	});
+
+	it("allows a new run once the previous run is terminal", async () => {
+		await createQueuedRunTx(tdb.db, {
+			runId: "run-1",
+			userId: "user-1",
+			conversationId: "conv-1",
+		});
+		await tdb.db
+			.update(runs)
+			.set({ status: "done" })
+			.where(eq(runs.runId, "run-1"));
+
+		const next = await createQueuedRunTx(tdb.db, {
+			runId: "run-2",
+			userId: "user-1",
+			conversationId: "conv-1",
+		});
+		expect(next.status).toBe("queued");
+	});
+});
+
+async function queueRun(runId: string, conversationId: string) {
+	return await createQueuedRunTx(tdb.db, {
+		runId,
+		userId: "user-1",
+		conversationId,
+	});
+}
+
+/** Push a run's created_at into the past so claim-order tests are deterministic
+ * (PGlite can give two inserts the same timestamp). */
+async function backdateRun(runId: string, msAgo: number) {
+	await tdb.db
+		.update(runs)
+		.set({ createdAt: sql`now() - (${msAgo} * interval '1 millisecond')` })
+		.where(eq(runs.runId, runId));
+}
+
+describe("claimNextRunTx", () => {
+	it("returns null when no run is queued", async () => {
+		const claimed = await claimNextRunTx(tdb.db, { workerId: "worker-1" });
+		expect(claimed).toBeNull();
+	});
+
+	it("claims the oldest queued run and takes execution ownership", async () => {
+		await queueRun("run-newer", "conv-1");
+		await queueRun("run-older", "conv-2");
+		await backdateRun("run-older", 5_000);
+
+		const claimed = await claimNextRunTx(tdb.db, { workerId: "worker-1" });
+
+		expect(claimed).toMatchObject({
+			runId: "run-older",
+			status: "running",
+			lockedBy: "worker-1",
+		});
+		expect(claimed?.lockedUntil?.getTime()).toBeGreaterThan(Date.now());
+		expect(claimed?.heartbeatAt).toBeInstanceOf(Date);
+	});
+
+	// PGlite is single-connection, so this exercises the claim CAS, not true
+	// cross-connection FOR UPDATE SKIP LOCKED contention — that is covered by
+	// the local-Postgres integration layer of the testing plan.
+	it("never hands the same run to two claimants", async () => {
+		await queueRun("run-1", "conv-1");
+		await queueRun("run-2", "conv-2");
+
+		const first = await claimNextRunTx(tdb.db, { workerId: "worker-1" });
+		const second = await claimNextRunTx(tdb.db, { workerId: "worker-2" });
+		const third = await claimNextRunTx(tdb.db, { workerId: "worker-3" });
+
+		expect(first).not.toBeNull();
+		expect(second).not.toBeNull();
+		expect(first?.runId).not.toBe(second?.runId);
+		expect(third).toBeNull();
+	});
+});
+
+/** Queue and claim one run so append/terminal tests start from a live claim. */
+async function claimRun(
+	runId: string,
+	conversationId: string,
+	workerId: string,
+) {
+	await queueRun(runId, conversationId);
+	await backdateRun(runId, 5_000);
+	const claimed = await claimNextRunTx(tdb.db, { workerId });
+	if (claimed?.runId !== runId) {
+		throw new Error(`test setup claimed ${claimed?.runId}, wanted ${runId}`);
+	}
+	return claimed;
+}
+
+/** Force a claimed run's locked_until past, as if the worker stalled. */
+async function expireOwnership(runId: string) {
+	await tdb.db
+		.update(runs)
+		.set({ lockedUntil: sql`now() - interval '1 second'` })
+		.where(eq(runs.runId, runId));
+}
+
+async function readEvents(runId: string) {
+	return await tdb.db
+		.select()
+		.from(runEvents)
+		.where(eq(runEvents.runId, runId))
+		.orderBy(runEvents.seq);
+}
+
+describe("appendRunEventTx", () => {
+	it("allocates monotonic database-owned sequence numbers", async () => {
+		await claimRun("run-1", "conv-1", "worker-1");
+
+		const first = await appendRunEventTx(tdb.db, {
+			runId: "run-1",
+			workerId: "worker-1",
+			type: "text_delta",
+			payload: { text: "hel" },
+			appendClass: "model",
+		});
+		const second = await appendRunEventTx(tdb.db, {
+			runId: "run-1",
+			workerId: "worker-1",
+			type: "text_delta",
+			payload: { text: "lo" },
+			appendClass: "model",
+		});
+
+		expect(first.seq).toBe(1);
+		expect(second.seq).toBe(2);
+		const events = await readEvents("run-1");
+		expect(events.map((e) => [e.seq, e.type])).toEqual([
+			[1, "text_delta"],
+			[2, "text_delta"],
+		]);
+		expect(events[0]?.payload).toEqual({ text: "hel" });
+	});
+
+	it("rejects a model append on a run that is not running", async () => {
+		await queueRun("run-1", "conv-1");
+
+		await expect(
+			appendRunEventTx(tdb.db, {
+				runId: "run-1",
+				workerId: "worker-1",
+				type: "text_delta",
+				payload: {},
+				appendClass: "model",
+			}),
+		).rejects.toBeInstanceOf(RunFenceError);
+	});
+
+	it("rejects an append from a worker that does not own the run", async () => {
+		await claimRun("run-1", "conv-1", "worker-1");
+
+		await expect(
+			appendRunEventTx(tdb.db, {
+				runId: "run-1",
+				workerId: "worker-2",
+				type: "text_delta",
+				payload: {},
+				appendClass: "model",
+			}),
+		).rejects.toBeInstanceOf(RunFenceError);
+	});
+
+	it("rejects a stale worker append after locked_until has passed", async () => {
+		await claimRun("run-1", "conv-1", "worker-1");
+		await expireOwnership("run-1");
+
+		await expect(
+			appendRunEventTx(tdb.db, {
+				runId: "run-1",
+				workerId: "worker-1",
+				type: "text_delta",
+				payload: {},
+				appendClass: "model",
+			}),
+		).rejects.toBeInstanceOf(RunFenceError);
+	});
+
+	it("rejects model appends after cancellation is requested", async () => {
+		await claimRun("run-1", "conv-1", "worker-1");
+		await tdb.db
+			.update(runs)
+			.set({ status: "cancel_requested" })
+			.where(eq(runs.runId, "run-1"));
+
+		await expect(
+			appendRunEventTx(tdb.db, {
+				runId: "run-1",
+				workerId: "worker-1",
+				type: "text_delta",
+				payload: {},
+				appendClass: "model",
+			}),
+		).rejects.toBeInstanceOf(RunFenceError);
+	});
+
+	it("allows cancellation audit appends while running or cancel_requested", async () => {
+		await claimRun("run-1", "conv-1", "worker-1");
+
+		const whileRunning = await appendRunEventTx(tdb.db, {
+			runId: "run-1",
+			workerId: "worker-1",
+			type: "model_interrupt_requested",
+			payload: {},
+			appendClass: "cancellation",
+		});
+		await tdb.db
+			.update(runs)
+			.set({ status: "cancel_requested" })
+			.where(eq(runs.runId, "run-1"));
+		const whileCancelRequested = await appendRunEventTx(tdb.db, {
+			runId: "run-1",
+			workerId: "worker-1",
+			type: "command_canceled",
+			payload: {},
+			appendClass: "cancellation",
+		});
+
+		expect(whileRunning.seq).toBe(1);
+		expect(whileCancelRequested.seq).toBe(2);
+	});
+
+	it("still fences cancellation audit appends by lock deadline", async () => {
+		await claimRun("run-1", "conv-1", "worker-1");
+		await tdb.db
+			.update(runs)
+			.set({ status: "cancel_requested" })
+			.where(eq(runs.runId, "run-1"));
+		await expireOwnership("run-1");
+
+		await expect(
+			appendRunEventTx(tdb.db, {
+				runId: "run-1",
+				workerId: "worker-1",
+				type: "command_canceled",
+				payload: {},
+				appendClass: "cancellation",
+			}),
+		).rejects.toBeInstanceOf(RunFenceError);
+	});
+});
+
+describe("transitionRunTerminalTx", () => {
+	it("completes a running run and appends exactly one run_done event", async () => {
+		await claimRun("run-1", "conv-1", "worker-1");
+		await appendRunEventTx(tdb.db, {
+			runId: "run-1",
+			workerId: "worker-1",
+			type: "text_delta",
+			payload: { text: "hi" },
+			appendClass: "model",
+		});
+
+		const run = await transitionRunTerminalTx(tdb.db, {
+			runId: "run-1",
+			workerId: "worker-1",
+			status: "done",
+		});
+
+		expect(run).toMatchObject({
+			runId: "run-1",
+			status: "done",
+			lockedBy: null,
+			lockedUntil: null,
+		});
+		expect(run.terminalAt).toBeInstanceOf(Date);
+		const events = await readEvents("run-1");
+		expect(events.map((e) => [e.seq, e.type])).toEqual([
+			[1, "text_delta"],
+			[2, "run_done"],
+		]);
+	});
+
+	it("rejects a second terminal transition for the same run", async () => {
+		await claimRun("run-1", "conv-1", "worker-1");
+		await transitionRunTerminalTx(tdb.db, {
+			runId: "run-1",
+			workerId: "worker-1",
+			status: "done",
+		});
+
+		await expect(
+			transitionRunTerminalTx(tdb.db, {
+				runId: "run-1",
+				workerId: "worker-1",
+				status: "error",
+				payload: { message: "boom" },
+			}),
+		).rejects.toBeInstanceOf(RunFenceError);
+		const events = await readEvents("run-1");
+		expect(events.map((e) => e.type)).toEqual(["run_done"]);
+	});
+
+	it("refuses done once cancellation was requested; canceled wins", async () => {
+		await claimRun("run-1", "conv-1", "worker-1");
+		await tdb.db
+			.update(runs)
+			.set({ status: "cancel_requested" })
+			.where(eq(runs.runId, "run-1"));
+
+		await expect(
+			transitionRunTerminalTx(tdb.db, {
+				runId: "run-1",
+				workerId: "worker-1",
+				status: "done",
+			}),
+		).rejects.toBeInstanceOf(RunFenceError);
+
+		const run = await transitionRunTerminalTx(tdb.db, {
+			runId: "run-1",
+			workerId: "worker-1",
+			status: "canceled",
+		});
+		expect(run.status).toBe("canceled");
+		const events = await readEvents("run-1");
+		expect(events.map((e) => e.type)).toEqual(["run_canceled"]);
+	});
+
+	it("refuses error once cancellation was requested", async () => {
+		// "Do not overload `error` for user-initiated cancellation": after
+		// cancel_requested the only legal terminal is canceled, even when the
+		// SDK errors during the interrupt.
+		await claimRun("run-1", "conv-1", "worker-1");
+		await tdb.db
+			.update(runs)
+			.set({ status: "cancel_requested" })
+			.where(eq(runs.runId, "run-1"));
+
+		await expect(
+			transitionRunTerminalTx(tdb.db, {
+				runId: "run-1",
+				workerId: "worker-1",
+				status: "error",
+				payload: { message: "sdk exploded mid-interrupt" },
+			}),
+		).rejects.toBeInstanceOf(RunFenceError);
+	});
+
+	it("marks a running run as error with the error payload", async () => {
+		await claimRun("run-1", "conv-1", "worker-1");
+
+		const run = await transitionRunTerminalTx(tdb.db, {
+			runId: "run-1",
+			workerId: "worker-1",
+			status: "error",
+			payload: { message: "sandbox died" },
+		});
+
+		expect(run.status).toBe("error");
+		const events = await readEvents("run-1");
+		expect(events.map((e) => [e.type, e.payload])).toEqual([
+			["run_error", { message: "sandbox died" }],
+		]);
+	});
+
+	it("rejects a terminal transition from a non-owner or expired ownership", async () => {
+		await claimRun("run-1", "conv-1", "worker-1");
+
+		await expect(
+			transitionRunTerminalTx(tdb.db, {
+				runId: "run-1",
+				workerId: "worker-2",
+				status: "done",
+			}),
+		).rejects.toBeInstanceOf(RunFenceError);
+
+		await expireOwnership("run-1");
+		await expect(
+			transitionRunTerminalTx(tdb.db, {
+				runId: "run-1",
+				workerId: "worker-1",
+				status: "done",
+			}),
+		).rejects.toBeInstanceOf(RunFenceError);
+	});
+});
+
+describe("requestRunCancellationTx", () => {
+	const ref = { runId: "run-1", userId: "user-1", conversationId: "conv-1" };
+
+	it("cancels a queued run immediately and appends run_canceled", async () => {
+		await queueRun("run-1", "conv-1");
+
+		const result = await requestRunCancellationTx(tdb.db, ref);
+
+		expect(result.outcome).toBe("canceled");
+		if (result.outcome !== "canceled") throw new Error("unreachable");
+		expect(result.run).toMatchObject({
+			runId: "run-1",
+			status: "canceled",
+			lockedBy: null,
+			lockedUntil: null,
+		});
+		expect(result.run.terminalAt).toBeInstanceOf(Date);
+		const events = await readEvents("run-1");
+		expect(events.map((e) => [e.seq, e.type])).toEqual([[1, "run_canceled"]]);
+	});
+
+	it("moves a running run to cancel_requested and leaves ownership intact", async () => {
+		await claimRun("run-1", "conv-1", "worker-1");
+
+		const result = await requestRunCancellationTx(tdb.db, ref);
+
+		expect(result.outcome).toBe("cancel_requested");
+		if (result.outcome !== "cancel_requested") throw new Error("unreachable");
+		expect(result.run.status).toBe("cancel_requested");
+		expect(result.run.lockedBy).toBe("worker-1");
+		expect(result.run.cancelRequestedAt).toBeInstanceOf(Date);
+		// No terminal event yet: the owning worker appends run_canceled when it
+		// actually terminalizes.
+		expect(await readEvents("run-1")).toEqual([]);
+	});
+
+	it("is idempotent while cancellation is already requested", async () => {
+		await claimRun("run-1", "conv-1", "worker-1");
+		await requestRunCancellationTx(tdb.db, ref);
+
+		const again = await requestRunCancellationTx(tdb.db, ref);
+
+		expect(again.outcome).toBe("cancel_requested");
+		expect(await readEvents("run-1")).toEqual([]);
+	});
+
+	it("reports an already-terminal run without touching it", async () => {
+		await claimRun("run-1", "conv-1", "worker-1");
+		await transitionRunTerminalTx(tdb.db, {
+			runId: "run-1",
+			workerId: "worker-1",
+			status: "done",
+		});
+
+		const result = await requestRunCancellationTx(tdb.db, ref);
+
+		expect(result.outcome).toBe("already_terminal");
+		if (result.outcome !== "already_terminal") throw new Error("unreachable");
+		expect(result.run.status).toBe("done");
+		const events = await readEvents("run-1");
+		expect(events.map((e) => e.type)).toEqual(["run_done"]);
+	});
+
+	it("reports not_found for missing or foreign runs", async () => {
+		await queueRun("run-1", "conv-1");
+
+		expect(
+			await requestRunCancellationTx(tdb.db, {
+				...ref,
+				runId: "run-ghost",
+			}),
+		).toEqual({ outcome: "not_found" });
+		expect(
+			await requestRunCancellationTx(tdb.db, {
+				...ref,
+				userId: "user-2",
+			}),
+		).toEqual({ outcome: "not_found" });
+		expect(
+			await requestRunCancellationTx(tdb.db, {
+				...ref,
+				conversationId: "conv-2",
+			}),
+		).toEqual({ outcome: "not_found" });
+	});
+});
+
+describe("heartbeatRunTx", () => {
+	it("extends the lock deadline for the owning worker", async () => {
+		await claimRun("run-1", "conv-1", "worker-1");
+		// Pull the deadline near expiry so the fixed-duration renewal is visible.
+		await tdb.db
+			.update(runs)
+			.set({ lockedUntil: sql`now() + interval '1 second'` })
+			.where(eq(runs.runId, "run-1"));
+
+		const renewed = await heartbeatRunTx(tdb.db, {
+			runId: "run-1",
+			workerId: "worker-1",
+		});
+
+		expect(renewed).not.toBeNull();
+		expect(renewed?.lockedUntil?.getTime()).toBeGreaterThan(
+			Date.now() + 30_000,
+		);
+		expect(renewed?.heartbeatAt).toBeInstanceOf(Date);
+	});
+
+	it("lets the control loop observe a pending cancellation request", async () => {
+		await claimRun("run-1", "conv-1", "worker-1");
+		await requestRunCancellationTx(tdb.db, {
+			runId: "run-1",
+			userId: "user-1",
+			conversationId: "conv-1",
+		});
+
+		const renewed = await heartbeatRunTx(tdb.db, {
+			runId: "run-1",
+			workerId: "worker-1",
+		});
+
+		expect(renewed?.status).toBe("cancel_requested");
+		expect(renewed?.cancelRequestedAt).toBeInstanceOf(Date);
+	});
+
+	it("does not renew for a worker that does not own the run", async () => {
+		await claimRun("run-1", "conv-1", "worker-1");
+
+		const renewed = await heartbeatRunTx(tdb.db, {
+			runId: "run-1",
+			workerId: "worker-2",
+		});
+
+		expect(renewed).toBeNull();
+	});
+
+	it("does not revive expired ownership", async () => {
+		await claimRun("run-1", "conv-1", "worker-1");
+		await expireOwnership("run-1");
+
+		const renewed = await heartbeatRunTx(tdb.db, {
+			runId: "run-1",
+			workerId: "worker-1",
+		});
+
+		expect(renewed).toBeNull();
+	});
+
+	it("does not renew a terminal run", async () => {
+		await claimRun("run-1", "conv-1", "worker-1");
+		await transitionRunTerminalTx(tdb.db, {
+			runId: "run-1",
+			workerId: "worker-1",
+			status: "done",
+		});
+
+		const renewed = await heartbeatRunTx(tdb.db, {
+			runId: "run-1",
+			workerId: "worker-1",
+		});
+
+		expect(renewed).toBeNull();
+	});
+});
+
+describe("markStaleRunsTx", () => {
+	it("terminalizes a stale running run as error with a run_error event", async () => {
+		await claimRun("run-1", "conv-1", "worker-1");
+		await expireOwnership("run-1");
+
+		const recovered = await markStaleRunsTx(tdb.db);
+
+		expect(recovered.map((r) => [r.runId, r.status])).toEqual([
+			["run-1", "error"],
+		]);
+		expect(recovered[0]?.lockedBy).toBeNull();
+		expect(recovered[0]?.terminalAt).toBeInstanceOf(Date);
+		const events = await readEvents("run-1");
+		expect(events.map((e) => e.type)).toEqual(["run_error"]);
+	});
+
+	it("terminalizes a stale cancel_requested run as canceled", async () => {
+		await claimRun("run-1", "conv-1", "worker-1");
+		await requestRunCancellationTx(tdb.db, {
+			runId: "run-1",
+			userId: "user-1",
+			conversationId: "conv-1",
+		});
+		await expireOwnership("run-1");
+
+		const recovered = await markStaleRunsTx(tdb.db);
+
+		expect(recovered.map((r) => [r.runId, r.status])).toEqual([
+			["run-1", "canceled"],
+		]);
+		const events = await readEvents("run-1");
+		expect(events.map((e) => e.type)).toEqual(["run_canceled"]);
+	});
+
+	it("leaves queued runs and live claims alone", async () => {
+		await queueRun("run-queued", "conv-1");
+		await claimRun("run-live", "conv-2", "worker-1");
+
+		const recovered = await markStaleRunsTx(tdb.db);
+
+		expect(recovered).toEqual([]);
+		const [queued] = await tdb.db
+			.select()
+			.from(runs)
+			.where(eq(runs.runId, "run-queued"));
+		const [live] = await tdb.db
+			.select()
+			.from(runs)
+			.where(eq(runs.runId, "run-live"));
+		expect(queued?.status).toBe("queued");
+		expect(live?.status).toBe("running");
+	});
+
+	it("never double-terminalizes: a second sweep finds nothing", async () => {
+		await claimRun("run-1", "conv-1", "worker-1");
+		await expireOwnership("run-1");
+		await markStaleRunsTx(tdb.db);
+
+		const again = await markStaleRunsTx(tdb.db);
+
+		expect(again).toEqual([]);
+		const events = await readEvents("run-1");
+		expect(events.map((e) => e.type)).toEqual(["run_error"]);
+	});
+
+	it("rejects the stale worker's appends once recovery has terminalized", async () => {
+		await claimRun("run-1", "conv-1", "worker-1");
+		await expireOwnership("run-1");
+		await markStaleRunsTx(tdb.db);
+
+		await expect(
+			appendRunEventTx(tdb.db, {
+				runId: "run-1",
+				workerId: "worker-1",
+				type: "text_delta",
+				payload: {},
+				appendClass: "model",
+			}),
+		).rejects.toBeInstanceOf(RunFenceError);
+	});
+});

--- a/apps/chat-api/src/features/run-store/run-store.ts
+++ b/apps/chat-api/src/features/run-store/run-store.ts
@@ -1,0 +1,477 @@
+import { and, eq, inArray, sql } from "drizzle-orm";
+import type { Database } from "@/db/client";
+import { runEvents, runs } from "@/db/schema";
+
+/**
+ * Narrow transaction helpers over `runs`/`run_events` — the only write path
+ * for run state (design doc "State Ownership"). Each helper owns one
+ * transaction: sequence allocation is database-owned (`runs.next_event_seq`,
+ * never app-side `max(seq) + 1`), and every status change or append is fenced
+ * inside the same statement that performs it, so app-side select/update races
+ * cannot happen through this module. The ownership fence for v1 is
+ * `locked_by` + `locked_until` — no fencing token, because a run is claimed
+ * exactly once (failed runs never requeue; stale runs are terminalized, never
+ * reclaimed).
+ */
+
+/** All legal `runs.status` values (mirrors the DB check constraint). */
+export type RunStatus =
+	| "queued"
+	| "running"
+	| "cancel_requested"
+	| "done"
+	| "error"
+	| "canceled";
+
+/** A persisted run row. `status` is narrowed from text: rows are only ever
+ * written through these helpers, which accept the typed union. */
+export type RunRecord = Omit<typeof runs.$inferSelect, "status"> & {
+	status: RunStatus;
+};
+
+/**
+ * Queue admission failed: the conversation already has an active
+ * (queued/running/cancel_requested) run. Surfaced as busy/backpressure by the
+ * caller; the partial unique index is the authority.
+ */
+export class ActiveRunConflictError extends Error {
+	override name = "ActiveRunConflictError" as const;
+}
+
+/**
+ * An ownership/status fence rejected the write: the run is not in a status
+ * the append class allows, is owned by another worker, or the caller's
+ * `locked_until` deadline has passed. The caller must stop treating the run
+ * as its own; recovery (or the actual owner) is in charge now.
+ */
+export class RunFenceError extends Error {
+	override name = "RunFenceError" as const;
+}
+
+/** JSON body persisted with a run event. */
+export type RunEventPayload = Record<string, unknown>;
+
+/**
+ * The two owned append classes (design doc "State Ownership"): `model` is
+ * normal SDK content — assistant text, tool results — and is only legal while
+ * the run is `running`; `cancellation` is the bounded cleanup/audit trail the
+ * owning worker may still write after `cancel_requested`. Terminal events are
+ * deliberately not an append class here — they only exist through the
+ * terminal transition helpers.
+ */
+export type RunEventAppendClass = "model" | "cancellation";
+
+const APPEND_CLASS_STATUSES: Record<RunEventAppendClass, RunStatus[]> = {
+	model: ["running"],
+	cancellation: ["running", "cancel_requested"],
+};
+
+/** The three terminal statuses a worker can transition an owned run into. */
+export type TerminalRunStatus = "done" | "error" | "canceled";
+
+/** The helper owns the status→event-type mapping so a terminal run can never
+ * carry a mismatched terminal event. */
+const TERMINAL_EVENT_TYPES: Record<TerminalRunStatus, string> = {
+	done: "run_done",
+	error: "run_error",
+	canceled: "run_canceled",
+};
+
+/** `done` must lose to a recorded cancellation request, and `error` must not
+ * overload user-initiated cancellation (an SDK failure after the interrupt
+ * still surfaces as `canceled`), so both are only legal from `running`; only
+ * `canceled` also closes a `cancel_requested` run. */
+const TERMINAL_FROM_STATUSES: Record<TerminalRunStatus, RunStatus[]> = {
+	done: ["running"],
+	error: ["running"],
+	canceled: ["running", "cancel_requested"],
+};
+
+/**
+ * Insert one `queued` run. The `runs_one_active_per_conversation` partial
+ * unique index enforces single-admission at the DB layer; a violation is
+ * mapped to {@link ActiveRunConflictError}. Any other failure (including a
+ * duplicate `runId`) is rethrown untouched.
+ */
+export async function createQueuedRunTx(
+	db: Database,
+	input: { runId: string; userId: string; conversationId: string },
+): Promise<RunRecord> {
+	try {
+		const [row] = await db
+			.insert(runs)
+			.values({
+				runId: input.runId,
+				userId: input.userId,
+				conversationId: input.conversationId,
+				status: "queued",
+			})
+			.returning();
+		if (!row) throw new Error(`insert of run ${input.runId} returned no row`);
+		return toRunRecord(row);
+	} catch (error) {
+		if (isActiveRunConflict(error)) {
+			throw new ActiveRunConflictError(
+				`conversation ${input.conversationId} already has an active run`,
+				{ cause: error },
+			);
+		}
+		throw error;
+	}
+}
+
+/** How far ahead a claim/heartbeat pushes `locked_until` (design: 60s hold,
+ * 15s heartbeat — four missed heartbeats before a run is recoverable). */
+const LOCK_DURATION_MS = 60_000;
+
+/**
+ * Claim the oldest queued run for `workerId`, or return `null` when the queue
+ * is empty. One atomic statement: the candidate select (`FOR UPDATE SKIP
+ * LOCKED`, so concurrent claimants skip each other's candidate instead of
+ * blocking or double-claiming), the `status = 'queued'` recheck, and the
+ * ownership write all happen inside a single UPDATE — never a separate
+ * app-side select followed by an update.
+ */
+export async function claimNextRunTx(
+	db: Database,
+	input: { workerId: string },
+): Promise<RunRecord | null> {
+	const [row] = await db
+		.update(runs)
+		.set({
+			status: "running",
+			lockedBy: input.workerId,
+			lockedUntil: sql`now() + (${LOCK_DURATION_MS} * interval '1 millisecond')`,
+			heartbeatAt: sql`now()`,
+			updatedAt: sql`now()`,
+		})
+		.where(
+			and(
+				eq(runs.status, "queued"),
+				sql`${runs.runId} in (
+					select run_id from runs
+					where status = 'queued'
+					order by created_at
+					for update skip locked
+					limit 1
+				)`,
+			),
+		)
+		.returning();
+	return row ? toRunRecord(row) : null;
+}
+
+/**
+ * Append one owned run event, allocating `seq` from `runs.next_event_seq` and
+ * inserting the event row in the same transaction — the counter update carries
+ * the fence for the append class (status set, `locked_by = workerId`,
+ * `locked_until > now()`), so a stale or non-owning worker cannot allocate a
+ * sequence number at all. Throws {@link RunFenceError} when the fence rejects.
+ */
+export async function appendRunEventTx(
+	db: Database,
+	input: {
+		runId: string;
+		workerId: string;
+		type: string;
+		payload: RunEventPayload;
+		appendClass: RunEventAppendClass;
+	},
+): Promise<{ seq: number }> {
+	return await db.transaction(async (tx) => {
+		const [allocated] = await tx
+			.update(runs)
+			.set({
+				nextEventSeq: sql`${runs.nextEventSeq} + 1`,
+				updatedAt: sql`now()`,
+			})
+			.where(
+				and(
+					eq(runs.runId, input.runId),
+					inArray(runs.status, APPEND_CLASS_STATUSES[input.appendClass]),
+					eq(runs.lockedBy, input.workerId),
+					sql`${runs.lockedUntil} > now()`,
+				),
+			)
+			// In UPDATE ... RETURNING the column holds its new value, so the
+			// pre-increment counter — this append's seq — is `next_event_seq - 1`.
+			.returning({ seq: sql`${runs.nextEventSeq} - 1` });
+		if (!allocated) {
+			throw new RunFenceError(
+				`${input.appendClass} append to run ${input.runId} rejected: ` +
+					`run is not in an appendable status or worker ${input.workerId} no longer owns it`,
+			);
+		}
+		const seq = Number(allocated.seq);
+		await tx.insert(runEvents).values({
+			runId: input.runId,
+			seq,
+			type: input.type,
+			payload: input.payload,
+		});
+		return { seq };
+	});
+}
+
+/**
+ * Move an owned run to a terminal status and append its one terminal event —
+ * the status CAS, ownership clear (`locked_by`/`locked_until` → NULL),
+ * `terminal_at`, sequence allocation, and event insert are one transaction.
+ * The from-status CAS makes double-terminalization impossible (the second
+ * caller finds no row and gets {@link RunFenceError}), which is what makes
+ * "exactly one terminal event per run" hold. Fenced like an owned append:
+ * only the worker holding live ownership may terminalize its run.
+ */
+export async function transitionRunTerminalTx(
+	db: Database,
+	input: {
+		runId: string;
+		workerId: string;
+		status: TerminalRunStatus;
+		payload?: RunEventPayload;
+	},
+): Promise<RunRecord> {
+	return await db.transaction(async (tx) => {
+		const [row] = await tx
+			.update(runs)
+			.set({
+				status: input.status,
+				nextEventSeq: sql`${runs.nextEventSeq} + 1`,
+				lockedBy: null,
+				lockedUntil: null,
+				terminalAt: sql`now()`,
+				updatedAt: sql`now()`,
+			})
+			.where(
+				and(
+					eq(runs.runId, input.runId),
+					inArray(runs.status, TERMINAL_FROM_STATUSES[input.status]),
+					eq(runs.lockedBy, input.workerId),
+					sql`${runs.lockedUntil} > now()`,
+				),
+			)
+			.returning();
+		if (!row) {
+			throw new RunFenceError(
+				`terminal transition of run ${input.runId} to ${input.status} rejected: ` +
+					`run is already terminal, not transitionable to ${input.status}, or worker ${input.workerId} no longer owns it`,
+			);
+		}
+		await insertTerminalEvent(tx, row, input.status, input.payload ?? {});
+		return toRunRecord(row);
+	});
+}
+
+/** A Drizzle client scoped to one open transaction. */
+type DbTx = Parameters<Parameters<Database["transaction"]>[0]>[0];
+
+/**
+ * Insert the one terminal event for a run row a terminal CAS just returned —
+ * that CAS already incremented `next_event_seq`, so the pre-increment value
+ * (`nextEventSeq - 1`) is this event's seq.
+ */
+async function insertTerminalEvent(
+	tx: DbTx,
+	row: typeof runs.$inferSelect,
+	status: TerminalRunStatus,
+	payload: RunEventPayload,
+): Promise<void> {
+	await tx.insert(runEvents).values({
+		runId: row.runId,
+		seq: row.nextEventSeq - 1,
+		type: TERMINAL_EVENT_TYPES[status],
+		payload,
+	});
+}
+
+/**
+ * How a cancellation request landed. `canceled`: the run was still queued and
+ * is now terminal with its `run_canceled` event. `cancel_requested`: the run
+ * is executing; the owning worker keeps ownership and terminalizes after
+ * interrupting (repeat requests are idempotent no-ops). `already_terminal`:
+ * nothing to cancel — `run` carries the status the caller should report.
+ */
+export type RunCancellationResult =
+	| {
+			outcome: "canceled" | "cancel_requested" | "already_terminal";
+			run: RunRecord;
+	  }
+	| { outcome: "not_found" };
+
+/**
+ * Record a user cancellation request for an owned run. The row is locked
+ * (`FOR UPDATE`) for the whole decision, so the status branch cannot race a
+ * concurrent claim, append, or terminal transition. `userId`/`conversationId`
+ * scope the lookup to the owner — a foreign run is `not_found`, never a state
+ * change.
+ */
+export async function requestRunCancellationTx(
+	db: Database,
+	input: { runId: string; userId: string; conversationId: string },
+): Promise<RunCancellationResult> {
+	return await db.transaction(async (tx) => {
+		const [run] = await tx
+			.select()
+			.from(runs)
+			.where(
+				and(
+					eq(runs.runId, input.runId),
+					eq(runs.userId, input.userId),
+					eq(runs.conversationId, input.conversationId),
+				),
+			)
+			.for("update");
+		if (!run) return { outcome: "not_found" };
+
+		if (run.status === "queued") {
+			// Never claimed, so there is no owner to hand the cancellation to:
+			// terminalize directly, with the same counter-allocated terminal event
+			// a worker transition would produce.
+			const [row] = await tx
+				.update(runs)
+				.set({
+					status: "canceled",
+					nextEventSeq: sql`${runs.nextEventSeq} + 1`,
+					cancelRequestedAt: sql`now()`,
+					lockedBy: null,
+					lockedUntil: null,
+					terminalAt: sql`now()`,
+					updatedAt: sql`now()`,
+				})
+				.where(and(eq(runs.runId, input.runId), eq(runs.status, "queued")))
+				.returning();
+			if (!row) throw new Error(`queued run ${input.runId} vanished mid-lock`);
+			await insertTerminalEvent(tx, row, "canceled", {});
+			return { outcome: "canceled", run: toRunRecord(row) };
+		}
+
+		if (run.status === "running") {
+			const [row] = await tx
+				.update(runs)
+				.set({
+					status: "cancel_requested",
+					cancelRequestedAt: sql`now()`,
+					updatedAt: sql`now()`,
+				})
+				.where(and(eq(runs.runId, input.runId), eq(runs.status, "running")))
+				.returning();
+			if (!row) throw new Error(`running run ${input.runId} vanished mid-lock`);
+			return { outcome: "cancel_requested", run: toRunRecord(row) };
+		}
+
+		if (run.status === "cancel_requested") {
+			return { outcome: "cancel_requested", run: toRunRecord(run) };
+		}
+
+		return { outcome: "already_terminal", run: toRunRecord(run) };
+	});
+}
+
+/**
+ * Renew the caller's ownership of an active run — push `locked_until` ahead —
+ * and return the fresh row, so the worker's control loop both keeps the run
+ * alive and observes `cancel_requested` through this one call. Fenced like an
+ * append: active status, matching `locked_by`, and an unexpired
+ * `locked_until`. Returns `null` when the fence rejects — expired ownership
+ * is never revived (the run belongs to stale-run recovery now), and the
+ * caller must abandon the run locally.
+ */
+export async function heartbeatRunTx(
+	db: Database,
+	input: { runId: string; workerId: string },
+): Promise<RunRecord | null> {
+	const [row] = await db
+		.update(runs)
+		.set({
+			heartbeatAt: sql`now()`,
+			lockedUntil: sql`now() + (${LOCK_DURATION_MS} * interval '1 millisecond')`,
+			updatedAt: sql`now()`,
+		})
+		.where(
+			and(
+				eq(runs.runId, input.runId),
+				inArray(runs.status, ["running", "cancel_requested"]),
+				eq(runs.lockedBy, input.workerId),
+				sql`${runs.lockedUntil} > now()`,
+			),
+		)
+		.returning();
+	return row ? toRunRecord(row) : null;
+}
+
+/**
+ * Stale-run recovery: terminalize every active run whose `locked_until` has
+ * passed — `cancel_requested` becomes `canceled`, `running` becomes `error`
+ * (a v1 run is never reclaimed). Each run's status CAS and terminal event
+ * share the transaction, and candidates are taken `FOR UPDATE SKIP LOCKED`,
+ * so concurrent recovery loops across the fleet split the work instead of
+ * blocking, and a run can never be double-terminalized. Returns the runs it
+ * recovered so the caller can clean up their sandbox side effects.
+ */
+export async function markStaleRunsTx(db: Database): Promise<RunRecord[]> {
+	return await db.transaction(async (tx) => {
+		const stale = await tx
+			.select({ runId: runs.runId, status: runs.status })
+			.from(runs)
+			.where(
+				and(
+					inArray(runs.status, ["running", "cancel_requested"]),
+					// Complements the append fence exactly: appends require
+					// locked_until > now(), so anything at or past the deadline is
+					// unowned and recoverable.
+					sql`${runs.lockedUntil} <= now()`,
+				),
+			)
+			.for("update", { skipLocked: true });
+
+		const recovered: RunRecord[] = [];
+		for (const candidate of stale) {
+			const status: TerminalRunStatus =
+				candidate.status === "cancel_requested" ? "canceled" : "error";
+			const [row] = await tx
+				.update(runs)
+				.set({
+					status,
+					nextEventSeq: sql`${runs.nextEventSeq} + 1`,
+					lockedBy: null,
+					lockedUntil: null,
+					terminalAt: sql`now()`,
+					updatedAt: sql`now()`,
+				})
+				.where(
+					and(
+						eq(runs.runId, candidate.runId),
+						inArray(runs.status, ["running", "cancel_requested"]),
+					),
+				)
+				.returning();
+			if (!row) continue;
+			await insertTerminalEvent(tx, row, status, { reason: "stale_worker" });
+			recovered.push(toRunRecord(row));
+		}
+		return recovered;
+	});
+}
+
+function toRunRecord(row: typeof runs.$inferSelect): RunRecord {
+	return { ...row, status: row.status as RunStatus };
+}
+
+/**
+ * True when the error chain is a unique violation of the
+ * `runs_one_active_per_conversation` partial index. Matched by constraint
+ * name (node-postgres exposes `constraint`) with a message fallback (pglite
+ * in tests), so a duplicate-`runId` primary-key violation stays distinct.
+ */
+function isActiveRunConflict(error: unknown): boolean {
+	for (
+		let e: unknown = error;
+		e instanceof Error;
+		e = (e as { cause?: unknown }).cause
+	) {
+		const constraint = (e as { constraint?: unknown }).constraint;
+		if (constraint === "runs_one_active_per_conversation") return true;
+		if (e.message.includes("runs_one_active_per_conversation")) return true;
+	}
+	return false;
+}


### PR DESCRIPTION
Closes #175

## What changed

Adds `apps/chat-api/src/features/run-store/` — the narrow transaction helpers over `runs`/`run_events` that are the only write path for run state (plan Task 1.2, Milestone 1):

`createQueuedRunTx`, `claimNextRunTx`, `appendRunEventTx`, `transitionRunTerminalTx`, `requestRunCancellationTx`, `heartbeatRunTx`, `markStaleRunsTx`

## Why

The split-runtime worker (Milestone 3) and the conversation API (Milestone 2) both need run state whose ordering and ownership invariants live in the database, not in application code. These helpers make the design doc's rules structural:

- **Atomic claim**: `claimNextRunTx` is one UPDATE over a `FOR UPDATE SKIP LOCKED` candidate select with a `status = 'queued'` recheck — no app-side select-then-update race is possible through any public helper.
- **DB-owned ordering**: every event append (owned, cancellation-terminal, stale recovery) allocates `seq` from `runs.next_event_seq` inside the same transaction as the insert; never `max(seq) + 1` app-side.
- **Append-class fences**: model/content appends require `status = running` + matching `locked_by` + live `locked_until`; cancellation audit appends also allow `cancel_requested`; terminal events exist only through the terminal helpers. A stale worker cannot even allocate a sequence number.
- **Exactly one terminal event**: the terminal transition is a status CAS that increments the counter, clears ownership, and inserts the event in one transaction — a second transition finds no row and gets `RunFenceError`.
- **Cancellation policy**: `done` and `error` are only legal from `running`, so a cancel-requested run can only terminalize as `canceled` — `error` never overloads user-initiated cancellation, per the design doc.
- **Stale recovery**: `markStaleRunsTx` terminalizes past-deadline runs (`cancel_requested` → `canceled`, `running` → `error`) with `SKIP LOCKED` candidates, so concurrent recovery loops split work and can never double-terminalize.

No fencing token, per the issue: a v1 run is claimed exactly once, so `locked_by` + `locked_until` is the complete ownership fence.

## Reviewer notes

- 34 tests on PGlite (`createTestDatabase`) cover every acceptance criterion, including both successful transitions and failed ownership fences.
- PGlite is single-connection, so the two-claimants test exercises the claim CAS but not true cross-connection `SKIP LOCKED` contention; the plan covers that at the local-Postgres integration layer (Milestone 3). The test carries a comment saying so.
- A two-axis review (standards + spec) ran before commit; it drove the claim/ownership vocabulary (CONTEXT.md bans "lease"), awaited `.rejects` assertions, the `error`-from-`cancel_requested` restriction, and removal of unrequested `lockDurationMs` configurability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)