### PR TITLE
Task 9.2: build the custom E2B template and require WORKER_E2B_TEMPLATE

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,6 +200,7 @@ Required:
 - `KB_DATABASE_URL` — **read-only** KB DB (`mymemo_kb`) for scoped document search. A separate role/credential from `AGENT_DATABASE_URL`
 - `OPENROUTER_API_KEY` / `OPENROUTER_BASE_URL` / `OPENROUTER_DEFAULT_MODEL` — direct OpenRouter (Anthropic-compatible) model traffic; trusted-worker-only
 - `E2B_API_KEY` — the untrusted filesystem/shell executor
+- `WORKER_E2B_TEMPLATE` — the custom E2B template run sandboxes are created from (Task 9.2, `apps/agent-worker/e2b-template/`): it ships the Grep/Glob toolchain — `rg` installed (the stock `base` template lacks it), `python3` confirmed — with the base image and ripgrep pinned. Build/verify with `bun run template:build` / `bun run template:verify`
 
 Optional:
 - `WORKER_MAX_CONCURRENT_RUNS` (default: `2`) — conservative per-task run concurrency; runs share the task's CPU/memory

--- a/apps/agent-worker/.env.example
+++ b/apps/agent-worker/.env.example
@@ -32,6 +32,12 @@ OPENROUTER_DEFAULT_MODEL=anthropic/claude-sonnet-4
 # Read directly by the E2B SDK from the environment.
 E2B_API_KEY=e2b_...
 
+# [required] E2B template id/alias run sandboxes are created from. The custom
+# template (e2b-template/) ships the Grep/Glob toolchain — rg installed (the
+# stock `base` template lacks it), python3 confirmed; build it with
+# `bun run template:build`.
+WORKER_E2B_TEMPLATE=mymemo-agent-sandbox
+
 # ── Optional (defaults shown) ───────────────────────────────────────────────────
 
 # Conservative per-task run concurrency; concurrent runs share the task's CPU/memory.

--- a/apps/agent-worker/e2b-template/README.md
+++ b/apps/agent-worker/e2b-template/README.md
@@ -1,0 +1,55 @@
+# Custom E2B sandbox template (`mymemo-agent-sandbox`)
+
+The agent's `Grep` and `Glob` tools shell out to `rg` and `python3` inside the
+run sandbox. E2B's stock `base` template ships `python3` but lacks `rg`, so
+every run sandbox is created from this custom template instead (Task 9.2) and
+the toolchain is confirmed at build time. Workers reference it by
+the **required** `WORKER_E2B_TEMPLATE` config — a worker refuses to boot
+without it.
+
+## What the template contains
+
+Defined code-first in [`template.ts`](template.ts) with the E2B Template SDK
+(the `e2b` package this workspace already depends on). The toolchain is
+pinned so rebuilds are reproducible:
+
+- **Base image**: `e2bdev/base` (the image behind E2B's stock `base`
+  template) pinned by manifest digest — neither Docker Hub's tags (a moving
+  `latest` plus unversioned packaging experiments) nor the SDK's
+  `fromBaseImage()` (no version parameter) offer a versioned reference, so
+  the digest is the only stable pin.
+- **ripgrep**: the official `ripgrep_<version>-1_amd64.deb` release artifact,
+  verified against its published sha256 before install.
+- **python3**: shipped by the base image; the build *confirms* it (a build
+  step runs `rg --version && python3 --version`), so base-image drift that
+  drops python3 fails the build instead of breaking sandboxes at run time.
+
+To bump a pin, edit the constants in `template.ts`, then rebuild and
+re-verify.
+
+## Build
+
+```bash
+# From apps/agent-worker (E2B_API_KEY comes from .env or the environment):
+bun run template:build            # builds/updates the alias mymemo-agent-sandbox
+bun run template:build my-name    # optional: build under a different name/tag
+```
+
+## Verify (Task 9.2 acceptance)
+
+Creates a sandbox from the template and asserts `rg --version` and
+`python3 --version` both succeed, then kills the sandbox. Exits non-zero on
+failure.
+
+```bash
+bun run template:verify                     # defaults to $WORKER_E2B_TEMPLATE, then the alias
+bun run template:verify my-name             # or an explicit name/id
+```
+
+## Deploy flow
+
+The deploy pipeline's "build or verify the E2B executor template" stage
+(design doc, deployment order step 3) is exactly these two commands run in
+sequence. The template only changes when this directory does, so routine
+service deploys need `template:verify` at most; run `template:build` when the
+pins or the definition change.

--- a/apps/agent-worker/e2b-template/build.ts
+++ b/apps/agent-worker/e2b-template/build.ts
@@ -1,0 +1,22 @@
+// Build (or rebuild) the custom sandbox template on E2B infrastructure.
+//
+//   E2B_API_KEY=... bun run template:build [name]
+//
+// `name` defaults to TEMPLATE_NAME; pass an override to build a side-by-side
+// candidate (e.g. `mymemo-agent-sandbox:next`) without touching the alias
+// workers point at. Follow with `bun run template:verify [name]`.
+import { defaultBuildLogger, Template } from "e2b";
+import { sandboxTemplate, TEMPLATE_NAME } from "./template";
+
+if (!process.env.E2B_API_KEY) {
+	console.error("E2B_API_KEY is required to build the template");
+	process.exit(2);
+}
+
+const name = process.argv[2] ?? TEMPLATE_NAME;
+
+console.log(`building E2B template ${name} ...`);
+const info = await Template.build(sandboxTemplate(), name, {
+	onBuildLogs: defaultBuildLogger(),
+});
+console.log(`built E2B template ${name}:`, JSON.stringify(info));

--- a/apps/agent-worker/e2b-template/template.ts
+++ b/apps/agent-worker/e2b-template/template.ts
@@ -1,0 +1,56 @@
+import { Template, type TemplateClass } from "e2b";
+
+/**
+ * The custom E2B sandbox template (Task 9.2). The agent's Grep/Glob tools
+ * shell out to `rg` and `python3` inside the sandbox. E2B's stock `base`
+ * template ships python3 (with git/curl/build tools) but no rg — every run
+ * sandbox is created from this template instead, so the search tools work
+ * identically in every sandbox.
+ *
+ * The toolchain is pinned so rebuilds are reproducible:
+ * - the base image by digest — neither Docker Hub (a moving `latest` plus
+ *   unversioned packaging-experiment tags) nor the SDK's fromBaseImage()
+ *   (no version parameter) offers a versioned e2bdev/base reference,
+ * - ripgrep by release version + sha256 of the published Debian package.
+ *
+ * Build with `bun run template:build`, then prove a sandbox created from it
+ * runs `rg --version` and `python3 --version` with `bun run template:verify`
+ * (the Task 9.2 acceptance check). See README.md for the deploy-flow slot.
+ */
+
+/** Default alias the template is built under and workers reference via
+ * `WORKER_E2B_TEMPLATE`. */
+export const TEMPLATE_NAME = "mymemo-agent-sandbox";
+
+/** The image behind E2B's stock `base` template, pinned to the multi-arch
+ * manifest digest of `latest` (2026-06-15). Bump deliberately: re-run
+ * template:build + template:verify. */
+export const BASE_IMAGE =
+	"e2bdev/base@sha256:4a369f01a820fe5e65f53c2c5727a78899daf86f0541b721097f289559c8b73f";
+
+export const RIPGREP_VERSION = "14.1.1";
+/** sha256 of ripgrep_14.1.1-1_amd64.deb, from the release's published
+ * .deb.sha256 asset. E2B sandboxes are x86_64, so amd64 is the only arch. */
+export const RIPGREP_DEB_SHA256 =
+	"2f0c732ef166b4f7be7190d4012d60b3f8467bdd6f795c0598817bd2ac1706ae";
+
+const RIPGREP_DEB = `ripgrep_${RIPGREP_VERSION}-1_amd64.deb`;
+const RIPGREP_DEB_URL = `https://github.com/BurntSushi/ripgrep/releases/download/${RIPGREP_VERSION}/${RIPGREP_DEB}`;
+
+/** The template definition: base image + pinned rg install + a build-time
+ * confirmation of the whole Grep/Glob toolchain (fails the build if the base
+ * image ever drops python3). */
+export function sandboxTemplate(): TemplateClass {
+	return Template()
+		.fromImage(BASE_IMAGE)
+		.runCmd(
+			[
+				`curl -fsSL -o /tmp/${RIPGREP_DEB} ${RIPGREP_DEB_URL}`,
+				`echo "${RIPGREP_DEB_SHA256}  /tmp/${RIPGREP_DEB}" | sha256sum -c -`,
+				`dpkg -i /tmp/${RIPGREP_DEB}`,
+				`rm /tmp/${RIPGREP_DEB}`,
+			],
+			{ user: "root" },
+		)
+		.runCmd("rg --version && python3 --version");
+}

--- a/apps/agent-worker/e2b-template/verify.ts
+++ b/apps/agent-worker/e2b-template/verify.ts
@@ -1,0 +1,50 @@
+// Task 9.2 acceptance check: a sandbox created from the template runs
+// `rg --version` and `python3 --version` successfully.
+//
+//   E2B_API_KEY=... bun run template:verify [templateNameOrId]
+//
+// The template defaults to WORKER_E2B_TEMPLATE, then TEMPLATE_NAME — the same
+// id a configured worker would provision run sandboxes from. Exits non-zero
+// on any failure so the deploy flow's template build/verify stage can gate on
+// it.
+import { CommandExitError, Sandbox } from "e2b";
+import { TEMPLATE_NAME } from "./template";
+
+if (!process.env.E2B_API_KEY) {
+	console.error("E2B_API_KEY is required to verify the template");
+	process.exit(2);
+}
+
+const template =
+	process.argv[2] ?? process.env.WORKER_E2B_TEMPLATE ?? TEMPLATE_NAME;
+
+// The toolchain the agent's Grep/Glob tools shell out to at run time.
+const checks = ["rg --version", "python3 --version"];
+
+console.log(`creating sandbox from template ${template} ...`);
+const sandbox = await Sandbox.create(template, {
+	timeoutMs: 120_000,
+	metadata: { purpose: "template-verify-9.2" },
+});
+
+let failed = false;
+try {
+	for (const command of checks) {
+		try {
+			// Default sandbox user, exactly as the run-time tools execute. The SDK
+			// throws CommandExitError on a non-zero exit.
+			const result = await sandbox.commands.run(command);
+			console.log(`ok ${command}: ${result.stdout.split("\n")[0]}`);
+		} catch (error) {
+			if (!(error instanceof CommandExitError)) throw error;
+			console.error(`FAIL ${command}: exit ${error.exitCode}`);
+			console.error(error.stderr);
+			failed = true;
+		}
+	}
+} finally {
+	await Sandbox.kill(sandbox.sandboxId).catch(() => {});
+}
+
+if (failed) process.exit(1);
+console.log(`template ${template} verified`);

--- a/apps/agent-worker/package.json
+++ b/apps/agent-worker/package.json
@@ -5,6 +5,8 @@
 		"dev": "bun run --hot src/index.ts",
 		"start": "bun run src/index.ts",
 		"spike:e2b": "bun run spikes/e2b-semantics/spike.ts",
+		"template:build": "bun run e2b-template/build.ts",
+		"template:verify": "bun run e2b-template/verify.ts",
 		"format": "biome format --write",
 		"lint": "biome lint --write",
 		"check": "biome check --write"

--- a/apps/agent-worker/src/config/env.test.ts
+++ b/apps/agent-worker/src/config/env.test.ts
@@ -14,6 +14,7 @@ function baseEnv(): Record<string, string | undefined> {
 		OPENROUTER_BASE_URL: "https://openrouter.ai/api",
 		OPENROUTER_DEFAULT_MODEL: "anthropic/claude-sonnet-4",
 		E2B_API_KEY: "e2b-test",
+		WORKER_E2B_TEMPLATE: "mymemo-agent-sandbox",
 		DB_SSL: "disable",
 	};
 }
@@ -26,6 +27,7 @@ describe("loadWorkerConfigFromEnv — required settings", () => {
 		"OPENROUTER_BASE_URL",
 		"OPENROUTER_DEFAULT_MODEL",
 		"E2B_API_KEY",
+		"WORKER_E2B_TEMPLATE",
 	];
 
 	it("loads cleanly with all required settings present", () => {
@@ -44,6 +46,11 @@ describe("loadWorkerConfigFromEnv — required settings", () => {
 		const config = loadWorkerConfigFromEnv(baseEnv());
 		expect(config.agentDatabaseUrl).toContain("mymemo_agent");
 		expect(config.kbDatabaseUrl).toContain("mymemo_kb");
+	});
+
+	it("surfaces the E2B template the worker provisions sandboxes from", () => {
+		const config = loadWorkerConfigFromEnv(baseEnv());
+		expect(config.e2bTemplate).toBe("mymemo-agent-sandbox");
 	});
 
 	it("surfaces the OpenRouter provider config", () => {

--- a/apps/agent-worker/src/config/env.ts
+++ b/apps/agent-worker/src/config/env.ts
@@ -33,6 +33,13 @@ export interface WorkerConfig {
 	};
 	/** E2B API key for the untrusted filesystem/shell executor. */
 	e2bApiKey: string;
+	/**
+	 * E2B template id/alias run sandboxes are created from. The custom template
+	 * (apps/agent-worker/e2b-template/) ships the Grep/Glob runtime toolchain —
+	 * `rg` installed (the stock `base` template lacks it), `python3` confirmed.
+	 * Required so a misconfigured worker fails at boot, not per run.
+	 */
+	e2bTemplate: string;
 	/** Conservative default run concurrency per worker task. */
 	maxConcurrentRuns: number;
 	/** Per-call cap for model-facing document search results. */
@@ -132,6 +139,7 @@ export function loadWorkerConfigFromEnv(env: Env): WorkerConfig {
 	assert(env.OPENROUTER_BASE_URL, "OPENROUTER_BASE_URL is required");
 	assert(env.OPENROUTER_DEFAULT_MODEL, "OPENROUTER_DEFAULT_MODEL is required");
 	assert(env.E2B_API_KEY, "E2B_API_KEY is required");
+	assert(env.WORKER_E2B_TEMPLATE, "WORKER_E2B_TEMPLATE is required");
 
 	const sslEnabled = env.DB_SSL !== "disable";
 
@@ -150,6 +158,7 @@ export function loadWorkerConfigFromEnv(env: Env): WorkerConfig {
 			defaultModel: env.OPENROUTER_DEFAULT_MODEL,
 		},
 		e2bApiKey: env.E2B_API_KEY,
+		e2bTemplate: env.WORKER_E2B_TEMPLATE,
 		maxConcurrentRuns: positiveIntOr(
 			env.WORKER_MAX_CONCURRENT_RUNS,
 			DEFAULT_MAX_CONCURRENT_RUNS,

--- a/apps/agent-worker/src/sandbox-env.test.ts
+++ b/apps/agent-worker/src/sandbox-env.test.ts
@@ -30,6 +30,7 @@ describe("buildSandboxEnv — credential boundary", () => {
 			OPENROUTER_BASE_URL: "https://openrouter.ai/api",
 			OPENROUTER_DEFAULT_MODEL: "anthropic/claude",
 			E2B_API_KEY: "e2b-secret",
+			WORKER_E2B_TEMPLATE: "mymemo-agent-sandbox",
 			DB_SSL: "disable",
 		});
 		// ...but buildSandboxEnv's signature only accepts the binding, so secrets

--- a/compose.yaml
+++ b/compose.yaml
@@ -67,6 +67,7 @@ services:
       OPENROUTER_BASE_URL: https://openrouter.ai/api
       OPENROUTER_DEFAULT_MODEL: anthropic/claude-sonnet-4
       E2B_API_KEY: local-unused
+      WORKER_E2B_TEMPLATE: local-unused
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/split-runtime-fargate-e2b-implementation-plan.md
+++ b/docs/split-runtime-fargate-e2b-implementation-plan.md
@@ -1096,7 +1096,7 @@ Acceptance (met):
   in ADR-0006, and are folded into Tasks 9.5–9.7 below. The spike directory is
   deleted.
 
-### Task 9.2: Build the Custom E2B Template
+### Task 9.2: Build the Custom E2B Template — DONE 2026-07-10
 
 `Grep`/`Glob` shell out to `rg` and `python3`, which the `base` template lacks.
 
@@ -1106,6 +1106,13 @@ Acceptance (met):
 Acceptance:
 
 - a sandbox created from the template runs `rg --version` and `python3 --version`.
+
+Built with the e2b Template SDK (`apps/agent-worker/e2b-template/`,
+`bun run template:build` / `template:verify`) as alias `mymemo-agent-sandbox`:
+`e2bdev/base` pinned by manifest digest, ripgrep 14.1.1 installed from the
+sha256-verified release deb, python3 confirmed at build time (the base ships
+3.11.6 — only `rg` was missing). Acceptance verified live 2026-07-10: a
+sandbox created from the template ran both commands.
 
 ### Task 9.3: Remove Snapshots (ADR-0007)
 

--- a/e2e/integration.test.ts
+++ b/e2e/integration.test.ts
@@ -129,6 +129,7 @@ describe.skipIf(!RUN)("split-runtime integration (real Postgres)", () => {
 			OPENROUTER_BASE_URL: "https://openrouter.ai/api",
 			OPENROUTER_DEFAULT_MODEL: "anthropic/claude-sonnet-4",
 			E2B_API_KEY: "integration-unused",
+			WORKER_E2B_TEMPLATE: "integration-unused",
 			WORKER_HEARTBEAT_INTERVAL_MS: "500",
 			PORT: String(WORKER_PORT),
 			LOG_LEVEL: "warn",

--- a/infra/terraform/examples/prod.tfvars.example
+++ b/infra/terraform/examples/prod.tfvars.example
@@ -23,6 +23,7 @@ chat_api_desired_count     = 1
 agent_worker_desired_count = 1
 
 e2b_template              = "sandbox-template-prod"
+worker_e2b_template       = "mymemo-agent-sandbox"
 openrouter_base_url       = "https://openrouter.ai/api"
 openrouter_default_model  = "anthropic/claude-sonnet-4"
 worker_max_concurrent_runs = 2

--- a/infra/terraform/locals.tf
+++ b/infra/terraform/locals.tf
@@ -73,6 +73,7 @@ locals {
     { name = "LOG_LEVEL", value = var.log_level },
     { name = "OPENROUTER_BASE_URL", value = var.openrouter_base_url },
     { name = "OPENROUTER_DEFAULT_MODEL", value = var.openrouter_default_model },
+    { name = "WORKER_E2B_TEMPLATE", value = var.worker_e2b_template },
     { name = "WORKER_MAX_CONCURRENT_RUNS", value = tostring(var.worker_max_concurrent_runs) },
     { name = "WORKER_HEARTBEAT_INTERVAL_MS", value = tostring(var.worker_heartbeat_interval_ms) },
     { name = "WORKER_SHUTDOWN_TIMEOUT_MS", value = tostring(var.worker_shutdown_timeout_ms) },

--- a/infra/terraform/prod.tfvars
+++ b/infra/terraform/prod.tfvars
@@ -20,6 +20,7 @@ chat_api_desired_count     = 1
 agent_worker_desired_count = 1
 
 e2b_template               = "sandbox-template-prod"
+worker_e2b_template        = "mymemo-agent-sandbox"
 openrouter_base_url        = "https://openrouter.ai/api"
 openrouter_default_model   = "anthropic/claude-sonnet-4"
 worker_max_concurrent_runs = 2

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -116,6 +116,12 @@ variable "e2b_template" {
   default     = "sandbox-template-dev"
 }
 
+variable "worker_e2b_template" {
+  description = "Custom E2B template agent-worker creates run sandboxes from (apps/agent-worker/e2b-template/); ships the Grep/Glob toolchain (rg, python3)."
+  type        = string
+  default     = "mymemo-agent-sandbox"
+}
+
 variable "openrouter_base_url" {
   description = "OpenRouter base URL used by agent-worker."
   type        = string

--- a/scripts/deploy-config.test.ts
+++ b/scripts/deploy-config.test.ts
@@ -97,6 +97,7 @@ describe("agent deployment config", () => {
 			"assign_public_ip = true",
 			'mymemo_service_api_security_group_ids = ["sg-05d48e36ef8966c9e"]',
 			'openrouter_default_model   = "anthropic/claude-sonnet-4"',
+			'worker_e2b_template        = "mymemo-agent-sandbox"',
 		]) {
 			expect(prodTfvars).toContain(required);
 		}
@@ -478,6 +479,7 @@ describe("agent deployment config", () => {
 				OPENROUTER_API_KEY: "openrouter-test-key",
 				OPENROUTER_BASE_URL: "https://openrouter.ai/api",
 				OPENROUTER_DEFAULT_MODEL: "anthropic/claude-sonnet-4",
+				WORKER_E2B_TEMPLATE: "mymemo-agent-sandbox",
 			}),
 		).not.toThrow();
 	});


### PR DESCRIPTION
Closes #228 (Task 9.2 of the Milestone 9 spec, #227).

## What changed

The agent's Grep/Glob tools shell out to `rg` and `python3` inside the run sandbox; E2B's stock `base` template ships python3 but lacks `rg`. This PR ships:

- **A code-first E2B template** (`apps/agent-worker/e2b-template/`, e2b Template SDK): `e2bdev/base` pinned by manifest digest (Docker Hub publishes no versioned tags, and `fromBaseImage()` takes no version — the digest is the only stable pin), ripgrep 14.1.1 installed from the sha256-verified release deb, and a build step that runs `rg --version && python3 --version` so base-image drift fails the build instead of breaking sandboxes at run time.
- **Reproducible build/verify commands** for the deploy flow's template build/verify stage: `bun run template:build` / `bun run template:verify` (verify creates a sandbox from the template, asserts both toolchain commands, kills the sandbox, exits non-zero on failure). See the directory README.
- **`WORKER_E2B_TEMPLATE` as required worker config**, validated at config load so a misconfigured worker fails at boot, not per run — wired through the env tests, compose, the e2e harness env, terraform (`worker_e2b_template` → `agent_worker_environment`, set in `prod.tfvars` + example tfvars), the deploy-config tests, AGENTS.md, and `.env.example`.

## Acceptance (all verified)

- ✅ Built live 2026-07-10 as alias `mymemo-agent-sandbox` (templateId `1ihrgzkg9oovzz7ud3vz`); `template:verify` created a sandbox and ran both commands (`ripgrep 14.1.1`, `Python 3.11.6`).
- ✅ `WORKER_E2B_TEMPLATE` missing → boot refusal, covered by the required-var test loop in `env.test.ts`.
- ✅ Pinned toolchain: base digest + rg version/sha256 verified against upstream; deploy-config tests assert the terraform-shaped worker env satisfies the config loader.

## Notes for review

- `config.e2bTemplate` is deliberately consumed nowhere yet — sandbox provisioning is Task 9.4/9.5; this PR only makes the id available and required.
- The plan doc marks Task 9.2 DONE per its convention.
- The legacy `e2b_template` terraform variable (chat-api's ignored `E2B_TEMPLATE`) is left untouched; renaming/removing it is a separate cleanup.
- Full workspace suite green (CI-equivalent, live tests skipped); terraform fmt+validate and Biome clean. A pre-existing live-only failure in `bash-tool.e2b.test.ts` (pgrep self-match counting artifact, unrelated to this change) is being fixed in a separate task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)