### PR TITLE
Fix flaky pglite test OOM: unpin closed handles + share one instance per file

### DIFF
--- a/apps/agent-worker/src/cleanup/cleanup-loop.test.ts
+++ b/apps/agent-worker/src/cleanup/cleanup-loop.test.ts
@@ -1,4 +1,11 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+} from "bun:test";
 import { orphanSandboxes } from "@mymemo/agent-db/schema";
 import { createTestDatabase, type TestDb } from "@mymemo/agent-db/testing";
 import type { WorkerLogger } from "../logger";
@@ -39,8 +46,18 @@ class FakePool implements AdvisoryLockPool {
 let tdb: TestDb;
 let janitor: FakeJanitor;
 
-beforeEach(async () => {
+// One PGlite instance for the whole file (spin-up is the slow part); each test
+// starts from a single fresh orphan row via delete + re-seed.
+beforeAll(async () => {
 	tdb = await createTestDatabase();
+});
+
+afterAll(async () => {
+	await tdb.close();
+});
+
+beforeEach(async () => {
+	await tdb.db.delete(orphanSandboxes);
 	janitor = new FakeJanitor();
 	await tdb.db.insert(orphanSandboxes).values({
 		sandboxId: "sbx-orphan",
@@ -50,10 +67,6 @@ beforeEach(async () => {
 		createdByWorkerId: "worker-old",
 		reason: "test",
 	});
-});
-
-afterEach(async () => {
-	await tdb.close();
 });
 
 function buildLoop(pool: AdvisoryLockPool) {

--- a/apps/agent-worker/src/run-loop.test.ts
+++ b/apps/agent-worker/src/run-loop.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
 import {
 	appendRunEventTx,
 	claimNextRunTx,
@@ -11,7 +11,7 @@ import {
 	loadConversationRuntimeTx,
 	updateRuntimeSandboxTx,
 } from "@mymemo/agent-db/runtime-store";
-import { runEvents, runs } from "@mymemo/agent-db/schema";
+import { conversationRuntime, runEvents, runs } from "@mymemo/agent-db/schema";
 import { createTestDatabase, type TestDb } from "@mymemo/agent-db/testing";
 import { eq, sql } from "drizzle-orm";
 import type { WorkerLogger } from "./logger";
@@ -23,12 +23,19 @@ const silentLogger: WorkerLogger = { info() {}, warn() {}, error() {} };
 
 let tdb: TestDb;
 
-beforeEach(async () => {
+// One PGlite instance for the whole file (spin-up is the slow part); each test
+// starts from empty tables via delete, keeping isolation without the cost.
+beforeAll(async () => {
 	tdb = await createTestDatabase();
 });
 
-afterEach(async () => {
+afterAll(async () => {
 	await tdb.close();
+});
+
+afterEach(async () => {
+	await tdb.db.delete(runs); // cascades run_events
+	await tdb.db.delete(conversationRuntime);
 });
 
 /** A promise whose resolution the test controls, to gate a processor. */

--- a/apps/agent-worker/src/sdk/run-processor.test.ts
+++ b/apps/agent-worker/src/sdk/run-processor.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
 import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 import { createQueuedRunTx } from "@mymemo/agent-db/run-store";
 import { runEvents, runs } from "@mymemo/agent-db/schema";
@@ -14,12 +14,18 @@ const silentLogger: WorkerLogger = { info() {}, warn() {}, error() {} };
 
 let tdb: TestDb;
 
-beforeEach(async () => {
+// One PGlite instance for the whole file (spin-up is the slow part); each test
+// starts from empty tables via delete, keeping isolation without the cost.
+beforeAll(async () => {
 	tdb = await createTestDatabase();
 });
 
-afterEach(async () => {
+afterAll(async () => {
 	await tdb.close();
+});
+
+afterEach(async () => {
+	await tdb.db.delete(runs); // cascades run_events
 });
 
 function assistantMessage(text: string): SDKMessage {

--- a/apps/agent-worker/src/sdk/session-store.test.ts
+++ b/apps/agent-worker/src/sdk/session-store.test.ts
@@ -1,9 +1,10 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
 import type {
 	SessionKey,
 	SessionStoreEntry,
 } from "@anthropic-ai/claude-agent-sdk";
 import type { ConversationRuntimeRecord } from "@mymemo/agent-db/runtime-store";
+import { agentSessions } from "@mymemo/agent-db/schema";
 import { createTestDatabase, type TestDb } from "@mymemo/agent-db/testing";
 import {
 	buildAgentSessionQueryConfig,
@@ -13,12 +14,19 @@ import {
 
 let tdb: TestDb;
 
-beforeEach(async () => {
+// One PGlite instance for the whole file (spin-up is the slow part); each test
+// starts from empty tables via delete, keeping isolation without the cost — the
+// agent_sessions dedup index would otherwise swallow the reused conv/session ids.
+beforeAll(async () => {
 	tdb = await createTestDatabase();
 });
 
-afterEach(async () => {
+afterAll(async () => {
 	await tdb.close();
+});
+
+afterEach(async () => {
+	await tdb.db.delete(agentSessions);
 });
 
 /** A main-transcript key for `conv-1`. projectKey is deliberately arbitrary —

--- a/apps/agent-worker/src/snapshot-barrier.test.ts
+++ b/apps/agent-worker/src/snapshot-barrier.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
 import { claimNextRunTx, createQueuedRunTx } from "@mymemo/agent-db/run-store";
 import {
 	createConversationRuntimeTx,
@@ -7,7 +7,7 @@ import {
 	type RunOwnershipRef,
 	updateRuntimeSandboxTx,
 } from "@mymemo/agent-db/runtime-store";
-import { runs } from "@mymemo/agent-db/schema";
+import { conversationRuntime, runs } from "@mymemo/agent-db/schema";
 import { createTestDatabase, type TestDb } from "@mymemo/agent-db/testing";
 import { eq, sql } from "drizzle-orm";
 import type { WorkerLogger } from "./logger";
@@ -21,12 +21,19 @@ const silentLogger: WorkerLogger = { info() {}, warn() {}, error() {} };
 
 let tdb: TestDb;
 
-beforeEach(async () => {
+// One PGlite instance for the whole file (spin-up is the slow part); each test
+// starts from empty tables via delete, keeping isolation without the cost.
+beforeAll(async () => {
 	tdb = await createTestDatabase();
 });
 
-afterEach(async () => {
+afterAll(async () => {
 	await tdb.close();
+});
+
+afterEach(async () => {
+	await tdb.db.delete(runs);
+	await tdb.db.delete(conversationRuntime);
 });
 
 const OWNER: RunOwnershipRef = {

--- a/apps/chat-api/src/features/conversation-store/postgres-conversation-store.test.ts
+++ b/apps/chat-api/src/features/conversation-store/postgres-conversation-store.test.ts
@@ -1,5 +1,6 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { createTestDatabase } from "@/db/testing";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { conversations } from "@/db/schema";
+import { createTestDatabase, type TestDb } from "@/db/testing";
 import type { ConversationRecord } from "./conversation-store";
 import { PostgresConversationStore } from "./postgres-conversation-store";
 
@@ -12,16 +13,22 @@ const collectionConversation: ConversationRecord = {
 };
 
 describe("PostgresConversationStore", () => {
+	let tdb: TestDb;
 	let store: PostgresConversationStore;
-	let close: () => Promise<void>;
 
-	beforeEach(async () => {
-		const tdb = await createTestDatabase();
-		close = tdb.close;
+	// One PGlite instance for the whole file (spin-up is the slow part); each test
+	// starts from an empty conversations table via delete, keeping isolation
+	// without the cost.
+	beforeAll(async () => {
+		tdb = await createTestDatabase();
 		store = new PostgresConversationStore(tdb.db);
 	});
 
-	afterEach(() => close());
+	afterAll(() => tdb.close());
+
+	afterEach(async () => {
+		await tdb.db.delete(conversations);
+	});
 
 	it("get returns null when the conversation does not exist", async () => {
 		expect(

--- a/apps/chat-api/src/features/run-events/run-event-reader.test.ts
+++ b/apps/chat-api/src/features/run-events/run-event-reader.test.ts
@@ -1,7 +1,14 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+} from "bun:test";
 import type { Database } from "@/db/client";
 import { runEvents, runs } from "@/db/schema";
-import { createTestDatabase } from "@/db/testing";
+import { createTestDatabase, type TestDb } from "@/db/testing";
 import { DrizzleRunEventReader } from "./run-event-reader";
 
 async function seedRun(db: Database, runId: string, conversationId = "conv-1") {
@@ -24,19 +31,24 @@ async function appendEvent(
 }
 
 describe("DrizzleRunEventReader", () => {
+	let tdb: TestDb;
 	let db: Database;
-	let close: () => Promise<void>;
 	let reader: DrizzleRunEventReader;
 
-	beforeEach(async () => {
-		const tdb = await createTestDatabase();
+	// One PGlite instance for the whole file (spin-up is the slow part); each
+	// test starts from empty tables via delete, keeping isolation without the cost.
+	beforeAll(async () => {
+		tdb = await createTestDatabase();
 		db = tdb.db;
-		close = tdb.close;
 		reader = new DrizzleRunEventReader(db);
-		await seedRun(db, "run-1");
 	});
 
-	afterEach(() => close());
+	afterAll(() => tdb.close());
+
+	beforeEach(async () => {
+		await db.delete(runs); // cascades run_events
+		await seedRun(db, "run-1");
+	});
 
 	it("returns events with seq greater than the cursor, ordered by seq", async () => {
 		await appendEvent(db, "run-1", 2, "assistant_text", { text: "b" });

--- a/apps/chat-api/src/features/run-store/postgres-run-store.test.ts
+++ b/apps/chat-api/src/features/run-store/postgres-run-store.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
 import { eq } from "drizzle-orm";
 import { conversations, runEvents, runs } from "@/db/schema";
 import { createTestDatabase, type TestDb } from "@/db/testing";
@@ -17,13 +17,20 @@ describe("PostgresRunStore", () => {
 	let tdb: TestDb;
 	let store: PostgresRunStore;
 
-	beforeEach(async () => {
+	// One PGlite instance for the whole file (spin-up is the slow part); each
+	// test starts from an empty runs table via delete, keeping isolation without
+	// the cost. The conversation seed is stable, so it is inserted once.
+	beforeAll(async () => {
 		tdb = await createTestDatabase();
 		store = new PostgresRunStore(tdb.db);
 		await tdb.db.insert(conversations).values(conversation);
 	});
 
-	afterEach(() => tdb.close());
+	afterAll(() => tdb.close());
+
+	afterEach(async () => {
+		await tdb.db.delete(runs); // cascades run_events; keeps the conversation seed
+	});
 
 	it("creates one queued run and records run_started transactionally", async () => {
 		const result = await store.createQueuedRun({

--- a/packages/agent-db/src/testing.ts
+++ b/packages/agent-db/src/testing.ts
@@ -38,6 +38,17 @@ export async function createTestDatabase(): Promise<TestDb> {
 	}
 	return {
 		db: drizzle(client, { schema }) as unknown as Database,
-		close: () => client.close(),
+		close: async () => {
+			await client.close();
+			// pglite holds its Postgres heap in WASM linear memory that `close()`
+			// releases only for the WASM instance — the ~1GB backing ArrayBuffer is
+			// reclaimed lazily by the JS GC. A suite that spins up one instance per
+			// test leaves those closed corpses uncollected, so peak memory climbs
+			// until a later `new PGlite()` cannot allocate and fails to initialize
+			// (a flaky, GC-timing-dependent CI OOM). Forcing a collection here caps
+			// peak at a single live instance; it costs ~17ms next to pglite's ~1.5s
+			// spin-up, so it is free relative to the test it guards.
+			if (typeof Bun !== "undefined") Bun.gc(true);
+		},
 	};
 }

--- a/packages/agent-db/src/testing.ts
+++ b/packages/agent-db/src/testing.ts
@@ -39,16 +39,24 @@ export async function createTestDatabase(): Promise<TestDb> {
 	return {
 		db: drizzle(client, { schema }) as unknown as Database,
 		close: async () => {
-			await client.close();
-			// pglite holds its Postgres heap in WASM linear memory that `close()`
-			// releases only for the WASM instance — the ~1GB backing ArrayBuffer is
-			// reclaimed lazily by the JS GC. A suite that spins up one instance per
-			// test leaves those closed corpses uncollected, so peak memory climbs
-			// until a later `new PGlite()` cannot allocate and fails to initialize
-			// (a flaky, GC-timing-dependent CI OOM). Forcing a collection here caps
-			// peak at a single live instance; it costs ~17ms next to pglite's ~1.5s
-			// spin-up, so it is free relative to the test it guards.
-			if (typeof Bun !== "undefined") Bun.gc(true);
+			try {
+				await client.close();
+			} finally {
+				// pglite's close() shuts Postgres down but keeps the Emscripten
+				// module — and its ~1GB WASM linear memory — referenced via
+				// `client.mod`. Test files hold their handle in a module-level
+				// `let tdb` that lives for the whole `bun test` process, so each
+				// closed-but-referenced instance stays pinned (~465MB, GC-immune)
+				// and peak memory climbs one corpse per pglite file until a later
+				// `new PGlite()` cannot allocate and fails to initialize — the flaky
+				// CI OOM. Dropping `client.mod` unpins the WASM memory even while the
+				// handle is referenced; the forced GC then reclaims it deterministically
+				// (measured: pinned arrayBuffers 2.3GB -> 0 with the null, unchanged
+				// without it). Runs in `finally` so it still fires if close() throws
+				// (e.g. a double-close raising "PGlite is closed").
+				(client as { mod?: unknown }).mod = undefined;
+				if (typeof Bun !== "undefined") Bun.gc(true);
+			}
 		},
 	};
 }


### PR DESCRIPTION
## Problem

CI's `test` job flakes on `error: PGlite failed to initialize properly` in the agent-worker suite (first seen on `main` at the merge of #219, [run 28836873425](https://github.com/X-GPT/mymemo-agent/actions/runs/28836873425)). Same commit passed on its PR branch — resource-dependent.

## Root cause (re-evaluated)

The test harness spins up a fresh in-process pglite (WASM Postgres) per test. `PGlite.close()` shuts Postgres down but keeps the Emscripten module — and its ~1 GB WASM linear memory — referenced via `client.mod`. Every test file holds its handle in a **module-level `let tdb`** that lives for the whole `bun test` process, so each closed instance stays **pinned and GC-immune** (~465 MB each), accumulating **one corpse per pglite test file**. #219 added one more pglite file and tipped `main` over the runner's threshold.

An earlier revision of this PR forced `Bun.gc(true)` in `close()`. That was **placebo**: a controlled A/B (the real suite in memory-capped containers, GC line present vs removed) died at the same test at every pressure level, because GC cannot free objects the test files still reference. Verified locally — the pinned handles survive GC:

```
5 closed handles, still referenced, after Bun.gc(true):  2263 MB   (without mod-null)
                                                            0 MB   (dropping client.mod)
```

## Fix

Two changes, each attacking one memory term:

1. **Harness (`packages/agent-db/src/testing.ts`)** — `close()` drops `client.mod` so the WASM memory becomes collectable *even while the handle is referenced*, then GCs it. `finally`-guarded so it still fires if `close()` throws (the exact CI failure path, where a double-close raises `"PGlite is closed"`). This protects every consumer, including future `beforeEach`-pattern files.
2. **Convert 8 per-test `beforeEach` files** (5 agent-worker, 3 chat-api) to one `beforeAll` pglite + per-test table reset — the in-repo `cleanup.test.ts` pattern. Cuts instances created per process **45 → 6** (agent-worker) and **16 → 5** (chat-api), removing per-test spin-up churn.

## Results (measured on one machine, agent-worker suite)

| | Peak RSS | Wall time |
|---|---|---|
| Before (placebo GC, 45 instances) | 4038 MB | 88.7 s |
| After (unpin + share-per-file) | **1780 MB** | **12.9 s** |

Full repo test suite green (`✓ All workspace tests passed`); Biome clean. Peak memory down ~56%, suite ~7× faster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)