### PR TITLE
Add stale-run recovery to the worker loop

### DIFF
--- a/apps/agent-worker/src/run-loop.test.ts
+++ b/apps/agent-worker/src/run-loop.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { createQueuedRunTx } from "@mymemo/agent-db/run-store";
+import {
+	appendRunEventTx,
+	claimNextRunTx,
+	createQueuedRunTx,
+	RunFenceError,
+	requestRunCancellationTx,
+} from "@mymemo/agent-db/run-store";
 import { runEvents, runs } from "@mymemo/agent-db/schema";
 import { createTestDatabase, type TestDb } from "@mymemo/agent-db/testing";
 import { eq, sql } from "drizzle-orm";
@@ -49,6 +55,26 @@ function buildLoop(worker: Worker, processor: RunProcessor) {
 
 async function queueRun(runId: string, conversationId: string) {
 	await createQueuedRunTx(tdb.db, { runId, userId: "user-1", conversationId });
+}
+
+async function claimRun(
+	runId: string,
+	conversationId: string,
+	workerId: string,
+) {
+	await queueRun(runId, conversationId);
+	const claimed = await claimNextRunTx(tdb.db, { workerId });
+	if (claimed?.runId !== runId) {
+		throw new Error(`test setup claimed ${claimed?.runId}, wanted ${runId}`);
+	}
+	return claimed;
+}
+
+async function expireOwnership(runId: string) {
+	await tdb.db
+		.update(runs)
+		.set({ lockedUntil: sql`now() - interval '1 second'` })
+		.where(eq(runs.runId, runId));
 }
 
 async function readRun(runId: string) {
@@ -262,6 +288,78 @@ describe("RunLoop — terminal outcomes", () => {
 
 		expect((await readRun("run-1"))?.status).toBe("canceled");
 		expect(await readEventTypes("run-1")).toEqual(["run_canceled"]);
+	});
+});
+
+describe("RunLoop — stale-run recovery", () => {
+	it("terminalizes stale running runs as error during a tick", async () => {
+		await claimRun("run-stale", "conv-1", "stale-worker");
+		await expireOwnership("run-stale");
+		const worker = buildWorker(1);
+		const loop = buildLoop(worker, appendTextProcessor);
+
+		const claimed = await loop.tick();
+		await worker.drain();
+
+		expect(claimed).toBe(0);
+		expect((await readRun("run-stale"))?.status).toBe("error");
+		expect(await readEventTypes("run-stale")).toEqual(["run_error"]);
+	});
+
+	it("terminalizes stale cancel-requested runs as canceled during a tick", async () => {
+		await claimRun("run-stale", "conv-1", "stale-worker");
+		await requestRunCancellationTx(tdb.db, {
+			runId: "run-stale",
+			userId: "user-1",
+			conversationId: "conv-1",
+		});
+		await expireOwnership("run-stale");
+		const worker = buildWorker(1);
+		const loop = buildLoop(worker, appendTextProcessor);
+
+		await loop.tick();
+		await worker.drain();
+
+		expect((await readRun("run-stale"))?.status).toBe("canceled");
+		expect(await readEventTypes("run-stale")).toEqual(["run_canceled"]);
+	});
+
+	it("rejects stale worker appends after loop recovery terminalizes the run", async () => {
+		await claimRun("run-stale", "conv-1", "stale-worker");
+		await expireOwnership("run-stale");
+		const worker = buildWorker(1);
+		const loop = buildLoop(worker, appendTextProcessor);
+
+		await loop.tick();
+
+		await expect(
+			appendRunEventTx(tdb.db, {
+				runId: "run-stale",
+				workerId: "stale-worker",
+				type: "assistant_text",
+				payload: { text: "too late" },
+				appendClass: "model",
+			}),
+		).rejects.toBeInstanceOf(RunFenceError);
+		expect(await readEventTypes("run-stale")).toEqual(["run_error"]);
+	});
+
+	it("does not double-terminalize when recovery beats an active processor", async () => {
+		const worker = buildWorker(1);
+		const gate = deferred();
+		const loop = buildLoop(worker, async () => {
+			await gate.promise;
+		});
+		await queueRun("run-1", "conv-1");
+		await loop.tick(); // claim + dispatch (processor blocks)
+		await expireOwnership("run-1");
+
+		await loop.tick(); // recovers stale run, then observes lost ownership
+		gate.resolve();
+		await worker.drain();
+
+		expect((await readRun("run-1"))?.status).toBe("error");
+		expect(await readEventTypes("run-1")).toEqual(["run_error"]);
 	});
 });
 

--- a/apps/agent-worker/src/run-loop.ts
+++ b/apps/agent-worker/src/run-loop.ts
@@ -4,6 +4,7 @@ import {
 	appendRunEventTx,
 	claimNextRunTx,
 	heartbeatRunTx,
+	markStaleRunsTx,
 	RunFenceError,
 	type RunRecord,
 	type TerminalRunStatus,
@@ -55,29 +56,34 @@ interface ActiveEntry {
 	state: RunEndState;
 }
 
+const STALE_RUN_RECOVERY_INTERVAL_MS = 15_000;
+
 /**
  * The agent-worker control loop over the shared run-store helpers. One `tick`:
- *  1. heartbeats every run this worker is executing — renewing `locked_until`
+ *  1. terminalizes stale runs through the shared recovery helper;
+ *  2. heartbeats every run this worker is executing — renewing `locked_until`
  *     and, in the same call, observing a `cancel_requested` or a lost ownership
  *     fence; and
- *  2. claims queued runs up to the supervisor's remaining capacity and
+ *  3. claims queued runs up to the supervisor's remaining capacity and
  *     dispatches each onto it.
  *
- * `tick` is the whole loop and is directly awaitable, so tests drive claim,
- * heartbeat, and terminalization deterministically (PGlite + explicit ticks,
- * no wall-clock timers — Bun lacks `setInterval` fake timers). `start` just
- * schedules `tick` on a timer; `stop` unschedules and drains in-flight runs.
+ * `tick` is the whole loop and is directly awaitable, so tests drive recovery,
+ * claim, heartbeat, and terminalization deterministically (PGlite + explicit
+ * ticks, no wall-clock timers — Bun lacks `setInterval` fake timers). `start`
+ * schedules both `tick` and the at-least-15s recovery sweep; `stop`
+ * unschedules them and drains in-flight runs.
  *
  * Ownership and single-terminalization are enforced by the DB fences in the
  * helpers, not here: two workers cannot claim one run (`FOR UPDATE SKIP
- * LOCKED`), a stale worker's appends/terminals are rejected (`locked_by` +
- * `locked_until`), and stale runs are recovered elsewhere. This loop's job is to
- * turn those helpers into a warm, bounded-concurrency service.
+ * LOCKED`), stale workers are fenced by `locked_by` + `locked_until`, and
+ * recovery CASes the same active statuses as worker terminalization. This
+ * loop's job is to turn those helpers into a warm, bounded-concurrency service.
  */
 export class RunLoop {
 	private readonly activeRuns = new Map<string, ActiveEntry>();
 	private running = false;
 	private timer: ReturnType<typeof setTimeout> | undefined;
+	private recoveryTimer: ReturnType<typeof setTimeout> | undefined;
 
 	constructor(private readonly opts: RunLoopOptions) {}
 
@@ -86,11 +92,12 @@ export class RunLoop {
 	}
 
 	/**
-	 * Run one control-loop iteration: heartbeat active runs, then claim and
-	 * dispatch queued runs up to capacity. Returns how many runs were claimed
-	 * this tick.
+	 * Run one control-loop iteration: recover stale runs, heartbeat active runs,
+	 * then claim and dispatch queued runs up to capacity. Returns how many runs
+	 * were claimed this tick.
 	 */
 	async tick(): Promise<number> {
+		await this.tryRecoverStaleRuns();
 		await this.heartbeatActive();
 		return this.claimAndDispatch();
 	}
@@ -117,6 +124,10 @@ export class RunLoop {
 			}
 		};
 		void runTick();
+		this.recoveryTimer = setTimeout(
+			() => void this.runRecoveryTimer(),
+			STALE_RUN_RECOVERY_INTERVAL_MS,
+		);
 	}
 
 	/** Stop scheduling new ticks and drain in-flight runs via the supervisor. */
@@ -126,7 +137,50 @@ export class RunLoop {
 			clearTimeout(this.timer);
 			this.timer = undefined;
 		}
+		if (this.recoveryTimer) {
+			clearTimeout(this.recoveryTimer);
+			this.recoveryTimer = undefined;
+		}
 		await this.opts.worker.shutdown();
+	}
+
+	private async runRecoveryTimer(): Promise<void> {
+		if (!this.running) return;
+		try {
+			await this.tryRecoverStaleRuns();
+		} finally {
+			if (this.running) {
+				this.recoveryTimer = setTimeout(
+					() => void this.runRecoveryTimer(),
+					STALE_RUN_RECOVERY_INTERVAL_MS,
+				);
+			}
+		}
+	}
+
+	private async tryRecoverStaleRuns(): Promise<void> {
+		try {
+			await this.recoverStaleRuns();
+		} catch (error) {
+			this.opts.logger.error({
+				message: "stale-run recovery failed",
+				workerId: this.workerId,
+				error: toMessage(error),
+			});
+		}
+	}
+
+	private async recoverStaleRuns(): Promise<void> {
+		const recovered = await markStaleRunsTx(this.opts.db);
+		if (recovered.length === 0) return;
+		this.opts.logger.warn({
+			message: "recovered stale runs",
+			workerId: this.workerId,
+			recoveredRuns: recovered.map((run) => ({
+				runId: run.runId,
+				status: run.status,
+			})),
+		});
 	}
 
 	private async heartbeatActive(): Promise<void> {


### PR DESCRIPTION
## Summary
- Add a stale-run recovery sweep to `RunLoop.tick()` and the background scheduler.
- Recover expired `running` and `cancel_requested` runs with DB-backed terminalization before heartbeating or claiming new work.
- Log recovery failures without crashing the loop.
- Extend worker tests to cover stale-run recovery, cancellation recovery, and fence behavior after recovery.

## Testing
- Added targeted `run-loop` tests for stale recovery and race cases.
- Existing worker test coverage exercises the new recovery path and terminal states.
- Not run (not requested).