### PR TITLE
Implement foreground-only Bash with a process-group wrapper (plan 5.2)

### DIFF
--- a/apps/agent-worker/src/bash-tool/bash-tool.e2b.test.ts
+++ b/apps/agent-worker/src/bash-tool/bash-tool.e2b.test.ts
@@ -1,0 +1,236 @@
+// Live E2B test (Task 5.2 acceptance): proves descendant cleanup works THROUGH
+// the process-group wrapper — the case the Task 4.1 spike (p6) showed the raw
+// SDK cannot do (a backgrounded child survives timeout/kill and reparents to
+// init). Skipped unless E2B_API_KEY is set, so CI without E2B credentials
+// passes; run locally with `E2B_API_KEY=... bun test bash-tool.e2b`.
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { CommandExitError, Sandbox, TimeoutError } from "e2b";
+import {
+	type BashToolContext,
+	type CommandAuditEvent,
+	type ManagedCommandSpec,
+	type RawCommandOutcome,
+	runBashTool,
+	type SandboxCommandClient,
+	type SandboxCommandSession,
+} from "./bash-tool";
+import {
+	buildKillGroupCommand,
+	buildReapCommand,
+	DEFAULT_COMMAND_CONTROL_DIR,
+	parseReapSurvivors,
+	WRAPPER_PROGRAM,
+	wrapperEnv,
+} from "./bash-wrapper";
+
+const LIVE = !!process.env.E2B_API_KEY;
+const TEMPLATE = process.env.E2B_TEMPLATE ?? "base";
+const WORKSPACE_ROOT = "/home/user";
+const TEST_TIMEOUT_MS = 180_000;
+
+const sleep = (ms: number): Promise<void> =>
+	new Promise((resolve) => setTimeout(resolve, ms));
+
+/** A real E2B-backed command client, built on the shared wrapper module. This
+ * is the substrate the pure `runBashTool` handler is designed against; it lives
+ * in the test (like the file-tools integration client) until the sandbox
+ * lifecycle is wired in a later milestone. */
+class E2BCommandClient implements SandboxCommandClient {
+	constructor(
+		private readonly sandbox: Sandbox,
+		private readonly controlDir: string,
+	) {}
+
+	start(spec: ManagedCommandSpec): SandboxCommandSession {
+		const outcome = this.run(spec);
+		return {
+			outcome,
+			kill: async () => {
+				await this.sandbox.commands.run(
+					buildKillGroupCommand({
+						commandId: spec.commandId,
+						controlDir: this.controlDir,
+						graceMs: 1_000,
+					}),
+				);
+			},
+			reap: async () => {
+				const result = await this.sandbox.commands.run(
+					buildReapCommand({
+						commandId: spec.commandId,
+						controlDir: this.controlDir,
+					}),
+				);
+				return { survivors: parseReapSurvivors(result.stdout) };
+			},
+		};
+	}
+
+	private async run(spec: ManagedCommandSpec): Promise<RawCommandOutcome> {
+		let stdout = "";
+		let stderr = "";
+		try {
+			const result = await this.sandbox.commands.run(WRAPPER_PROGRAM, {
+				cwd: spec.cwd,
+				envs: wrapperEnv({
+					command: spec.command,
+					commandId: spec.commandId,
+					controlDir: this.controlDir,
+				}),
+				// Backstop beyond the tool's own timer so a truly hung command is
+				// still bounded even if the group kill is somehow ineffective.
+				timeoutMs: spec.timeoutMs + 5_000,
+				onStdout: (data) => {
+					stdout += data;
+				},
+				onStderr: (data) => {
+					stderr += data;
+				},
+			});
+			return {
+				exitCode: result.exitCode,
+				stdout,
+				stderr,
+				stdoutTruncated: false,
+				stderrTruncated: false,
+				timedOut: false,
+			};
+		} catch (error) {
+			if (error instanceof CommandExitError) {
+				return {
+					exitCode: error.exitCode,
+					stdout,
+					stderr,
+					stdoutTruncated: false,
+					stderrTruncated: false,
+					timedOut: false,
+				};
+			}
+			if (error instanceof TimeoutError) {
+				return {
+					exitCode: null,
+					stdout,
+					stderr,
+					stdoutTruncated: false,
+					stderrTruncated: false,
+					timedOut: true,
+				};
+			}
+			throw error;
+		}
+	}
+}
+
+function makeContext(
+	sandbox: Sandbox,
+	signal: AbortSignal,
+): { context: BashToolContext; taints: string[]; audits: CommandAuditEvent[] } {
+	const taints: string[] = [];
+	const audits: CommandAuditEvent[] = [];
+	const context: BashToolContext = {
+		client: new E2BCommandClient(sandbox, DEFAULT_COMMAND_CONTROL_DIR),
+		workspaceRoot: WORKSPACE_ROOT,
+		binding: {
+			userId: "user-live",
+			conversationId: "conv-live",
+			runId: "run-live",
+			sandboxId: sandbox.sandboxId,
+		},
+		limits: {
+			systemMaxTimeoutMs: 120_000,
+			maxStdoutBytes: 65_536,
+			maxStderrBytes: 65_536,
+		},
+		signal,
+		markWorkspaceDirty: async () => {},
+		markSandboxTainted: async (reason: string) => {
+			taints.push(reason);
+		},
+		recordCommandAudit: async (event: CommandAuditEvent) => {
+			audits.push(event);
+		},
+	};
+	return { context, taints, audits };
+}
+
+async function countProcesses(
+	sandbox: Sandbox,
+	pattern: string,
+): Promise<number> {
+	const result = await sandbox.commands.run(
+		`pgrep -f -c ${JSON.stringify(pattern)} || true`,
+	);
+	return Number.parseInt(result.stdout.trim() || "0", 10);
+}
+
+describe.skipIf(!LIVE)("Bash tool against live E2B", () => {
+	let sandbox: Sandbox;
+
+	beforeAll(async () => {
+		sandbox = await Sandbox.create(TEMPLATE, {
+			timeoutMs: 120_000,
+			metadata: { test: "bash-tool-5.2" },
+		});
+	});
+
+	afterAll(async () => {
+		if (sandbox) {
+			await Sandbox.kill(sandbox.sandboxId).catch(() => {});
+		}
+	});
+
+	it(
+		"kills a cancelled command's whole process tree, leaving no descendants",
+		async () => {
+			const controller = new AbortController();
+			const { context, taints } = makeContext(sandbox, controller.signal);
+
+			// Two backgrounded grandchildren + wait: exactly the spike's p6 shape,
+			// which survived raw timeout/kill and reparented to init.
+			const marker = "sleep 3131";
+			const running = runBashTool(
+				{ command: `${marker} & ${marker} & wait` },
+				context,
+			);
+
+			// Wait for the descendants to actually be running, then cancel.
+			let spawned = 0;
+			for (let attempt = 0; attempt < 20 && spawned < 2; attempt++) {
+				await sleep(500);
+				spawned = await countProcesses(sandbox, marker);
+			}
+			expect(spawned).toBeGreaterThanOrEqual(2);
+
+			controller.abort();
+			const result = await running;
+
+			expect(JSON.parse(result.content[0]?.text ?? "{}").outcome).toBe(
+				"canceled",
+			);
+			expect(taints).toEqual([]);
+
+			// The proof: no descendant survived the group kill.
+			const survivors = await countProcesses(sandbox, marker);
+			expect(survivors).toBe(0);
+		},
+		TEST_TIMEOUT_MS,
+	);
+
+	it(
+		"runs a normal command to completion with bounded output",
+		async () => {
+			const controller = new AbortController();
+			const { context, taints } = makeContext(sandbox, controller.signal);
+
+			const result = await runBashTool({ command: "echo hello-e2b" }, context);
+
+			const parsed = JSON.parse(result.content[0]?.text ?? "{}");
+			expect(result.isError).toBeUndefined();
+			expect(parsed.exitCode).toBe(0);
+			expect(parsed.stdout).toContain("hello-e2b");
+			expect(parsed.outcome).toBe("completed");
+			expect(taints).toEqual([]);
+		},
+		TEST_TIMEOUT_MS,
+	);
+});

--- a/apps/agent-worker/src/bash-tool/bash-tool.test.ts
+++ b/apps/agent-worker/src/bash-tool/bash-tool.test.ts
@@ -1,0 +1,349 @@
+import { describe, expect, it } from "bun:test";
+import type { RunBinding } from "../sandbox-env";
+import {
+	type BashToolContext,
+	type CommandAuditEvent,
+	type ManagedCommandSpec,
+	type RawCommandOutcome,
+	runBashTool,
+	type SandboxCommandClient,
+	type SandboxCommandSession,
+} from "./bash-tool";
+
+const BINDING: RunBinding = {
+	userId: "user-1",
+	conversationId: "conv-1",
+	runId: "run-1",
+	sandboxId: "sbx-1",
+};
+
+const OK_OUTCOME: RawCommandOutcome = {
+	exitCode: 0,
+	stdout: "hello\n",
+	stderr: "",
+	stdoutTruncated: false,
+	stderrTruncated: false,
+	timedOut: false,
+};
+
+interface SessionScript {
+	/** How `outcome` resolves. `on-kill` resolves only once `kill()` runs. */
+	resolve?: "immediate" | "on-kill";
+	result?: RawCommandOutcome;
+	/** Reject `outcome` with this error instead of resolving. */
+	outcomeError?: Error;
+	survivors?: number;
+	reapError?: Error;
+}
+
+class FakeSession implements SandboxCommandSession {
+	killed = 0;
+	reaped = 0;
+	readonly outcome: Promise<RawCommandOutcome>;
+	private settle!: (outcome: RawCommandOutcome) => void;
+	private reject!: (error: Error) => void;
+
+	constructor(private readonly script: SessionScript) {
+		this.outcome = new Promise((resolve, reject) => {
+			this.settle = resolve;
+			this.reject = reject;
+		});
+		if (script.outcomeError) {
+			this.reject(script.outcomeError);
+		} else if ((script.resolve ?? "immediate") === "immediate") {
+			this.settle(script.result ?? OK_OUTCOME);
+		}
+	}
+
+	async kill(): Promise<void> {
+		this.killed++;
+		if (this.script.resolve === "on-kill") {
+			this.settle(this.script.result ?? OK_OUTCOME);
+		}
+	}
+
+	async reap(): Promise<{ survivors: number }> {
+		this.reaped++;
+		if (this.script.reapError) throw this.script.reapError;
+		return { survivors: this.script.survivors ?? 0 };
+	}
+}
+
+class FakeCommandClient implements SandboxCommandClient {
+	readonly starts: ManagedCommandSpec[] = [];
+	readonly sessions: FakeSession[] = [];
+
+	constructor(private readonly script: SessionScript = {}) {}
+
+	start(spec: ManagedCommandSpec): SandboxCommandSession {
+		this.starts.push(spec);
+		const session = new FakeSession(this.script);
+		this.sessions.push(session);
+		return session;
+	}
+}
+
+function makeContext(
+	overrides: Partial<BashToolContext> & { client: SandboxCommandClient },
+): {
+	context: BashToolContext;
+	audits: CommandAuditEvent[];
+	taints: string[];
+	dirtyCount: () => number;
+} {
+	const audits: CommandAuditEvent[] = [];
+	const taints: string[] = [];
+	let dirty = 0;
+	const context: BashToolContext = {
+		client: overrides.client,
+		workspaceRoot: overrides.workspaceRoot ?? "/workspace",
+		binding: overrides.binding ?? BINDING,
+		limits: overrides.limits ?? {
+			systemMaxTimeoutMs: 120_000,
+			maxStdoutBytes: 65_536,
+			maxStderrBytes: 65_536,
+		},
+		signal: overrides.signal ?? new AbortController().signal,
+		markWorkspaceDirty: async () => {
+			dirty++;
+		},
+		markSandboxTainted: async (reason: string) => {
+			taints.push(reason);
+		},
+		recordCommandAudit: async (event: CommandAuditEvent) => {
+			audits.push(event);
+		},
+	};
+	return { context, audits, taints, dirtyCount: () => dirty };
+}
+
+function parseResult(result: { content: { text: string }[] }) {
+	const [first] = result.content;
+	if (!first) throw new Error("missing tool content");
+	return JSON.parse(first.text);
+}
+
+describe("runBashTool", () => {
+	it("runs a command and returns bounded exit/stdout/stderr with outcome", async () => {
+		const client = new FakeCommandClient({ result: OK_OUTCOME });
+		const { context, dirtyCount } = makeContext({ client });
+
+		const result = await runBashTool({ command: "echo hello" }, context);
+
+		expect(result.isError).toBeUndefined();
+		expect(parseResult(result)).toEqual({
+			exitCode: 0,
+			stdout: "hello\n",
+			stderr: "",
+			stdoutTruncated: false,
+			stderrTruncated: false,
+			outcome: "completed",
+		});
+		expect(client.starts).toHaveLength(1);
+		expect(client.sessions[0]?.reaped).toBe(1);
+		expect(dirtyCount()).toBe(1);
+	});
+
+	it("clamps the requested timeout to the system maximum", async () => {
+		const client = new FakeCommandClient({ result: OK_OUTCOME });
+		const { context } = makeContext({
+			client,
+			limits: {
+				systemMaxTimeoutMs: 5_000,
+				maxStdoutBytes: 65_536,
+				maxStderrBytes: 65_536,
+			},
+		});
+
+		await runBashTool({ command: "sleep 1", timeoutMs: 10 * 60_000 }, context);
+
+		expect(client.starts[0]?.timeoutMs).toBe(5_000);
+	});
+
+	it("times out a hung command by killing its process group", async () => {
+		const client = new FakeCommandClient({
+			resolve: "on-kill",
+			result: { ...OK_OUTCOME, exitCode: null, timedOut: false },
+		});
+		const { context, audits } = makeContext({
+			client,
+			limits: {
+				systemMaxTimeoutMs: 15,
+				maxStdoutBytes: 65_536,
+				maxStderrBytes: 65_536,
+			},
+		});
+
+		const result = await runBashTool({ command: "sleep 300" }, context);
+
+		expect(client.sessions[0]?.killed).toBe(1);
+		expect(parseResult(result).outcome).toBe("timeout");
+		expect(audits.at(-1)?.outcome).toBe("timeout");
+	});
+
+	it("bounds oversized output and flags truncation", async () => {
+		const client = new FakeCommandClient({
+			result: {
+				...OK_OUTCOME,
+				stdout: "x".repeat(100),
+				stdoutTruncated: false,
+			},
+		});
+		const { context } = makeContext({
+			client,
+			limits: {
+				systemMaxTimeoutMs: 120_000,
+				maxStdoutBytes: 10,
+				maxStderrBytes: 10,
+			},
+		});
+
+		const result = await runBashTool({ command: "yes" }, context);
+
+		const parsed = parseResult(result);
+		expect(parsed.stdout).toBe("xxxxxxxxxx");
+		expect(parsed.stdoutTruncated).toBe(true);
+	});
+
+	it("rejects obvious detached forms before any sandbox call", async () => {
+		const client = new FakeCommandClient();
+		const { context } = makeContext({ client });
+
+		for (const command of [
+			"sleep 300 &",
+			"nohup long-task",
+			"my-cmd | disown",
+			"setsid daemon",
+		]) {
+			const result = await runBashTool({ command }, context);
+			expect(result.isError).toBe(true);
+			expect(result.content[0]?.text).toContain("foreground");
+		}
+		expect(client.starts).toEqual([]);
+	});
+
+	it("allows in-command backgrounding (the wrapper reaps it)", async () => {
+		const client = new FakeCommandClient({ result: OK_OUTCOME });
+		const { context } = makeContext({ client });
+
+		// `a && b` and `2>&1` contain `&` but are not detached forms.
+		const result = await runBashTool(
+			{ command: "make build && ./run 2>&1" },
+			context,
+		);
+
+		expect(result.isError).toBeUndefined();
+		expect(client.starts).toHaveLength(1);
+	});
+
+	it("invokes the cancel path when the run signal is already aborted", async () => {
+		const controller = new AbortController();
+		controller.abort();
+		const client = new FakeCommandClient({
+			resolve: "on-kill",
+			result: { ...OK_OUTCOME, exitCode: null },
+		});
+		const { context, audits } = makeContext({
+			client,
+			signal: controller.signal,
+		});
+
+		const result = await runBashTool({ command: "sleep 300" }, context);
+
+		expect(client.sessions[0]?.killed).toBe(1);
+		expect(parseResult(result).outcome).toBe("canceled");
+		expect(audits.at(-1)?.outcome).toBe("canceled");
+	});
+
+	it("invokes the cancel path when the signal aborts mid-command", async () => {
+		const controller = new AbortController();
+		const client = new FakeCommandClient({
+			resolve: "on-kill",
+			result: { ...OK_OUTCOME, exitCode: null },
+		});
+		const { context } = makeContext({ client, signal: controller.signal });
+
+		const running = runBashTool({ command: "sleep 300" }, context);
+		await Promise.resolve();
+		controller.abort();
+		const result = await running;
+
+		expect(client.sessions[0]?.killed).toBe(1);
+		expect(parseResult(result).outcome).toBe("canceled");
+	});
+
+	it("taints the sandbox and refuses a clean result when survivors remain", async () => {
+		const client = new FakeCommandClient({ result: OK_OUTCOME, survivors: 2 });
+		const { context, taints, audits } = makeContext({ client });
+
+		const result = await runBashTool({ command: "spawn-daemon" }, context);
+
+		expect(result.isError).toBe(true);
+		expect(result.content[0]?.text).toContain("unhealthy");
+		expect(taints).toHaveLength(1);
+		expect(taints[0]).toContain("cleanup failed");
+		expect(audits.at(-1)?.cleanupOk).toBe(false);
+	});
+
+	it("taints the sandbox when the reap itself fails", async () => {
+		const client = new FakeCommandClient({
+			result: OK_OUTCOME,
+			reapError: new Error("sandbox unreachable"),
+		});
+		const { context, taints } = makeContext({ client });
+
+		const result = await runBashTool({ command: "echo hi" }, context);
+
+		expect(result.isError).toBe(true);
+		expect(taints).toHaveLength(1);
+	});
+
+	it("binds every command's audit events to the full run binding", async () => {
+		const client = new FakeCommandClient({ result: OK_OUTCOME });
+		const { context, audits } = makeContext({ client });
+
+		await runBashTool({ command: "ls", cwd: "src" }, context);
+
+		expect(audits.map((event) => event.phase)).toEqual(["started", "finished"]);
+		for (const event of audits) {
+			expect(event.binding).toEqual(BINDING);
+			expect(event.command).toBe("ls");
+			expect(event.cwd).toBe("src");
+		}
+		// Both events describe the same command instance.
+		expect(audits[0]?.commandId).toBe(audits[1]?.commandId ?? "");
+	});
+
+	it("rejects a cwd outside the workspace before any sandbox call", async () => {
+		const client = new FakeCommandClient();
+		const { context } = makeContext({ client });
+
+		const result = await runBashTool({ command: "ls", cwd: "../etc" }, context);
+
+		expect(result.isError).toBe(true);
+		expect(client.starts).toEqual([]);
+	});
+
+	it("rejects an empty command", async () => {
+		const client = new FakeCommandClient();
+		const { context } = makeContext({ client });
+
+		const result = await runBashTool({ command: "   " }, context);
+
+		expect(result.isError).toBe(true);
+		expect(client.starts).toEqual([]);
+	});
+
+	it("surfaces a client failure as a bounded error but still reaps", async () => {
+		const client = new FakeCommandClient({
+			outcomeError: new Error("sandbox died"),
+		});
+		const { context } = makeContext({ client });
+
+		const result = await runBashTool({ command: "echo hi" }, context);
+
+		expect(result.isError).toBe(true);
+		expect(result.content[0]?.text).toContain("Bash failed");
+		expect(client.sessions[0]?.reaped).toBe(1);
+	});
+});

--- a/apps/agent-worker/src/bash-tool/bash-tool.ts
+++ b/apps/agent-worker/src/bash-tool/bash-tool.ts
@@ -1,0 +1,322 @@
+import { resolveWorkspacePath } from "../file-tools/file-tools";
+import type { RunBinding } from "../sandbox-env";
+
+/**
+ * Bounds on one Bash invocation. `systemMaxTimeoutMs` is the hard ceiling the
+ * model can never exceed; the per-stream byte caps bound what the tool holds
+ * and returns so a chatty command cannot blow up model context or memory.
+ */
+export interface BashToolLimits {
+	systemMaxTimeoutMs: number;
+	maxStdoutBytes: number;
+	maxStderrBytes: number;
+}
+
+export const DEFAULT_BASH_TOOL_LIMITS: BashToolLimits = {
+	systemMaxTimeoutMs: 120_000,
+	maxStdoutBytes: 65_536,
+	maxStderrBytes: 65_536,
+};
+
+/** What the worker asks the sandbox to run as a managed, group-owned command. */
+export interface ManagedCommandSpec {
+	commandId: string;
+	command: string;
+	/** Absolute, workspace-rooted working directory. */
+	cwd: string;
+	/** Hard ceiling (already clamped). The sandbox impl uses it as a backstop. */
+	timeoutMs: number;
+	maxStdoutBytes: number;
+	maxStderrBytes: number;
+}
+
+/** The normalized end state of a managed command. The sandbox impl converts
+ * E2B's non-zero-exit and timeout throws into this shape rather than throwing. */
+export interface RawCommandOutcome {
+	/** `null` when the command was killed (cancel/timeout) before it exited. */
+	exitCode: number | null;
+	stdout: string;
+	stderr: string;
+	stdoutTruncated: boolean;
+	stderrTruncated: boolean;
+	/** The sandbox impl's own hard backstop fired. */
+	timedOut: boolean;
+}
+
+/**
+ * A running managed command. `outcome` resolves when the process ends (on its
+ * own, or because `kill` felled its process group). `kill` and `reap` both act
+ * on the whole process group — `kill` is the cancel/timeout path, `reap` is the
+ * mandatory post-command cleanup that reports any survivors.
+ */
+export interface SandboxCommandSession {
+	readonly outcome: Promise<RawCommandOutcome>;
+	kill(): Promise<void>;
+	reap(): Promise<{ survivors: number }>;
+}
+
+export interface SandboxCommandClient {
+	start(spec: ManagedCommandSpec): SandboxCommandSession;
+}
+
+export type CommandOutcome = "completed" | "timeout" | "canceled" | "failed";
+
+/**
+ * One audit record for a command. Every command emits a `started` and a
+ * `finished` event, each carrying the full run binding
+ * (`{userId, conversationId, runId, sandboxId}`) so operators can attribute any
+ * shell activity in the sandbox to the exact run that caused it. The handler
+ * stays pure by emitting these to an injected sink; the SDK-loop wiring (M7)
+ * persists them as durable `run_events` (internal, so the projector maps no
+ * client frame — operators read them in the log, not the SSE stream).
+ */
+export interface CommandAuditEvent {
+	phase: "started" | "finished";
+	commandId: string;
+	binding: RunBinding;
+	command: string;
+	cwd: string;
+	timeoutMs: number;
+	exitCode?: number | null;
+	outcome?: CommandOutcome;
+	cleanupOk?: boolean;
+	stdoutTruncated?: boolean;
+	stderrTruncated?: boolean;
+}
+
+export interface BashToolContext {
+	client: SandboxCommandClient;
+	workspaceRoot: string;
+	binding: RunBinding;
+	limits: BashToolLimits;
+	/** Fires when the run is canceled or ownership is lost; kills the command. */
+	signal: AbortSignal;
+	markWorkspaceDirty(): Promise<void>;
+	/**
+	 * Records that this sandbox failed command-tree cleanup. The seam is wired to
+	 * `conversation_runtime.sandbox_tainted`; Task 5.3's snapshot barrier reads
+	 * that flag and forces `error` over `done`, so a sandbox with escaped
+	 * processes is never snapshotted or reported as a clean success.
+	 */
+	markSandboxTainted(reason: string): Promise<void>;
+	recordCommandAudit(event: CommandAuditEvent): Promise<void>;
+}
+
+export interface BashToolInput {
+	command: string;
+	cwd?: string;
+	timeoutMs?: number;
+}
+
+export interface BashToolResult {
+	content: { type: "text"; text: string }[];
+	isError?: true;
+}
+
+function toolText(payload: unknown): BashToolResult {
+	return {
+		content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+	};
+}
+
+function toolError(message: string): BashToolResult {
+	return { content: [{ type: "text", text: message }], isError: true };
+}
+
+/**
+ * Reject the obvious ways a command tries to detach from the foreground so it
+ * outlives the tool call. The process-group wrapper already reaps normal
+ * backgrounding (`cmd &`, `a & b`) when the command exits, but `nohup`,
+ * `disown`, and `setsid` deliberately escape the group and would surface as
+ * cleanup survivors — so we reject them up front with feedback the model can
+ * act on, rather than letting them taint the sandbox. A bare trailing `&` is
+ * rejected too: it signals a misunderstanding of Bash's foreground contract.
+ */
+function detectDetachedForm(command: string): string | undefined {
+	if (/(^|[^&>])&\s*$/.test(command)) {
+		return (
+			"Bash runs commands in the foreground. Remove the trailing `&` — " +
+			"background work is killed when the command returns."
+		);
+	}
+	if (/\b(nohup|disown|setsid)\b/.test(command)) {
+		return (
+			"Bash runs commands in the foreground. `nohup`, `disown`, and `setsid` " +
+			"are not allowed: the command and all its children must exit before the " +
+			"tool returns."
+		);
+	}
+	return undefined;
+}
+
+function clampTimeoutMs(
+	requested: number | undefined,
+	systemMaxMs: number,
+): number {
+	if (requested === undefined || !Number.isFinite(requested))
+		return systemMaxMs;
+	return Math.min(systemMaxMs, Math.max(1, Math.floor(requested)));
+}
+
+function boundUtf8(
+	text: string,
+	maxBytes: number,
+): { text: string; truncated: boolean } {
+	const encoder = new TextEncoder();
+	let bytes = 0;
+	let output = "";
+	for (const char of text) {
+		const nextBytes = encoder.encode(char).byteLength;
+		if (bytes + nextBytes > maxBytes) return { text: output, truncated: true };
+		bytes += nextBytes;
+		output += char;
+	}
+	return { text: output, truncated: false };
+}
+
+function boundedErrorMessage(error: unknown): string {
+	const message = error instanceof Error ? error.message : String(error);
+	return message.length > 240 ? `${message.slice(0, 237)}...` : message;
+}
+
+/**
+ * Run one foreground shell command in the sandbox under the process-group
+ * wrapper. All model-controlled shell execution goes through here; nothing runs
+ * in Fargate. The flow is: validate + clamp (before any sandbox call) → audit
+ * `started` → start the managed command → race the command against the system
+ * timeout and the run's cancel signal (either kills the process group) → reap
+ * the group and, if anything survived, taint the sandbox and refuse a clean
+ * result → audit `finished`.
+ */
+export async function runBashTool(
+	input: BashToolInput,
+	context: BashToolContext,
+): Promise<BashToolResult> {
+	const command = input.command?.trim();
+	if (!command) return toolError("Bash requires a non-empty command.");
+
+	const detached = detectDetachedForm(command);
+	if (detached) return toolError(detached);
+
+	const cwd = resolveWorkspacePath(input.cwd ?? ".", context.workspaceRoot);
+	if (!cwd.ok) return toolError(cwd.error);
+
+	const timeoutMs = clampTimeoutMs(
+		input.timeoutMs,
+		context.limits.systemMaxTimeoutMs,
+	);
+	const commandId = crypto.randomUUID();
+
+	await context.recordCommandAudit({
+		phase: "started",
+		commandId,
+		binding: context.binding,
+		command,
+		cwd: cwd.path.relativePath,
+		timeoutMs,
+	});
+
+	const session = context.client.start({
+		commandId,
+		command,
+		cwd: cwd.path.absolutePath,
+		timeoutMs,
+		maxStdoutBytes: context.limits.maxStdoutBytes,
+		maxStderrBytes: context.limits.maxStderrBytes,
+	});
+
+	let canceled = false;
+	let timedOut = false;
+	const onAbort = (): void => {
+		canceled = true;
+		void session.kill();
+	};
+	if (context.signal.aborted) {
+		canceled = true;
+		void session.kill();
+	} else {
+		context.signal.addEventListener("abort", onAbort, { once: true });
+	}
+	const timer = setTimeout(() => {
+		timedOut = true;
+		void session.kill();
+	}, timeoutMs);
+
+	let raw: RawCommandOutcome | undefined;
+	let runError: unknown;
+	try {
+		raw = await session.outcome;
+	} catch (error) {
+		runError = error;
+	} finally {
+		clearTimeout(timer);
+		context.signal.removeEventListener("abort", onAbort);
+	}
+
+	// Cleanup is mandatory and runs on every path, including a client failure: a
+	// half-started process group must never outlive the tool call.
+	let cleanupOk = true;
+	let cleanupError: string | undefined;
+	try {
+		const { survivors } = await session.reap();
+		if (survivors > 0) {
+			cleanupOk = false;
+			cleanupError = `${survivors} process(es) survived cleanup`;
+		}
+	} catch (error) {
+		cleanupOk = false;
+		cleanupError = boundedErrorMessage(error);
+	}
+
+	// A command that ran may have mutated the workspace even if it failed.
+	await context.markWorkspaceDirty();
+
+	const outcome: CommandOutcome = canceled
+		? "canceled"
+		: timedOut || raw?.timedOut
+			? "timeout"
+			: runError
+				? "failed"
+				: "completed";
+
+	if (!cleanupOk) {
+		await context.markSandboxTainted(
+			`bash command ${commandId} cleanup failed: ${cleanupError}`,
+		);
+	}
+
+	await context.recordCommandAudit({
+		phase: "finished",
+		commandId,
+		binding: context.binding,
+		command,
+		cwd: cwd.path.relativePath,
+		timeoutMs,
+		exitCode: raw?.exitCode ?? null,
+		outcome,
+		cleanupOk,
+		stdoutTruncated: raw?.stdoutTruncated ?? false,
+		stderrTruncated: raw?.stderrTruncated ?? false,
+	});
+
+	if (!cleanupOk) {
+		return toolError(
+			"Bash cleanup failed; the sandbox is marked unhealthy and this run " +
+				`cannot complete: ${cleanupError}`,
+		);
+	}
+	if (!raw) {
+		return toolError(`Bash failed: ${boundedErrorMessage(runError)}`);
+	}
+
+	const stdout = boundUtf8(raw.stdout, context.limits.maxStdoutBytes);
+	const stderr = boundUtf8(raw.stderr, context.limits.maxStderrBytes);
+	return toolText({
+		exitCode: raw.exitCode,
+		stdout: stdout.text,
+		stderr: stderr.text,
+		stdoutTruncated: raw.stdoutTruncated || stdout.truncated,
+		stderrTruncated: raw.stderrTruncated || stderr.truncated,
+		outcome,
+	});
+}

--- a/apps/agent-worker/src/bash-tool/bash-wrapper.test.ts
+++ b/apps/agent-worker/src/bash-tool/bash-wrapper.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "bun:test";
+import {
+	buildKillGroupCommand,
+	buildReapCommand,
+	controlFilePath,
+	DEFAULT_COMMAND_CONTROL_DIR,
+	parseReapSurvivors,
+	WRAPPER_PROGRAM,
+	wrapperEnv,
+} from "./bash-wrapper";
+
+describe("bash wrapper program", () => {
+	it("runs the command as a fresh session leader and records the group id", () => {
+		// setsid gives the command its own process group; the inner shell writes
+		// its pid (the group id) before exec'ing the user command.
+		expect(WRAPPER_PROGRAM).toContain("setsid sh -c");
+		expect(WRAPPER_PROGRAM).toContain('echo $$ > "$0"');
+		expect(WRAPPER_PROGRAM).toContain('exec sh -c "$1"');
+	});
+
+	it("signals the whole process group, not just the leader pid", () => {
+		// The negative pgid is the load-bearing detail the spike proved necessary.
+		expect(WRAPPER_PROGRAM).toContain('kill -TERM "-$pgid"');
+		expect(WRAPPER_PROGRAM).toContain('kill -KILL "-$pgid"');
+		expect(WRAPPER_PROGRAM).toContain("trap forward TERM INT");
+	});
+
+	it("re-exits with the command's own status", () => {
+		expect(WRAPPER_PROGRAM).toContain('wait "$child"');
+		expect(WRAPPER_PROGRAM).toContain("code=$?");
+		expect(WRAPPER_PROGRAM).toContain('exit "$code"');
+	});
+
+	it("passes the user command as data, never as executed shell text", () => {
+		const env = wrapperEnv({
+			command: "rm -rf / # hostile",
+			commandId: "cmd-1",
+			controlDir: DEFAULT_COMMAND_CONTROL_DIR,
+		});
+		expect(env.MYMEMO_CMD).toBe("rm -rf / # hostile");
+		expect(env.MYMEMO_CMD_ID).toBe("cmd-1");
+		expect(env.MYMEMO_CONTROL_DIR).toBe(DEFAULT_COMMAND_CONTROL_DIR);
+		// The program body must not interpolate the command itself.
+		expect(WRAPPER_PROGRAM).not.toContain("rm -rf");
+	});
+});
+
+describe("controlFilePath", () => {
+	it("keeps control files out of any workspace", () => {
+		expect(controlFilePath("cmd-9", DEFAULT_COMMAND_CONTROL_DIR)).toBe(
+			"/tmp/mymemo-commands/cmd-9.pgid",
+		);
+	});
+});
+
+describe("buildKillGroupCommand", () => {
+	it("sends TERM then KILL to the group with a grace period", () => {
+		const script = buildKillGroupCommand({
+			commandId: "cmd-2",
+			controlDir: DEFAULT_COMMAND_CONTROL_DIR,
+			graceMs: 2000,
+		});
+		expect(script).toContain("'/tmp/mymemo-commands/cmd-2.pgid'");
+		expect(script).toContain('kill -TERM "-$pgid"');
+		expect(script).toContain("sleep 2");
+		expect(script).toContain('kill -KILL "-$pgid"');
+	});
+});
+
+describe("buildReapCommand", () => {
+	it("force-kills the group and prints the survivor count", () => {
+		const script = buildReapCommand({
+			commandId: "cmd-3",
+			controlDir: DEFAULT_COMMAND_CONTROL_DIR,
+		});
+		expect(script).toContain('kill -KILL "-$pgid"');
+		expect(script).toContain("ps -eo pgid=,stat=");
+		expect(script).toContain("printf");
+	});
+});
+
+describe("parseReapSurvivors", () => {
+	it("reads the trailing count", () => {
+		expect(parseReapSurvivors("0\n")).toBe(0);
+		expect(parseReapSurvivors("noise\n3\n")).toBe(3);
+	});
+
+	it("treats unparseable output as a survivor so ambiguity taints", () => {
+		expect(parseReapSurvivors("")).toBe(1);
+		expect(parseReapSurvivors("what\n")).toBe(1);
+	});
+});

--- a/apps/agent-worker/src/bash-tool/bash-wrapper.ts
+++ b/apps/agent-worker/src/bash-tool/bash-wrapper.ts
@@ -1,0 +1,158 @@
+/**
+ * The sandbox-side process-group wrapper for foreground Bash.
+ *
+ * The E2B semantics spike (Task 4.1, issue #173) proved that neither a command
+ * `timeoutMs` expiry nor `commands.kill(pid)` cleans up a command's
+ * descendants: a backgrounded child survives and reparents to init. So before
+ * enabling Bash we must run every command as the leader of its own process
+ * group and signal the whole group on timeout / cancel / stale-run recovery.
+ *
+ * This module produces three shell fragments the worker feeds to E2B:
+ *  - {@link WRAPPER_PROGRAM} runs the user command as a fresh session leader
+ *    (its own process group) and records the group id to a control file;
+ *  - {@link buildKillGroupCommand} signals that group (TERM, grace, KILL);
+ *  - {@link buildReapCommand} force-kills the group and reports how many
+ *    processes survived, so a failed cleanup can taint the sandbox.
+ *
+ * The user command is passed only as an environment variable and reaches the
+ * shell as a positional argument, never concatenated into shell text, so a
+ * hostile command string cannot break out of the wrapper.
+ */
+
+/** Where per-command process-group id files live. Outside any workspace so the
+ * agent's own Read/Grep/Glob never see them. */
+export const DEFAULT_COMMAND_CONTROL_DIR = "/tmp/mymemo-commands";
+
+/** Env var names the wrapper reads. Kept as constants so the JS side and the
+ * shell side cannot drift. */
+export const WRAPPER_ENV = {
+	command: "MYMEMO_CMD",
+	commandId: "MYMEMO_CMD_ID",
+	controlDir: "MYMEMO_CONTROL_DIR",
+} as const;
+
+/** Absolute path of the control file holding one command's process-group id. */
+export function controlFilePath(commandId: string, controlDir: string): string {
+	return `${controlDir}/${commandId}.pgid`;
+}
+
+/**
+ * The environment the wrapper needs. Passed to E2B `commands.run({ envs })` so
+ * the user command travels as data, not as part of the executed shell text.
+ */
+export function wrapperEnv(input: {
+	command: string;
+	commandId: string;
+	controlDir: string;
+}): Record<string, string> {
+	return {
+		[WRAPPER_ENV.command]: input.command,
+		[WRAPPER_ENV.commandId]: input.commandId,
+		[WRAPPER_ENV.controlDir]: input.controlDir,
+	};
+}
+
+/**
+ * The wrapper program (POSIX sh; uses only setsid + coreutils so it runs under
+ * dash or bash). It:
+ *  1. starts the user command as a new session leader via `setsid`, so the
+ *     command and every descendant share one process group;
+ *  2. has that inner shell record its own pid (== the new process-group id) to
+ *     the control file *before* exec'ing the user command, so the worker can
+ *     find the group even if the wrapper is later SIGKILLed;
+ *  3. forwards TERM/INT to the whole group; and
+ *  4. on exit, force-kills the group (sweeping any strays the command left) and
+ *     removes the control file.
+ *
+ * `wait` returns the command's own exit status, which the wrapper re-exits with
+ * so E2B surfaces the real code.
+ */
+export const WRAPPER_PROGRAM = `set -u
+: "\${${WRAPPER_ENV.command}:?}"
+: "\${${WRAPPER_ENV.commandId}:?}"
+: "\${${WRAPPER_ENV.controlDir}:?}"
+control="\${${WRAPPER_ENV.controlDir}}/\${${WRAPPER_ENV.commandId}}.pgid"
+mkdir -p "\${${WRAPPER_ENV.controlDir}}"
+# New session => new process group led by the inner shell; it writes its own pid
+# (the group id) then becomes the user command via exec, keeping that pid.
+setsid sh -c 'echo $$ > "$0"; exec sh -c "$1"' "$control" "\${${WRAPPER_ENV.command}}" &
+child=$!
+forward() {
+	pgid=$(cat "$control" 2>/dev/null || true)
+	[ -n "\${pgid:-}" ] && kill -TERM "-$pgid" 2>/dev/null || true
+}
+trap forward TERM INT
+wait "$child"
+code=$?
+pgid=$(cat "$control" 2>/dev/null || true)
+[ -n "\${pgid:-}" ] && kill -KILL "-$pgid" 2>/dev/null || true
+rm -f "$control" 2>/dev/null || true
+exit "$code"
+`;
+
+/** Round a millisecond grace period to a `sleep`-friendly seconds string. */
+function graceSeconds(graceMs: number): string {
+	const seconds = Math.max(0, graceMs) / 1000;
+	return (Math.round(seconds * 1000) / 1000).toString();
+}
+
+/**
+ * Signal a command's process group: TERM, a grace period, then KILL. Reads the
+ * group id from the control file, so it works from a separate `commands.run`
+ * call while the wrapper is still the foreground command. A no-op if the
+ * control file is gone (the command already finished and swept itself).
+ */
+export function buildKillGroupCommand(input: {
+	commandId: string;
+	controlDir: string;
+	graceMs: number;
+}): string {
+	const control = shellQuote(
+		controlFilePath(input.commandId, input.controlDir),
+	);
+	return `pgid=$(cat ${control} 2>/dev/null || true)
+if [ -n "\${pgid:-}" ]; then
+	kill -TERM "-$pgid" 2>/dev/null || true
+	sleep ${graceSeconds(input.graceMs)}
+	kill -KILL "-$pgid" 2>/dev/null || true
+fi
+`;
+}
+
+/**
+ * Force-kill the command's process group and print how many processes survive
+ * in it (zombies excluded — they are already dead and awaiting reap). A
+ * non-zero count means cleanup genuinely failed and the sandbox must be
+ * tainted. Also removes the control file.
+ */
+export function buildReapCommand(input: {
+	commandId: string;
+	controlDir: string;
+}): string {
+	const control = shellQuote(
+		controlFilePath(input.commandId, input.controlDir),
+	);
+	return `pgid=$(cat ${control} 2>/dev/null || true)
+count=0
+if [ -n "\${pgid:-}" ]; then
+	kill -KILL "-$pgid" 2>/dev/null || true
+	count=$(ps -eo pgid=,stat= 2>/dev/null | awk -v g="$pgid" '$1==g && $2 !~ /Z/ {n++} END{print n+0}')
+fi
+rm -f ${control} 2>/dev/null || true
+printf '%s\\n' "$count"
+`;
+}
+
+/** Parse the trailing survivor count printed by {@link buildReapCommand}. */
+export function parseReapSurvivors(stdout: string): number {
+	const lines = stdout.trim().split("\n");
+	const last = lines[lines.length - 1]?.trim() ?? "";
+	const parsed = Number.parseInt(last, 10);
+	// Unparseable output means we cannot prove the group is empty; treat as a
+	// survivor so an ambiguous cleanup taints rather than silently passing.
+	return Number.isInteger(parsed) && parsed >= 0 ? parsed : 1;
+}
+
+function shellQuote(value: string): string {
+	return `'${value.replaceAll("'", "'\\''")}'`;
+}

--- a/apps/agent-worker/src/file-tools/file-tools.ts
+++ b/apps/agent-worker/src/file-tools/file-tools.ts
@@ -83,12 +83,12 @@ export interface FileToolResult {
 	isError?: true;
 }
 
-interface WorkspacePath {
+export interface WorkspacePath {
 	absolutePath: string;
 	relativePath: string;
 }
 
-type WorkspacePathResult =
+export type WorkspacePathResult =
 	| { ok: true; path: WorkspacePath }
 	| { ok: false; error: string };
 
@@ -294,7 +294,7 @@ export async function runGlobFileTool(
 	}
 }
 
-function resolveWorkspacePath(
+export function resolveWorkspacePath(
 	inputPath: string | undefined,
 	workspaceRoot: string,
 ): WorkspacePathResult {


### PR DESCRIPTION
Implements Task 5.2 (Milestone 5) — issue #184. Adds the model-facing `Bash(command, cwd?, timeoutMs?)` executor for `agent-worker`. All model-controlled shell runs **only in E2B, never in Fargate**.

## Why the wrapper

The Task 4.1 E2B semantics spike (proof p6, see `apps/agent-worker/spikes/e2b-semantics/NOTES.md`) proved that neither an E2B command `timeoutMs` expiry nor `commands.kill(pid)` reaps a command's descendants — a backgrounded child survives and reparents to init. So a sandbox-side **process-group wrapper is a hard prerequisite** for enabling Bash, and it is built here.

## What changed

- **`bash-tool/bash-wrapper.ts`** — runs each command as a fresh `setsid` session leader (its own process group), records the group id to a control file, and exposes group-kill (TERM → grace → KILL) and reap+survivor-count command builders. The user command travels as an env var → positional arg, never concatenated into shell text, so a hostile command string cannot break out of the wrapper.
- **`bash-tool/bash-tool.ts`** — pure `runBashTool` handler over a `SandboxCommandClient` seam (mirroring the Task 5.1 file tools). It:
  - clamps the requested timeout to the system maximum;
  - bounds stdout/stderr and flags truncation;
  - rejects obvious detached forms (`&`, `nohup`, `disown`, `setsid`) with model-readable feedback before any sandbox call;
  - resolves `cwd` inside the workspace (reusing the file-tools path-safety);
  - wires the run's cancel signal **and** the timeout to the process-group kill;
  - after every command reaps the group — survivors (or a failed reap) taint the sandbox and refuse a clean result;
  - emits `started`/`finished` audit events bound to `{userId, conversationId, runId, sandboxId}`.
- **`file-tools/file-tools.ts`** — exports `resolveWorkspacePath` (+ its result types) so path-safety has a single implementation shared by both tools.

## Acceptance criteria (issue #184)

| Criterion | Where |
|---|---|
| timeout clamped to system max | `clampTimeoutMs` |
| output bounded | per-stream byte caps + `boundUtf8` |
| detached forms rejected w/ feedback | `detectDetachedForm` |
| cancellation → cancel path | run signal → `session.kill()` (group kill) |
| cleanup failure taints + blocks `done` | reap survivors/throw → `markSandboxTainted` + error result |
| command bound to `{userId,conversationId,runId,sandboxId}` | `recordCommandAudit` start/finish |
| live E2B descendant-cleanup proof | `bash-tool.e2b.test.ts` (refutes spike p6) |

## Reviewer notes

- **Two intentional milestone-boundary seams.** `recordCommandAudit` and `markSandboxTainted` are injected callbacks, unwired in this diff — matching how Task 5.1 left `markWorkspaceDirty` unwired. Taint's durable target is `conversation_runtime.sandbox_tainted`; **Task 5.3's snapshot barrier** is what reads it to force `error` over `done`. The audit sink becomes durable `run_events` when the SDK loop assembles tools in **M7**. So the `done`-enforcement link is not end-to-end *in this diff by design*.
- **Live E2B test is `skipIf` without `E2B_API_KEY`**, so CI without E2B credentials passes. Run the real proof locally with `E2B_API_KEY=... bun test bash-tool.e2b` — it reproduces the exact p6 shape (`sleep 3131 & sleep 3131 & wait`), cancels, and asserts zero descendant survivors.

## Verification

- Unit tests with fakes cover all acceptance criteria (14 tool + 9 wrapper tests).
- Full workspace suite passes; `tsc --noEmit` clean; Biome clean.
- Two-axis `/code-review` (Standards + Spec) run: no standards breaches; spec faithful, the two "partial" items are the documented milestone-boundary seams above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)