### PR TITLE
Add fenced conversation runtime store; drop sandbox_leases (plan 4.2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,7 +142,8 @@ The former chat-api → sandbox-daemon `/turn` edge is removed from chat-api's l
 | `src/features/run-store/` | Durable run queue/event-log store over `runs` and `run_events`; queues `user.message` turns and replays run events |
 | `src/features/run-events/` | Durable run-event projection and wake-up plumbing (`project-run.ts`, `project-run-event.ts`, `run-event-reader.ts`, `run-notifier.ts`) |
 | `src/features/streaming/` | SSE sender/types reused by the conversation routes (`sse-sender.ts`, `events.ts`) |
-| `src/db/` | Drizzle schema (`schema.ts`: `conversations`, `runs`, `run_events`, `sandbox_leases`), client (`client.ts`), and migration runner (`migrate.ts`) for the writable DB; migrations in `drizzle/` |
+| `src/db/` | Drizzle schema (`schema.ts`: `conversations`, `runs`, `run_events`, `conversation_runtime`, `orphan_sandboxes`), client (`client.ts`), and migration runner (`migrate.ts`) for the writable DB; migrations in `drizzle/` |
+| `src/features/conversation-runtime-store/` | Persistent E2B workspace metadata over `conversation_runtime` (sandbox pointer, snapshot rotation, checkpoint/taint state) — every mutation fenced on the claiming run's `locked_by`/`locked_until` — plus the unfenced `orphan_sandboxes` recovery ledger |
 | `src/config/env.ts` | Environment validation |
 | `apps/gateway/src/server.ts` | `createGateway(config, db)` — the merged control plane: registers health, then the document routes, then the catch-all LLM proxy (order is correctness-critical). Pure: config in, app out |
 | `apps/gateway/src/auth/` | `bearer.ts` (the one shared `bearerClaims` token-verify seam + 401/403 helpers) and `claims.ts` (`requireDocumentClaims` scope guard) |

--- a/apps/chat-api/drizzle/0001_wandering_namora.sql
+++ b/apps/chat-api/drizzle/0001_wandering_namora.sql
@@ -1,0 +1,25 @@
+CREATE TABLE "conversation_runtime" (
+	"user_id" text NOT NULL,
+	"conversation_id" text NOT NULL,
+	"sandbox_id" text,
+	"sandbox_tainted" boolean DEFAULT false NOT NULL,
+	"latest_snapshot_id" text,
+	"previous_snapshot_id" text,
+	"workspace_checkpoint_status" text DEFAULT 'clean' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "conversation_runtime_user_id_conversation_id_pk" PRIMARY KEY("user_id","conversation_id"),
+	CONSTRAINT "conversation_runtime_checkpoint_status_check" CHECK ("conversation_runtime"."workspace_checkpoint_status" in ('clean', 'dirty_uncheckpointed'))
+);
+--> statement-breakpoint
+CREATE TABLE "orphan_sandboxes" (
+	"sandbox_id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"conversation_id" text NOT NULL,
+	"run_id" text NOT NULL,
+	"created_by_worker_id" text NOT NULL,
+	"reason" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DROP TABLE "sandbox_leases" CASCADE;

--- a/apps/chat-api/drizzle/meta/0001_snapshot.json
+++ b/apps/chat-api/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,556 @@
+{
+  "id": "575c6612-9643-4cb1-b64f-7f6ef82c2b40",
+  "prevId": "34231bdc-ad7d-46fd-a43d-807ec29181e5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.conversation_runtime": {
+      "name": "conversation_runtime",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_tainted": {
+          "name": "sandbox_tainted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "latest_snapshot_id": {
+          "name": "latest_snapshot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_snapshot_id": {
+          "name": "previous_snapshot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_checkpoint_status": {
+          "name": "workspace_checkpoint_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'clean'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "conversation_runtime_user_id_conversation_id_pk": {
+          "name": "conversation_runtime_user_id_conversation_id_pk",
+          "columns": [
+            "user_id",
+            "conversation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "conversation_runtime_checkpoint_status_check": {
+          "name": "conversation_runtime_checkpoint_status_check",
+          "value": "\"conversation_runtime\".\"workspace_checkpoint_status\" in ('clean', 'dirty_uncheckpointed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_id": {
+          "name": "summary_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "conversations_user_id_conversation_id_pk": {
+          "name": "conversations_user_id_conversation_id_pk",
+          "columns": [
+            "user_id",
+            "conversation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "conversations_scope_check": {
+          "name": "conversations_scope_check",
+          "value": "\"conversations\".\"scope\" in ('general', 'collection', 'document')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.document_access_events": {
+      "name": "document_access_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_ids": {
+          "name": "document_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_access_events_run_id_idx": {
+          "name": "document_access_events_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_access_events_created_at_idx": {
+          "name": "document_access_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "document_access_events_scope_type_check": {
+          "name": "document_access_events_scope_type_check",
+          "value": "\"document_access_events\".\"scope_type\" in ('general', 'collection', 'document')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.orphan_sandboxes": {
+      "name": "orphan_sandboxes",
+      "schema": "",
+      "columns": {
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_worker_id": {
+          "name": "created_by_worker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_events": {
+      "name": "run_events",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "run_events_run_id_runs_run_id_fk": {
+          "name": "run_events_run_id_runs_run_id_fk",
+          "tableFrom": "run_events",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "run_events_run_id_seq_pk": {
+          "name": "run_events_run_id_seq_pk",
+          "columns": [
+            "run_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runs": {
+      "name": "runs",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locked_by": {
+          "name": "locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_event_seq": {
+          "name": "next_event_seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "runs_one_active_per_conversation": {
+          "name": "runs_one_active_per_conversation",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"runs\".\"status\" in ('queued', 'running', 'cancel_requested')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_queue_claim_idx": {
+          "name": "runs_queue_claim_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runs\".\"status\" = 'queued'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_stale_recovery_idx": {
+          "name": "runs_stale_recovery_idx",
+          "columns": [
+            {
+              "expression": "locked_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runs\".\"status\" in ('running', 'cancel_requested')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_cleanup_idx": {
+          "name": "runs_cleanup_idx",
+          "columns": [
+            {
+              "expression": "terminal_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runs\".\"status\" in ('done', 'error', 'canceled')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runs_status_check": {
+          "name": "runs_status_check",
+          "value": "\"runs\".\"status\" in ('queued', 'running', 'cancel_requested', 'done', 'error', 'canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/chat-api/drizzle/meta/_journal.json
+++ b/apps/chat-api/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1783229094438,
       "tag": "0000_smooth_titanium_man",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1783300007602,
+      "tag": "0001_wandering_namora",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/chat-api/src/db/run-schema.test.ts
+++ b/apps/chat-api/src/db/run-schema.test.ts
@@ -1,7 +1,32 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+} from "bun:test";
 import { eq, sql } from "drizzle-orm";
 import { createTestDatabase, type TestDb } from "@/db/testing";
 import { documentAccessEvents, runEvents, runs } from "./schema";
+
+let tdb: TestDb;
+
+// One PGlite (WASM) instance for the whole file — a per-test instance
+// multiplies WASM memory that is not reclaimed promptly and OOMs CI runners.
+// Tests are isolated by clearing the tables they touch instead.
+beforeAll(async () => {
+	tdb = await createTestDatabase();
+});
+
+afterAll(async () => {
+	await tdb.close();
+});
+
+beforeEach(async () => {
+	await tdb.db.delete(runs); // cascades run_events
+	await tdb.db.delete(documentAccessEvents);
+});
 
 async function expectDbWriteToFail(write: () => PromiseLike<unknown>) {
 	let failed = false;
@@ -14,16 +39,6 @@ async function expectDbWriteToFail(write: () => PromiseLike<unknown>) {
 }
 
 describe("run queue schema", () => {
-	let tdb: TestDb;
-
-	beforeEach(async () => {
-		tdb = await createTestDatabase();
-	});
-
-	afterEach(async () => {
-		await tdb.close();
-	});
-
 	it("creates runs with queue defaults", async () => {
 		const [run] = await tdb.db
 			.insert(runs)
@@ -210,16 +225,6 @@ describe("run queue schema", () => {
 });
 
 describe("document access audit schema", () => {
-	let tdb: TestDb;
-
-	beforeEach(async () => {
-		tdb = await createTestDatabase();
-	});
-
-	afterEach(async () => {
-		await tdb.close();
-	});
-
 	it("records document access rows with defaults", async () => {
 		const [event] = await tdb.db
 			.insert(documentAccessEvents)

--- a/apps/chat-api/src/db/schema.ts
+++ b/apps/chat-api/src/db/schema.ts
@@ -2,6 +2,7 @@ import { sql } from "drizzle-orm";
 import {
 	bigint,
 	bigserial,
+	boolean,
 	check,
 	index,
 	jsonb,
@@ -21,58 +22,88 @@ import {
  */
 
 /**
- * Sandbox-lease registry (MYM-17 / MYM-42). One row per conversation, keyed by
+ * Persistent E2B workspace metadata (Task 4.2 / ADR-0002): one row per
  * `(user_id, conversation_id)` — the composite primary key makes per-user /
- * per-conversation isolation a database invariant: two users, or two
- * conversations, can never resolve to one row and so can never share a sandbox.
- *
- * The row carries two concerns:
- *  - **Ownership lease** (`owner_id`, `fencing_token`, `lease_expires_at`): the
- *    concurrency control. A turn `claimLease` becomes owner via an atomic
- *    `ON CONFLICT … WHERE expired/free` CAS, heartbeats `lease_expires_at`
- *    forward while running, and clears ownership on release. A crashed owner's
- *    lease simply expires and another replica can steal it. `fencing_token` is
- *    bumped on every claim so a renew/release only affects the exact hold that
- *    acquired it (a stolen hold becomes a no-op).
- *  - **Warm-sandbox pointer** (`sandbox_id`, `agent_session_id`): a disposable
- *    optimization that survives between turns. Nullable — a freshly claimed row
- *    has no sandbox yet; only the sandbox *id* is stored (the daemon URL + edge
- *    token are recomputed from the reattached handle on reuse, never persisted).
+ * per-conversation isolation a database invariant. This row replaces the old
+ * `sandbox_leases` warm-pointer role only; unlike the lease it grants **no
+ * active execution ownership** — that lives exclusively in `runs`, and every
+ * mutation here must be fenced on the claiming run's `locked_by`/`locked_until`
+ * through the conversation-runtime-store helpers, so a worker that lost its
+ * run cannot overwrite pointers a recovered conversation now relies on.
  */
-export const sandboxLeases = pgTable(
-	"sandbox_leases",
+export const conversationRuntime = pgTable(
+	"conversation_runtime",
 	{
 		userId: text("user_id").notNull(),
 		conversationId: text("conversation_id").notNull(),
-		/** Process instance currently holding the lease; NULL between turns. */
-		ownerId: text("owner_id"),
-		/** Monotonic per-conversation hold counter; bumped on every claim. */
-		fencingToken: bigint("fencing_token", { mode: "number" })
-			.notNull()
-			.default(0),
-		/** Lease deadline; heartbeated forward while a turn runs. Past = free. */
-		leaseExpiresAt: timestamp("lease_expires_at", { withTimezone: true }),
-		/** The warm sandbox; a reusing process reattaches to it by id. Nullable. */
+		/** Current E2B sandbox (running or paused); NULL when none exists. */
 		sandboxId: text("sandbox_id"),
-		/** Claude SDK resume state last threaded into this conversation. */
-		agentSessionId: text("agent_session_id"),
+		/**
+		 * True when command cleanup could not be proven (stale-run recovery,
+		 * failed command-tree kill): the sandbox must not be snapshotted or
+		 * reused until cleanup proves otherwise. Reset whenever the pointer is
+		 * replaced or cleared — taint describes the current sandbox only.
+		 */
+		sandboxTainted: boolean("sandbox_tainted").notNull().default(false),
+		/** Newest successful checkpoint; the product restore path. */
+		latestSnapshotId: text("latest_snapshot_id"),
+		/** Prior successful checkpoint, kept for operator-driven rollback. */
+		previousSnapshotId: text("previous_snapshot_id"),
+		/**
+		 * 'clean' = the workspace holds no user work newer than
+		 * `latest_snapshot_id` (or is fresh); 'dirty_uncheckpointed' = a
+		 * checkpoint failed after user work, so the next turn must reconnect
+		 * and checkpoint before anything else.
+		 */
+		workspaceCheckpointStatus: text("workspace_checkpoint_status")
+			.notNull()
+			.default("clean"),
 		createdAt: timestamp("created_at", { withTimezone: true })
 			.notNull()
 			.defaultNow(),
-		/** Bumped on every write so the idle reaper can age leases out. */
 		updatedAt: timestamp("updated_at", { withTimezone: true })
 			.notNull()
 			.defaultNow(),
 	},
-	(t) => [primaryKey({ columns: [t.userId, t.conversationId] })],
+	(t) => [
+		primaryKey({ columns: [t.userId, t.conversationId] }),
+		check(
+			"conversation_runtime_checkpoint_status_check",
+			sql`${t.workspaceCheckpointStatus} in ('clean', 'dirty_uncheckpointed')`,
+		),
+	],
 );
+
+/**
+ * Recovery ledger for E2B sandboxes created but never safely stored as the
+ * current `conversation_runtime.sandbox_id` (run ownership lost before the
+ * fenced update, kill unconfirmed). Deliberately no FK to `runs` and no
+ * ownership fence on inserts: recording happens precisely when ownership was
+ * already lost, and the ledger must survive run cleanup — it is the only
+ * database record keeping a paid external resource inside ownership. The
+ * cleanup job kills entries after verifying they are not the current
+ * `conversation_runtime.sandbox_id`.
+ */
+export const orphanSandboxes = pgTable("orphan_sandboxes", {
+	/** PK: recording the same sandbox twice is an idempotent no-op. */
+	sandboxId: text("sandbox_id").primaryKey(),
+	userId: text("user_id").notNull(),
+	conversationId: text("conversation_id").notNull(),
+	runId: text("run_id").notNull(),
+	createdByWorkerId: text("created_by_worker_id").notNull(),
+	/** Why the sandbox escaped ownership, for operators (free text). */
+	reason: text("reason").notNull(),
+	createdAt: timestamp("created_at", { withTimezone: true })
+		.notNull()
+		.defaultNow(),
+});
 
 /**
  * Durable conversation record — the source of truth for a conversation's
  * immutable document scope, keyed like the lease by `(user_id, conversation_id)`.
- * Kept separate from `sandbox_leases` on purpose: the lease is a disposable
- * optimization the reaper may delete, whereas the scope is a correctness/
- * security boundary that must outlive any sandbox. Created once and never
+ * Kept separate from `conversation_runtime` on purpose: runtime rows are
+ * disposable workspace metadata cleanup may delete, whereas the scope is a
+ * correctness/security boundary that must outlive any sandbox. Created once and never
  * re-scoped (the scope columns are written at creation and read each turn).
  */
 export const conversations = pgTable(

--- a/apps/chat-api/src/features/conversation-runtime-store/conversation-runtime-store.test.ts
+++ b/apps/chat-api/src/features/conversation-runtime-store/conversation-runtime-store.test.ts
@@ -1,6 +1,13 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+} from "bun:test";
 import { eq, sql } from "drizzle-orm";
-import { runs } from "@/db/schema";
+import { conversationRuntime, orphanSandboxes, runs } from "@/db/schema";
 import { createTestDatabase, type TestDb } from "@/db/testing";
 import {
 	claimNextRunTx,
@@ -20,12 +27,21 @@ import {
 
 let tdb: TestDb;
 
-beforeEach(async () => {
+// One PGlite (WASM) instance for the whole file — a per-test instance
+// multiplies WASM memory that is not reclaimed promptly and OOMs CI runners.
+// Tests are isolated by clearing the tables they touch instead.
+beforeAll(async () => {
 	tdb = await createTestDatabase();
 });
 
-afterEach(async () => {
+afterAll(async () => {
 	await tdb.close();
+});
+
+beforeEach(async () => {
+	await tdb.db.delete(runs); // cascades run_events
+	await tdb.db.delete(conversationRuntime);
+	await tdb.db.delete(orphanSandboxes);
 });
 
 async function tableExists(name: string): Promise<boolean> {

--- a/apps/chat-api/src/features/conversation-runtime-store/conversation-runtime-store.test.ts
+++ b/apps/chat-api/src/features/conversation-runtime-store/conversation-runtime-store.test.ts
@@ -1,0 +1,412 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { eq, sql } from "drizzle-orm";
+import { runs } from "@/db/schema";
+import { createTestDatabase, type TestDb } from "@/db/testing";
+import {
+	claimNextRunTx,
+	createQueuedRunTx,
+	markStaleRunsTx,
+	RunFenceError,
+} from "@/features/run-store";
+import {
+	createConversationRuntimeTx,
+	loadConversationRuntimeTx,
+	markRuntimeCheckpointStatusTx,
+	markRuntimeSandboxTaintedTx,
+	recordOrphanSandboxTx,
+	recordRuntimeSnapshotTx,
+	updateRuntimeSandboxTx,
+} from "./conversation-runtime-store";
+
+let tdb: TestDb;
+
+beforeEach(async () => {
+	tdb = await createTestDatabase();
+});
+
+afterEach(async () => {
+	await tdb.close();
+});
+
+async function tableExists(name: string): Promise<boolean> {
+	const result = await tdb.db.execute(
+		sql`select 1 from information_schema.tables
+			where table_schema = 'public' and table_name = ${name}`,
+	);
+	return result.rows.length > 0;
+}
+
+describe("migration", () => {
+	it("creates conversation_runtime and orphan_sandboxes and drops sandbox_leases", async () => {
+		// ADR-0002: the prototype path's lease authority dies in the same
+		// migration that creates the runtime metadata that replaces it.
+		expect(await tableExists("conversation_runtime")).toBe(true);
+		expect(await tableExists("orphan_sandboxes")).toBe(true);
+		expect(await tableExists("sandbox_leases")).toBe(false);
+	});
+});
+
+/** The identity every fenced helper is keyed by in these tests. */
+const OWNER = {
+	userId: "user-1",
+	conversationId: "conv-1",
+	runId: "run-1",
+	workerId: "worker-1",
+};
+
+/** Queue and claim OWNER's run so `worker-1` holds live run ownership. */
+async function claimOwnedRun() {
+	await createQueuedRunTx(tdb.db, {
+		runId: OWNER.runId,
+		userId: OWNER.userId,
+		conversationId: OWNER.conversationId,
+	});
+	const claimed = await claimNextRunTx(tdb.db, { workerId: OWNER.workerId });
+	if (claimed?.runId !== OWNER.runId) {
+		throw new Error("test setup failed to claim the owned run");
+	}
+}
+
+/** Expire the owner's lock so the run is ownership-lost (stale). */
+async function expireOwnership() {
+	await tdb.db
+		.update(runs)
+		.set({ lockedUntil: sql`now() - interval '1 second'` })
+		.where(eq(runs.runId, OWNER.runId));
+}
+
+describe("loadConversationRuntimeTx", () => {
+	it("returns null when no runtime row exists", async () => {
+		expect(
+			await loadConversationRuntimeTx(tdb.db, {
+				userId: OWNER.userId,
+				conversationId: OWNER.conversationId,
+			}),
+		).toBeNull();
+	});
+});
+
+describe("createConversationRuntimeTx", () => {
+	it("creates an empty runtime row when the caller owns the active run", async () => {
+		await claimOwnedRun();
+
+		const runtime = await createConversationRuntimeTx(tdb.db, OWNER);
+
+		expect(runtime).toMatchObject({
+			userId: OWNER.userId,
+			conversationId: OWNER.conversationId,
+			sandboxId: null,
+			sandboxTainted: false,
+			latestSnapshotId: null,
+			previousSnapshotId: null,
+			workspaceCheckpointStatus: "clean",
+		});
+		expect(
+			await loadConversationRuntimeTx(tdb.db, {
+				userId: OWNER.userId,
+				conversationId: OWNER.conversationId,
+			}),
+		).toMatchObject({ sandboxId: null });
+	});
+
+	it("returns the existing row when the runtime row was already created", async () => {
+		await claimOwnedRun();
+		await createConversationRuntimeTx(tdb.db, OWNER);
+
+		const again = await createConversationRuntimeTx(tdb.db, OWNER);
+
+		expect(again).toMatchObject({
+			userId: OWNER.userId,
+			conversationId: OWNER.conversationId,
+		});
+	});
+
+	it("rejects creation after run ownership is lost", async () => {
+		await claimOwnedRun();
+		await expireOwnership();
+
+		await expect(
+			createConversationRuntimeTx(tdb.db, OWNER),
+		).rejects.toBeInstanceOf(RunFenceError);
+		expect(
+			await loadConversationRuntimeTx(tdb.db, {
+				userId: OWNER.userId,
+				conversationId: OWNER.conversationId,
+			}),
+		).toBeNull();
+	});
+
+	it("rejects creation by a worker that does not hold the run", async () => {
+		await claimOwnedRun();
+
+		await expect(
+			createConversationRuntimeTx(tdb.db, { ...OWNER, workerId: "worker-2" }),
+		).rejects.toBeInstanceOf(RunFenceError);
+	});
+});
+
+describe("updateRuntimeSandboxTx", () => {
+	it("stores the current sandbox id while the run is owned", async () => {
+		await claimOwnedRun();
+		await createConversationRuntimeTx(tdb.db, OWNER);
+
+		const runtime = await updateRuntimeSandboxTx(tdb.db, {
+			...OWNER,
+			sandboxId: "sbx-1",
+		});
+
+		expect(runtime.sandboxId).toBe("sbx-1");
+		expect(runtime.sandboxTainted).toBe(false);
+	});
+
+	it("clears the sandbox pointer with null", async () => {
+		await claimOwnedRun();
+		await createConversationRuntimeTx(tdb.db, OWNER);
+		await updateRuntimeSandboxTx(tdb.db, { ...OWNER, sandboxId: "sbx-1" });
+
+		const runtime = await updateRuntimeSandboxTx(tdb.db, {
+			...OWNER,
+			sandboxId: null,
+		});
+
+		expect(runtime.sandboxId).toBeNull();
+	});
+
+	it("rejects the update after run ownership is lost", async () => {
+		await claimOwnedRun();
+		await createConversationRuntimeTx(tdb.db, OWNER);
+		await expireOwnership();
+
+		await expect(
+			updateRuntimeSandboxTx(tdb.db, { ...OWNER, sandboxId: "sbx-stale" }),
+		).rejects.toBeInstanceOf(RunFenceError);
+		expect(
+			await loadConversationRuntimeTx(tdb.db, {
+				userId: OWNER.userId,
+				conversationId: OWNER.conversationId,
+			}),
+		).toMatchObject({ sandboxId: null });
+	});
+
+	it("rejects the update after stale-run recovery terminalizes the run", async () => {
+		await claimOwnedRun();
+		await createConversationRuntimeTx(tdb.db, OWNER);
+		await updateRuntimeSandboxTx(tdb.db, { ...OWNER, sandboxId: "sbx-1" });
+		await expireOwnership();
+		await markStaleRunsTx(tdb.db);
+
+		await expect(
+			updateRuntimeSandboxTx(tdb.db, { ...OWNER, sandboxId: "sbx-2" }),
+		).rejects.toBeInstanceOf(RunFenceError);
+		expect(
+			await loadConversationRuntimeTx(tdb.db, {
+				userId: OWNER.userId,
+				conversationId: OWNER.conversationId,
+			}),
+		).toMatchObject({ sandboxId: "sbx-1" });
+	});
+});
+
+describe("recordRuntimeSnapshotTx", () => {
+	it("rotates latest to previous and marks the workspace clean", async () => {
+		await claimOwnedRun();
+		await createConversationRuntimeTx(tdb.db, OWNER);
+
+		const first = await recordRuntimeSnapshotTx(tdb.db, {
+			...OWNER,
+			snapshotId: "snap-1",
+		});
+		expect(first).toMatchObject({
+			latestSnapshotId: "snap-1",
+			previousSnapshotId: null,
+			workspaceCheckpointStatus: "clean",
+		});
+
+		const second = await recordRuntimeSnapshotTx(tdb.db, {
+			...OWNER,
+			snapshotId: "snap-2",
+		});
+		expect(second).toMatchObject({
+			latestSnapshotId: "snap-2",
+			previousSnapshotId: "snap-1",
+			workspaceCheckpointStatus: "clean",
+		});
+	});
+
+	it("re-recording the same snapshot id keeps the rollback pointer", async () => {
+		// A retried checkpoint (or E2B's repeating `templateId:tag` ids, per the
+		// spike) must not rotate latest into previous — that would leave both
+		// pointers equal and orphan the real rollback snapshot for cleanup.
+		await claimOwnedRun();
+		await createConversationRuntimeTx(tdb.db, OWNER);
+		await recordRuntimeSnapshotTx(tdb.db, { ...OWNER, snapshotId: "snap-1" });
+		await recordRuntimeSnapshotTx(tdb.db, { ...OWNER, snapshotId: "snap-2" });
+
+		const retried = await recordRuntimeSnapshotTx(tdb.db, {
+			...OWNER,
+			snapshotId: "snap-2",
+		});
+
+		expect(retried).toMatchObject({
+			latestSnapshotId: "snap-2",
+			previousSnapshotId: "snap-1",
+			workspaceCheckpointStatus: "clean",
+		});
+	});
+
+	it("clears a dirty_uncheckpointed mark once a checkpoint succeeds", async () => {
+		await claimOwnedRun();
+		await createConversationRuntimeTx(tdb.db, OWNER);
+		await markRuntimeCheckpointStatusTx(tdb.db, {
+			...OWNER,
+			status: "dirty_uncheckpointed",
+		});
+
+		const runtime = await recordRuntimeSnapshotTx(tdb.db, {
+			...OWNER,
+			snapshotId: "snap-1",
+		});
+
+		expect(runtime.workspaceCheckpointStatus).toBe("clean");
+	});
+
+	it("rejects the snapshot record after run ownership is lost", async () => {
+		await claimOwnedRun();
+		await createConversationRuntimeTx(tdb.db, OWNER);
+		await recordRuntimeSnapshotTx(tdb.db, { ...OWNER, snapshotId: "snap-1" });
+		await expireOwnership();
+
+		await expect(
+			recordRuntimeSnapshotTx(tdb.db, { ...OWNER, snapshotId: "snap-2" }),
+		).rejects.toBeInstanceOf(RunFenceError);
+		expect(
+			await loadConversationRuntimeTx(tdb.db, {
+				userId: OWNER.userId,
+				conversationId: OWNER.conversationId,
+			}),
+		).toMatchObject({ latestSnapshotId: "snap-1", previousSnapshotId: null });
+	});
+});
+
+describe("markRuntimeCheckpointStatusTx", () => {
+	it("marks dirty_uncheckpointed without touching the snapshot ids", async () => {
+		// Acceptance: checkpoint failure leaves the latest snapshot unchanged —
+		// the last successful checkpoint stays the recovery source of truth.
+		await claimOwnedRun();
+		await createConversationRuntimeTx(tdb.db, OWNER);
+		await recordRuntimeSnapshotTx(tdb.db, { ...OWNER, snapshotId: "snap-1" });
+		await recordRuntimeSnapshotTx(tdb.db, { ...OWNER, snapshotId: "snap-2" });
+
+		const runtime = await markRuntimeCheckpointStatusTx(tdb.db, {
+			...OWNER,
+			status: "dirty_uncheckpointed",
+		});
+
+		expect(runtime).toMatchObject({
+			workspaceCheckpointStatus: "dirty_uncheckpointed",
+			latestSnapshotId: "snap-2",
+			previousSnapshotId: "snap-1",
+		});
+	});
+
+	it("rejects the mark after run ownership is lost", async () => {
+		await claimOwnedRun();
+		await createConversationRuntimeTx(tdb.db, OWNER);
+		await expireOwnership();
+
+		await expect(
+			markRuntimeCheckpointStatusTx(tdb.db, {
+				...OWNER,
+				status: "dirty_uncheckpointed",
+			}),
+		).rejects.toBeInstanceOf(RunFenceError);
+	});
+});
+
+describe("markRuntimeSandboxTaintedTx", () => {
+	it("taints the sandbox while keeping its pointer for cleanup", async () => {
+		await claimOwnedRun();
+		await createConversationRuntimeTx(tdb.db, OWNER);
+		await updateRuntimeSandboxTx(tdb.db, { ...OWNER, sandboxId: "sbx-1" });
+
+		const runtime = await markRuntimeSandboxTaintedTx(tdb.db, OWNER);
+
+		expect(runtime).toMatchObject({ sandboxId: "sbx-1", sandboxTainted: true });
+	});
+
+	it("is reset when a replacement sandbox id is stored", async () => {
+		await claimOwnedRun();
+		await createConversationRuntimeTx(tdb.db, OWNER);
+		await updateRuntimeSandboxTx(tdb.db, { ...OWNER, sandboxId: "sbx-1" });
+		await markRuntimeSandboxTaintedTx(tdb.db, OWNER);
+
+		const runtime = await updateRuntimeSandboxTx(tdb.db, {
+			...OWNER,
+			sandboxId: "sbx-2",
+		});
+
+		expect(runtime).toMatchObject({
+			sandboxId: "sbx-2",
+			sandboxTainted: false,
+		});
+	});
+
+	it("rejects the taint mark after run ownership is lost", async () => {
+		await claimOwnedRun();
+		await createConversationRuntimeTx(tdb.db, OWNER);
+		await expireOwnership();
+
+		await expect(
+			markRuntimeSandboxTaintedTx(tdb.db, OWNER),
+		).rejects.toBeInstanceOf(RunFenceError);
+	});
+});
+
+describe("recordOrphanSandboxTx", () => {
+	it("records a replacement sandbox after the fenced update failed", async () => {
+		// The issue's recovery sequence: worker created a replacement sandbox,
+		// lost run ownership before the fenced pointer update, and its kill of
+		// the replacement could not be confirmed — the ledger insert must
+		// succeed precisely because ownership is already gone.
+		await claimOwnedRun();
+		await createConversationRuntimeTx(tdb.db, OWNER);
+		await expireOwnership();
+		await expect(
+			updateRuntimeSandboxTx(tdb.db, { ...OWNER, sandboxId: "sbx-orphan" }),
+		).rejects.toBeInstanceOf(RunFenceError);
+
+		const orphan = await recordOrphanSandboxTx(tdb.db, {
+			sandboxId: "sbx-orphan",
+			userId: OWNER.userId,
+			conversationId: OWNER.conversationId,
+			runId: OWNER.runId,
+			createdByWorkerId: OWNER.workerId,
+			reason: "ownership lost before fenced sandbox update; kill unconfirmed",
+		});
+
+		expect(orphan).toMatchObject({
+			sandboxId: "sbx-orphan",
+			runId: OWNER.runId,
+			createdByWorkerId: OWNER.workerId,
+		});
+	});
+
+	it("is idempotent for the same sandbox id", async () => {
+		const input = {
+			sandboxId: "sbx-orphan",
+			userId: OWNER.userId,
+			conversationId: OWNER.conversationId,
+			runId: OWNER.runId,
+			createdByWorkerId: OWNER.workerId,
+			reason: "kill unconfirmed",
+		};
+
+		const first = await recordOrphanSandboxTx(tdb.db, input);
+		const second = await recordOrphanSandboxTx(tdb.db, {
+			...input,
+			reason: "retried recording",
+		});
+
+		expect(second).toEqual(first);
+	});
+});

--- a/apps/chat-api/src/features/conversation-runtime-store/conversation-runtime-store.ts
+++ b/apps/chat-api/src/features/conversation-runtime-store/conversation-runtime-store.ts
@@ -1,0 +1,285 @@
+import { and, eq, inArray, sql } from "drizzle-orm";
+import type { PgUpdateSetSource } from "drizzle-orm/pg-core";
+import type { Database } from "@/db/client";
+import { conversationRuntime, orphanSandboxes, runs } from "@/db/schema";
+import { RunFenceError } from "@/features/run-store";
+
+/**
+ * Narrow transaction helpers over `conversation_runtime` and
+ * `orphan_sandboxes` — the only write path for persistent E2B workspace
+ * metadata (design doc "State Ownership", Task 4.2). The table grants no
+ * execution ownership of its own: every mutation is fenced on the claiming
+ * run's ownership in `runs` (`status` active, `locked_by = workerId`,
+ * `locked_until > now()`): every update carries the fence as an `EXISTS`
+ * subquery inside the same statement that performs the write, and row
+ * creation checks the same predicate `FOR SHARE` in its transaction — so a
+ * worker that stalls past its lock cannot overwrite pointers a recovered
+ * conversation now relies on. The one deliberate exception is orphan
+ * recording, which exists precisely for the ownership-already-lost path.
+ *
+ * `cancel_requested` is inside the fence (mirroring the run-store
+ * "cancellation" append class): command cleanup during cancellation is where
+ * sandbox taint decisions happen, and those must stay durable.
+ */
+
+/** Run statuses under which the owning worker may mutate runtime metadata. */
+const OWNED_ACTIVE_STATUSES = ["running", "cancel_requested"] as const;
+
+/**
+ * 'clean' = the workspace holds no user work newer than `latest_snapshot_id`
+ * (or is fresh); 'dirty_uncheckpointed' = a checkpoint failed after user
+ * work, so the next turn must reconnect and checkpoint before anything else.
+ */
+export type WorkspaceCheckpointStatus = "clean" | "dirty_uncheckpointed";
+
+/** A persisted runtime row. `workspaceCheckpointStatus` is narrowed from
+ * text: rows are only ever written through these helpers, which accept the
+ * typed union, and the DB check constraint defends the legal values. */
+export type ConversationRuntimeRecord = Omit<
+	typeof conversationRuntime.$inferSelect,
+	"workspaceCheckpointStatus"
+> & { workspaceCheckpointStatus: WorkspaceCheckpointStatus };
+
+/**
+ * The identity a fenced mutation acts under: the conversation's runtime row
+ * being mutated plus the run/worker whose live ownership authorizes it.
+ */
+export interface RunOwnershipRef {
+	userId: string;
+	conversationId: string;
+	runId: string;
+	workerId: string;
+}
+
+/**
+ * The ownership fence as conditions on `runs`: satisfiable only while
+ * `workerId` holds the named run for this exact conversation with an
+ * unexpired lock. The single source of the fence — both the `EXISTS` form
+ * and the create-path `FOR SHARE` check are built from it.
+ */
+function ownedRunConditions(owner: RunOwnershipRef) {
+	return and(
+		eq(runs.runId, owner.runId),
+		eq(runs.userId, owner.userId),
+		eq(runs.conversationId, owner.conversationId),
+		inArray(runs.status, [...OWNED_ACTIVE_STATUSES]),
+		eq(runs.lockedBy, owner.workerId),
+		sql`${runs.lockedUntil} > now()`,
+	);
+}
+
+/** {@link ownedRunConditions} as a predicate a mutating statement carries
+ * inside itself, never as a separate app-side check. */
+function ownedRunExists(owner: RunOwnershipRef) {
+	return sql`exists (select 1 from ${runs} where ${ownedRunConditions(owner)})`;
+}
+
+function fenceRejected(owner: RunOwnershipRef, operation: string): never {
+	throw new RunFenceError(
+		`${operation} for conversation ${owner.conversationId} rejected: ` +
+			`worker ${owner.workerId} no longer owns run ${owner.runId}`,
+	);
+}
+
+/** Load the runtime row, or `null` when the conversation has none yet.
+ * Reads are not fenced — only mutations need ownership. */
+export async function loadConversationRuntimeTx(
+	db: Database,
+	input: { userId: string; conversationId: string },
+): Promise<ConversationRuntimeRecord | null> {
+	const [row] = await db
+		.select()
+		.from(conversationRuntime)
+		.where(
+			and(
+				eq(conversationRuntime.userId, input.userId),
+				eq(conversationRuntime.conversationId, input.conversationId),
+			),
+		)
+		.limit(1);
+	return row ? toRuntimeRecord(row) : null;
+}
+
+/**
+ * Create the conversation's runtime row (empty pointers, `clean`). The fence
+ * is checked `FOR SHARE` in the same transaction as the insert, so stale-run
+ * recovery cannot terminalize the authorizing run between check and insert.
+ * Idempotent: if a previous attempt already created the row, the existing row
+ * is returned unchanged (concurrent creators are impossible — the partial
+ * unique index on `runs` allows only one active run per conversation).
+ */
+export async function createConversationRuntimeTx(
+	db: Database,
+	owner: RunOwnershipRef,
+): Promise<ConversationRuntimeRecord> {
+	return await db.transaction(async (tx) => {
+		const owned = await tx
+			.select({ runId: runs.runId })
+			.from(runs)
+			.where(ownedRunConditions(owner))
+			.for("share");
+		if (!owned[0]) fenceRejected(owner, "runtime row creation");
+
+		const [inserted] = await tx
+			.insert(conversationRuntime)
+			.values({ userId: owner.userId, conversationId: owner.conversationId })
+			.onConflictDoNothing()
+			.returning();
+		if (inserted) return toRuntimeRecord(inserted);
+
+		const [existing] = await tx
+			.select()
+			.from(conversationRuntime)
+			.where(
+				and(
+					eq(conversationRuntime.userId, owner.userId),
+					eq(conversationRuntime.conversationId, owner.conversationId),
+				),
+			);
+		if (!existing) {
+			throw new Error(
+				`runtime row for conversation ${owner.conversationId} vanished mid-transaction`,
+			);
+		}
+		return toRuntimeRecord(existing);
+	});
+}
+
+/**
+ * Store (or clear, with `null`) the conversation's current sandbox pointer.
+ * Always resets `sandbox_tainted`: a newly stored pointer names a
+ * just-created/just-verified sandbox, and a cleared pointer has nothing left
+ * to taint. Taint is only ever set through {@link markRuntimeSandboxTaintedTx}.
+ */
+export async function updateRuntimeSandboxTx(
+	db: Database,
+	input: RunOwnershipRef & { sandboxId: string | null },
+): Promise<ConversationRuntimeRecord> {
+	return await fencedRuntimeUpdate(db, input, "sandbox pointer update", {
+		sandboxId: input.sandboxId,
+		sandboxTainted: false,
+	});
+}
+
+/**
+ * One fenced runtime UPDATE: the ownership predicate rides inside the same
+ * statement as the write. Zero rows means the fence rejected (or the row was
+ * never created — equally a caller that must stop treating the run as its
+ * own), surfaced as {@link RunFenceError}.
+ */
+async function fencedRuntimeUpdate(
+	db: Database,
+	owner: RunOwnershipRef,
+	operation: string,
+	set: PgUpdateSetSource<typeof conversationRuntime>,
+): Promise<ConversationRuntimeRecord> {
+	const [row] = await db
+		.update(conversationRuntime)
+		.set({ ...set, updatedAt: sql`now()` })
+		.where(
+			and(
+				eq(conversationRuntime.userId, owner.userId),
+				eq(conversationRuntime.conversationId, owner.conversationId),
+				ownedRunExists(owner),
+			),
+		)
+		.returning();
+	if (!row) fenceRejected(owner, operation);
+	return toRuntimeRecord(row);
+}
+
+/**
+ * Record a successful checkpoint: the new snapshot becomes latest, the prior
+ * latest is kept as previous (operator-driven rollback only), and the
+ * workspace is clean by definition — the snapshot covers everything in it.
+ * One UPDATE, so the rotation reads the pre-update column values atomically.
+ * Rotation only happens when the id actually changes: re-recording the
+ * current latest (a retry, or E2B's repeating `templateId:tag` ids) must not
+ * collapse both pointers onto one id and orphan the real rollback snapshot.
+ */
+export async function recordRuntimeSnapshotTx(
+	db: Database,
+	input: RunOwnershipRef & { snapshotId: string },
+): Promise<ConversationRuntimeRecord> {
+	return await fencedRuntimeUpdate(db, input, "snapshot record", {
+		previousSnapshotId: sql`case
+			when ${conversationRuntime.latestSnapshotId} is distinct from ${input.snapshotId}
+			then ${conversationRuntime.latestSnapshotId}
+			else ${conversationRuntime.previousSnapshotId}
+		end`,
+		latestSnapshotId: input.snapshotId,
+		workspaceCheckpointStatus: "clean",
+	});
+}
+
+/**
+ * Mark the workspace checkpoint status without touching the snapshot ids —
+ * the checkpoint-failure path (`dirty_uncheckpointed`) must leave
+ * `latest_snapshot_id` as the last known-good checkpoint, and a restore path
+ * marks `clean` after standing a sandbox up from it.
+ */
+export async function markRuntimeCheckpointStatusTx(
+	db: Database,
+	input: RunOwnershipRef & { status: WorkspaceCheckpointStatus },
+): Promise<ConversationRuntimeRecord> {
+	return await fencedRuntimeUpdate(db, input, "checkpoint status mark", {
+		workspaceCheckpointStatus: input.status,
+	});
+}
+
+/**
+ * Mark the current sandbox tainted (command cleanup unproven): the pointer is
+ * kept so cleanup can find and kill it, but the sandbox must not be
+ * snapshotted or reused until replaced via {@link updateRuntimeSandboxTx}.
+ */
+export async function markRuntimeSandboxTaintedTx(
+	db: Database,
+	owner: RunOwnershipRef,
+): Promise<ConversationRuntimeRecord> {
+	return await fencedRuntimeUpdate(db, owner, "sandbox taint mark", {
+		sandboxTainted: true,
+	});
+}
+
+/** A persisted orphan-ledger row. */
+export type OrphanSandboxRecord = typeof orphanSandboxes.$inferSelect;
+
+/**
+ * Record a sandbox that escaped database ownership (created, then the fenced
+ * pointer update failed and the kill could not be confirmed). Deliberately
+ * unfenced — this path exists precisely because run ownership is already
+ * lost. Idempotent per sandbox id: re-recording returns the original row
+ * unchanged, so a retrying worker cannot overwrite the first record.
+ */
+export async function recordOrphanSandboxTx(
+	db: Database,
+	input: typeof orphanSandboxes.$inferInsert,
+): Promise<OrphanSandboxRecord> {
+	const [inserted] = await db
+		.insert(orphanSandboxes)
+		.values(input)
+		.onConflictDoNothing()
+		.returning();
+	if (inserted) return inserted;
+
+	const [existing] = await db
+		.select()
+		.from(orphanSandboxes)
+		.where(eq(orphanSandboxes.sandboxId, input.sandboxId));
+	if (!existing) {
+		throw new Error(
+			`orphan record for sandbox ${input.sandboxId} vanished between insert and read`,
+		);
+	}
+	return existing;
+}
+
+function toRuntimeRecord(
+	row: typeof conversationRuntime.$inferSelect,
+): ConversationRuntimeRecord {
+	return {
+		...row,
+		workspaceCheckpointStatus:
+			row.workspaceCheckpointStatus as WorkspaceCheckpointStatus,
+	};
+}

--- a/apps/chat-api/src/features/conversation-runtime-store/index.ts
+++ b/apps/chat-api/src/features/conversation-runtime-store/index.ts
@@ -1,0 +1,15 @@
+export type {
+	ConversationRuntimeRecord,
+	OrphanSandboxRecord,
+	RunOwnershipRef,
+	WorkspaceCheckpointStatus,
+} from "./conversation-runtime-store";
+export {
+	createConversationRuntimeTx,
+	loadConversationRuntimeTx,
+	markRuntimeCheckpointStatusTx,
+	markRuntimeSandboxTaintedTx,
+	recordOrphanSandboxTx,
+	recordRuntimeSnapshotTx,
+	updateRuntimeSandboxTx,
+} from "./conversation-runtime-store";

--- a/apps/chat-api/src/features/run-store/run-store.test.ts
+++ b/apps/chat-api/src/features/run-store/run-store.test.ts
@@ -1,4 +1,11 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+} from "bun:test";
 import { eq, sql } from "drizzle-orm";
 import { runEvents, runs } from "@/db/schema";
 import { createTestDatabase, type TestDb } from "@/db/testing";
@@ -16,12 +23,19 @@ import {
 
 let tdb: TestDb;
 
-beforeEach(async () => {
+// One PGlite (WASM) instance for the whole file — a per-test instance
+// multiplies WASM memory that is not reclaimed promptly and OOMs CI runners.
+// Tests are isolated by clearing the tables they touch instead.
+beforeAll(async () => {
 	tdb = await createTestDatabase();
 });
 
-afterEach(async () => {
+afterAll(async () => {
 	await tdb.close();
+});
+
+beforeEach(async () => {
+	await tdb.db.delete(runs); // cascades run_events
 });
 
 describe("createQueuedRunTx", () => {


### PR DESCRIPTION
Closes #182 — Task 4.2 (Milestone 4) of `docs/split-runtime-fargate-e2b-implementation-plan.md`, shape confirmed by the #173 spike findings.

## What changed

- **One migration (`0001_wandering_namora.sql`)** creates `conversation_runtime` and `orphan_sandboxes` and drops `sandbox_leases` — the drop rides the same migration per ADR-0002 (the prototype path's concurrency authority is gone after the hard swap). `sandbox_leases` had no remaining code consumers.
- **`conversation_runtime`**: one row per `{userId, conversationId}` — current `sandbox_id`, `sandbox_tainted`, latest/previous snapshot ids, `workspace_checkpoint_status` (check-constrained to `clean | dirty_uncheckpointed`). Grants no execution ownership; that stays in `runs`. The agent session resume pointer deliberately waits for Milestone 7 (ADR-0005).
- **`orphan_sandboxes`**: recovery ledger for sandboxes that escaped database ownership (fenced update failed, kill unconfirmed). No FK to `runs` — same rationale as `document_access_events`: the ledger must survive run cleanup.
- **New store** `apps/chat-api/src/features/conversation-runtime-store/`, following the `run-store` house pattern: `load`, `create`, `updateRuntimeSandbox`, `recordRuntimeSnapshot`, `markRuntimeCheckpointStatus`, `markRuntimeSandboxTainted`, `recordOrphanSandbox`. Every mutation carries the run-ownership fence (`status` active, `locked_by = workerId`, `locked_until > now()`) inside the mutating statement (`EXISTS` subquery; the create path checks the same predicate `FOR SHARE` in its transaction). Orphan recording is deliberately unfenced — it exists precisely for the ownership-already-lost path.

## Acceptance criteria → tests

21 tests at the store seam over migrated PGlite (`conversation-runtime-store.test.ts`):

- metadata updates fail after run ownership is lost (lock expiry **and** stale-run recovery terminalization)
- after a failed fenced update, the replacement sandbox is recordable as an orphan (the kill itself is an E2B side effect owned by Milestone 5)
- checkpoint failure leaves `latest_snapshot_id` unchanged and marks `dirty_uncheckpointed`
- all runtime mutations go through the fenced helpers (the store is the only write path)
- `sandbox_leases` dropped in the same migration that creates `conversation_runtime`

## Reviewer notes

- **Fence breadth**: mutations are allowed under `running` *and* `cancel_requested` — the design's cancellation-cleanup path is where sandbox-taint decisions must stay durable (mirrors the run-store "cancellation" append class). The design doc's example SQL shows `running` only; the prose says "active run ownership".
- **Snapshot rotation is retry-idempotent**: re-recording the current `snapshotId` (worker retry, or E2B's repeating `templateId:tag` ids seen in the spike) does not collapse `previous = latest`, which would have orphaned the real rollback snapshot for cleanup.
- `updateRuntimeSandboxTx` always resets `sandbox_tainted` — taint describes the current sandbox only; it is set exclusively via `markRuntimeSandboxTaintedTx`.
- Full workspace suite green (401 tests); typecheck and Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)