### PR TITLE
Implement path-safe worker file tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ jobs:
           # Pinned for reproducible CI — match the version the lockfile was
           # generated with. Bump deliberately alongside local upgrades.
           bun-version: 1.3.0
+      # The agent-worker file-tools integration test drives the real grep
+      # command path, which shells out to ripgrep; the runner image does not
+      # ship it.
+      - run: sudo apt-get update && sudo apt-get install -y ripgrep
       - run: bun install --frozen-lockfile
       - run: bun run test
 

--- a/apps/agent-worker/src/file-tools/file-tools.integration.test.ts
+++ b/apps/agent-worker/src/file-tools/file-tools.integration.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+	type FileToolLimits,
+	runGlobFileTool,
+	runGrepFileTool,
+	type SandboxFileClient,
+	type SandboxFileCommand,
+	type SandboxFileCommandResult,
+	type SandboxFileRead,
+	type SandboxFileWrite,
+} from "./file-tools";
+
+class LocalCommandSandboxFileClient implements SandboxFileClient {
+	async readFile(input: SandboxFileRead): Promise<string> {
+		const bytes = await Bun.file(input.path).arrayBuffer();
+		return new TextDecoder().decode(bytes.slice(0, input.maxBytes));
+	}
+
+	async writeFile(input: SandboxFileWrite): Promise<void> {
+		await Bun.write(input.path, input.content);
+	}
+
+	async runCommand(
+		input: SandboxFileCommand,
+	): Promise<SandboxFileCommandResult> {
+		const proc = Bun.spawn(["/bin/sh", "-lc", input.command], {
+			cwd: input.cwd,
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const timeout = setTimeout(() => proc.kill(), input.timeoutMs);
+		try {
+			const [exitCode, stdout, stderr] = await Promise.all([
+				proc.exited,
+				new Response(proc.stdout).text(),
+				new Response(proc.stderr).text(),
+			]);
+			const bounded = boundOutput(stdout, input.maxOutputBytes);
+			return {
+				exitCode,
+				stdout: bounded.text,
+				stderr,
+				truncated: bounded.truncated,
+			};
+		} finally {
+			clearTimeout(timeout);
+		}
+	}
+}
+
+const limits: FileToolLimits = {
+	readMaxBytes: 1024,
+	readMaxLines: 200,
+	grepMaxResults: 100,
+	globMaxResults: 500,
+	commandMaxOutputBytes: 16_384,
+	commandTimeoutMs: 10_000,
+};
+
+let workspaceRoot: string | undefined;
+
+afterEach(async () => {
+	if (workspaceRoot) {
+		await rm(workspaceRoot, { recursive: true, force: true });
+		workspaceRoot = undefined;
+	}
+});
+
+function parseResult(result: { content: { text: string }[] }) {
+	const [first] = result.content;
+	if (!first) throw new Error("missing tool content");
+	return JSON.parse(first.text);
+}
+
+function boundOutput(
+	text: string,
+	maxBytes: number,
+): { text: string; truncated: boolean } {
+	const encoder = new TextEncoder();
+	let bytes = 0;
+	let output = "";
+	for (const char of text) {
+		const nextBytes = encoder.encode(char).byteLength;
+		if (bytes + nextBytes > maxBytes) {
+			return { text: output, truncated: true };
+		}
+		bytes += nextBytes;
+		output += char;
+	}
+	return { text: output, truncated: false };
+}
+
+describe("command-backed file tools", () => {
+	it("runs grep and glob against the real command path with bounded sorted results", async () => {
+		workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "mymemo-file-tools-"));
+		await mkdir(path.join(workspaceRoot, "src"));
+		await Bun.write(path.join(workspaceRoot, "notes.txt"), "alpha\nbeta\n");
+		await Bun.write(path.join(workspaceRoot, "src", "memo.txt"), "alpha\n");
+		await Bun.write(path.join(workspaceRoot, ".hidden.txt"), "alpha\n");
+
+		const context = {
+			client: new LocalCommandSandboxFileClient(),
+			workspaceRoot,
+			limits,
+			markWorkspaceDirty: async () => {},
+		};
+
+		const grepResult = await runGrepFileTool(
+			{ pattern: "alpha", maxResults: 10 },
+			context,
+		);
+		expect(grepResult.isError).toBeUndefined();
+		expect(parseResult(grepResult)).toEqual({
+			matches: [
+				{ path: "notes.txt", line: 1, column: 1, text: "alpha" },
+				{ path: "src/memo.txt", line: 1, column: 1, text: "alpha" },
+			],
+			truncated: false,
+		});
+
+		const globResult = await runGlobFileTool(
+			{ pattern: "**/*.txt", maxResults: 10 },
+			context,
+		);
+		expect(globResult.isError).toBeUndefined();
+		expect(parseResult(globResult)).toEqual({
+			paths: ["notes.txt", "src/memo.txt"],
+			truncated: false,
+		});
+	});
+});

--- a/apps/agent-worker/src/file-tools/file-tools.test.ts
+++ b/apps/agent-worker/src/file-tools/file-tools.test.ts
@@ -1,0 +1,290 @@
+import { describe, expect, it } from "bun:test";
+import {
+	runEditFileTool,
+	runGlobFileTool,
+	runGrepFileTool,
+	runReadFileTool,
+	runWriteFileTool,
+	type SandboxFileClient,
+	type SandboxFileCommand,
+	type SandboxFileCommandResult,
+	type SandboxFileRead,
+	type SandboxFileWrite,
+} from "./file-tools";
+
+class FakeSandboxFileClient implements SandboxFileClient {
+	readonly reads: SandboxFileRead[] = [];
+	readonly writes: SandboxFileWrite[] = [];
+	readonly commands: SandboxFileCommand[] = [];
+	writeError: Error | undefined;
+	commandError: Error | undefined;
+	commandResult: SandboxFileCommandResult = {
+		exitCode: 0,
+		stdout: "",
+		stderr: "",
+		truncated: false,
+	};
+
+	constructor(private readonly readContent = "") {}
+
+	async readFile(input: SandboxFileRead): Promise<string> {
+		this.reads.push(input);
+		return this.readContent;
+	}
+
+	async writeFile(input: SandboxFileWrite): Promise<void> {
+		this.writes.push(input);
+		if (this.writeError) throw this.writeError;
+	}
+
+	async runCommand(
+		input: SandboxFileCommand,
+	): Promise<SandboxFileCommandResult> {
+		this.commands.push(input);
+		if (this.commandError) throw this.commandError;
+		return this.commandResult;
+	}
+}
+
+const baseContext = {
+	workspaceRoot: "/workspace",
+	limits: {
+		readMaxBytes: 12,
+		readMaxLines: 2,
+		grepMaxResults: 100,
+		globMaxResults: 500,
+		commandMaxOutputBytes: 16_384,
+		commandTimeoutMs: 10_000,
+	},
+	markWorkspaceDirty: async () => {},
+};
+
+function parseResult(result: { content: { text: string }[] }) {
+	const [first] = result.content;
+	if (!first) throw new Error("missing tool content");
+	return JSON.parse(first.text);
+}
+
+describe("Read file tool", () => {
+	it("rejects path traversal before calling the sandbox", async () => {
+		const client = new FakeSandboxFileClient();
+
+		const result = await runReadFileTool(
+			{ path: "../secret.txt" },
+			{ ...baseContext, client },
+		);
+
+		expect(result.isError).toBe(true);
+		expect(result.content[0]?.text).toContain(
+			"path must stay inside workspace",
+		);
+		expect(client.reads).toEqual([]);
+		expect(client.commands).toEqual([]);
+	});
+
+	it("rejects absolute paths outside the workspace before calling the sandbox", async () => {
+		const client = new FakeSandboxFileClient();
+
+		const result = await runReadFileTool(
+			{ path: "/etc/passwd" },
+			{ ...baseContext, client },
+		);
+
+		expect(result.isError).toBe(true);
+		expect(result.content[0]?.text).toContain(
+			"path must stay inside workspace",
+		);
+		expect(client.reads).toEqual([]);
+		expect(client.commands).toEqual([]);
+	});
+
+	it("applies byte and line caps to returned content", async () => {
+		const client = new FakeSandboxFileClient("alpha\nbravo\ncharlie\n");
+
+		const result = await runReadFileTool(
+			{ path: "notes.txt" },
+			{ ...baseContext, client },
+		);
+
+		expect(result.isError).toBeUndefined();
+		expect(client.reads).toEqual([
+			{ path: "/workspace/notes.txt", maxBytes: 13 },
+		]);
+		expect(parseResult(result)).toEqual({
+			path: "notes.txt",
+			content: "alpha\nbravo",
+			startLine: 1,
+			linesRead: 2,
+			truncated: true,
+		});
+	});
+});
+
+describe("Write file tool", () => {
+	it("marks the workspace dirty only after the sandbox write succeeds", async () => {
+		const client = new FakeSandboxFileClient();
+		const events: string[] = [];
+
+		const result = await runWriteFileTool(
+			{ path: "notes.txt", content: "hello" },
+			{
+				...baseContext,
+				client,
+				markWorkspaceDirty: async () => {
+					events.push("dirty");
+				},
+			},
+		);
+
+		expect(result.isError).toBeUndefined();
+		expect(client.writes).toEqual([
+			{ path: "/workspace/notes.txt", content: "hello" },
+		]);
+		expect(events).toEqual(["dirty"]);
+		expect(parseResult(result)).toEqual({
+			path: "notes.txt",
+			bytesWritten: 5,
+		});
+	});
+
+	it("does not mark the workspace dirty when the sandbox write fails", async () => {
+		const client = new FakeSandboxFileClient();
+		client.writeError = new Error("E2B write exploded with a long detail");
+		let dirty = false;
+
+		const result = await runWriteFileTool(
+			{ path: "notes.txt", content: "hello" },
+			{
+				...baseContext,
+				client,
+				markWorkspaceDirty: async () => {
+					dirty = true;
+				},
+			},
+		);
+
+		expect(result.isError).toBe(true);
+		expect(result.content[0]?.text).toBe(
+			"Write failed: E2B write exploded with a long detail",
+		);
+		expect(dirty).toBe(false);
+	});
+});
+
+describe("Edit file tool", () => {
+	it("replaces all exact matches and marks dirty after the write succeeds", async () => {
+		const client = new FakeSandboxFileClient("hello hello");
+		let dirty = false;
+
+		const result = await runEditFileTool(
+			{ path: "notes.txt", oldText: "hello", newText: "hi" },
+			{
+				...baseContext,
+				client,
+				markWorkspaceDirty: async () => {
+					dirty = true;
+				},
+			},
+		);
+
+		expect(result.isError).toBeUndefined();
+		expect(client.reads).toEqual([
+			{ path: "/workspace/notes.txt", maxBytes: 13 },
+		]);
+		expect(client.writes).toEqual([
+			{ path: "/workspace/notes.txt", content: "hi hi" },
+		]);
+		expect(dirty).toBe(true);
+		expect(parseResult(result)).toEqual({
+			path: "notes.txt",
+			replacements: 2,
+		});
+	});
+
+	it("does not mark dirty when the replacement write fails", async () => {
+		const client = new FakeSandboxFileClient("hello");
+		client.writeError = new Error("E2B write failed");
+		let dirty = false;
+
+		const result = await runEditFileTool(
+			{ path: "notes.txt", oldText: "hello", newText: "hi" },
+			{
+				...baseContext,
+				client,
+				markWorkspaceDirty: async () => {
+					dirty = true;
+				},
+			},
+		);
+
+		expect(result.isError).toBe(true);
+		expect(dirty).toBe(false);
+	});
+});
+
+describe("Grep file tool", () => {
+	it("returns deterministic bounded matches from command output", async () => {
+		const client = new FakeSandboxFileClient();
+		client.commandResult = {
+			exitCode: 0,
+			stderr: "",
+			truncated: false,
+			stdout: "b.txt\t2\t2\tbeta\na.txt\t1\t1\talpha\n",
+		};
+
+		const result = await runGrepFileTool(
+			{ pattern: "a", path: ".", maxResults: 1 },
+			{ ...baseContext, client },
+		);
+
+		expect(result.isError).toBeUndefined();
+		expect(client.commands).toHaveLength(1);
+		expect(client.commands[0]?.cwd).toBe("/workspace");
+		expect(client.commands[0]?.maxOutputBytes).toBe(16_384);
+		expect(parseResult(result)).toEqual({
+			matches: [{ path: "a.txt", line: 1, column: 1, text: "alpha" }],
+			truncated: true,
+		});
+	});
+
+	it("converts sandbox command errors into bounded tool errors", async () => {
+		const client = new FakeSandboxFileClient();
+		client.commandError = new Error(`E2B unavailable ${"x".repeat(400)}`);
+
+		const result = await runGrepFileTool(
+			{ pattern: "needle" },
+			{ ...baseContext, client },
+		);
+
+		expect(result.isError).toBe(true);
+		expect(
+			result.content[0]?.text.startsWith("Grep failed: E2B unavailable"),
+		).toBe(true);
+		expect(result.content[0]?.text.length).toBeLessThan(280);
+	});
+});
+
+describe("Glob file tool", () => {
+	it("returns deterministic bounded paths from command output", async () => {
+		const client = new FakeSandboxFileClient();
+		client.commandResult = {
+			exitCode: 0,
+			stdout: "z.txt\nb.txt\na.txt\n",
+			stderr: "",
+			truncated: false,
+		};
+
+		const result = await runGlobFileTool(
+			{ pattern: "*.txt", maxResults: 2 },
+			{ ...baseContext, client },
+		);
+
+		expect(result.isError).toBeUndefined();
+		expect(client.commands).toHaveLength(1);
+		expect(client.commands[0]?.cwd).toBe("/workspace");
+		expect(parseResult(result)).toEqual({
+			paths: ["a.txt", "b.txt"],
+			truncated: true,
+		});
+	});
+});

--- a/apps/agent-worker/src/file-tools/file-tools.ts
+++ b/apps/agent-worker/src/file-tools/file-tools.ts
@@ -1,0 +1,554 @@
+import path from "node:path/posix";
+
+export interface FileToolLimits {
+	readMaxBytes: number;
+	readMaxLines: number;
+	grepMaxResults: number;
+	globMaxResults: number;
+	commandMaxOutputBytes: number;
+	commandTimeoutMs: number;
+}
+
+export interface SandboxFileRead {
+	path: string;
+	maxBytes: number;
+}
+
+export interface SandboxFileWrite {
+	path: string;
+	content: string;
+}
+
+export interface SandboxFileCommand {
+	command: string;
+	cwd: string;
+	timeoutMs: number;
+	maxOutputBytes: number;
+}
+
+export interface SandboxFileCommandResult {
+	exitCode: number;
+	stdout: string;
+	stderr: string;
+	truncated: boolean;
+}
+
+export interface SandboxFileClient {
+	readFile(input: SandboxFileRead): Promise<string>;
+	writeFile(input: SandboxFileWrite): Promise<void>;
+	runCommand(input: SandboxFileCommand): Promise<SandboxFileCommandResult>;
+}
+
+export interface FileToolContext {
+	client: SandboxFileClient;
+	workspaceRoot: string;
+	limits: FileToolLimits;
+	markWorkspaceDirty(): Promise<void>;
+}
+
+export interface ReadFileToolInput {
+	path: string;
+	offset?: number;
+	limit?: number;
+}
+
+export interface WriteFileToolInput {
+	path: string;
+	content: string;
+}
+
+export interface EditFileToolInput {
+	path: string;
+	oldText: string;
+	newText: string;
+}
+
+export interface GrepFileToolInput {
+	pattern: string;
+	path?: string;
+	include?: string;
+	caseSensitive?: boolean;
+	maxResults?: number;
+}
+
+export interface GlobFileToolInput {
+	pattern: string;
+	path?: string;
+	includeHidden?: boolean;
+	maxResults?: number;
+}
+
+export interface FileToolResult {
+	content: { type: "text"; text: string }[];
+	isError?: true;
+}
+
+interface WorkspacePath {
+	absolutePath: string;
+	relativePath: string;
+}
+
+type WorkspacePathResult =
+	| { ok: true; path: WorkspacePath }
+	| { ok: false; error: string };
+
+function toolText(payload: unknown): FileToolResult {
+	return {
+		content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+	};
+}
+
+function toolError(message: string): FileToolResult {
+	return {
+		content: [{ type: "text", text: message }],
+		isError: true,
+	};
+}
+
+export async function runReadFileTool(
+	input: ReadFileToolInput,
+	context: FileToolContext,
+): Promise<FileToolResult> {
+	const resolved = resolveWorkspacePath(input.path, context.workspaceRoot);
+	if (!resolved.ok) return toolError(resolved.error);
+
+	try {
+		const rawContent = await context.client.readFile({
+			path: resolved.path.absolutePath,
+			maxBytes: context.limits.readMaxBytes + 1,
+		});
+		const byteWindow = takeUtf8Bytes(rawContent, context.limits.readMaxBytes);
+		const startLine = normalizeStartLine(input.offset);
+		const requestedLines = clampLineLimit(
+			input.limit,
+			context.limits.readMaxLines,
+		);
+		const lineWindow = takeLineWindow(
+			byteWindow.text,
+			startLine,
+			requestedLines,
+		);
+
+		return toolText({
+			path: resolved.path.relativePath,
+			content: lineWindow.text,
+			startLine,
+			linesRead: countLines(lineWindow.text),
+			truncated: byteWindow.truncated || lineWindow.truncated,
+		});
+	} catch (error) {
+		return toolError(`Read failed: ${boundedErrorMessage(error)}`);
+	}
+}
+
+export async function runWriteFileTool(
+	input: WriteFileToolInput,
+	context: FileToolContext,
+): Promise<FileToolResult> {
+	const resolved = resolveWorkspacePath(input.path, context.workspaceRoot);
+	if (!resolved.ok) return toolError(resolved.error);
+
+	try {
+		await context.client.writeFile({
+			path: resolved.path.absolutePath,
+			content: input.content,
+		});
+		await context.markWorkspaceDirty();
+		return toolText({
+			path: resolved.path.relativePath,
+			bytesWritten: utf8ByteLength(input.content),
+		});
+	} catch (error) {
+		return toolError(`Write failed: ${boundedErrorMessage(error)}`);
+	}
+}
+
+export async function runEditFileTool(
+	input: EditFileToolInput,
+	context: FileToolContext,
+): Promise<FileToolResult> {
+	if (input.oldText === "") {
+		return toolError("Edit requires non-empty oldText.");
+	}
+	const resolved = resolveWorkspacePath(input.path, context.workspaceRoot);
+	if (!resolved.ok) return toolError(resolved.error);
+
+	try {
+		const rawContent = await context.client.readFile({
+			path: resolved.path.absolutePath,
+			maxBytes: context.limits.readMaxBytes + 1,
+		});
+		const byteWindow = takeUtf8Bytes(rawContent, context.limits.readMaxBytes);
+		if (byteWindow.truncated) {
+			return toolError("Edit failed: file exceeds edit size limit.");
+		}
+		const replacements = countOccurrences(byteWindow.text, input.oldText);
+		if (replacements === 0) {
+			return toolError("Edit failed: oldText was not found.");
+		}
+
+		await context.client.writeFile({
+			path: resolved.path.absolutePath,
+			content: byteWindow.text.split(input.oldText).join(input.newText),
+		});
+		await context.markWorkspaceDirty();
+		return toolText({
+			path: resolved.path.relativePath,
+			replacements,
+		});
+	} catch (error) {
+		return toolError(`Edit failed: ${boundedErrorMessage(error)}`);
+	}
+}
+
+export async function runGrepFileTool(
+	input: GrepFileToolInput,
+	context: FileToolContext,
+): Promise<FileToolResult> {
+	if (!input.pattern) return toolError("Grep requires a non-empty pattern.");
+	const resolved = resolveWorkspacePath(
+		input.path ?? ".",
+		context.workspaceRoot,
+	);
+	if (!resolved.ok) return toolError(resolved.error);
+	if (input.include) {
+		const includeError = validateWorkspacePattern(input.include, "include");
+		if (includeError) return toolError(includeError);
+	}
+
+	const maxResults = clampResultLimit(
+		input.maxResults,
+		context.limits.grepMaxResults,
+	);
+	try {
+		const commandResult = await context.client.runCommand({
+			command: buildGrepCommand({
+				pattern: input.pattern,
+				path: resolved.path.relativePath,
+				include: input.include,
+				caseSensitive: input.caseSensitive ?? true,
+				maxResults,
+			}),
+			cwd: path.normalize(context.workspaceRoot),
+			timeoutMs: context.limits.commandTimeoutMs,
+			maxOutputBytes: context.limits.commandMaxOutputBytes,
+		});
+		const commandError = commandFailure(commandResult);
+		if (commandError) return toolError(`Grep failed: ${commandError}`);
+
+		const parsed = parseRipgrepVimgrep(commandResult.stdout, maxResults);
+		return toolText({
+			matches: parsed.matches,
+			truncated: parsed.truncated || commandResult.truncated,
+		});
+	} catch (error) {
+		return toolError(`Grep failed: ${boundedErrorMessage(error)}`);
+	}
+}
+
+export async function runGlobFileTool(
+	input: GlobFileToolInput,
+	context: FileToolContext,
+): Promise<FileToolResult> {
+	const patternError = validateWorkspacePattern(input.pattern, "Glob");
+	if (patternError) return toolError(patternError);
+	const resolved = resolveWorkspacePath(
+		input.path ?? ".",
+		context.workspaceRoot,
+	);
+	if (!resolved.ok) return toolError(resolved.error);
+
+	const maxResults = clampResultLimit(
+		input.maxResults,
+		context.limits.globMaxResults,
+	);
+	try {
+		const commandResult = await context.client.runCommand({
+			command: buildGlobCommand({
+				pattern: input.pattern,
+				path: resolved.path.relativePath,
+				includeHidden: input.includeHidden ?? false,
+				maxResults,
+			}),
+			cwd: path.normalize(context.workspaceRoot),
+			timeoutMs: context.limits.commandTimeoutMs,
+			maxOutputBytes: context.limits.commandMaxOutputBytes,
+		});
+		const commandError = commandFailure(commandResult);
+		if (commandError) return toolError(`Glob failed: ${commandError}`);
+
+		const paths = commandResult.stdout
+			.split("\n")
+			.map((line) => line.trim())
+			.filter(Boolean)
+			.map(normalizeCommandRelativePath)
+			.filter((line): line is string => line !== undefined)
+			.sort();
+		const uniquePaths = [...new Set(paths)];
+		return toolText({
+			paths: uniquePaths.slice(0, maxResults),
+			truncated: uniquePaths.length > maxResults || commandResult.truncated,
+		});
+	} catch (error) {
+		return toolError(`Glob failed: ${boundedErrorMessage(error)}`);
+	}
+}
+
+function resolveWorkspacePath(
+	inputPath: string | undefined,
+	workspaceRoot: string,
+): WorkspacePathResult {
+	const rawPath = inputPath?.trim();
+	if (!rawPath) return { ok: false, error: "path is required." };
+	if (rawPath.includes("\0")) return { ok: false, error: "path is invalid." };
+	if (hasTraversalSegment(rawPath)) {
+		return { ok: false, error: "path must stay inside workspace." };
+	}
+
+	const root = path.normalize(workspaceRoot);
+	if (!path.isAbsolute(root)) {
+		return { ok: false, error: "workspace root must be absolute." };
+	}
+
+	const absolutePath = path.isAbsolute(rawPath)
+		? path.normalize(rawPath)
+		: path.normalize(path.join(root, rawPath));
+
+	if (!isInsideWorkspace(absolutePath, root)) {
+		return { ok: false, error: "path must stay inside workspace." };
+	}
+
+	const relativePath = path.relative(root, absolutePath) || ".";
+	return { ok: true, path: { absolutePath, relativePath } };
+}
+
+function hasTraversalSegment(inputPath: string): boolean {
+	return inputPath.split(/[\\/]+/).some((segment) => segment === "..");
+}
+
+function isInsideWorkspace(
+	absolutePath: string,
+	workspaceRoot: string,
+): boolean {
+	return (
+		absolutePath === workspaceRoot ||
+		absolutePath.startsWith(`${workspaceRoot}/`)
+	);
+}
+
+function takeUtf8Bytes(
+	text: string,
+	maxBytes: number,
+): { text: string; truncated: boolean } {
+	const encoder = new TextEncoder();
+	let bytes = 0;
+	let output = "";
+	for (const char of text) {
+		const nextBytes = encoder.encode(char).byteLength;
+		if (bytes + nextBytes > maxBytes) {
+			return { text: output, truncated: true };
+		}
+		bytes += nextBytes;
+		output += char;
+	}
+	return { text: output, truncated: false };
+}
+
+function utf8ByteLength(text: string): number {
+	return new TextEncoder().encode(text).byteLength;
+}
+
+function normalizeStartLine(offset: number | undefined): number {
+	if (offset === undefined) return 1;
+	return Math.max(1, Math.floor(offset));
+}
+
+function clampLineLimit(
+	requested: number | undefined,
+	configuredMax: number,
+): number {
+	if (requested === undefined) return configuredMax;
+	return Math.min(configuredMax, Math.max(1, Math.floor(requested)));
+}
+
+function takeLineWindow(
+	text: string,
+	startLine: number,
+	limit: number,
+): { text: string; truncated: boolean } {
+	if (!text) return { text: "", truncated: false };
+	const lines = text.split("\n");
+	const startIndex = startLine - 1;
+	const selected = lines.slice(startIndex, startIndex + limit);
+	return {
+		text: selected.join("\n"),
+		truncated: startIndex > 0 || lines.length > startIndex + limit,
+	};
+}
+
+function countLines(text: string): number {
+	if (!text) return 0;
+	return text.split("\n").length;
+}
+
+function countOccurrences(text: string, needle: string): number {
+	return text.split(needle).length - 1;
+}
+
+function clampResultLimit(
+	requested: number | undefined,
+	configuredMax: number,
+): number {
+	if (requested === undefined) return configuredMax;
+	return Math.min(configuredMax, Math.max(1, Math.floor(requested)));
+}
+
+function buildGrepCommand(input: {
+	pattern: string;
+	path: string;
+	include: string | undefined;
+	caseSensitive: boolean;
+	maxResults: number;
+}): string {
+	const args = [
+		"rg",
+		"--vimgrep",
+		"--field-match-separator",
+		"\t",
+		"--color",
+		"never",
+		"--sort",
+		"path",
+		"--line-number",
+		"--column",
+	];
+	if (!input.caseSensitive) args.push("--ignore-case");
+	if (input.include) args.push("--glob", input.include);
+	args.push("--", input.pattern, input.path);
+	return `${args.map(shellQuote).join(" ")} | head -n ${input.maxResults + 1}`;
+}
+
+function buildGlobCommand(input: {
+	pattern: string;
+	path: string;
+	includeHidden: boolean;
+	maxResults: number;
+}): string {
+	const script = `
+import glob
+import os
+import sys
+
+search_path = sys.argv[1]
+pattern = sys.argv[2]
+include_hidden = sys.argv[3] == "1"
+limit = int(sys.argv[4])
+root = os.getcwd()
+search_root = os.path.normpath(os.path.join(root, search_path))
+matches = []
+for candidate in glob.glob(os.path.join(search_root, pattern), recursive=True):
+    normalized = os.path.normpath(candidate)
+    rel = os.path.relpath(normalized, root)
+    if rel == "." or rel.startswith(".."):
+        continue
+    parts = rel.split(os.sep)
+    if not include_hidden and any(part.startswith(".") for part in parts):
+        continue
+    matches.append(rel)
+
+for rel in sorted(set(matches))[:limit]:
+    print(rel)
+`;
+	return [
+		"python3",
+		"-c",
+		script,
+		input.path,
+		input.pattern,
+		input.includeHidden ? "1" : "0",
+		String(input.maxResults + 1),
+	]
+		.map(shellQuote)
+		.join(" ");
+}
+
+function parseRipgrepVimgrep(
+	stdout: string,
+	maxResults: number,
+): {
+	matches: { path: string; line: number; column: number; text: string }[];
+	truncated: boolean;
+} {
+	const matches: {
+		path: string;
+		line: number;
+		column: number;
+		text: string;
+	}[] = [];
+	for (const line of stdout.split("\n")) {
+		if (!line.trim()) continue;
+		const [rawPath, rawLine, rawColumn, ...rawText] = line.split("\t");
+		if (!rawPath || !rawLine || !rawColumn) continue;
+		const normalizedPath = normalizeCommandRelativePath(rawPath);
+		if (!normalizedPath) continue;
+		const lineNumber = Number(rawLine);
+		const column = Number(rawColumn);
+		if (!Number.isFinite(lineNumber) || !Number.isFinite(column)) continue;
+		matches.push({
+			path: normalizedPath,
+			line: lineNumber,
+			column,
+			text: rawText.join("\t"),
+		});
+	}
+	matches.sort((a, b) => {
+		const pathOrder = a.path.localeCompare(b.path);
+		if (pathOrder !== 0) return pathOrder;
+		if (a.line !== b.line) return a.line - b.line;
+		return a.column - b.column;
+	});
+	return {
+		matches: matches.slice(0, maxResults),
+		truncated: matches.length > maxResults,
+	};
+}
+
+function normalizeCommandRelativePath(rawPath: string): string | undefined {
+	const normalized = path.normalize(rawPath);
+	if (
+		path.isAbsolute(normalized) ||
+		normalized === ".." ||
+		normalized.startsWith("../")
+	) {
+		return undefined;
+	}
+	return normalized;
+}
+
+function validateWorkspacePattern(
+	pattern: string,
+	label: string,
+): string | undefined {
+	if (!pattern.trim()) return `${label} requires a non-empty pattern.`;
+	if (pattern.includes("\0")) return `${label} pattern is invalid.`;
+	if (path.isAbsolute(pattern) || hasTraversalSegment(pattern)) {
+		return `${label} pattern must stay inside workspace.`;
+	}
+}
+
+function commandFailure(result: SandboxFileCommandResult): string | undefined {
+	const stderr = result.stderr.trim();
+	if (stderr) return boundedErrorMessage(stderr);
+	if (result.exitCode !== 0 && result.exitCode !== 1) {
+		return `command exited with status ${result.exitCode}`;
+	}
+}
+
+function shellQuote(value: string): string {
+	return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function boundedErrorMessage(error: unknown): string {
+	const message = error instanceof Error ? error.message : String(error);
+	return message.length > 240 ? `${message.slice(0, 237)}...` : message;
+}


### PR DESCRIPTION
This pull request adds comprehensive integration and unit tests for the file tools module, significantly increasing test coverage and ensuring correct behavior for file operations, path validation, error handling, and command-backed tools. The tests cover both real filesystem interactions and sandboxed client behaviors.

**Integration tests for real file operations:**
- Added `file-tools.integration.test.ts` to verify `runGrepFileTool` and `runGlobFileTool` against actual files and directories, ensuring that results are correctly bounded and sorted, and that only visible files are included.

**Unit tests for file tool behaviors:**
- Added `file-tools.test.ts` with a `FakeSandboxFileClient` to simulate file and command operations, testing:
  - Path validation to prevent traversal outside the workspace and proper error reporting.
  - Byte and line caps for file reads, and correct result formatting.
  - Write and edit operations, ensuring workspace state is marked dirty only after successful writes, and errors are handled gracefully.
  - Deterministic, bounded results for `runGrepFileTool` and `runGlobFileTool`, including error truncation and result sorting.