### PR TITLE
Fix RDS TLS failure in deploy: use sslmode=no-verify

### DIFF
--- a/apps/agent-worker/src/config/env.ts
+++ b/apps/agent-worker/src/config/env.ts
@@ -80,10 +80,18 @@ const DEFAULT_CLEANUP_INTERVAL_MS = 300_000; // 5 minutes
 const DEFAULT_SNAPSHOT_RETENTION_MS = 604_800_000; // 7 days
 const DEFAULT_PORT = 8080;
 
-/** Append `sslmode=require` unless TLS is disabled or the URL already sets it. */
+/**
+ * Append `sslmode=no-verify` unless TLS is disabled or the URL already sets it.
+ * We want the connection encrypted but not CA-verified: RDS presents the Amazon
+ * RDS CA, which is not in Node's default trust store. node-postgres's
+ * pg-connection-string aliases `sslmode=require` to `verify-full` (strict
+ * CA-chain verification), so `require` fails with SELF_SIGNED_CERT_IN_CHAIN;
+ * `no-verify` maps to `rejectUnauthorized: false`. Do not change back to
+ * `require` without also shipping the RDS CA bundle (e.g. NODE_EXTRA_CA_CERTS).
+ */
 function withSsl(url: string, enabled: boolean): string {
 	if (!enabled || /[?&]sslmode=/.test(url)) return url;
-	return `${url}${url.includes("?") ? "&" : "?"}sslmode=require`;
+	return `${url}${url.includes("?") ? "&" : "?"}sslmode=no-verify`;
 }
 
 /**

--- a/apps/chat-api/src/config/env.ts
+++ b/apps/chat-api/src/config/env.ts
@@ -65,10 +65,18 @@ function withPassword(url: string, password: string | undefined): string {
 	return `${scheme}${userinfo}:${encodeURIComponent(password)}@${rest}`;
 }
 
-/** Append `sslmode=require` unless TLS is disabled or the URL already sets it. */
+/**
+ * Append `sslmode=no-verify` unless TLS is disabled or the URL already sets it.
+ * We want the connection encrypted but not CA-verified: RDS presents the Amazon
+ * RDS CA, which is not in Node's default trust store. node-postgres's
+ * pg-connection-string aliases `sslmode=require` to `verify-full` (strict
+ * CA-chain verification), so `require` fails with SELF_SIGNED_CERT_IN_CHAIN;
+ * `no-verify` maps to `rejectUnauthorized: false`. Do not change back to
+ * `require` without also shipping the RDS CA bundle (e.g. NODE_EXTRA_CA_CERTS).
+ */
 function withSsl(url: string, enabled: boolean): string {
 	if (!enabled || /[?&]sslmode=/.test(url)) return url;
-	return `${url}${url.includes("?") ? "&" : "?"}sslmode=require`;
+	return `${url}${url.includes("?") ? "&" : "?"}sslmode=no-verify`;
 }
 
 /**

--- a/apps/worker-scaler/src/config.ts
+++ b/apps/worker-scaler/src/config.ts
@@ -21,9 +21,18 @@ const DEFAULT_MIN_TASKS = 1;
 const DEFAULT_TARGET_CONCURRENT_RUNS_PER_TASK = 2;
 const DEFAULT_SCALE_IN_COOLDOWN_MS = 10 * 60 * 1000;
 
+/**
+ * Append `sslmode=no-verify` unless TLS is disabled or the URL already sets it.
+ * We want the connection encrypted but not CA-verified: RDS presents the Amazon
+ * RDS CA, which is not in Node's default trust store. node-postgres's
+ * pg-connection-string aliases `sslmode=require` to `verify-full` (strict
+ * CA-chain verification), so `require` fails with SELF_SIGNED_CERT_IN_CHAIN;
+ * `no-verify` maps to `rejectUnauthorized: false`. Do not change back to
+ * `require` without also shipping the RDS CA bundle (e.g. NODE_EXTRA_CA_CERTS).
+ */
 function withSsl(url: string, enabled: boolean): string {
 	if (!enabled || /[?&]sslmode=/.test(url)) return url;
-	return `${url}${url.includes("?") ? "&" : "?"}sslmode=require`;
+	return `${url}${url.includes("?") ? "&" : "?"}sslmode=no-verify`;
 }
 
 function withPassword(url: string, password: string | undefined): string {


### PR DESCRIPTION
## What

Change the DB connection SSL policy from `sslmode=require` to `sslmode=no-verify` in all three services that connect to the writable RDS via node-postgres:

- `apps/chat-api/src/config/env.ts` — used by the failing `bun run db:migrate` task
- `apps/agent-worker/src/config/env.ts`
- `apps/worker-scaler/src/config.ts`

## Why

The **Release deploy** workflow fails at **Run agent DB migrations** ([run 28867390259](https://github.com/X-GPT/mymemo-agent/actions/runs/28867390259)). The GitHub log only surfaces `Essential container in task exited (exit code 1)`; the real error is in the container's CloudWatch stream:

```
error: Failed query: CREATE SCHEMA IF NOT EXISTS "drizzle"
error: self signed certificate in certificate chain
code: "SELF_SIGNED_CERT_IN_CHAIN"
```

It dies on the **first connection**, before any migration runs — so this is not the new `agent_sessions` (`0002`) migration.

**Root cause:** commit `e7c8fd1` (Jul 5, *"swap Drizzle to node-postgres"*) introduced `pg` / `pg-connection-string@2.14.0` for the first time. That version aliases `sslmode=require` to `verify-full` (strict CA-chain verification), logged at runtime as:

> `SECURITY WARNING: The SSL modes 'prefer', 'require', and 'verify-ca' are treated as aliases for 'verify-full'.`

RDS presents the Amazon RDS CA, which isn't in Node's default trust store → `SELF_SIGNED_CERT_IN_CHAIN`. The previous driver treated `require` as "encrypt, don't verify," which is why deploys were green through Jul 2 and began failing Jul 6/7.

Verified against the library source: `sslmode=require` keeps `rejectUnauthorized: true`, whereas `sslmode=no-verify` sets `rejectUnauthorized: false`. `packages/agent-db/src/client.ts` already documented this exact hazard and named `sslmode=no-verify` as the remedy.

## Blast radius

chat-api, agent-worker, and worker-scaler all share the same `withSsl` → `sslmode=require` code path against the same RDS. The deploy trips at the migration step first, but the rolled service tasks would have failed identically. All three are fixed here.

## Notes for the reviewer

- The image tag is content-derived, so this must be merged and **Release deploy re-run** to build a chat-api image carrying the fix (the migration task pulls `var.chat_api_image`).
- Each `withSsl` gained a doc comment explaining why `require` is wrong here, to prevent a well-meaning revert.
- **Not done (surgical scope):** `withSsl`/`withPassword` are now triplicated across three services — worth consolidating into `@mymemo/agent-db` later; that duplication is why one policy change touched three files.
- **Hardening alternative not taken:** keep `verify-full` and ship the [Amazon RDS global CA](https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem) via `NODE_EXTRA_CA_CERTS`.

## Testing

- `bun test` on the three config suites: 40 pass, 0 fail (they run with `DB_SSL=disable`, so none asserted the appended value).
- Biome check clean on the three files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)