### PR TITLE
Design docs: wire the real Claude Agent SDK (ADRs 0006-0008, plan M9)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -49,6 +49,14 @@ An indexed chunk of a document — the search and citation unit. A passage
 points at its document.
 _Avoid_: chunk, excerpt
 
+**Workspace**:
+The conversation's sandbox filesystem (E2B `/home/user`) where the model's
+file and shell tools act. It *is* the paused E2B sandbox between turns —
+persistence is best-effort: reconnect restores it, but a lost sandbox starts
+the next turn empty. Not the Fargate query cwd (that is only a stable
+projectKey anchor), and not durable like the agent session.
+_Avoid_: sandbox (that is the runtime; the workspace is its filesystem)
+
 **Docs cache**:
 The reserved directory in a conversation's sandbox workspace where loaded
 document content is materialized. Reconstructible from the KB, persists

--- a/docs/adr/0006-wire-real-sdk-fail-closed-tool-boundary.md
+++ b/docs/adr/0006-wire-real-sdk-fail-closed-tool-boundary.md
@@ -1,0 +1,75 @@
+# Wire the real Claude Agent SDK behind a fail-closed tool boundary
+
+Status: accepted
+
+Milestone 7 built the SDK run loop behind the `RunProcessor` seam
+(`agent-stream.ts`, `run-tools.ts`, `session-store.ts`) but left `index.ts`
+wiring the synthetic processor and `startRunQuery` unimplemented. This decision
+records how the real query is configured when we replace the synthetic
+processor with `createSdkRunProcessor(startRunQuery)`.
+
+The SDK's `query()` spawns the Claude Code runtime **as a subprocess in the
+trusted Fargate worker**. That subprocess ships built-in `Bash`/`Read`/`Write`/
+`Edit`/`Grep`/`Glob` tools that execute against the **Fargate** filesystem —
+which would violate the split-runtime constraint (no model-controlled shell or
+file access in Fargate) and bypass every path/byte bound and the E2B isolation.
+So the query is configured so the model can reach **only** our in-process MCP
+executor tools (`mcp__mymemo-executor__*`), which route to E2B:
+
+- `tools: []` — disable all built-in tools; `mcpServers` is a separate channel
+  and is unaffected.
+- `settingSources: []` — the subprocess loads no Fargate-side `CLAUDE.md`/
+  settings.
+- `permissionMode: 'dontAsk'` + `allowedTools` naming exactly our MCP tools —
+  there is no human to answer a permission prompt, so an unexpected tool must be
+  **denied**, never left to hang, and never bypassed.
+- A static, minimal MyMemo system prompt (a plain string, no `claude_code`
+  preset): the tool surface is bespoke, and the preset assumes native tools we
+  disabled. It states the role, that the executor tools act on the E2B workspace
+  (`/home/user`), and that `SearchDocuments`/`LoadDocuments` reach the scoped KB.
+- OpenRouter via `env` + `model` from `buildModelClientConfig` (ADR-0003), the
+  provisioned run's tools as `mcpServers`, the linked `abortController`, and the
+  user message (read from the run's `run_started` event) as the prompt.
+
+Real model execution against a pinned external dependency in our exact runtime
+is not proven by documentation. A throwaway `spikes/sdk-runtime/` spike (same
+lifecycle as the Task 4.1 E2B spike) gates this work: it proves `query()` spawns
+under `executable: 'bun'` and completes a turn against OpenRouter, that
+`Options.env` merges rather than replaces the subprocess env, that the CLI
+resolves after `bun install --production`, that the MCP tools are callable with
+nothing prompting, that `interrupt()` halts a query, and that the `result`/
+`mirror_error` message shapes and `SessionStore` resume that `agent-stream.ts`
+and `session-store.ts` already assume are real. Findings finalize the
+`executable` choice and fold back into the plan before the wiring is built.
+
+## Considered Options
+
+- **`tools: []` + fail-closed allowlist (`dontAsk` + `allowedTools`)** (chosen) —
+  two independent guards: built-ins are gone, and even if one reappeared it is
+  denied, not executed in Fargate.
+- **`bypassPermissions`** — rejected: leans entirely on `tools: []` being the
+  only guard; auto-runs any tool. One guard where the codebase's ethos (exposure
+  gate, projector) is fail-closed.
+- **`claude_code` preset (± append)** for the system prompt — rejected: the
+  preset describes the native tools we disabled and injects working-directory/
+  git/auto-memory sections computed from the Fargate projectKey anchor, not the
+  E2B workspace — actively misleading. A static custom string is also cacheable
+  across conversations.
+- **Assume the SDK behaves as documented** (no spike) — rejected: the Task 4.1
+  spike found the design's guessed E2B option shape was wrong and forced an
+  entire module (`bash-wrapper.ts`); the SDK subprocess carries the same risk.
+
+## Consequences
+
+- The client-visible tool surface is exactly the eight `mcp__mymemo-executor__*`
+  tools; the SDK subprocess in Fargate executes no model-controlled shell or
+  file operation.
+- The spike is task #1 and may flip `executable: 'bun'` to `'node'` (adding a
+  runtime to the image). Nothing downstream is built until it passes.
+- A durable smoke test (real `query()` against OpenRouter + E2B, run against the
+  built image) becomes the regression guard the spike's one-time proof hands off
+  to; the in-image run is what catches the `--production` prune/`PATH` trap.
+- On a failed turn the client `error` frame carries a **generic** message; the
+  full error is logged worker-side. Wiring the real SDK is what first fills the
+  failure with uncontrolled provider/E2B/exception text, which must not reach the
+  client.

--- a/docs/adr/0007-drop-snapshots-paused-sandbox-persistence.md
+++ b/docs/adr/0007-drop-snapshots-paused-sandbox-persistence.md
@@ -1,0 +1,74 @@
+# Drop E2B snapshots; paused-sandbox-only workspace persistence
+
+Status: accepted
+
+The design (Task 4.1, Task 5.3, Milestone 8) made E2B **snapshots** the
+durability layer for a conversation's workspace: snapshot-if-dirty at each
+turn's end through a barrier, restore from `latest_snapshot_id` when the paused
+sandbox is lost, rotate `previous`/`latest`, and reap on a retention window.
+This decision removes that layer entirely to cut the complexity it carried
+(the snapshot barrier, dirty tracking, `dirty_uncheckpointed` recovery, snapshot
+rotation/retention, and the restore path).
+
+The Task 4.1 spike proved the properties that make snapshots unnecessary for
+v1: E2B `onTimeout: 'pause'` preserves the sandbox filesystem, `Sandbox.connect`
+auto-resumes a paused sandbox in ~250 ms, and paused sandboxes are retained
+indefinitely (no TTL). E2B's published limits (verified: e2b.dev/pricing,
+e2b.dev/docs/sandbox/persistence) put the concurrent cap on **running**
+sandboxes (hobby 20 / pro 100) and bill "per second of a running sandbox";
+disk is **per-sandbox** (hobby 10 GiB / pro 20 GiB), not a shared account quota.
+So a paused sandbox held indefinitely per conversation surfaces no documented
+cost, cap, or quota pressure on the current tier.
+
+**The persistence model becomes:** the paused E2B sandbox *is* the workspace,
+pointed to by `conversation_runtime.sandbox_id`. Turn ends → stop renewing →
+the sandbox idle-pauses. Next turn → `connect(sandbox_id)` → auto-resume, files
+intact. Provisioning collapses to: pointer set and not tainted → connect; else
+(connect fails, or tainted) → create a fresh sandbox and repoint. There is no
+"restore from snapshot" middle path.
+
+The accepted trade: workspace files are now **best-effort, not durable** — if a
+sandbox is ever lost (killed on taint/error, or an E2B incident), that
+conversation's files are gone and the next turn starts empty. Crucially,
+conversation **continuity is unaffected**: the model's cross-turn memory lives
+in Postgres `agent_sessions` (ADR-0005), not in the sandbox, so the agent still
+remembers the conversation — it may only find its scratch files gone.
+
+## Considered Options
+
+- **Snapshots as a durable, bounded-cost checkpoint layer** (the prior design) —
+  rejected now: durable and cost-bounded, but it is the single largest source of
+  workspace-lifecycle complexity, and the spike + pricing show a paused sandbox
+  already persists indefinitely at no documented cost on our tier.
+- **Paused-sandbox-only persistence** (chosen) — best-effort file durability,
+  far less machinery; continuity stays durable via `agent_sessions`.
+- **Fresh sandbox every turn (no persistence)** — rejected: loses the workspace
+  every turn, so the model cannot build on prior file work.
+
+## Consequences
+
+- Removed: the snapshot barrier (`snapshot-barrier.ts` and its call in
+  `RunLoop.finish()`), the dirty flag (its only consumer was the barrier), the
+  `dirty_uncheckpointed` state and its recovery, the restore-from-snapshot path,
+  and snapshot rotation/retention. `WORKER_SNAPSHOT_RETENTION_MS` is removed.
+- Schema: drop `latest_snapshot_id`, `previous_snapshot_id`, and
+  `workspace_checkpoint_status` from `conversation_runtime`, plus the runtime
+  helpers that write them, via a migration (no prod data on these columns).
+- **No idle reaper** — not even a follow-up. Keep-forever is safe on the current
+  tier per the verified limits. A one-line note remains: if E2B ever introduces a
+  paused-sandbox count or storage limit, an idle reaper on the existing cleanup
+  loop is the mitigation.
+- The cleanup loop keeps only two sweeps, both cost-independent: **orphaned**
+  sandboxes (recorded via `recordOrphanSandboxTx` whenever a tainted/failed
+  sandbox is replaced, so a superseded sandbox never leaks) and
+  **deleted-conversation** sandboxes (privacy/correctness — the user deleted the
+  conversation; its sandbox holding their files must be killed).
+- A tainted sandbox (command cleanup unproven) is never reused: provisioning
+  goes straight to a fresh sandbox and orphan-records the tainted one.
+- Amends ADR-0005: session-transcript cleanup rode on "the same cleanup that owns
+  snapshots"; snapshots are gone, but that cleanup loop remains (for orphans and
+  deleted conversations), so transcript cleanup still rides on it.
+- The design doc's snapshot sections (Task 4.1 durability model, Task 5.3, the
+  Milestone 8 snapshot-retention sweep, and the smoke-suite "survives sandbox
+  pause/reconnect" step, which now exercises paused-sandbox reconnect rather than
+  snapshot restore) are superseded by this ADR.

--- a/docs/adr/0008-token-streaming-redis-two-tier-deferred.md
+++ b/docs/adr/0008-token-streaming-redis-two-tier-deferred.md
@@ -1,0 +1,64 @@
+# Token streaming via a Redis live lane (deferred)
+
+Status: proposed (deferred to its own increment)
+
+Today the SSE stream is a projection of durably-recorded `run_events`: the
+worker appends one `assistant_text` event per **complete assistant message**,
+and chat-api's projector maps each to a `text_delta` frame. This is what
+"wire the real SDK" ships — message-granularity, Postgres-only. It reads as
+bursts of text (one per assistant message) rather than smooth token streaming.
+
+Smooth token streaming is desirable but expensive under the current invariant:
+because every client frame is a durable write, one `text_delta` per token would
+mean hundreds of fenced `appendRunEventTx` + `NOTIFY` transactions per turn.
+This ADR records the sanctioned target for reaching token-level streaming, so
+the trade-offs are captured, without building it now.
+
+**Target (two-tier):**
+
+- The worker sets `includePartialMessages: true` and **publishes each token
+  delta to a Redis pub/sub channel keyed per run** (`run:{runId}`), while still
+  appending the one **complete** `assistant_text` to Postgres at message end
+  (the durable tier, unchanged from what ships now).
+- chat-api's SSE becomes a **merge** of (i) durable `run_events` for lifecycle
+  and replay, and (ii) live Redis deltas for token text.
+- **Dual-source dedup rule:** the durable complete-message frame is **suppressed
+  during live tailing** and emitted **only on replay/reconnect**. A live client
+  renders Redis token deltas; a reconnecting/late client — for whom the
+  ephemeral pub/sub deltas are already gone — replays the complete
+  `assistant_text` from Postgres. Final text is identical either way.
+- Redis is **best-effort/additive**: if it is down, live streaming degrades to
+  message-granularity from Postgres and the run never fails for it. **Postgres
+  remains the single source of truth**, even though it is no longer the single
+  source of *frames*.
+- Pub/sub, not Redis Streams: the durable tier is Postgres, so the live lane
+  needs no retention. (`NOTIFY` is unsuitable — 8 KB payload cap, not built for
+  high-frequency token streams.)
+
+## Considered Options
+
+- **Message-granularity, Postgres-only** (ships now) — cheap, exact replay,
+  bursty UX. The forward-compatible base: its durable write is exactly the
+  complete-message tier the Redis design keeps, so shipping it wastes nothing.
+- **Per-delta durable append** — rejected: 100s of transactions/turn; the
+  baseline B that does not scale.
+- **Delta batching in Postgres** (coalesce ~150 ms) — viable middle path;
+  preserves "replay is the only SSE source." Not chosen because the product
+  decision is a live Redis lane.
+- **Redis live lane + Postgres complete-message** (chosen target) — best live
+  UX, cheapest durable path; knowingly trades the single-frame-source invariant.
+- **Projector-side typewriter** — rejected: fake streaming; the worker only
+  appends after the whole message completes, so it adds latency without
+  real-time-ness.
+
+## Consequences
+
+- New infrastructure: a Redis instance reachable by both services, `REDIS_URL`
+  in each, worker publish + chat-api subscribe, and the SSE merge.
+- Knowingly breaks the "run-event replay is the only SSE source" exit criterion
+  for the **live** path only; replay stays a pure projection. This is the
+  accepted trade recorded here.
+- Deferred: not part of "wire the real SDK." That increment ships the
+  message-granularity base; this ADR and increment follow. Proving
+  `includePartialMessages`'s partial-message shape is that increment's spike
+  (an s8 the SDK-runtime spike deliberately omits).

--- a/docs/split-runtime-fargate-e2b-implementation-plan.md
+++ b/docs/split-runtime-fargate-e2b-implementation-plan.md
@@ -1042,3 +1042,146 @@ Exit criteria:
 - run-event replay is the only SSE source.
 - no provider, KB, or broad document credential is present in E2B.
 - cleanup jobs are enabled and conservative.
+
+## Milestone 9: Wire the Real SDK Run Loop
+
+Goal: replace the synthetic processor with a real Claude Agent SDK query per
+run, backed by a provisioned E2B sandbox, and remove the snapshot layer
+(ADR-0006, ADR-0007). Tasks are ordered; Task 9.1 gates the rest.
+
+### Task 9.1: SDK Runtime Spike (gate)
+
+Throwaway `spikes/sdk-runtime/` proof runner (same lifecycle as the Task 4.1
+E2B spike: findings → this plan + ADR-0006, then delete the directory). It
+retires the assumptions the wiring — and already-written code — rest on:
+
+- s1: `query({ executable: 'bun', env, model })` spawns the CLI and completes a
+  trivial turn against OpenRouter; `ANTHROPIC_API_KEY: ""` does not break auth.
+- s2: `Options.env` merges over the subprocess env (keeps `PATH`) rather than
+  replacing it — else the env builder must spread `process.env`.
+- s3: the CLI resolves after `bun install --production`, run inside the built
+  image (the prune/`PATH` trap; needs `docker run`).
+- s4: `tools: []` + `settingSources: []` + an in-process MCP server +
+  `allowedTools` + `dontAsk` → the `mcp__mymemo-executor__*` tools are callable,
+  nothing prompts or hangs, and no built-in executes.
+- s5: `interrupt()` halts an in-flight query.
+- s6: the terminal `result` carries `session_id` + `is_error` + `subtype`/
+  `result`/`errors` as `agent-stream.ts` assumes — and whether a `mirror_error`
+  system message is a real emitted shape or a phantom the continuity logic
+  guards for nothing.
+- s7: a custom `SessionStore` + `resume` loads the prior transcript, and
+  `projectKey` is stable across two same-cwd queries.
+
+Acceptance:
+
+- s1–s7 pass, or the finding flips a decision (e.g. `executable: 'node'` +
+  `node` in the image) and is recorded before wiring proceeds.
+
+### Task 9.2: Build the Custom E2B Template
+
+`Grep`/`Glob` shell out to `rg` and `python3`, which the `base` template lacks.
+
+- an E2B template that installs `rg`, confirms `python3`, and pins the toolchain.
+- its id is `WORKER_E2B_TEMPLATE` (validated at config load).
+
+Acceptance:
+
+- a sandbox created from the template runs `rg --version` and `python3 --version`.
+
+### Task 9.3: Remove Snapshots (ADR-0007)
+
+Rip out the snapshot layer before building provisioning on the simpler model.
+
+Tests first:
+
+- `RunLoop.finish()` terminalizes `done` without a snapshot barrier.
+- provisioning has no restore-from-snapshot path.
+
+Changes:
+
+- delete `snapshot-barrier.ts` and its call in `finish()`; drop the dirty flag
+  and the `dirty_uncheckpointed` state and recovery.
+- migration: drop `latest_snapshot_id`, `previous_snapshot_id`,
+  `workspace_checkpoint_status` from `conversation_runtime`; remove the runtime
+  helpers that write them and `WORKER_SNAPSHOT_RETENTION_MS`.
+- retarget the cleanup loop to orphan + deleted-conversation sweeps only.
+
+### Task 9.4: SandboxProvisioner and E2B Clients
+
+The E2B-facing seam `startRunQuery` composes with (unit tests inject a fake).
+
+Tests first:
+
+- promote `E2BCommandClient` from `bash-tool.e2b.test.ts` to production; the
+  test imports the production class.
+- a new `E2BFileClient` (`SandboxFileClient` over `sandbox.files` +
+  `sandbox.commands.run`) passes the file-tools integration contract.
+- `provisionForRun` returns `{ sandboxId, isNew, workspaceRoot, commandClient,
+  fileClient, renew(), dispose() }`; `dispose()` stops renewal (the sandbox
+  idle-pauses), never kills the live workspace.
+
+Verify:
+
+- a live E2B test (skipped without `E2B_API_KEY`) exercises the real file
+  client: `rg`-backed `Grep`, `python3`-backed `Glob`, read/write round-trip.
+
+### Task 9.5: startRunQuery Orchestration
+
+Compose provisioning, the fence, session config, and the query.
+
+Tests first:
+
+- reads the run's `run_started` event (new `loadRunStartedTx` helper) for the
+  message + frozen scope; message → prompt, scope → `documentScope`.
+- provisioning: ensure the runtime row (idempotent `createConversationRuntimeTx`)
+  → connect if `sandboxId` set and not tainted → else create fresh; a new
+  sandbox is written via fenced `updateRuntimeSandboxTx`.
+- on `RunFenceError` after creating a new sandbox: `dispose`/kill it,
+  `recordOrphanSandboxTx` on kill failure, abandon the run.
+- a tainted pointer goes straight to a fresh sandbox and orphan-records the old
+  one; every pointer replace orphan-records the prior sandbox.
+- a per-run renewal timer pushes `setTimeout(now + WORKER_SANDBOX_IDLE_MS)` on a
+  monotonic deadline; renewal failure aborts a linked controller → the run ends
+  `error`, never `done`.
+- the query is built with `tools: []`, `settingSources: []`,
+  `permissionMode: 'dontAsk'`, `allowedTools` = the MCP tool names, the static
+  system prompt, `env`/`model` from `buildModelClientConfig`, `mcpServers` = the
+  run's executor tools, the linked `abortController`, and `sessionStore`/`cwd`/
+  `resume` from `buildAgentSessionQueryConfig`.
+- the processor returns real `{ workspaceDirty: false, sandbox: null }` (no
+  snapshots), `managedCommandRunning: false`, and the resume `agentSession`.
+
+Verify:
+
+- unit tests inject a fake `SandboxProvisioner` + fake SDK query (no
+  credentials); the fence/orphan/renewal logic is deterministic.
+
+### Task 9.6: Swap the Processor, Config, and Image
+
+Tests first:
+
+- `index.ts` wires `createSdkRunProcessor(startRunQuery)`, not the synthetic one.
+- config adds `WORKER_E2B_TEMPLATE`, `WORKER_SANDBOX_IDLE_MS` (default 5 min),
+  and env-configurable `WORKER_FILE_GREP_MAX_RESULTS`,
+  `WORKER_FILE_GLOB_MAX_RESULTS`, `WORKER_FILE_READ_MAX_BYTES`,
+  `WORKER_BASH_TIMEOUT_MS`, `WORKER_BASH_MAX_OUTPUT_BYTES` (each with a default).
+- `finish()`'s failure branch logs the full error worker-side and writes a
+  generic client `error` message.
+- command audit binds to the structured logger with the full run binding.
+
+Changes:
+
+- Dockerfile: `mkdir -p /workspace && chown bun:bun /workspace` before
+  `USER bun`; the worker `mkdir -p`s the per-conversation cwd before `query()`.
+
+### Task 9.7: Live Smoke and Image Check
+
+Acceptance:
+
+- a live smoke test (real `query()` against OpenRouter + E2B, credentialed):
+  create conversation → `user.message` → a turn with a tool call hitting E2B →
+  assistant text streamed as `run_events` → `run_done`; a second turn resumes
+  the session and reconnects to the same sandbox with files intact.
+- a credential-free image check: `docker run <image>` resolves the SDK CLI
+  under `bun` (the prune/`PATH` regression guard the spike proved once).
+


### PR DESCRIPTION
## What

Design docs for **wiring the real Claude Agent SDK run loop** in `agent-worker`, replacing the Milestone-3 synthetic processor with a real `query()` per run backed by E2B. **Docs-only — no `apps/`/`packages/` code changes.**

- **ADR-0006** — run the SDK behind a **fail-closed tool boundary**: `tools:[]` + `settingSources:[]` disable built-ins so no model-controlled shell/file runs in Fargate; `permissionMode:'dontAsk'` + `allowedTools` auto-approve only the `mcp__mymemo-executor__*` tools (deny anything else, never hang); static minimal system prompt; OpenRouter via `env`/`model`. Gated by a throwaway `spikes/sdk-runtime/` spike (s1–s7).
- **ADR-0007** — **drop E2B snapshots**. The paused sandbox *is* the workspace (best-effort file persistence); conversation continuity stays durable in Postgres `agent_sessions`; **no idle reaper** (verified E2B limits: paused sandboxes are excluded from the concurrent-running cap and disk is per-sandbox). Cuts the snapshot barrier, dirty tracking, `dirty_uncheckpointed` recovery, restore path, and retention.
- **ADR-0008** — **defer** token streaming to a Redis live lane + Postgres complete-message (dual-source dedup; Postgres stays the source of truth). Message-granularity ships now and is forward-compatible.
- **CONTEXT.md** — add the **Workspace** glossary term.
- **Plan** — add **Milestone 9** (Tasks 9.1–9.7) with an explicit dependency chain: spike → snapshot-removal → provisioner → orchestration → wiring.

## Why

Produced by a `/grill-with-docs` session that stress-tested the design to shared understanding. Every factual claim (SDK option names, symbols, schema columns, "currently wired" state) was **adversarially verified against the codebase** — 35 claims, all confirmed.

## For reviewers

- **Code and decision intentionally disagree right now:** the snapshot machinery (`snapshot-barrier.ts`, its call in `RunLoop.finish()`, the `conversation_runtime` snapshot columns, `WORKER_SNAPSHOT_RETENTION_MS`) is **still present**. ADR-0007 records the decision to remove it; plan Task **9.3** does the removal. Don't read the surviving snapshot code as the intended design.
- ADR-0007 **amends** ADR-0005 (session-transcript cleanup rode on "the same cleanup that owns snapshots" — that loop remains, for orphans + deleted conversations).
- The build order in Milestone 9 is load-bearing: snapshot-removal must land **before** provisioning, and the spike (9.1) gates everything and may flip `executable:'bun'`→`'node'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
