### PR TITLE
Bump actions/checkout to v7 in release-deploy workflow

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -33,7 +33,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Load deploy config
         run: |


### PR DESCRIPTION
## What

Update `actions/checkout` from `@v4` to `@v7` in `.github/workflows/release-deploy.yml`.

## Why

The CI workflow (`.github/workflows/ci.yml`) already pins `actions/checkout@v7`, but `release-deploy.yml` lagged behind at `@v4`. This brings both workflows onto the current latest release (v7.0.0), so the checkout action version is consistent across the repo.

## Notes for reviewer

- Single-line change; no behavioral difference expected for the deploy job.
- All `actions/checkout` references in the repo are now on `v7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)