### PR TITLE
Fix pgrep self-match in the live E2B bash-tool test

### DIFF
--- a/apps/agent-worker/src/bash-tool/bash-tool.e2b.test.ts
+++ b/apps/agent-worker/src/bash-tool/bash-tool.e2b.test.ts
@@ -156,8 +156,12 @@ async function countProcesses(
 	sandbox: Sandbox,
 	pattern: string,
 ): Promise<number> {
+	// Bracket the first character ("[s]leep 3131") so the pattern does not match
+	// the shell envd runs this very command through — its command line carries
+	// the pattern text and would otherwise inflate every count by one.
+	const selfExcluding = `[${pattern.slice(0, 1)}]${pattern.slice(1)}`;
 	const result = await sandbox.commands.run(
-		`pgrep -f -c ${JSON.stringify(pattern)} || true`,
+		`pgrep -f -c ${JSON.stringify(selfExcluding)} || true`,
 	);
 	return Number.parseInt(result.stdout.trim() || "0", 10);
 }


### PR DESCRIPTION
## What changed

The `countProcesses` helper in `apps/agent-worker/src/bash-tool/bash-tool.e2b.test.ts` now brackets the first character of the pattern (`sleep 3131` → `[s]leep 3131`) before passing it to `pgrep -f -c`.

## Why

The live test "kills a cancelled command's whole process tree, leaving no descendants" failed with `expect(survivors).toBe(0)` receiving 1. A live probe (2026-07-10) showed the cause is the measurement, not the kill: E2B's envd executes `sandbox.commands.run` through a shell whose own command line contains the pgrep pattern, so even a **fresh sandbox with no sleep processes** already counts 1. The zero-survivors assertion could never pass.

The bracket trick makes the regex still match real `sleep 3131` processes while no longer matching its own carrier shell. Because the fix lives inside the shared helper, the `spawned >= 2` pre-check and the survivors assertion count the same way.

## Notes for reviewers

- The process-group kill was always working — this is a test-measurement fix only; no product code is touched.
- This is a pre-existing Task 5.2 test, unrelated to #228, which only surfaced it because a real E2B key is now present locally (the placeholder key previously failed this test at auth instead).
- Verified live with a real `E2B_API_KEY`: `bun test src/bash-tool/bash-tool.e2b.test.ts` from `apps/agent-worker` — 2 pass, 0 fail, all 9 assertions executed (not skipped). Note CI without E2B credentials skips this file, so the green run here is the meaningful verification.
- Biome check is clean on the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)