### PR TITLE
Read shared VPC ID from remote state with a conditional subnet fallback

### DIFF
--- a/infra/terraform/locals.tf
+++ b/infra/terraform/locals.tf
@@ -11,7 +11,9 @@ locals {
   shared_service_outputs = data.terraform_remote_state.mymemo_service.outputs
 
   shared_ecs_subnet_ids = tolist(local.shared_service_outputs.ecs_subnet_ids)
-  shared_vpc_id         = local.shared_service_outputs.vpc_id
+
+  shared_vpc_id_output = try(local.shared_service_outputs.vpc_id, null)
+  shared_vpc_id        = coalesce(local.shared_vpc_id_output, one(data.aws_subnet.shared_ecs_first[*].vpc_id))
 
   shared_ecs_cluster_arn_output  = try(local.shared_service_outputs.ecs_cluster_arn, null)
   shared_ecs_cluster_name_output = try(local.shared_service_outputs.ecs_cluster_name, null)

--- a/infra/terraform/shared_state.tf
+++ b/infra/terraform/shared_state.tf
@@ -14,6 +14,12 @@ data "aws_vpc" "shared" {
   id = local.shared_vpc_id
 }
 
+data "aws_subnet" "shared_ecs_first" {
+  count = local.shared_vpc_id_output == null ? 1 : 0
+
+  id = local.shared_ecs_subnet_ids[0]
+}
+
 data "aws_ecs_cluster" "shared" {
   count = local.shared_ecs_cluster_arn_output == null && local.shared_ecs_cluster_name_output != null ? 1 : 0
 


### PR DESCRIPTION
## Problem

The Release deploy workflow fails at the Terraform plan step (run 28783315981):

```
Error: Unsupported attribute
  on locals.tf line 14: local.shared_service_outputs.vpc_id
This object does not have an attribute named "vpc_id".
```

The mymemo-service remote state (`mymemo/staging.tfstate`) exposes 22 outputs and `vpc_id` is not one of them — nor does the mymemo-service repo define that output. The direct read was introduced in 214d0af ("Fix shared VPC remote state lookup"), which reverted the working subnet-derived lookup from 7862b67; every plan since has failed. The successful July 2 applies that created the current infrastructure ran with the subnet-derivation code.

## Fix

Restore the subnet-derived VPC lookup, but as a **conditional fallback** following the same `try()`/`coalesce()` pattern the ECS cluster lookup already uses:

- prefer the `vpc_id` remote-state output when mymemo-service exposes it (X-GPT/mymemo-service#8 adds that output)
- otherwise derive the VPC from the first shared ECS subnet via `data.aws_subnet` (evaluated only when the output is absent)

This matches the README's documented shared-network contract ("reads these from remote state when exposed... fallback AWS data sources are conditional") and avoids duplicating the VPC ID literal into this repo's deploy config. No IAM change needed — the deploy role already has `ec2:Describe*`.

## Verification

- `terraform fmt -check` and `terraform validate` pass
- Confirmed against the live state: `ecs_subnet_ids` is present, so the fallback path resolves; once mymemo-service applies its `vpc_id` output, the direct read takes over automatically

After merge, re-run the Release deploy workflow — the failed run died before apply, so nothing is half-deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
