### PR TITLE
Fix TS2352 protected-member cast in the pglite test harness

### DIFF
--- a/packages/agent-db/src/testing.ts
+++ b/packages/agent-db/src/testing.ts
@@ -54,7 +54,7 @@ export async function createTestDatabase(): Promise<TestDb> {
 				// (measured: pinned arrayBuffers 2.3GB -> 0 with the null, unchanged
 				// without it). Runs in `finally` so it still fires if close() throws
 				// (e.g. a double-close raising "PGlite is closed").
-				(client as { mod?: unknown }).mod = undefined;
+				(client as unknown as { mod?: unknown }).mod = undefined;
 				if (typeof Bun !== "undefined") Bun.gc(true);
 			}
 		},


### PR DESCRIPTION
## What changed

One-line fix in `packages/agent-db/src/testing.ts`: the `close()` cleanup casts the PGlite client to `{ mod?: unknown }` to drop the Emscripten module reference (the WASM-memory unpin from the OOM fix). TypeScript rejects that direct cast with TS2352 because `mod` is `protected` on `PGlite` but public in the target shape. The cast now routes through `unknown` first (`client as unknown as { mod?: unknown }`), per the compiler's own suggestion.

## Why

`bunx tsc --noEmit` run from `apps/agent-worker` failed on this pre-existing error, so the workspace didn't typecheck cleanly.

## Verification

- `bunx tsc --noEmit` in `apps/agent-worker` passes with no errors
- `bun test` in `packages/agent-db` passes (69 tests, 0 failures)

The runtime behavior is unchanged — same assignment, same cleanup semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)