### PR TITLE
Update deploy-config guard to expect the conditional VPC fallback

### DIFF
--- a/scripts/deploy-config.test.ts
+++ b/scripts/deploy-config.test.ts
@@ -326,8 +326,12 @@ describe("agent deployment config", () => {
 		const networkConfig = readFileSync(join(terraformDir, "network.tf"), "utf8");
 		const outputs = readFileSync(join(terraformDir, "outputs.tf"), "utf8");
 
-		expect(locals).toContain("shared_vpc_id         = local.shared_service_outputs.vpc_id");
-		expect(sharedState).not.toContain('data "aws_subnet" "shared_ecs_first"');
+		expect(locals).toContain("shared_vpc_id_output = try(local.shared_service_outputs.vpc_id, null)");
+		expect(locals).toContain(
+			"shared_vpc_id        = coalesce(local.shared_vpc_id_output, one(data.aws_subnet.shared_ecs_first[*].vpc_id))",
+		);
+		expect(sharedState).toContain('data "aws_subnet" "shared_ecs_first"');
+		expect(sharedState).toContain("count = local.shared_vpc_id_output == null ? 1 : 0");
 		expect(sharedState).toContain('data "aws_ecs_cluster" "shared"');
 		expect(sharedState).not.toContain('data "aws_ecs_service" "mymemo_service_api"');
 		expect(sharedState).toContain("count = local.shared_ecs_cluster_arn_output == null");


### PR DESCRIPTION
## Problem

#211 fixed the shared VPC lookup (conditional remote-state read with an `aws_subnet` fallback) but was merged with a failing CI check: the "shared infrastructure fallbacks are explicit and conditional" test in `scripts/deploy-config.test.ts` still pinned the old shape — a direct `vpc_id` remote-state read with the subnet fallback forbidden. That is the exact shape that breaks every Terraform plan while mymemo-service does not export `vpc_id`, and it is what prompted 214d0af to revert the previously working lookup. Main's CI is currently red because of it.

## Fix

Update the guard's assertions to match the test's own stated intent: the VPC lookup reads `vpc_id` from remote state when exposed and falls back to a **conditional** `data "aws_subnet"` lookup (`count = local.shared_vpc_id_output == null ? 1 : 0`), the same `try()`/`coalesce()` pattern the ECS cluster lookup uses.

## Verification

- `bun test scripts/deploy-config.test.ts`: 25 pass, 0 fail
- Full `bun run test` workspace suite: 137 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)