### PR TITLE
Add worker-embedded orphan sandbox and snapshot cleanup (plan 8.1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,6 +217,8 @@ Optional:
 - `WORKER_DOCUMENT_LOAD_MAX_DOCUMENTS` (default: `10`), `WORKER_DOCUMENT_LOAD_PER_DOCUMENT_MAX_BYTES` (default: `262144`), `WORKER_DOCUMENT_LOAD_PER_CALL_MAX_BYTES` (default: `1048576`) — caps for the model-facing `LoadDocuments` tool (documents-as-files, ADR-0004): the max ids per call, and the per-document / per-call byte caps on content materialized into the conversation's reserved docs cache
 - `WORKER_HEARTBEAT_INTERVAL_MS` (default: `15000`) — how often an active run renews its lease
 - `WORKER_SHUTDOWN_TIMEOUT_MS` (default: `30000`) — grace period to drain active runs on SIGINT/SIGTERM before forcing exit
+- `WORKER_CLEANUP_INTERVAL_MS` (default: `300000`) — how often the worker-embedded orphan/snapshot cleanup loop (Task 8.1) attempts a pass; the pass is single-flighted across replicas by a Postgres advisory lock, so only one worker runs it at a time
+- `WORKER_SNAPSHOT_RETENTION_MS` (default: `604800000`, 7 days) — idle window (measured against `conversation_runtime.updated_at`) before a conversation's superseded (`previous`) snapshot is deleted, keeping the `latest` restore path
 - `PORT` (default: `8080`) — `/health` endpoint port
 - `LOG_LEVEL` (default: `info`)
 - `DB_PASSWORD` — spliced into `AGENT_DATABASE_URL` when passwordless; `DB_SSL` (default: on; `disable` for local non-TLS)

--- a/apps/agent-worker/package.json
+++ b/apps/agent-worker/package.json
@@ -12,6 +12,7 @@
 	"dependencies": {
 		"@mymemo/agent-db": "workspace:*",
 		"drizzle-orm": "^0.45.2",
+		"e2b": "^2.14.0",
 		"pg": "^8.22.0",
 		"pino": "^9.14.0"
 	},
@@ -19,7 +20,6 @@
 		"@biomejs/biome": "^2.3.11",
 		"@electric-sql/pglite": "^0.5.3",
 		"@types/bun": "^1.3.11",
-		"@types/pg": "^8.20.0",
-		"e2b": "^2.14.0"
+		"@types/pg": "^8.20.0"
 	}
 }

--- a/apps/agent-worker/src/cleanup/advisory-lock.test.ts
+++ b/apps/agent-worker/src/cleanup/advisory-lock.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "bun:test";
+import {
+	type AdvisoryLockClient,
+	type AdvisoryLockPool,
+	tryWithAdvisoryLock,
+} from "./advisory-lock";
+
+const KEY = 42;
+
+/** A fake pooled connection recording the SQL it saw and whether it released. */
+class FakeClient implements AdvisoryLockClient {
+	queries: string[] = [];
+	released = false;
+	constructor(private readonly locked: boolean) {}
+
+	async query(text: string): Promise<{ rows: Array<Record<string, unknown>> }> {
+		this.queries.push(text);
+		if (text.includes("pg_try_advisory_lock")) {
+			return { rows: [{ locked: this.locked }] };
+		}
+		return { rows: [] };
+	}
+	release(): void {
+		this.released = true;
+	}
+}
+
+class FakePool implements AdvisoryLockPool {
+	last: FakeClient | undefined;
+	constructor(private readonly locked: boolean) {}
+	async connect(): Promise<AdvisoryLockClient> {
+		this.last = new FakeClient(this.locked);
+		return this.last;
+	}
+}
+
+describe("tryWithAdvisoryLock", () => {
+	it("runs fn, unlocks, and releases when the lock is acquired", async () => {
+		const pool = new FakePool(true);
+		let ran = false;
+
+		const outcome = await tryWithAdvisoryLock(pool, KEY, async () => {
+			ran = true;
+			return "done";
+		});
+
+		expect(outcome).toEqual({ ran: true, result: "done" });
+		expect(ran).toBe(true);
+		expect(pool.last?.queries).toEqual([
+			"select pg_try_advisory_lock($1) as locked",
+			"select pg_advisory_unlock($1)",
+		]);
+		expect(pool.last?.released).toBe(true);
+	});
+
+	it("skips fn but still releases when the lock is not acquired", async () => {
+		const pool = new FakePool(false);
+		let ran = false;
+
+		const outcome = await tryWithAdvisoryLock(pool, KEY, async () => {
+			ran = true;
+		});
+
+		expect(outcome).toEqual({ ran: false });
+		expect(ran).toBe(false);
+		// No unlock is issued for a lock we never took.
+		expect(pool.last?.queries).toEqual([
+			"select pg_try_advisory_lock($1) as locked",
+		]);
+		expect(pool.last?.released).toBe(true);
+	});
+
+	it("unlocks and releases even when fn throws", async () => {
+		const pool = new FakePool(true);
+
+		await expect(
+			tryWithAdvisoryLock(pool, KEY, async () => {
+				throw new Error("boom");
+			}),
+		).rejects.toThrow("boom");
+
+		expect(pool.last?.queries).toContain("select pg_advisory_unlock($1)");
+		expect(pool.last?.released).toBe(true);
+	});
+});

--- a/apps/agent-worker/src/cleanup/advisory-lock.ts
+++ b/apps/agent-worker/src/cleanup/advisory-lock.ts
@@ -1,0 +1,59 @@
+/**
+ * Single-flighting for the worker-embedded cleanup pass (design "Deployment
+ * Shape": cleanup loops are worker-embedded and single-flighted via a Postgres
+ * advisory lock — no separate scheduled job). Every worker replica runs the
+ * loop, but only the one holding the lock runs a pass; the rest skip. This is
+ * an optimization, not a correctness requirement — the pass's E2B operations
+ * are all idempotent — but it avoids N replicas doing the same reconciliation.
+ */
+
+/** The minimal pooled-connection surface the lock needs; `pg.Pool` satisfies it. */
+export interface AdvisoryLockPool {
+	connect(): Promise<AdvisoryLockClient>;
+}
+
+export interface AdvisoryLockClient {
+	query(
+		text: string,
+		params?: unknown[],
+	): Promise<{ rows: Array<Record<string, unknown>> }>;
+	/** Return the connection to the pool. */
+	release(): void;
+}
+
+/**
+ * Fixed 63-bit key for the cleanup advisory lock (ASCII "mymclean"-derived);
+ * every replica must use the same value or they would not exclude each other.
+ */
+export const CLEANUP_ADVISORY_LOCK_KEY = 8_242_869_154_306_402;
+
+/**
+ * Run `fn` iff this process can take the session advisory lock for `key`. The
+ * lock is acquired and released on ONE dedicated pooled connection — a
+ * session-scoped `pg_try_advisory_lock` bound to a different backend than its
+ * `pg_advisory_unlock` would never release. The connection is held idle (not in
+ * a transaction) for the pass duration, so E2B HTTP calls in `fn` never sit
+ * inside an open transaction. Returns `{ ran: false }` when another replica
+ * holds the lock.
+ */
+export async function tryWithAdvisoryLock<T>(
+	pool: AdvisoryLockPool,
+	key: number,
+	fn: () => Promise<T>,
+): Promise<{ ran: true; result: T } | { ran: false }> {
+	const client = await pool.connect();
+	try {
+		const acquired = await client.query(
+			"select pg_try_advisory_lock($1) as locked",
+			[key],
+		);
+		if (acquired.rows[0]?.locked !== true) return { ran: false };
+		try {
+			return { ran: true, result: await fn() };
+		} finally {
+			await client.query("select pg_advisory_unlock($1)", [key]);
+		}
+	} finally {
+		client.release();
+	}
+}

--- a/apps/agent-worker/src/cleanup/cleanup-loop.test.ts
+++ b/apps/agent-worker/src/cleanup/cleanup-loop.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { orphanSandboxes } from "@mymemo/agent-db/schema";
+import { createTestDatabase, type TestDb } from "@mymemo/agent-db/testing";
+import type { WorkerLogger } from "../logger";
+import type { AdvisoryLockClient, AdvisoryLockPool } from "./advisory-lock";
+import type { SandboxJanitor } from "./cleanup";
+import { CleanupLoop } from "./cleanup-loop";
+
+const silentLogger: WorkerLogger = { info() {}, warn() {}, error() {} };
+
+class FakeJanitor implements SandboxJanitor {
+	killed: string[] = [];
+	async killSandbox(id: string): Promise<void> {
+		this.killed.push(id);
+	}
+	async deleteSnapshot(): Promise<void> {}
+}
+
+/** Grants or withholds the lock; can also fail `connect` to prove isolation. */
+class FakePool implements AdvisoryLockPool {
+	constructor(
+		private readonly locked: boolean,
+		private readonly failConnect = false,
+	) {}
+	async connect(): Promise<AdvisoryLockClient> {
+		if (this.failConnect) throw new Error("pool exhausted");
+		const locked = this.locked;
+		return {
+			async query(text: string) {
+				return text.includes("pg_try_advisory_lock")
+					? { rows: [{ locked }] }
+					: { rows: [] };
+			},
+			release() {},
+		};
+	}
+}
+
+let tdb: TestDb;
+let janitor: FakeJanitor;
+
+beforeEach(async () => {
+	tdb = await createTestDatabase();
+	janitor = new FakeJanitor();
+	await tdb.db.insert(orphanSandboxes).values({
+		sandboxId: "sbx-orphan",
+		userId: "user-1",
+		conversationId: "conv-1",
+		runId: "run-1",
+		createdByWorkerId: "worker-old",
+		reason: "test",
+	});
+});
+
+afterEach(async () => {
+	await tdb.close();
+});
+
+function buildLoop(pool: AdvisoryLockPool) {
+	return new CleanupLoop({
+		db: tdb.db,
+		pool,
+		janitor,
+		workerId: "worker-1",
+		config: { snapshotRetentionMs: 60_000 },
+		intervalMs: 60_000,
+		logger: silentLogger,
+	});
+}
+
+describe("CleanupLoop.runOnce", () => {
+	it("runs a pass and returns the summary when it holds the lock", async () => {
+		const loop = buildLoop(new FakePool(true));
+
+		const summary = await loop.runOnce();
+
+		expect(summary?.orphanSandboxesKilled).toBe(1);
+		expect(janitor.killed).toEqual(["sbx-orphan"]);
+	});
+
+	it("skips the pass when another replica holds the lock", async () => {
+		const loop = buildLoop(new FakePool(false));
+
+		const summary = await loop.runOnce();
+
+		expect(summary).toBeUndefined();
+		expect(janitor.killed).toEqual([]);
+		// The orphan is untouched, left for whoever holds the lock.
+		const remaining = await tdb.db.select().from(orphanSandboxes);
+		expect(remaining).toHaveLength(1);
+	});
+
+	it("never throws when acquiring the lock fails", async () => {
+		const loop = buildLoop(new FakePool(true, true));
+
+		const summary = await loop.runOnce();
+
+		expect(summary).toBeUndefined();
+		expect(janitor.killed).toEqual([]);
+	});
+});
+
+describe("CleanupLoop start/stop", () => {
+	it("does not run before the first interval and stops cleanly", async () => {
+		const loop = buildLoop(new FakePool(true));
+
+		loop.start();
+		// First attempt is scheduled one interval out, so nothing has run yet.
+		expect(janitor.killed).toEqual([]);
+		loop.stop();
+		expect(janitor.killed).toEqual([]);
+	});
+});

--- a/apps/agent-worker/src/cleanup/cleanup-loop.ts
+++ b/apps/agent-worker/src/cleanup/cleanup-loop.ts
@@ -1,0 +1,102 @@
+import type { Database } from "@mymemo/agent-db/client";
+import type { WorkerLogger } from "../logger";
+import {
+	type AdvisoryLockPool,
+	CLEANUP_ADVISORY_LOCK_KEY,
+	tryWithAdvisoryLock,
+} from "./advisory-lock";
+import {
+	type CleanupConfig,
+	type CleanupSummary,
+	runCleanupPass,
+	type SandboxJanitor,
+} from "./cleanup";
+
+export interface CleanupLoopOptions {
+	db: Database;
+	/** Dedicated-connection source for the single-flight advisory lock. */
+	pool: AdvisoryLockPool;
+	janitor: SandboxJanitor;
+	workerId: string;
+	config: CleanupConfig;
+	/** How often {@link CleanupLoop.start} attempts a pass. */
+	intervalMs: number;
+	logger: WorkerLogger;
+}
+
+/**
+ * The worker-embedded cleanup loop (Task 8.1). On a timer it attempts one
+ * {@link runCleanupPass} under the Postgres advisory lock, so across replicas at
+ * most one pass runs at a time. It is intentionally independent of the run loop
+ * — its own timer, its own error isolation — so a cleanup failure can never
+ * block claiming or executing user runs: {@link runOnce} never throws, and a
+ * failing pass is logged and retried on the next interval.
+ *
+ * `runOnce` is directly awaitable so tests drive it deterministically without
+ * wall-clock timers (Bun has no `setInterval` fake timers); `start`/`stop` just
+ * schedule and unschedule it.
+ */
+export class CleanupLoop {
+	private running = false;
+	private timer: ReturnType<typeof setTimeout> | undefined;
+
+	constructor(private readonly opts: CleanupLoopOptions) {}
+
+	/**
+	 * Attempt one cleanup pass. Returns the pass summary when this replica held
+	 * the lock and ran, or `undefined` when another replica held it or the
+	 * attempt failed. Never throws — the loop must survive any single failure.
+	 */
+	async runOnce(): Promise<CleanupSummary | undefined> {
+		try {
+			const outcome = await tryWithAdvisoryLock(
+				this.opts.pool,
+				CLEANUP_ADVISORY_LOCK_KEY,
+				() =>
+					runCleanupPass({
+						db: this.opts.db,
+						janitor: this.opts.janitor,
+						workerId: this.opts.workerId,
+						config: this.opts.config,
+						logger: this.opts.logger,
+					}),
+			);
+			if (!outcome.ran) return undefined;
+			this.opts.logger.info({
+				message: "cleanup pass complete",
+				workerId: this.opts.workerId,
+				...outcome.result,
+			});
+			return outcome.result;
+		} catch (error) {
+			this.opts.logger.error({
+				message: "cleanup pass failed",
+				workerId: this.opts.workerId,
+				error: error instanceof Error ? error.message : String(error),
+			});
+			return undefined;
+		}
+	}
+
+	/** Begin attempting a pass every `intervalMs`. The first attempt waits one
+	 * interval — cleanup is background hygiene, not startup-critical. */
+	start(): void {
+		if (this.running) return;
+		this.running = true;
+		const tick = async (): Promise<void> => {
+			if (!this.running) return;
+			await this.runOnce();
+			if (this.running) this.timer = setTimeout(tick, this.opts.intervalMs);
+		};
+		this.timer = setTimeout(tick, this.opts.intervalMs);
+	}
+
+	/** Stop scheduling further passes. An in-flight pass finishes on its own. */
+	stop(): void {
+		this.running = false;
+		if (this.timer) {
+			clearTimeout(this.timer);
+			this.timer = undefined;
+		}
+	}
+}

--- a/apps/agent-worker/src/cleanup/cleanup.test.ts
+++ b/apps/agent-worker/src/cleanup/cleanup.test.ts
@@ -1,0 +1,364 @@
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+} from "bun:test";
+import {
+	conversationRuntime,
+	conversations,
+	orphanSandboxes,
+} from "@mymemo/agent-db/schema";
+import { createTestDatabase, type TestDb } from "@mymemo/agent-db/testing";
+import { and, eq } from "drizzle-orm";
+import type { WorkerLogger } from "../logger";
+import {
+	type CleanupPassOptions,
+	runCleanupPass,
+	type SandboxJanitor,
+} from "./cleanup";
+
+const silentLogger: WorkerLogger = { info() {}, warn() {}, error() {} };
+
+/** Records janitor calls; can be told to fail specific ids to prove retry. */
+class FakeJanitor implements SandboxJanitor {
+	killed: string[] = [];
+	deletedSnapshots: string[] = [];
+	killFailIds = new Set<string>();
+	deleteFailIds = new Set<string>();
+
+	async killSandbox(sandboxId: string): Promise<void> {
+		if (this.killFailIds.has(sandboxId)) throw new Error("E2B kill failed");
+		this.killed.push(sandboxId);
+	}
+	async deleteSnapshot(snapshotId: string): Promise<void> {
+		if (this.deleteFailIds.has(snapshotId))
+			throw new Error("E2B delete failed");
+		this.deletedSnapshots.push(snapshotId);
+	}
+}
+
+const HOUR_MS = 3_600_000;
+const RETENTION_MS = 60_000;
+
+let tdb: TestDb;
+let janitor: FakeJanitor;
+
+// One PGlite instance for the whole file (spin-up is the slow part); each test
+// starts from empty tables via truncate, keeping isolation without the cost.
+beforeAll(async () => {
+	tdb = await createTestDatabase();
+});
+
+afterAll(async () => {
+	await tdb.close();
+});
+
+beforeEach(() => {
+	janitor = new FakeJanitor();
+});
+
+afterEach(async () => {
+	await tdb.db.delete(orphanSandboxes);
+	await tdb.db.delete(conversationRuntime);
+	await tdb.db.delete(conversations);
+});
+
+function pass(overrides?: Partial<CleanupPassOptions>) {
+	return runCleanupPass({
+		db: tdb.db,
+		janitor,
+		workerId: "worker-1",
+		config: { snapshotRetentionMs: RETENTION_MS },
+		logger: silentLogger,
+		...overrides,
+	});
+}
+
+async function insertConversation(userId: string, conversationId: string) {
+	await tdb.db
+		.insert(conversations)
+		.values({ userId, conversationId, scope: "general" });
+}
+
+async function insertRuntime(row: {
+	userId: string;
+	conversationId: string;
+	sandboxId?: string | null;
+	latestSnapshotId?: string | null;
+	previousSnapshotId?: string | null;
+	updatedAt?: Date;
+}) {
+	await tdb.db.insert(conversationRuntime).values(row);
+}
+
+async function insertOrphan(sandboxId: string, conversationId = "conv-x") {
+	await tdb.db.insert(orphanSandboxes).values({
+		sandboxId,
+		userId: "user-1",
+		conversationId,
+		runId: "run-x",
+		createdByWorkerId: "worker-old",
+		reason: "test",
+	});
+}
+
+async function orphanIds(): Promise<string[]> {
+	const rows = await tdb.db
+		.select({ id: orphanSandboxes.sandboxId })
+		.from(orphanSandboxes);
+	return rows.map((r) => r.id).sort();
+}
+
+async function runtimeRow(userId: string, conversationId: string) {
+	const [row] = await tdb.db
+		.select()
+		.from(conversationRuntime)
+		.where(
+			and(
+				eq(conversationRuntime.userId, userId),
+				eq(conversationRuntime.conversationId, conversationId),
+			),
+		);
+	return row;
+}
+
+describe("orphan sandbox cleanup", () => {
+	it("never kills a sandbox still referenced by conversation_runtime", async () => {
+		await insertConversation("user-1", "conv-1");
+		await insertRuntime({
+			userId: "user-1",
+			conversationId: "conv-1",
+			sandboxId: "sbx-referenced",
+		});
+		await insertOrphan("sbx-referenced");
+
+		const summary = await pass();
+
+		expect(janitor.killed).toEqual([]);
+		expect(await orphanIds()).toEqual(["sbx-referenced"]);
+		expect(summary.orphanSandboxesSkippedReferenced).toBe(1);
+		expect(summary.orphanSandboxesKilled).toBe(0);
+	});
+
+	it("kills an unreferenced orphan and removes its ledger row", async () => {
+		await insertOrphan("sbx-orphan");
+
+		const summary = await pass();
+
+		expect(janitor.killed).toEqual(["sbx-orphan"]);
+		expect(await orphanIds()).toEqual([]);
+		expect(summary.orphanSandboxesKilled).toBe(1);
+	});
+
+	it("retries a failed kill: the ledger row survives, a later pass kills it", async () => {
+		await insertOrphan("sbx-flaky");
+		janitor.killFailIds.add("sbx-flaky");
+
+		const first = await pass();
+		expect(first.orphanSandboxesFailed).toBe(1);
+		expect(await orphanIds()).toEqual(["sbx-flaky"]);
+
+		janitor.killFailIds.clear();
+		const second = await pass();
+		expect(second.orphanSandboxesKilled).toBe(1);
+		expect(await orphanIds()).toEqual([]);
+	});
+
+	it("isolates a failing orphan from a healthy one in the same pass", async () => {
+		await insertOrphan("sbx-bad");
+		await insertOrphan("sbx-good");
+		janitor.killFailIds.add("sbx-bad");
+
+		const summary = await pass();
+
+		expect(janitor.killed).toEqual(["sbx-good"]);
+		expect(await orphanIds()).toEqual(["sbx-bad"]);
+		expect(summary.orphanSandboxesKilled).toBe(1);
+		expect(summary.orphanSandboxesFailed).toBe(1);
+	});
+});
+
+describe("unreferenced snapshot retention", () => {
+	it("deletes an idle conversation's superseded snapshot, keeping latest", async () => {
+		await insertConversation("user-1", "conv-1");
+		await insertRuntime({
+			userId: "user-1",
+			conversationId: "conv-1",
+			latestSnapshotId: "snap-latest",
+			previousSnapshotId: "snap-previous",
+			updatedAt: new Date(Date.now() - HOUR_MS),
+		});
+
+		const summary = await pass();
+
+		expect(janitor.deletedSnapshots).toEqual(["snap-previous"]);
+		const row = await runtimeRow("user-1", "conv-1");
+		expect(row?.previousSnapshotId).toBeNull();
+		expect(row?.latestSnapshotId).toBe("snap-latest");
+		expect(summary.snapshotsDeleted).toBe(1);
+	});
+
+	it("leaves a recently-active conversation's snapshot until retention elapses", async () => {
+		await insertConversation("user-1", "conv-1");
+		await insertRuntime({
+			userId: "user-1",
+			conversationId: "conv-1",
+			latestSnapshotId: "snap-latest",
+			previousSnapshotId: "snap-previous",
+			// default updatedAt = now(): well within the retention window.
+		});
+
+		const summary = await pass();
+
+		expect(janitor.deletedSnapshots).toEqual([]);
+		const row = await runtimeRow("user-1", "conv-1");
+		expect(row?.previousSnapshotId).toBe("snap-previous");
+		expect(summary.snapshotsDeleted).toBe(0);
+	});
+
+	it("never deletes a snapshot still referenced as another conversation's latest", async () => {
+		await insertConversation("user-1", "conv-idle");
+		await insertConversation("user-1", "conv-active");
+		await insertRuntime({
+			userId: "user-1",
+			conversationId: "conv-idle",
+			previousSnapshotId: "snap-shared",
+			updatedAt: new Date(Date.now() - HOUR_MS),
+		});
+		await insertRuntime({
+			userId: "user-1",
+			conversationId: "conv-active",
+			latestSnapshotId: "snap-shared",
+		});
+
+		await pass();
+
+		expect(janitor.deletedSnapshots).toEqual([]);
+		const idle = await runtimeRow("user-1", "conv-idle");
+		expect(idle?.previousSnapshotId).toBe("snap-shared");
+	});
+
+	it("retries a failed snapshot delete: the pointer survives for a later pass", async () => {
+		await insertConversation("user-1", "conv-1");
+		await insertRuntime({
+			userId: "user-1",
+			conversationId: "conv-1",
+			previousSnapshotId: "snap-flaky",
+			updatedAt: new Date(Date.now() - HOUR_MS),
+		});
+		janitor.deleteFailIds.add("snap-flaky");
+
+		const first = await pass();
+		expect(first.snapshotsFailed).toBe(1);
+		expect((await runtimeRow("user-1", "conv-1"))?.previousSnapshotId).toBe(
+			"snap-flaky",
+		);
+
+		janitor.deleteFailIds.clear();
+		const second = await pass();
+		expect(second.snapshotsDeleted).toBe(1);
+		expect(
+			(await runtimeRow("user-1", "conv-1"))?.previousSnapshotId,
+		).toBeNull();
+	});
+});
+
+describe("deleted-conversation cleanup", () => {
+	it("kills sandbox + snapshots then removes the runtime row", async () => {
+		// No conversations row => the conversation was deleted.
+		await insertRuntime({
+			userId: "user-1",
+			conversationId: "conv-gone",
+			sandboxId: "sbx-gone",
+			latestSnapshotId: "snap-latest",
+			previousSnapshotId: "snap-previous",
+		});
+
+		const summary = await pass();
+
+		expect(janitor.killed).toEqual(["sbx-gone"]);
+		expect(janitor.deletedSnapshots.sort()).toEqual([
+			"snap-latest",
+			"snap-previous",
+		]);
+		expect(await runtimeRow("user-1", "conv-gone")).toBeUndefined();
+		expect(summary.deletedRuntimesRemoved).toBe(1);
+	});
+
+	it("records an orphan and still clears the pointer when the kill fails", async () => {
+		await insertRuntime({
+			userId: "user-1",
+			conversationId: "conv-gone",
+			sandboxId: "sbx-stuck",
+		});
+		janitor.killFailIds.add("sbx-stuck");
+
+		const summary = await pass();
+
+		// Kill failed -> retry state recorded in the orphan ledger...
+		expect(await orphanIds()).toEqual(["sbx-stuck"]);
+		// ...so the runtime pointer may be cleared.
+		expect(await runtimeRow("user-1", "conv-gone")).toBeUndefined();
+		expect(summary.deletedRuntimesRemoved).toBe(1);
+	});
+
+	it("retains the runtime row when a snapshot delete fails", async () => {
+		await insertRuntime({
+			userId: "user-1",
+			conversationId: "conv-gone",
+			sandboxId: "sbx-gone",
+			latestSnapshotId: "snap-stuck",
+		});
+		janitor.deleteFailIds.add("snap-stuck");
+
+		const summary = await pass();
+
+		expect(janitor.killed).toEqual(["sbx-gone"]);
+		expect(await runtimeRow("user-1", "conv-gone")).toBeDefined();
+		expect(summary.deletedRuntimesRetained).toBe(1);
+		expect(summary.deletedRuntimesRemoved).toBe(0);
+	});
+
+	it("leaves runtime rows of still-existing conversations untouched", async () => {
+		await insertConversation("user-1", "conv-live");
+		await insertRuntime({
+			userId: "user-1",
+			conversationId: "conv-live",
+			sandboxId: "sbx-live",
+			latestSnapshotId: "snap-live",
+		});
+
+		const summary = await pass();
+
+		expect(janitor.killed).toEqual([]);
+		expect(janitor.deletedSnapshots).toEqual([]);
+		expect(await runtimeRow("user-1", "conv-live")).toBeDefined();
+		expect(summary.deletedRuntimesRemoved).toBe(0);
+	});
+
+	it("does not delete a snapshot a surviving conversation still references", async () => {
+		await insertConversation("user-1", "conv-live");
+		await insertRuntime({
+			userId: "user-1",
+			conversationId: "conv-live",
+			latestSnapshotId: "snap-shared",
+		});
+		// Deleted conversation shares the snapshot id (repeating templateId:tag).
+		await insertRuntime({
+			userId: "user-1",
+			conversationId: "conv-gone",
+			latestSnapshotId: "snap-shared",
+		});
+
+		await pass();
+
+		expect(janitor.deletedSnapshots).toEqual([]);
+		// The deleted row is still removed; the live conversation keeps the snapshot.
+		expect(await runtimeRow("user-1", "conv-gone")).toBeUndefined();
+		expect(await runtimeRow("user-1", "conv-live")).toBeDefined();
+	});
+});

--- a/apps/agent-worker/src/cleanup/cleanup.ts
+++ b/apps/agent-worker/src/cleanup/cleanup.ts
@@ -1,0 +1,424 @@
+import type { Database } from "@mymemo/agent-db/client";
+import {
+	conversationRuntime,
+	conversations,
+	orphanSandboxes,
+} from "@mymemo/agent-db/schema";
+import { and, eq, gte, isNotNull, isNull, lt } from "drizzle-orm";
+import type { WorkerLogger } from "../logger";
+
+/**
+ * Runtime hygiene for external E2B resources Postgres cannot delete
+ * transactionally (design doc "Why Cleanup Exists", Task 8.1): orphaned
+ * sandboxes, unreferenced snapshots past retention, and runtime rows for
+ * deleted conversations/users. The database is the source of truth for what is
+ * *referenced*; the janitor reconciles E2B against it. The one rule everything
+ * here obeys: never kill a sandbox or snapshot still referenced by
+ * `conversation_runtime`.
+ *
+ * The pass is deliberately unfenced (it runs when no run owns a conversation)
+ * but conservative, idempotent, and per-row isolated: every E2B call is
+ * idempotent (kill/delete of an already-gone resource resolves), a failing row
+ * is left in place to retry on the next pass, and a failing sweep never aborts
+ * the others — so cleanup can never block unrelated user runs.
+ */
+
+/**
+ * The narrow E2B port cleanup needs, injected like the other executor tools'
+ * sandbox clients (no concrete E2B wiring lives in worker production code yet).
+ * Both operations must be idempotent: killing/deleting a resource that is
+ * already gone resolves successfully; only a real, retryable failure rejects.
+ */
+export interface SandboxJanitor {
+	/** Kill an E2B sandbox by id. Resolve if killed or already gone. */
+	killSandbox(sandboxId: string): Promise<void>;
+	/** Delete an E2B snapshot by id. Resolve if deleted or already gone. */
+	deleteSnapshot(snapshotId: string): Promise<void>;
+}
+
+export interface CleanupConfig {
+	/**
+	 * Idle window before a conversation's superseded (`previous`) snapshot
+	 * becomes eligible for deletion. Measured against `updated_at`, the last
+	 * runtime mutation — an actively-used conversation bumps it and so is never a
+	 * candidate. The spike's retention decision: days, not minutes.
+	 */
+	snapshotRetentionMs: number;
+}
+
+/** Per-pass tallies, returned for structured logging and asserted by tests. */
+export interface CleanupSummary {
+	orphanSandboxesKilled: number;
+	orphanSandboxesFailed: number;
+	orphanSandboxesSkippedReferenced: number;
+	snapshotsDeleted: number;
+	snapshotsFailed: number;
+	deletedRuntimesRemoved: number;
+	deletedRuntimesRetained: number;
+}
+
+export interface CleanupPassOptions {
+	db: Database;
+	janitor: SandboxJanitor;
+	/** Records who recorded an orphan when a deleted-conversation kill fails. */
+	workerId: string;
+	config: CleanupConfig;
+	logger: WorkerLogger;
+	/** Injectable clock for deterministic retention tests; defaults to now. */
+	now?: Date;
+}
+
+function zeroSummary(): CleanupSummary {
+	return {
+		orphanSandboxesKilled: 0,
+		orphanSandboxesFailed: 0,
+		orphanSandboxesSkippedReferenced: 0,
+		snapshotsDeleted: 0,
+		snapshotsFailed: 0,
+		deletedRuntimesRemoved: 0,
+		deletedRuntimesRetained: 0,
+	};
+}
+
+/**
+ * One cleanup pass: the three sweeps, each isolated so a whole-sweep failure
+ * (e.g. a transient DB error) is logged and the remaining sweeps still run.
+ * Returns the merged per-sweep tallies.
+ */
+export async function runCleanupPass(
+	options: CleanupPassOptions,
+): Promise<CleanupSummary> {
+	const summary = zeroSummary();
+	await runSweep(options.logger, "orphan-sandboxes", async () => {
+		Object.assign(summary, await sweepOrphanSandboxes(options));
+	});
+	await runSweep(options.logger, "unreferenced-snapshots", async () => {
+		Object.assign(summary, await sweepUnreferencedSnapshots(options));
+	});
+	await runSweep(options.logger, "deleted-conversations", async () => {
+		Object.assign(summary, await sweepDeletedConversations(options));
+	});
+	return summary;
+}
+
+async function runSweep(
+	logger: WorkerLogger,
+	sweep: string,
+	fn: () => Promise<void>,
+): Promise<void> {
+	try {
+		await fn();
+	} catch (error) {
+		logger.error({
+			message: "cleanup sweep failed",
+			sweep,
+			error: toMessage(error),
+		});
+	}
+}
+
+/**
+ * Kill sandboxes recorded in the `orphan_sandboxes` ledger — but never one that
+ * is currently a conversation's live pointer (the ledger records at the moment
+ * ownership was lost, so a legitimately-owned sandbox should never appear, yet
+ * we check anyway and leave any referenced entry untouched). A confirmed kill
+ * removes the ledger row; a failed kill leaves it to retry next pass.
+ */
+async function sweepOrphanSandboxes(
+	options: CleanupPassOptions,
+): Promise<Partial<CleanupSummary>> {
+	const { db, janitor, logger } = options;
+	const orphans = await db.select().from(orphanSandboxes);
+	if (orphans.length === 0) return {};
+
+	const referenced = await referencedSandboxIds(db);
+	let killed = 0;
+	let failed = 0;
+	let skipped = 0;
+	for (const orphan of orphans) {
+		if (referenced.has(orphan.sandboxId)) {
+			skipped++;
+			logger.warn({
+				message: "orphan sandbox is still referenced; leaving it",
+				sandboxId: orphan.sandboxId,
+			});
+			continue;
+		}
+		try {
+			await janitor.killSandbox(orphan.sandboxId);
+		} catch (error) {
+			failed++;
+			logger.warn({
+				message: "orphan sandbox kill failed; will retry",
+				sandboxId: orphan.sandboxId,
+				error: toMessage(error),
+			});
+			continue;
+		}
+		await db
+			.delete(orphanSandboxes)
+			.where(eq(orphanSandboxes.sandboxId, orphan.sandboxId));
+		killed++;
+	}
+	return {
+		orphanSandboxesKilled: killed,
+		orphanSandboxesFailed: failed,
+		orphanSandboxesSkippedReferenced: skipped,
+	};
+}
+
+/**
+ * Delete each conversation's superseded (`previous`) snapshot once the
+ * conversation has been idle past the retention window, keeping `latest` (the
+ * live restore path). A candidate is never deleted while its id is still a
+ * restore path anywhere: any conversation's `latest`, or an unexpired `previous`
+ * (guards E2B's repeating `templateId:tag` ids from cross-conversation
+ * deletion). On success the column is cleared with a compare-and-set on the id,
+ * so a concurrent run that rotated a fresh `previous` in is never clobbered.
+ */
+async function sweepUnreferencedSnapshots(
+	options: CleanupPassOptions,
+): Promise<Partial<CleanupSummary>> {
+	const { db, janitor, logger } = options;
+	const now = options.now ?? new Date();
+	const cutoff = new Date(now.getTime() - options.config.snapshotRetentionMs);
+
+	const candidates = await db
+		.select({
+			userId: conversationRuntime.userId,
+			conversationId: conversationRuntime.conversationId,
+			previousSnapshotId: conversationRuntime.previousSnapshotId,
+		})
+		.from(conversationRuntime)
+		.where(
+			and(
+				isNotNull(conversationRuntime.previousSnapshotId),
+				lt(conversationRuntime.updatedAt, cutoff),
+			),
+		);
+	if (candidates.length === 0) return {};
+
+	const protectedIds = await protectedSnapshotIds(db, cutoff);
+	let deleted = 0;
+	let failed = 0;
+	for (const candidate of candidates) {
+		const snapshotId = candidate.previousSnapshotId;
+		if (snapshotId === null || protectedIds.has(snapshotId)) continue;
+		try {
+			await janitor.deleteSnapshot(snapshotId);
+		} catch (error) {
+			failed++;
+			logger.warn({
+				message: "snapshot delete failed; will retry",
+				snapshotId,
+				error: toMessage(error),
+			});
+			continue;
+		}
+		// Compare-and-set on the id: if a run rotated a new `previous` in between
+		// the select and here, that value differs and we leave it alone.
+		await db
+			.update(conversationRuntime)
+			.set({ previousSnapshotId: null, updatedAt: new Date() })
+			.where(
+				and(
+					eq(conversationRuntime.userId, candidate.userId),
+					eq(conversationRuntime.conversationId, candidate.conversationId),
+					eq(conversationRuntime.previousSnapshotId, snapshotId),
+				),
+			);
+		deleted++;
+	}
+	return { snapshotsDeleted: deleted, snapshotsFailed: failed };
+}
+
+/**
+ * Remove `conversation_runtime` rows whose conversation no longer exists (a
+ * deleted conversation or user), killing the sandbox and deleting snapshots
+ * first. The runtime row (and its pointers) is only removed once the sandbox is
+ * handled — killed, or its id recorded in the orphan ledger for retry — and its
+ * snapshots are deleted; otherwise the row is retained to retry next pass. A
+ * snapshot still owned by a surviving conversation is left untouched.
+ */
+async function sweepDeletedConversations(
+	options: CleanupPassOptions,
+): Promise<Partial<CleanupSummary>> {
+	const { db, janitor, logger, workerId } = options;
+	const orphaned = await db
+		.select({
+			userId: conversationRuntime.userId,
+			conversationId: conversationRuntime.conversationId,
+			sandboxId: conversationRuntime.sandboxId,
+			latestSnapshotId: conversationRuntime.latestSnapshotId,
+			previousSnapshotId: conversationRuntime.previousSnapshotId,
+		})
+		.from(conversationRuntime)
+		.leftJoin(
+			conversations,
+			and(
+				eq(conversations.userId, conversationRuntime.userId),
+				eq(conversations.conversationId, conversationRuntime.conversationId),
+			),
+		)
+		.where(isNull(conversations.conversationId));
+	if (orphaned.length === 0) return {};
+
+	const liveReferenced = await liveReferencedSnapshotIds(db);
+	let removed = 0;
+	let retained = 0;
+	for (const row of orphaned) {
+		let handled = true;
+
+		if (row.sandboxId !== null) {
+			handled = await handleDeletedSandbox(options, row.sandboxId, {
+				userId: row.userId,
+				conversationId: row.conversationId,
+				workerId,
+			});
+		}
+
+		for (const snapshotId of [row.latestSnapshotId, row.previousSnapshotId]) {
+			if (snapshotId === null || liveReferenced.has(snapshotId)) continue;
+			try {
+				await janitor.deleteSnapshot(snapshotId);
+			} catch (error) {
+				handled = false;
+				logger.warn({
+					message: "deleted-conversation snapshot delete failed; will retry",
+					snapshotId,
+					conversationId: row.conversationId,
+					error: toMessage(error),
+				});
+			}
+		}
+
+		if (!handled) {
+			retained++;
+			continue;
+		}
+		await db
+			.delete(conversationRuntime)
+			.where(
+				and(
+					eq(conversationRuntime.userId, row.userId),
+					eq(conversationRuntime.conversationId, row.conversationId),
+				),
+			);
+		removed++;
+	}
+	return { deletedRuntimesRemoved: removed, deletedRuntimesRetained: retained };
+}
+
+/**
+ * Handle the sandbox of a deleted conversation. A confirmed kill is enough; a
+ * failed kill is delegated to the orphan ledger so the orphan sweep retries it,
+ * which also lets the runtime pointer be cleared ("kill succeeds or records
+ * retry state"). Only a failure to even record the orphan leaves the sandbox
+ * unhandled, keeping the runtime row for a full retry.
+ */
+async function handleDeletedSandbox(
+	options: CleanupPassOptions,
+	sandboxId: string,
+	owner: { userId: string; conversationId: string; workerId: string },
+): Promise<boolean> {
+	const { db, janitor, logger } = options;
+	try {
+		await janitor.killSandbox(sandboxId);
+		return true;
+	} catch (killError) {
+		try {
+			await db
+				.insert(orphanSandboxes)
+				.values({
+					sandboxId,
+					userId: owner.userId,
+					conversationId: owner.conversationId,
+					runId: CLEANUP_RUN_ID,
+					createdByWorkerId: owner.workerId,
+					reason: "conversation deleted; kill failed during cleanup",
+				})
+				.onConflictDoNothing();
+			logger.warn({
+				message: "deleted-conversation sandbox kill failed; recorded as orphan",
+				sandboxId,
+				conversationId: owner.conversationId,
+				error: toMessage(killError),
+			});
+			return true;
+		} catch (recordError) {
+			logger.error({
+				message:
+					"deleted-conversation sandbox neither killed nor recorded; retaining row",
+				sandboxId,
+				conversationId: owner.conversationId,
+				error: toMessage(recordError),
+			});
+			return false;
+		}
+	}
+}
+
+/** Sentinel `run_id` for orphan rows recorded by cleanup (there is no run). */
+const CLEANUP_RUN_ID = "cleanup";
+
+/** Sandbox ids named as the current pointer by any runtime row. */
+async function referencedSandboxIds(db: Database): Promise<Set<string>> {
+	const rows = await db
+		.select({ sandboxId: conversationRuntime.sandboxId })
+		.from(conversationRuntime)
+		.where(isNotNull(conversationRuntime.sandboxId));
+	return toIdSet(rows.map((r) => r.sandboxId));
+}
+
+/**
+ * Snapshot ids that are still a live restore path: any conversation's `latest`,
+ * or a `previous` not yet past retention. A candidate matching one of these is
+ * never deleted.
+ */
+async function protectedSnapshotIds(
+	db: Database,
+	cutoff: Date,
+): Promise<Set<string>> {
+	const latest = await db
+		.select({ id: conversationRuntime.latestSnapshotId })
+		.from(conversationRuntime)
+		.where(isNotNull(conversationRuntime.latestSnapshotId));
+	const unexpiredPrevious = await db
+		.select({ id: conversationRuntime.previousSnapshotId })
+		.from(conversationRuntime)
+		.where(
+			and(
+				isNotNull(conversationRuntime.previousSnapshotId),
+				gte(conversationRuntime.updatedAt, cutoff),
+			),
+		);
+	return toIdSet([...latest, ...unexpiredPrevious].map((r) => r.id));
+}
+
+/** Snapshot ids (latest or previous) referenced by a still-existing conversation. */
+async function liveReferencedSnapshotIds(db: Database): Promise<Set<string>> {
+	const rows = await db
+		.select({
+			latest: conversationRuntime.latestSnapshotId,
+			previous: conversationRuntime.previousSnapshotId,
+		})
+		.from(conversationRuntime)
+		.innerJoin(
+			conversations,
+			and(
+				eq(conversations.userId, conversationRuntime.userId),
+				eq(conversations.conversationId, conversationRuntime.conversationId),
+			),
+		);
+	return toIdSet(rows.flatMap((r) => [r.latest, r.previous]));
+}
+
+function toIdSet(ids: Array<string | null>): Set<string> {
+	const set = new Set<string>();
+	for (const id of ids) if (id !== null) set.add(id);
+	return set;
+}
+
+function toMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/apps/agent-worker/src/cleanup/e2b-janitor.ts
+++ b/apps/agent-worker/src/cleanup/e2b-janitor.ts
@@ -1,0 +1,22 @@
+import { Sandbox } from "e2b";
+import type { SandboxJanitor } from "./cleanup";
+
+/**
+ * The concrete {@link SandboxJanitor} over the real E2B SDK — the worker's only
+ * live E2B access for cleanup, injected at the entrypoint so the cleanup logic
+ * stays unit-testable against a fake (see cleanup.test.ts). Both static calls
+ * return `false` (they do not throw) when the resource is already gone, so a
+ * not-found reconciles as success; only a real transport/auth failure rejects,
+ * which the sweeps catch and leave for the next pass to retry.
+ */
+export function createE2bSandboxJanitor(apiKey: string): SandboxJanitor {
+	const opts = { apiKey };
+	return {
+		async killSandbox(sandboxId: string): Promise<void> {
+			await Sandbox.kill(sandboxId, opts);
+		},
+		async deleteSnapshot(snapshotId: string): Promise<void> {
+			await Sandbox.deleteSnapshot(snapshotId, opts);
+		},
+	};
+}

--- a/apps/agent-worker/src/config/env.test.ts
+++ b/apps/agent-worker/src/config/env.test.ts
@@ -96,6 +96,31 @@ describe("loadWorkerConfigFromEnv — concurrency and intervals", () => {
 	});
 });
 
+describe("loadWorkerConfigFromEnv — cleanup loop", () => {
+	it("defaults the cleanup interval and a multi-day snapshot retention", () => {
+		const config = loadWorkerConfigFromEnv(baseEnv());
+		expect(config.cleanup.intervalMs).toBe(300_000);
+		expect(config.cleanup.snapshotRetentionMs).toBe(604_800_000);
+	});
+
+	it("honors cleanup overrides", () => {
+		const env = baseEnv();
+		env.WORKER_CLEANUP_INTERVAL_MS = "120000";
+		env.WORKER_SNAPSHOT_RETENTION_MS = "86400000";
+		const config = loadWorkerConfigFromEnv(env);
+		expect(config.cleanup.intervalMs).toBe(120_000);
+		expect(config.cleanup.snapshotRetentionMs).toBe(86_400_000);
+	});
+
+	it("rejects a non-positive cleanup interval override", () => {
+		const env = baseEnv();
+		env.WORKER_CLEANUP_INTERVAL_MS = "0";
+		expect(() => loadWorkerConfigFromEnv(env)).toThrow(
+			/WORKER_CLEANUP_INTERVAL_MS/,
+		);
+	});
+});
+
 describe("loadWorkerConfigFromEnv — LoadDocuments caps", () => {
 	it("defaults the document-load caps", () => {
 		const config = loadWorkerConfigFromEnv(baseEnv());

--- a/apps/agent-worker/src/config/env.ts
+++ b/apps/agent-worker/src/config/env.ts
@@ -50,6 +50,17 @@ export interface WorkerConfig {
 	heartbeatIntervalMs: number;
 	/** Grace period to drain active runs on shutdown before forcing exit (ms). */
 	shutdownTimeoutMs: number;
+	/** Worker-embedded orphan/snapshot cleanup loop (Task 8.1). */
+	cleanup: {
+		/** How often the single-flighted cleanup pass is attempted (ms). */
+		intervalMs: number;
+		/**
+		 * Idle window before a conversation's superseded snapshot is deleted (ms).
+		 * The spike's retention decision is days, not minutes: resume-from-paused
+		 * is cheap, so there is no rush to reclaim a rollback snapshot.
+		 */
+		snapshotRetentionMs: number;
+	};
 	/** pino log level. */
 	logLevel: string;
 	/** Port the health endpoint listens on. */
@@ -65,6 +76,8 @@ const DEFAULT_DOCUMENT_LOAD_PER_DOCUMENT_MAX_BYTES = 262_144;
 const DEFAULT_DOCUMENT_LOAD_PER_CALL_MAX_BYTES = 1_048_576;
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 15_000;
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 30_000;
+const DEFAULT_CLEANUP_INTERVAL_MS = 300_000; // 5 minutes
+const DEFAULT_SNAPSHOT_RETENTION_MS = 604_800_000; // 7 days
 const DEFAULT_PORT = 8080;
 
 /** Append `sslmode=require` unless TLS is disabled or the URL already sets it. */
@@ -166,6 +179,18 @@ export function loadWorkerConfigFromEnv(env: Env): WorkerConfig {
 			DEFAULT_SHUTDOWN_TIMEOUT_MS,
 			"WORKER_SHUTDOWN_TIMEOUT_MS",
 		),
+		cleanup: {
+			intervalMs: positiveIntOr(
+				env.WORKER_CLEANUP_INTERVAL_MS,
+				DEFAULT_CLEANUP_INTERVAL_MS,
+				"WORKER_CLEANUP_INTERVAL_MS",
+			),
+			snapshotRetentionMs: positiveIntOr(
+				env.WORKER_SNAPSHOT_RETENTION_MS,
+				DEFAULT_SNAPSHOT_RETENTION_MS,
+				"WORKER_SNAPSHOT_RETENTION_MS",
+			),
+		},
 		logLevel: env.LOG_LEVEL || "info",
 		port: positiveIntOr(env.PORT, DEFAULT_PORT, "PORT"),
 	};

--- a/apps/agent-worker/src/index.ts
+++ b/apps/agent-worker/src/index.ts
@@ -1,4 +1,7 @@
 import { createDatabase } from "@mymemo/agent-db/client";
+import type { AdvisoryLockPool } from "./cleanup/advisory-lock";
+import { CleanupLoop } from "./cleanup/cleanup-loop";
+import { createE2bSandboxJanitor } from "./cleanup/e2b-janitor";
 import { loadWorkerConfigFromEnv } from "./config/env";
 import { startHealthServer } from "./health";
 import { createLogger } from "./logger";
@@ -30,9 +33,24 @@ const runLoop = new RunLoop({
 	heartbeatIntervalMs: config.heartbeatIntervalMs,
 	logger,
 });
+// Worker-embedded orphan/snapshot cleanup (Task 8.1). Single-flighted across
+// replicas by a Postgres advisory lock taken on a dedicated connection from
+// Drizzle's underlying pg pool (`db.$client`). The pass only calls E2B once
+// real orphans/snapshots exist, so it is a no-op until the executor path is
+// creating sandboxes.
+const cleanupLoop = new CleanupLoop({
+	db,
+	pool: db.$client as unknown as AdvisoryLockPool,
+	janitor: createE2bSandboxJanitor(config.e2bApiKey),
+	workerId,
+	config: { snapshotRetentionMs: config.cleanup.snapshotRetentionMs },
+	intervalMs: config.cleanup.intervalMs,
+	logger,
+});
 const server = startHealthServer(worker, config.port, logger);
 
 runLoop.start();
+cleanupLoop.start();
 
 logger.info({
 	message: "agent-worker started",
@@ -46,6 +64,7 @@ async function handleShutdownSignal(signal: NodeJS.Signals): Promise<void> {
 	if (shuttingDown) return;
 	shuttingDown = true;
 	logger.info({ message: "Received shutdown signal", signal, workerId });
+	cleanupLoop.stop();
 	await runLoop.stop();
 	server.stop();
 	logger.info({ message: "agent-worker stopped", workerId });

--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
       "dependencies": {
         "@mymemo/agent-db": "workspace:*",
         "drizzle-orm": "^0.45.2",
+        "e2b": "^2.14.0",
         "pg": "^8.22.0",
         "pino": "^9.14.0",
       },
@@ -24,7 +25,6 @@
         "@electric-sql/pglite": "^0.5.3",
         "@types/bun": "^1.3.11",
         "@types/pg": "^8.20.0",
-        "e2b": "^2.14.0",
       },
     },
     "apps/chat-api": {


### PR DESCRIPTION
Closes #192 — Task 8.1 of `docs/split-runtime-fargate-e2b-implementation-plan.md`.

## What & why

Runtime hygiene for external E2B resources Postgres cannot delete transactionally: a **worker-embedded cleanup loop**, single-flighted across replicas by a Postgres advisory lock (no separate scheduled job, per the plan's Deployment Shape). It reconciles the DB — the source of truth for what is *referenced* — against an injected `SandboxJanitor` E2B port, obeying one rule everywhere: **never kill a sandbox or snapshot still referenced by `conversation_runtime`**.

Three sweeps, each row/sweep isolated so a failure retries on the next pass and never blocks unrelated user runs:

- **Orphan sandboxes** — kill `orphan_sandboxes` ledger entries not referenced by any `conversation_runtime.sandbox_id`; a confirmed kill drops the ledger row, a failure retries. A referenced entry is left untouched.
- **Unreferenced snapshots** — delete a conversation's superseded (`previous`) snapshot once it has been idle past the retention window, keeping `latest` (the live restore path). A candidate still referenced as any conversation's `latest` (or an unexpired `previous`) is protected — guarding E2B's repeating `templateId:tag` ids from cross-conversation deletion. The column is cleared with a compare-and-set so a concurrent run's fresh rotation is never clobbered.
- **Deleted conversations** — kill sandbox + delete snapshots for runtime rows whose conversation no longer exists, removing the row (and its pointers) only after the kill succeeds **or** the sandbox is recorded in the orphan ledger for retry.

## Acceptance criteria (all covered by tests)

- [x] orphan sandbox cleanup never kills the currently referenced sandbox
- [x] cleanup retries failures
- [x] old unreferenced snapshots become eligible after retention
- [x] conversation deletion clears runtime sandbox pointers only after kill succeeds or records retry state
- [x] cleanup failures do not block unrelated user runs

## Design notes for reviewers

- The cleanup logic reconciles the DB against an injected `SandboxJanitor` port, so it is unit-tested against PGlite + a fake (20 new tests). `createE2bSandboxJanitor` is the thin live adapter over the SDK's static `Sandbox.kill`/`deleteSnapshot` (both return `false` — no throw — on an already-gone resource, matching the idempotent contract).
- The loop **is wired into the worker entrypoint** and single-flighted via `pg_try_advisory_lock` on a dedicated pooled connection (`db.$client`). It makes zero E2B calls until real orphans/snapshots exist, so it is a safe no-op until the executor path is creating sandboxes. `e2b` is promoted to a runtime dependency for the adapter.
- **Ambiguity call:** the schema has no snapshot ledger (only `latest_snapshot_id`/`previous_snapshot_id` on `conversation_runtime`), so "old unreferenced snapshots" is operationalized as *a conversation's superseded `previous` snapshot, aged out by `updated_at` idle time*. If a tracked ledger of every rotated-out snapshot was intended, that's the piece to revisit.

## Config

- `WORKER_CLEANUP_INTERVAL_MS` (default `300000`, 5m)
- `WORKER_SNAPSHOT_RETENTION_MS` (default `604800000`, 7d)

## Testing

- Worker `tsc --noEmit` clean.
- Full workspace suite green: `bun run test` — 147 agent-worker tests (incl. 20 new cleanup tests); the 4 skips are the pre-existing live-E2B tests.
- Reviewed via `/code-review` (Standards + Spec axes) before finalizing; the Standards axis's one blocking finding (loop not started) is resolved by the entrypoint wiring above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)