### PR TITLE
Task 9.1 SDK runtime spike: verdicts folded into ADR-0006 and plan Milestone 9

### DIFF
--- a/docs/adr/0006-wire-real-sdk-fail-closed-tool-boundary.md
+++ b/docs/adr/0006-wire-real-sdk-fail-closed-tool-boundary.md
@@ -27,20 +27,49 @@ executor tools (`mcp__mymemo-executor__*`), which route to E2B:
   preset): the tool surface is bespoke, and the preset assumes native tools we
   disabled. It states the role, that the executor tools act on the E2B workspace
   (`/home/user`), and that `SearchDocuments`/`LoadDocuments` reach the scoped KB.
-- OpenRouter via `env` + `model` from `buildModelClientConfig` (ADR-0003), the
-  provisioned run's tools as `mcpServers`, the linked `abortController`, and the
-  user message (read from the run's `run_started` event) as the prompt.
+- OpenRouter via `env` + `model` from `buildModelClientConfig` (ADR-0003) —
+  with the model-client vars spread **over `process.env`**, because `Options.env`
+  replaces the subprocess env (spike s2) — the provisioned run's tools as
+  `mcpServers`, the linked `abortController`, the boot-verified
+  `pathToClaudeCodeExecutable` (spike s3), and the user message (read from the
+  run's `run_started` event) as a **plain string** prompt (spike s5).
 
 Real model execution against a pinned external dependency in our exact runtime
 is not proven by documentation. A throwaway `spikes/sdk-runtime/` spike (same
-lifecycle as the Task 4.1 E2B spike) gates this work: it proves `query()` spawns
-under `executable: 'bun'` and completes a turn against OpenRouter, that
-`Options.env` merges rather than replaces the subprocess env, that the CLI
-resolves after `bun install --production`, that the MCP tools are callable with
-nothing prompting, that `interrupt()` halts a query, and that the `result`/
-`mirror_error` message shapes and `SessionStore` resume that `agent-stream.ts`
-and `session-store.ts` already assume are real. Findings finalize the
-`executable` choice and fold back into the plan before the wiring is built.
+lifecycle as the Task 4.1 E2B spike) gated this work; it ran 2026-07-09 against
+real OpenRouter and the built worker image (per-proof verdicts in plan Task
+9.1). The boundary held exactly as designed: the `system/init` tool list
+contained only the MCP executor tools, the allowlisted tool executed, an
+unlisted tool was auto-denied without prompting or hanging (visible in
+`result.permission_denials`), and the `result`/`mirror_error` shapes and
+`SessionStore` resume that `agent-stream.ts` and `session-store.ts` assume are
+all real. Three findings amend the wiring and are binding on it:
+
+- **The CLI is a native platform binary; `executable: 'bun' | 'node'` is
+  inert.** The SDK spawns `@anthropic-ai/claude-agent-sdk-{platform}-{arch}
+  [-musl]/claude` (its optional platform packages — no `cli.js` exists in
+  0.2.117), so no JS runtime runs the CLI and the bun-vs-node question
+  dissolves. But on linux the SDK tries **musl before glibc**, `bun install
+  --production` puts both variants in the Debian-based image, and the musl
+  binary cannot exec on glibc — so default resolution **fails inside the built
+  image**. The worker must pin `pathToClaudeCodeExecutable` to the glibc
+  platform binary — resolved from the SDK package's own module context
+  (`require.resolve(..., { paths: [sdkDir] })`; the platform packages are the
+  SDK's optional deps, not ours) — and verify it once at boot, fail-fast. A
+  live in-image turn passed with the pinned path.
+- **`Options.env` replaces the subprocess env, it does not merge.** A query
+  env of one canary var reached the CLI as exactly that var (plus an injected
+  `CLAUDE_CODE_ENTRYPOINT`) — no `PATH`, no `HOME`. The query env is therefore
+  `{ ...process.env, ...buildModelClientConfig(...).env }` plus an ephemeral
+  `CLAUDE_CONFIG_DIR` for the CLI's local transcript copy (the `sessionStore`
+  mirror is a dual-write; the local copy still gets written).
+- **The prompt must be a plain string (or an input stream that completes) —
+  never held open.** `interrupt()` halts a string-prompt turn and the stream
+  self-terminates in ~3 s, ending with an `is_error` result whose text is
+  internal diagnostics and a thrown stream error — which `RunLoop.finish`
+  already remaps to `canceled` (cancellation wins over failure). With a
+  held-open streaming input, generation halts but the stream **never ends**
+  and the consuming worker would hang until stale-run recovery.
 
 ## Considered Options
 
@@ -64,11 +93,14 @@ and `session-store.ts` already assume are real. Findings finalize the
 - The client-visible tool surface is exactly the eight `mcp__mymemo-executor__*`
   tools; the SDK subprocess in Fargate executes no model-controlled shell or
   file operation.
-- The spike is task #1 and may flip `executable: 'bun'` to `'node'` (adding a
-  runtime to the image). Nothing downstream is built until it passes.
+- The spike ran and passed with the three amendments above. No runtime is added
+  to the image; the `executable` question is retired. The image instead ships
+  the SDK's glibc linux platform package and the worker pins + boot-verifies
+  `pathToClaudeCodeExecutable` to it.
 - A durable smoke test (real `query()` against OpenRouter + E2B, run against the
   built image) becomes the regression guard the spike's one-time proof hands off
-  to; the in-image run is what catches the `--production` prune/`PATH` trap.
+  to; the in-image run is what catches the platform-binary resolution trap
+  (musl-first) and any `--production` prune regression.
 - On a failed turn the client `error` frame carries a **generic** message; the
   full error is logged worker-side. Wiring the real SDK is what first fills the
   failure with uncontrolled provider/E2B/exception text, which must not reach the

--- a/docs/split-runtime-fargate-e2b-implementation-plan.md
+++ b/docs/split-runtime-fargate-e2b-implementation-plan.md
@@ -1049,33 +1049,52 @@ Goal: replace the synthetic processor with a real Claude Agent SDK query per
 run, backed by a provisioned E2B sandbox, and remove the snapshot layer
 (ADR-0006, ADR-0007). Tasks are ordered; Task 9.1 gates the rest.
 
-### Task 9.1: SDK Runtime Spike (gate)
+### Task 9.1: SDK Runtime Spike (gate) — DONE 2026-07-09
 
 Throwaway `spikes/sdk-runtime/` proof runner (same lifecycle as the Task 4.1
-E2B spike: findings → this plan + ADR-0006, then delete the directory). It
-retires the assumptions the wiring — and already-written code — rest on:
+E2B spike: findings → this plan + ADR-0006, then delete the directory). Ran
+against real OpenRouter (`anthropic/claude-sonnet-4`) and the built
+linux/amd64 worker image; SDK `0.2.117`. Verdicts:
 
-- s1: `query({ executable: 'bun', env, model })` spawns the CLI and completes a
-  trivial turn against OpenRouter; `ANTHROPIC_API_KEY: ""` does not break auth.
-- s2: `Options.env` merges over the subprocess env (keeps `PATH`) rather than
-  replacing it — else the env builder must spread `process.env`.
-- s3: the CLI resolves after `bun install --production`, run inside the built
-  image (the prune/`PATH` trap; needs `docker run`).
-- s4: `tools: []` + `settingSources: []` + an in-process MCP server +
-  `allowedTools` + `dontAsk` → the `mcp__mymemo-executor__*` tools are callable,
-  nothing prompts or hangs, and no built-in executes.
-- s5: `interrupt()` halts an in-flight query.
-- s6: the terminal `result` carries `session_id` + `is_error` + `subtype`/
-  `result`/`errors` as `agent-stream.ts` assumes — and whether a `mirror_error`
-  system message is a real emitted shape or a phantom the continuity logic
-  guards for nothing.
-- s7: a custom `SessionStore` + `resume` loads the prior transcript, and
-  `projectKey` is stable across two same-cwd queries.
+- s1 **PASS**: `query()` completes a trivial turn against OpenRouter in ~4–7 s;
+  `ANTHROPIC_API_KEY: ""` + `ANTHROPIC_AUTH_TOKEN` Bearer auth works. But the
+  spawned "CLI" is the SDK's **native platform binary** (its optional
+  `…-{platform}-{arch}[-musl]` packages; no `cli.js` in 0.2.117), so
+  `executable: 'bun' | 'node'` is inert on the default path — the bun-vs-node
+  question dissolves.
+- s2 **REPLACES**: `Options.env` replaces the subprocess env (a one-var env
+  reached the CLI as exactly that var; no `PATH`/`HOME`). The query env
+  builder must spread `process.env` under the model-client vars and set an
+  ephemeral `CLAUDE_CONFIG_DIR`.
+- s3 **musl-first trap**: `bun install --production` in the Debian image
+  installs both linux-x64 variants, the SDK resolves **musl before glibc**,
+  and the musl binary cannot exec on glibc — a real in-image `query()` failed
+  at spawn. Fix proven in-image: pin `pathToClaudeCodeExecutable` to the glibc
+  platform binary (resolved with `{ paths: [<sdk dir>] }`), after which a full
+  live in-image turn passed. Resolve + verify once at worker boot.
+- s4 **PASS**: `tools: []` + `settingSources: []` + in-process MCP server +
+  `allowedTools` + `dontAsk` is fail-closed: init tool list contains only the
+  MCP tools, the allowlisted tool runs, an unlisted tool is auto-denied
+  without prompting or hanging (`result.permission_denials` records it).
+- s5 **PASS with a wiring rule**: `interrupt()` halts a **string-prompt** turn
+  and the stream self-terminates (~3 s) via an `is_error` result + thrown
+  stream error — `RunLoop.finish` already remaps abort+throw to `canceled`. A
+  **held-open streaming input never ends** after interrupt; `startRunQuery`
+  must pass the user message as a plain string.
+- s6 **PASS**: the terminal `result` carries `session_id`/`is_error`/`subtype`
+  with `result` (success) / `errors` (error) as `agent-stream.ts` assumes;
+  `mirror_error` is a **real emitted shape** (a rejecting `SessionStore.append`
+  produced `system/mirror_error` messages), not a phantom.
+- s7 **PASS**: a custom `SessionStore` + `resume` restored the transcript on a
+  simulated fresh worker (fresh `CLAUDE_CONFIG_DIR`); `projectKey` is the
+  dash-sanitized cwd and byte-stable across same-cwd queries; the resumed turn
+  keeps the same `session_id`.
 
-Acceptance:
+Acceptance (met):
 
-- s1–s7 pass, or the finding flips a decision (e.g. `executable: 'node'` +
-  `node` in the image) and is recorded before wiring proceeds.
+- s1–s7 answered; the s2/s3 flips and the s5 wiring rule are recorded here and
+  in ADR-0006, and are folded into Tasks 9.5–9.7 below. The spike directory is
+  deleted.
 
 ### Task 9.2: Build the Custom E2B Template
 
@@ -1145,9 +1164,14 @@ Tests first:
   `error`, never `done`.
 - the query is built with `tools: []`, `settingSources: []`,
   `permissionMode: 'dontAsk'`, `allowedTools` = the MCP tool names, the static
-  system prompt, `env`/`model` from `buildModelClientConfig`, `mcpServers` = the
-  run's executor tools, the linked `abortController`, and `sessionStore`/`cwd`/
-  `resume` from `buildAgentSessionQueryConfig`.
+  system prompt, `env`/`model` from `buildModelClientConfig` — the model-client
+  vars spread over `process.env` plus an ephemeral `CLAUDE_CONFIG_DIR`, because
+  `Options.env` replaces the subprocess env (spike s2) — the boot-verified
+  `pathToClaudeCodeExecutable` (spike s3), `mcpServers` = the run's executor
+  tools, the linked `abortController`, `sessionStore`/`cwd`/`resume` from
+  `buildAgentSessionQueryConfig`, and the user message as a **plain string**
+  prompt — never a held-open input stream, which hangs after `interrupt()`
+  (spike s5).
 - the processor returns real `{ workspaceDirty: false, sandbox: null }` (no
   snapshots), `managedCommandRunning: false`, and the resume `agentSession`.
 
@@ -1161,6 +1185,11 @@ Verify:
 Tests first:
 
 - `index.ts` wires `createSdkRunProcessor(startRunQuery)`, not the synthetic one.
+- boot resolves `pathToClaudeCodeExecutable` to the SDK's **glibc** linux
+  platform binary (`require.resolve("@anthropic-ai/claude-agent-sdk-linux-
+  {arch}/claude", { paths: [<sdk package dir>] })`) and fails fast if it is
+  missing or does not exec (spike s3: the SDK's own musl-first default fails
+  in the Debian-based image).
 - config adds `WORKER_E2B_TEMPLATE`, `WORKER_SANDBOX_IDLE_MS` (default 5 min),
   and env-configurable `WORKER_FILE_GREP_MAX_RESULTS`,
   `WORKER_FILE_GLOB_MAX_RESULTS`, `WORKER_FILE_READ_MAX_BYTES`,
@@ -1182,6 +1211,8 @@ Acceptance:
   create conversation → `user.message` → a turn with a tool call hitting E2B →
   assistant text streamed as `run_events` → `run_done`; a second turn resumes
   the session and reconnects to the same sandbox with files intact.
-- a credential-free image check: `docker run <image>` resolves the SDK CLI
-  under `bun` (the prune/`PATH` regression guard the spike proved once).
+- a credential-free image check: `docker run <image>` resolves **and execs**
+  the pinned glibc SDK CLI binary (`--version`) — the musl-first
+  platform-binary trap and `--production` prune regression guard the spike
+  proved once.
 


### PR DESCRIPTION
## What

Ran the Task 9.1 SDK-runtime spike (the gate for Milestone 9) and folded the findings into `docs/adr/0006-wire-real-sdk-fail-closed-tool-boundary.md` and the implementation plan. The spike itself was throwaway code (`apps/agent-worker/spikes/sdk-runtime/`, mirroring the Task 4.1 E2B spike) and is already deleted — this PR is docs-only.

Proofs ran 2026-07-09 against real OpenRouter (`anthropic/claude-sonnet-4`) and a real `docker build` of the worker image, SDK `@anthropic-ai/claude-agent-sdk@0.2.117`.

## Verdicts

| id | proof | verdict |
|----|-------|---------|
| s1 | `query()` completes a turn against OpenRouter; `ANTHROPIC_API_KEY: ""` OK | PASS |
| s2 | `Options.env` merges over the subprocess env | NO — **replaces** |
| s3 | CLI resolves after `bun install --production` in the built image | NO — **musl-first trap**; pin the path |
| s4 | `tools: []` + `settingSources: []` + MCP server + `allowedTools` + `dontAsk` fail-closed | PASS |
| s5 | `interrupt()` halts an in-flight query | PASS — string prompt only |
| s6 | `result` shape + `mirror_error` are real | PASS |
| s7 | `SessionStore` + `resume` + stable cwd-derived `projectKey` | PASS |

## Why it matters (the three binding amendments)

1. **The `executable: 'bun' | 'node'` question dissolves.** The SDK spawns a native platform binary (its optional `…-{platform}-{arch}[-musl]` packages; no `cli.js` exists in 0.2.117). But on linux it tries **musl before glibc**, bun installs both variants into the Debian image, and the musl binary cannot exec there — a real in-image `query()` failed at spawn. Fix proven in-image: pin `pathToClaudeCodeExecutable` to the glibc platform binary (resolved with `{ paths: [<sdk dir>] }`) and verify at worker boot, fail-fast. Task 9.6/9.7 updated accordingly.
2. **`Options.env` replaces the subprocess env** — the query env builder must spread `process.env` under the model-client vars and set an ephemeral `CLAUDE_CONFIG_DIR`. Task 9.5 updated.
3. **The prompt must be a plain string.** `interrupt()` halts a string-prompt turn and the stream self-terminates (~3 s; `RunLoop.finish` already remaps the resulting throw to `canceled`), but a held-open streaming input **never ends** after interrupt and would hang the consume loop. Task 9.5 updated.

s4/s6/s7 confirmed the Milestone 7 code (`agent-stream.ts`, `run-tools.ts`, `session-store.ts`) assumes real SDK shapes: init tool list contains only the MCP executor tools with unlisted tools auto-denied (no prompt, no hang), `mirror_error` is a real emitted message (not a phantom), and a custom `SessionStore` + `resume` restores the transcript on a fresh worker with a byte-stable cwd-derived `projectKey` (ADR-0005 holds).

## Reviewer notes

- Base-image question was considered: switching to `oven/bun:1-alpine` would make musl-first resolution correct implicitly, but pinning the path keeps the dependency explicit, fail-fast, and on Bun's primary (glibc) target — see the ADR's amended findings block.
- Next step per the handoff: `/to-prd` → `/to-issues` for Milestone 9, preserving the dependency chain (9.1 done → 9.3 snapshot removal → 9.4 → 9.5 → 9.6 → 9.7; 9.2 in parallel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)