### PR TITLE
Add the SandboxProvisioner seam and production E2B command/file clients

### DIFF
--- a/apps/agent-worker/src/bash-tool/bash-tool.e2b.test.ts
+++ b/apps/agent-worker/src/bash-tool/bash-tool.e2b.test.ts
@@ -4,24 +4,14 @@
 // init). Skipped unless E2B_API_KEY is set, so CI without E2B credentials
 // passes; run locally with `E2B_API_KEY=... bun test bash-tool.e2b`.
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { CommandExitError, Sandbox, TimeoutError } from "e2b";
+import { Sandbox } from "e2b";
+import { E2BCommandClient } from "../e2b/command-client";
 import {
 	type BashToolContext,
 	type CommandAuditEvent,
-	type ManagedCommandSpec,
-	type RawCommandOutcome,
 	runBashTool,
-	type SandboxCommandClient,
-	type SandboxCommandSession,
 } from "./bash-tool";
-import {
-	buildKillGroupCommand,
-	buildReapCommand,
-	DEFAULT_COMMAND_CONTROL_DIR,
-	parseReapSurvivors,
-	WRAPPER_PROGRAM,
-	wrapperEnv,
-} from "./bash-wrapper";
+import { DEFAULT_COMMAND_CONTROL_DIR } from "./bash-wrapper";
 
 const LIVE = !!process.env.E2B_API_KEY;
 const TEMPLATE = process.env.E2B_TEMPLATE ?? "base";
@@ -30,96 +20,6 @@ const TEST_TIMEOUT_MS = 180_000;
 
 const sleep = (ms: number): Promise<void> =>
 	new Promise((resolve) => setTimeout(resolve, ms));
-
-/** A real E2B-backed command client, built on the shared wrapper module. This
- * is the substrate the pure `runBashTool` handler is designed against; it lives
- * in the test (like the file-tools integration client) until the sandbox
- * lifecycle is wired in a later milestone. */
-class E2BCommandClient implements SandboxCommandClient {
-	constructor(
-		private readonly sandbox: Sandbox,
-		private readonly controlDir: string,
-	) {}
-
-	start(spec: ManagedCommandSpec): SandboxCommandSession {
-		const outcome = this.run(spec);
-		return {
-			outcome,
-			kill: async () => {
-				await this.sandbox.commands.run(
-					buildKillGroupCommand({
-						commandId: spec.commandId,
-						controlDir: this.controlDir,
-						graceMs: 1_000,
-					}),
-				);
-			},
-			reap: async () => {
-				const result = await this.sandbox.commands.run(
-					buildReapCommand({
-						commandId: spec.commandId,
-						controlDir: this.controlDir,
-					}),
-				);
-				return { survivors: parseReapSurvivors(result.stdout) };
-			},
-		};
-	}
-
-	private async run(spec: ManagedCommandSpec): Promise<RawCommandOutcome> {
-		let stdout = "";
-		let stderr = "";
-		try {
-			const result = await this.sandbox.commands.run(WRAPPER_PROGRAM, {
-				cwd: spec.cwd,
-				envs: wrapperEnv({
-					command: spec.command,
-					commandId: spec.commandId,
-					controlDir: this.controlDir,
-				}),
-				// Backstop beyond the tool's own timer so a truly hung command is
-				// still bounded even if the group kill is somehow ineffective.
-				timeoutMs: spec.timeoutMs + 5_000,
-				onStdout: (data) => {
-					stdout += data;
-				},
-				onStderr: (data) => {
-					stderr += data;
-				},
-			});
-			return {
-				exitCode: result.exitCode,
-				stdout,
-				stderr,
-				stdoutTruncated: false,
-				stderrTruncated: false,
-				timedOut: false,
-			};
-		} catch (error) {
-			if (error instanceof CommandExitError) {
-				return {
-					exitCode: error.exitCode,
-					stdout,
-					stderr,
-					stdoutTruncated: false,
-					stderrTruncated: false,
-					timedOut: false,
-				};
-			}
-			if (error instanceof TimeoutError) {
-				return {
-					exitCode: null,
-					stdout,
-					stderr,
-					stdoutTruncated: false,
-					stderrTruncated: false,
-					timedOut: true,
-				};
-			}
-			throw error;
-		}
-	}
-}
 
 function makeContext(
 	sandbox: Sandbox,

--- a/apps/agent-worker/src/e2b/command-client.test.ts
+++ b/apps/agent-worker/src/e2b/command-client.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "bun:test";
+import { CommandExitError, TimeoutError } from "e2b";
+import type { ManagedCommandSpec } from "../bash-tool/bash-tool";
+import {
+	buildKillGroupCommand,
+	buildReapCommand,
+	DEFAULT_COMMAND_CONTROL_DIR,
+	WRAPPER_PROGRAM,
+	wrapperEnv,
+} from "../bash-tool/bash-wrapper";
+import { type CommandSandbox, E2BCommandClient } from "./command-client";
+
+type RunCall = {
+	cmd: string;
+	opts?: {
+		cwd?: string;
+		envs?: Record<string, string>;
+		timeoutMs?: number;
+		onStdout?: (data: string) => void | Promise<void>;
+		onStderr?: (data: string) => void | Promise<void>;
+	};
+};
+
+/** A fake E2B sandbox whose `commands.run` replays a scripted response after
+ * streaming the given output through the callbacks, as the real SDK does. */
+function makeFakeSandbox(
+	respond: (call: RunCall) => Promise<{ exitCode: number; stdout?: string }>,
+): {
+	sandbox: CommandSandbox;
+	calls: RunCall[];
+} {
+	const calls: RunCall[] = [];
+	return {
+		calls,
+		sandbox: {
+			commands: {
+				run: async (cmd, opts) => {
+					const call = { cmd, opts };
+					calls.push(call);
+					const result = await respond(call);
+					return {
+						exitCode: result.exitCode,
+						stdout: result.stdout ?? "",
+						stderr: "",
+					};
+				},
+			},
+		},
+	};
+}
+
+const spec: ManagedCommandSpec = {
+	commandId: "cmd-1",
+	command: "echo hi",
+	cwd: "/home/user",
+	timeoutMs: 10_000,
+	maxStdoutBytes: 65_536,
+	maxStderrBytes: 65_536,
+};
+
+describe("E2BCommandClient", () => {
+	it("runs the wrapper program with the command in env and a backstop timeout", async () => {
+		const { sandbox, calls } = makeFakeSandbox(async (call) => {
+			await call.opts?.onStdout?.("hi\n");
+			return { exitCode: 0 };
+		});
+		const client = new E2BCommandClient(sandbox, DEFAULT_COMMAND_CONTROL_DIR);
+
+		const outcome = await client.start(spec).outcome;
+
+		expect(calls[0]?.cmd).toBe(WRAPPER_PROGRAM);
+		expect(calls[0]?.opts?.cwd).toBe(spec.cwd);
+		expect(calls[0]?.opts?.timeoutMs).toBe(spec.timeoutMs + 5_000);
+		expect(calls[0]?.opts?.envs).toEqual(
+			wrapperEnv({
+				command: spec.command,
+				commandId: spec.commandId,
+				controlDir: DEFAULT_COMMAND_CONTROL_DIR,
+			}),
+		);
+		expect(outcome).toEqual({
+			exitCode: 0,
+			stdout: "hi\n",
+			stderr: "",
+			stdoutTruncated: false,
+			stderrTruncated: false,
+			timedOut: false,
+		});
+	});
+
+	it("maps a non-zero-exit throw to an exit-code outcome with streamed output", async () => {
+		const { sandbox } = makeFakeSandbox(async (call) => {
+			await call.opts?.onStderr?.("boom\n");
+			throw new CommandExitError({ exitCode: 7, stdout: "", stderr: "" });
+		});
+		const client = new E2BCommandClient(sandbox, DEFAULT_COMMAND_CONTROL_DIR);
+
+		const outcome = await client.start(spec).outcome;
+
+		expect(outcome.exitCode).toBe(7);
+		expect(outcome.stderr).toBe("boom\n");
+		expect(outcome.timedOut).toBe(false);
+	});
+
+	it("maps the SDK backstop timeout to a timedOut outcome with a null exit code", async () => {
+		const { sandbox } = makeFakeSandbox(async () => {
+			throw new TimeoutError("command timed out");
+		});
+		const client = new E2BCommandClient(sandbox, DEFAULT_COMMAND_CONTROL_DIR);
+
+		const outcome = await client.start(spec).outcome;
+
+		expect(outcome.exitCode).toBeNull();
+		expect(outcome.timedOut).toBe(true);
+	});
+
+	it("propagates transport failures instead of shaping them into outcomes", async () => {
+		const { sandbox } = makeFakeSandbox(async () => {
+			throw new Error("connection lost");
+		});
+		const client = new E2BCommandClient(sandbox, DEFAULT_COMMAND_CONTROL_DIR);
+
+		await expect(client.start(spec).outcome).rejects.toThrow(
+			"connection lost",
+		);
+	});
+
+	it("kill and reap act on the command's process group via the control dir", async () => {
+		const { sandbox, calls } = makeFakeSandbox(async (call) =>
+			call.cmd === WRAPPER_PROGRAM
+				? { exitCode: 0 }
+				: { exitCode: 0, stdout: "0\n" },
+		);
+		const client = new E2BCommandClient(sandbox, DEFAULT_COMMAND_CONTROL_DIR);
+		const session = client.start(spec);
+		await session.outcome;
+
+		await session.kill();
+		const { survivors } = await session.reap();
+
+		expect(calls.map((call) => call.cmd)).toEqual([
+			WRAPPER_PROGRAM,
+			buildKillGroupCommand({
+				commandId: spec.commandId,
+				controlDir: DEFAULT_COMMAND_CONTROL_DIR,
+				graceMs: 1_000,
+			}),
+			buildReapCommand({
+				commandId: spec.commandId,
+				controlDir: DEFAULT_COMMAND_CONTROL_DIR,
+			}),
+		]);
+		expect(survivors).toBe(0);
+	});
+});

--- a/apps/agent-worker/src/e2b/command-client.ts
+++ b/apps/agent-worker/src/e2b/command-client.ts
@@ -1,0 +1,128 @@
+import { CommandExitError, TimeoutError } from "e2b";
+import type {
+	ManagedCommandSpec,
+	RawCommandOutcome,
+	SandboxCommandClient,
+	SandboxCommandSession,
+} from "../bash-tool/bash-tool";
+import {
+	buildKillGroupCommand,
+	buildReapCommand,
+	parseReapSurvivors,
+	WRAPPER_PROGRAM,
+	wrapperEnv,
+} from "../bash-tool/bash-wrapper";
+
+/**
+ * The slice of an E2B `Sandbox` the executor clients drive. A structural
+ * subset of the real SDK class, so production code passes a `Sandbox` while
+ * unit tests pass a fake without touching E2B — the provisioner
+ * (sandbox-provisioner.ts) is the only module that ever holds the real thing.
+ */
+export interface CommandSandbox {
+	commands: {
+		run(
+			cmd: string,
+			opts?: {
+				cwd?: string;
+				envs?: Record<string, string>;
+				timeoutMs?: number;
+				onStdout?: (data: string) => void | Promise<void>;
+				onStderr?: (data: string) => void | Promise<void>;
+			},
+		): Promise<{ exitCode: number; stdout: string; stderr: string }>;
+	};
+}
+
+/**
+ * The real E2B-backed {@link SandboxCommandClient}, built on the shared
+ * process-group wrapper module. Proven against live E2B by the Task 5.2
+ * acceptance test (bash-tool.e2b.test.ts), which showed descendant cleanup
+ * works through the wrapper where the raw SDK kill cannot do it; promoted to
+ * production for the sandbox provisioner (Task 9.4).
+ */
+export class E2BCommandClient implements SandboxCommandClient {
+	constructor(
+		private readonly sandbox: CommandSandbox,
+		private readonly controlDir: string,
+	) {}
+
+	start(spec: ManagedCommandSpec): SandboxCommandSession {
+		const outcome = this.run(spec);
+		return {
+			outcome,
+			kill: async () => {
+				await this.sandbox.commands.run(
+					buildKillGroupCommand({
+						commandId: spec.commandId,
+						controlDir: this.controlDir,
+						graceMs: 1_000,
+					}),
+				);
+			},
+			reap: async () => {
+				const result = await this.sandbox.commands.run(
+					buildReapCommand({
+						commandId: spec.commandId,
+						controlDir: this.controlDir,
+					}),
+				);
+				return { survivors: parseReapSurvivors(result.stdout) };
+			},
+		};
+	}
+
+	private async run(spec: ManagedCommandSpec): Promise<RawCommandOutcome> {
+		let stdout = "";
+		let stderr = "";
+		try {
+			const result = await this.sandbox.commands.run(WRAPPER_PROGRAM, {
+				cwd: spec.cwd,
+				envs: wrapperEnv({
+					command: spec.command,
+					commandId: spec.commandId,
+					controlDir: this.controlDir,
+				}),
+				// Backstop beyond the tool's own timer so a truly hung command is
+				// still bounded even if the group kill is somehow ineffective.
+				timeoutMs: spec.timeoutMs + 5_000,
+				onStdout: (data) => {
+					stdout += data;
+				},
+				onStderr: (data) => {
+					stderr += data;
+				},
+			});
+			return {
+				exitCode: result.exitCode,
+				stdout,
+				stderr,
+				stdoutTruncated: false,
+				stderrTruncated: false,
+				timedOut: false,
+			};
+		} catch (error) {
+			if (error instanceof CommandExitError) {
+				return {
+					exitCode: error.exitCode,
+					stdout,
+					stderr,
+					stdoutTruncated: false,
+					stderrTruncated: false,
+					timedOut: false,
+				};
+			}
+			if (error instanceof TimeoutError) {
+				return {
+					exitCode: null,
+					stdout,
+					stderr,
+					stdoutTruncated: false,
+					stderrTruncated: false,
+					timedOut: true,
+				};
+			}
+			throw error;
+		}
+	}
+}

--- a/apps/agent-worker/src/e2b/file-client.e2b.test.ts
+++ b/apps/agent-worker/src/e2b/file-client.e2b.test.ts
@@ -1,0 +1,117 @@
+// Live E2B test (Task 9.4 acceptance): proves the production E2BFileClient
+// against a real sandbox provisioned from the custom template (Task 9.2),
+// which ships the `rg`/`python3` the Grep/Glob tools shell out to — the stock
+// `base` template lacks rg. Skipped unless E2B_API_KEY is set; run locally
+// with `E2B_API_KEY=... bun test file-client.e2b` (WORKER_E2B_TEMPLATE
+// overrides the default template alias, as in template:verify).
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { Sandbox } from "e2b";
+import { TEMPLATE_NAME } from "../../e2b-template/template";
+import type { FileToolLimits } from "../file-tools/file-tools";
+import { runReadFileTool, runWriteFileTool } from "../file-tools/file-tools";
+import { parseToolResult, runFileToolsContract } from "../file-tools/testing";
+import type { WorkerLogger } from "../logger";
+import {
+	createE2bSandboxProvisioner,
+	type ProvisionedSandbox,
+} from "./sandbox-provisioner";
+
+const API_KEY = process.env.E2B_API_KEY;
+const TEMPLATE = process.env.WORKER_E2B_TEMPLATE ?? TEMPLATE_NAME;
+const LIVE = !!API_KEY;
+const TEST_TIMEOUT_MS = 180_000;
+
+const noopLogger: WorkerLogger = {
+	info: () => {},
+	warn: () => {},
+	error: () => {},
+};
+
+const limits: FileToolLimits = {
+	readMaxBytes: 1024,
+	readMaxLines: 200,
+	grepMaxResults: 100,
+	globMaxResults: 500,
+	commandMaxOutputBytes: 16_384,
+	commandTimeoutMs: 10_000,
+};
+
+describe.skipIf(!LIVE)("E2BFileClient against live E2B", () => {
+	let provisioned: ProvisionedSandbox;
+
+	beforeAll(async () => {
+		const provisioner = createE2bSandboxProvisioner({
+			// biome-ignore lint/style/noNonNullAssertion: skipIf(!LIVE) guarantees it is set
+			apiKey: API_KEY!,
+			template: TEMPLATE,
+			sandboxIdleMs: 120_000,
+			logger: noopLogger,
+		});
+		provisioned = await provisioner.provisionForRun({
+			userId: "user-live",
+			conversationId: "conv-live",
+			sandboxId: null,
+			sandboxTainted: false,
+		});
+		expect(provisioned.isNew).toBe(true);
+	});
+
+	afterAll(async () => {
+		if (provisioned) {
+			provisioned.dispose();
+			// dispose() never kills by design; the test must not leak a paused
+			// sandbox, so kill it directly.
+			await Sandbox.kill(provisioned.sandboxId, { apiKey: API_KEY }).catch(
+				() => {},
+			);
+		}
+	});
+
+	it(
+		"passes the file-tools integration contract (rg-backed Grep, python3-backed Glob)",
+		async () => {
+			await runFileToolsContract({
+				client: provisioned.fileClient,
+				// A dedicated subdirectory so template home-directory files cannot
+				// leak into the contract's exact-match expectations.
+				workspaceRoot: `${provisioned.workspaceRoot}/file-tools-contract`,
+				limits,
+			});
+		},
+		TEST_TIMEOUT_MS,
+	);
+
+	it(
+		"round-trips a write and read through the file tools and renews the sandbox",
+		async () => {
+			const context = {
+				client: provisioned.fileClient,
+				workspaceRoot: provisioned.workspaceRoot,
+				limits,
+			};
+			const content = "line one\nline two\n";
+
+			const writeResult = await runWriteFileTool(
+				{ path: "notes/roundtrip.txt", content },
+				context,
+			);
+			expect(writeResult.isError).toBeUndefined();
+
+			const readResult = await runReadFileTool(
+				{ path: "notes/roundtrip.txt" },
+				context,
+			);
+			expect(readResult.isError).toBeUndefined();
+			expect(parseToolResult(readResult)).toMatchObject({
+				path: "notes/roundtrip.txt",
+				content,
+				truncated: false,
+			});
+
+			// The keep-alive path against the real API: extending the idle window
+			// must succeed while the sandbox is live.
+			await provisioned.renew();
+		},
+		TEST_TIMEOUT_MS,
+	);
+});

--- a/apps/agent-worker/src/e2b/file-client.test.ts
+++ b/apps/agent-worker/src/e2b/file-client.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "bun:test";
+import { CommandExitError } from "e2b";
+import { E2BFileClient, type FileSandbox } from "./file-client";
+
+type RunCall = { cmd: string; opts?: { cwd?: string; timeoutMs?: number } };
+
+function makeFakeSandbox(options: {
+	fileBytes?: Uint8Array;
+	runCommand?: (call: RunCall) => Promise<{
+		exitCode: number;
+		stdout: string;
+		stderr: string;
+	}>;
+}): {
+	sandbox: FileSandbox;
+	reads: string[];
+	writes: { path: string; data: string }[];
+	runs: RunCall[];
+} {
+	const reads: string[] = [];
+	const writes: { path: string; data: string }[] = [];
+	const runs: RunCall[] = [];
+	return {
+		reads,
+		writes,
+		runs,
+		sandbox: {
+			files: {
+				read: async (path, _opts) => {
+					reads.push(path);
+					return options.fileBytes ?? new Uint8Array();
+				},
+				write: async (path, data) => {
+					writes.push({ path, data });
+					return {};
+				},
+			},
+			commands: {
+				run: async (cmd, opts) => {
+					const call = { cmd, opts };
+					runs.push(call);
+					if (!options.runCommand) throw new Error("unexpected command");
+					return options.runCommand(call);
+				},
+			},
+		},
+	};
+}
+
+describe("E2BFileClient", () => {
+	it("reads file content capped at maxBytes", async () => {
+		const { sandbox, reads } = makeFakeSandbox({
+			fileBytes: new TextEncoder().encode("alpha beta"),
+		});
+		const client = new E2BFileClient(sandbox);
+
+		const content = await client.readFile({
+			path: "/home/user/notes.txt",
+			maxBytes: 5,
+		});
+
+		expect(content).toBe("alpha");
+		expect(reads).toEqual(["/home/user/notes.txt"]);
+	});
+
+	it("writes file content at the given path", async () => {
+		const { sandbox, writes } = makeFakeSandbox({});
+		const client = new E2BFileClient(sandbox);
+
+		await client.writeFile({ path: "/home/user/out.txt", content: "hello" });
+
+		expect(writes).toEqual([{ path: "/home/user/out.txt", data: "hello" }]);
+	});
+
+	it("runs a command with cwd and timeout, bounding stdout to maxOutputBytes", async () => {
+		const { sandbox, runs } = makeFakeSandbox({
+			runCommand: async () => ({
+				exitCode: 0,
+				stdout: "abcdefgh",
+				stderr: "",
+			}),
+		});
+		const client = new E2BFileClient(sandbox);
+
+		const result = await client.runCommand({
+			command: "rg alpha",
+			cwd: "/home/user",
+			timeoutMs: 10_000,
+			maxOutputBytes: 4,
+		});
+
+		expect(runs).toEqual([
+			{ cmd: "rg alpha", opts: { cwd: "/home/user", timeoutMs: 10_000 } },
+		]);
+		expect(result).toEqual({
+			exitCode: 0,
+			stdout: "abcd",
+			stderr: "",
+			truncated: true,
+		});
+	});
+
+	it("returns a non-zero exit as a result, not a throw (rg exits 1 on no matches)", async () => {
+		const { sandbox } = makeFakeSandbox({
+			runCommand: async () => {
+				throw new CommandExitError({ exitCode: 1, stdout: "", stderr: "" });
+			},
+		});
+		const client = new E2BFileClient(sandbox);
+
+		const result = await client.runCommand({
+			command: "rg missing",
+			cwd: "/home/user",
+			timeoutMs: 10_000,
+			maxOutputBytes: 1024,
+		});
+
+		expect(result).toEqual({
+			exitCode: 1,
+			stdout: "",
+			stderr: "",
+			truncated: false,
+		});
+	});
+
+	it("propagates non-exit command failures", async () => {
+		const { sandbox } = makeFakeSandbox({
+			runCommand: async () => {
+				throw new Error("connection lost");
+			},
+		});
+		const client = new E2BFileClient(sandbox);
+
+		await expect(
+			client.runCommand({
+				command: "rg alpha",
+				cwd: "/home/user",
+				timeoutMs: 10_000,
+				maxOutputBytes: 1024,
+			}),
+		).rejects.toThrow("connection lost");
+	});
+});

--- a/apps/agent-worker/src/e2b/file-client.ts
+++ b/apps/agent-worker/src/e2b/file-client.ts
@@ -1,0 +1,73 @@
+import { CommandExitError } from "e2b";
+import type {
+	SandboxFileClient,
+	SandboxFileCommand,
+	SandboxFileCommandResult,
+	SandboxFileRead,
+	SandboxFileWrite,
+} from "../file-tools/file-tools";
+import { takeUtf8Bytes } from "../file-tools/file-tools";
+import type { CommandSandbox } from "./command-client";
+
+/** The slice of an E2B `Sandbox` the file client drives: the files API plus
+ * command execution (Grep/Glob shell out to `rg`/`python3` in the sandbox). */
+export interface FileSandbox extends CommandSandbox {
+	files: {
+		read(path: string, opts: { format: "bytes" }): Promise<Uint8Array>;
+		write(path: string, data: string): Promise<unknown>;
+	};
+}
+
+/**
+ * The real E2B-backed {@link SandboxFileClient} (Task 9.4): reads and writes go
+ * through the sandbox files API, and the Grep/Glob command path goes through
+ * `commands.run`. Exit-code interpretation belongs to the file tools, so a
+ * non-zero exit comes back as a result — only transport failures throw.
+ */
+export class E2BFileClient implements SandboxFileClient {
+	constructor(private readonly sandbox: FileSandbox) {}
+
+	async readFile(input: SandboxFileRead): Promise<string> {
+		// The whole file crosses the wire; `maxBytes` bounds what we hold and
+		// return, mirroring the contract's local reference client.
+		const bytes = await this.sandbox.files.read(input.path, {
+			format: "bytes",
+		});
+		return new TextDecoder().decode(bytes.slice(0, input.maxBytes));
+	}
+
+	async writeFile(input: SandboxFileWrite): Promise<void> {
+		await this.sandbox.files.write(input.path, input.content);
+	}
+
+	async runCommand(
+		input: SandboxFileCommand,
+	): Promise<SandboxFileCommandResult> {
+		try {
+			const result = await this.sandbox.commands.run(input.command, {
+				cwd: input.cwd,
+				timeoutMs: input.timeoutMs,
+			});
+			return boundedCommandResult(result, input.maxOutputBytes);
+		} catch (error) {
+			if (error instanceof CommandExitError) {
+				return boundedCommandResult(error, input.maxOutputBytes);
+			}
+			throw error;
+		}
+	}
+}
+
+function boundedCommandResult(
+	result: { exitCode: number; stdout: string; stderr: string },
+	maxOutputBytes: number,
+): SandboxFileCommandResult {
+	const stdout = takeUtf8Bytes(result.stdout, maxOutputBytes);
+	const stderr = takeUtf8Bytes(result.stderr, maxOutputBytes);
+	return {
+		exitCode: result.exitCode,
+		stdout: stdout.text,
+		stderr: stderr.text,
+		truncated: stdout.truncated,
+	};
+}

--- a/apps/agent-worker/src/e2b/sandbox-provisioner.test.ts
+++ b/apps/agent-worker/src/e2b/sandbox-provisioner.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from "bun:test";
+import type { WorkerLogger } from "../logger";
+import {
+	createSandboxProvisioner,
+	type ProvisionerSandbox,
+	SANDBOX_WORKSPACE_ROOT,
+	type SandboxProvisionerDeps,
+} from "./sandbox-provisioner";
+
+function makeFakeSandbox(sandboxId: string): {
+	sandbox: ProvisionerSandbox;
+	setTimeoutCalls: number[];
+} {
+	const setTimeoutCalls: number[] = [];
+	return {
+		setTimeoutCalls,
+		sandbox: {
+			sandboxId,
+			setTimeout: async (timeoutMs: number) => {
+				setTimeoutCalls.push(timeoutMs);
+			},
+			commands: {
+				run: async () => {
+					throw new Error("unexpected command");
+				},
+			},
+			files: {
+				read: async () => {
+					throw new Error("unexpected read");
+				},
+				write: async () => {
+					throw new Error("unexpected write");
+				},
+			},
+		},
+	};
+}
+
+function makeLogger(): {
+	logger: WorkerLogger;
+	warns: Record<string, unknown>[];
+} {
+	const warns: Record<string, unknown>[] = [];
+	return {
+		warns,
+		logger: {
+			info: () => {},
+			warn: (obj) => {
+				warns.push(obj);
+			},
+			error: () => {},
+		},
+	};
+}
+
+function makeDeps(overrides?: Partial<SandboxProvisionerDeps>): {
+	deps: SandboxProvisionerDeps;
+	connected: ReturnType<typeof makeFakeSandbox>;
+	created: ReturnType<typeof makeFakeSandbox>;
+	connectCalls: string[];
+	createCalls: { userId: string; conversationId: string }[];
+	warns: Record<string, unknown>[];
+} {
+	const connected = makeFakeSandbox("sbx-connected");
+	const created = makeFakeSandbox("sbx-created");
+	const connectCalls: string[] = [];
+	const createCalls: { userId: string; conversationId: string }[] = [];
+	const { logger, warns } = makeLogger();
+	return {
+		connected,
+		created,
+		connectCalls,
+		createCalls,
+		warns,
+		deps: {
+			sandboxIdleMs: 300_000,
+			logger,
+			connectSandbox: async (sandboxId) => {
+				connectCalls.push(sandboxId);
+				return connected.sandbox;
+			},
+			createSandbox: async (input) => {
+				createCalls.push(input);
+				return created.sandbox;
+			},
+			...overrides,
+		},
+	};
+}
+
+const input = {
+	userId: "user-1",
+	conversationId: "conv-1",
+	sandboxId: "sbx-existing" as string | null,
+	sandboxTainted: false,
+};
+
+describe("createSandboxProvisioner", () => {
+	it("connects to the conversation's sandbox when the pointer is set and not tainted", async () => {
+		const { deps, connectCalls, createCalls } = makeDeps();
+		const provisioner = createSandboxProvisioner(deps);
+
+		const provisioned = await provisioner.provisionForRun(input);
+
+		expect(connectCalls).toEqual(["sbx-existing"]);
+		expect(createCalls).toEqual([]);
+		expect(provisioned.sandboxId).toBe("sbx-connected");
+		expect(provisioned.isNew).toBe(false);
+		expect(provisioned.workspaceRoot).toBe(SANDBOX_WORKSPACE_ROOT);
+		expect(provisioned.commandClient).toBeDefined();
+		expect(provisioned.fileClient).toBeDefined();
+	});
+
+	it("creates a fresh sandbox when the conversation has none", async () => {
+		const { deps, connectCalls, createCalls } = makeDeps();
+		const provisioner = createSandboxProvisioner(deps);
+
+		const provisioned = await provisioner.provisionForRun({
+			...input,
+			sandboxId: null,
+		});
+
+		expect(connectCalls).toEqual([]);
+		expect(createCalls).toEqual([
+			{ userId: "user-1", conversationId: "conv-1" },
+		]);
+		expect(provisioned.sandboxId).toBe("sbx-created");
+		expect(provisioned.isNew).toBe(true);
+	});
+
+	it("never reuses a tainted sandbox: goes straight to a fresh one", async () => {
+		const { deps, connectCalls, createCalls } = makeDeps();
+		const provisioner = createSandboxProvisioner(deps);
+
+		const provisioned = await provisioner.provisionForRun({
+			...input,
+			sandboxTainted: true,
+		});
+
+		expect(connectCalls).toEqual([]);
+		expect(createCalls).toHaveLength(1);
+		expect(provisioned.isNew).toBe(true);
+	});
+
+	it("falls back to a fresh sandbox when connect fails, logging the reason", async () => {
+		const { deps, createCalls, warns } = makeDeps({
+			connectSandbox: async () => {
+				throw new Error("sandbox was killed");
+			},
+		});
+		const provisioner = createSandboxProvisioner(deps);
+
+		const provisioned = await provisioner.provisionForRun(input);
+
+		expect(createCalls).toHaveLength(1);
+		expect(provisioned.sandboxId).toBe("sbx-created");
+		expect(provisioned.isNew).toBe(true);
+		expect(warns).toHaveLength(1);
+		expect(warns[0]).toMatchObject({
+			sandboxId: "sbx-existing",
+			conversationId: "conv-1",
+			error: "sandbox was killed",
+		});
+	});
+
+	it("propagates a create failure", async () => {
+		const { deps } = makeDeps({
+			createSandbox: async () => {
+				throw new Error("template not found");
+			},
+		});
+		const provisioner = createSandboxProvisioner(deps);
+
+		await expect(
+			provisioner.provisionForRun({ ...input, sandboxId: null }),
+		).rejects.toThrow("template not found");
+	});
+
+	it("renew extends the sandbox's idle window", async () => {
+		const { deps, connected } = makeDeps();
+		const provisioner = createSandboxProvisioner(deps);
+		const provisioned = await provisioner.provisionForRun(input);
+
+		await provisioned.renew();
+		await provisioned.renew();
+
+		expect(connected.setTimeoutCalls).toEqual([300_000, 300_000]);
+	});
+
+	it("dispose stops renewal and never kills the live workspace", async () => {
+		const { deps, created } = makeDeps();
+		const provisioner = createSandboxProvisioner(deps);
+		const provisioned = await provisioner.provisionForRun({
+			...input,
+			sandboxId: null,
+		});
+		await provisioned.renew();
+
+		provisioned.dispose();
+		provisioned.dispose(); // idempotent
+		await provisioned.renew(); // a racing timer tick after dispose is inert
+
+		// The only sandbox call ever made is the pre-dispose renewal — the handle
+		// exposes no kill, so the workspace idle-pauses instead of dying.
+		expect(created.setTimeoutCalls).toEqual([300_000]);
+	});
+});

--- a/apps/agent-worker/src/e2b/sandbox-provisioner.ts
+++ b/apps/agent-worker/src/e2b/sandbox-provisioner.ts
@@ -1,0 +1,176 @@
+import { Sandbox } from "e2b";
+import type { SandboxCommandClient } from "../bash-tool/bash-tool";
+import { DEFAULT_COMMAND_CONTROL_DIR } from "../bash-tool/bash-wrapper";
+import type { SandboxFileClient } from "../file-tools/file-tools";
+import type { WorkerLogger } from "../logger";
+import { type CommandSandbox, E2BCommandClient } from "./command-client";
+import { E2BFileClient, type FileSandbox } from "./file-client";
+
+/**
+ * The sandbox workspace root every run's file and shell work resolves under:
+ * the E2B user home. Distinct from the SDK query's Fargate-side working
+ * directory (a per-conversation session anchor) — never conflate the two
+ * filesystems.
+ */
+export const SANDBOX_WORKSPACE_ROOT = "/home/user";
+
+/** What provisioning needs to know about the conversation's workspace: the
+ * `conversation_runtime` sandbox pointer and its taint state, plus the identity
+ * used to attribute a newly created sandbox. Reading the pointer and persisting
+ * a replacement are the caller's (fenced) responsibility. */
+export interface ProvisionForRunInput {
+	userId: string;
+	conversationId: string;
+	/** The conversation's current sandbox, or `null` when it has none yet. */
+	sandboxId: string | null;
+	sandboxTainted: boolean;
+}
+
+/**
+ * One run's ready-to-use workspace handle (plan Task 9.4, shape fixed by the
+ * spec). The clients are bound to the live sandbox; `renew()` extends its idle
+ * window while the turn is active.
+ */
+export interface ProvisionedSandbox {
+	sandboxId: string;
+	/** `true` when a fresh sandbox was created — the pointer was unset, tainted,
+	 * or connecting failed — so the caller must repoint the conversation. */
+	isNew: boolean;
+	workspaceRoot: string;
+	commandClient: SandboxCommandClient;
+	fileClient: SandboxFileClient;
+	/** Extend the sandbox's idle window to now + the configured idle timeout. */
+	renew(): Promise<void>;
+	/**
+	 * Stop renewal so the sandbox idle-pauses (ADR-0007: the paused sandbox IS
+	 * the persisted workspace). Never kills the live workspace; after dispose a
+	 * straggling `renew()` is inert rather than extending the sandbox.
+	 */
+	dispose(): void;
+}
+
+/**
+ * The one seam every E2B side effect lives behind (spec Milestone 9): run
+ * orchestration is written against this interface and tested with a fake, so
+ * fencing, orphan recording, and renewal logic never need credentials.
+ */
+export interface SandboxProvisioner {
+	provisionForRun(input: ProvisionForRunInput): Promise<ProvisionedSandbox>;
+}
+
+/** The slice of an E2B `Sandbox` a provisioned handle holds. */
+export interface ProvisionerSandbox extends CommandSandbox, FileSandbox {
+	readonly sandboxId: string;
+	setTimeout(timeoutMs: number): Promise<void>;
+}
+
+export interface SandboxProvisionerDeps {
+	/** Idle window each connect/create/renew grants; unrenewed, the sandbox
+	 * pauses this long after the last extension. */
+	sandboxIdleMs: number;
+	logger: WorkerLogger;
+	/** Connect to (and auto-resume) an existing sandbox. */
+	connectSandbox(sandboxId: string): Promise<ProvisionerSandbox>;
+	/** Create a fresh sandbox from the pinned template. */
+	createSandbox(input: {
+		userId: string;
+		conversationId: string;
+	}): Promise<ProvisionerSandbox>;
+}
+
+/**
+ * Connect-or-create provisioning over injected sandbox constructors
+ * (ADR-0007): pointer set and not tainted → connect (auto-resume, files
+ * intact); connect failure or a tainted pointer → fresh sandbox from the
+ * pinned template. A tainted sandbox is never reused, and the provisioner
+ * never kills one — replacement bookkeeping (fenced repoint, orphan record)
+ * belongs to the caller, which sees `isNew` against the pointer it passed.
+ */
+export function createSandboxProvisioner(
+	deps: SandboxProvisionerDeps,
+): SandboxProvisioner {
+	return {
+		async provisionForRun(input) {
+			if (input.sandboxId !== null && !input.sandboxTainted) {
+				try {
+					const sandbox = await deps.connectSandbox(input.sandboxId);
+					return provisionedHandle(sandbox, false, deps.sandboxIdleMs);
+				} catch (error) {
+					deps.logger.warn({
+						message: "sandbox connect failed; provisioning a fresh sandbox",
+						sandboxId: input.sandboxId,
+						conversationId: input.conversationId,
+						error: toMessage(error),
+					});
+				}
+			}
+			const sandbox = await deps.createSandbox({
+				userId: input.userId,
+				conversationId: input.conversationId,
+			});
+			return provisionedHandle(sandbox, true, deps.sandboxIdleMs);
+		},
+	};
+}
+
+function provisionedHandle(
+	sandbox: ProvisionerSandbox,
+	isNew: boolean,
+	sandboxIdleMs: number,
+): ProvisionedSandbox {
+	let disposed = false;
+	return {
+		sandboxId: sandbox.sandboxId,
+		isNew,
+		workspaceRoot: SANDBOX_WORKSPACE_ROOT,
+		commandClient: new E2BCommandClient(sandbox, DEFAULT_COMMAND_CONTROL_DIR),
+		fileClient: new E2BFileClient(sandbox),
+		renew: async () => {
+			if (disposed) return;
+			await sandbox.setTimeout(sandboxIdleMs);
+		},
+		dispose: () => {
+			disposed = true;
+		},
+	};
+}
+
+export interface E2bSandboxProvisionerConfig {
+	apiKey: string;
+	/** The pinned E2B template id fresh sandboxes are created from (Task 9.2:
+	 * ships the `rg`/`python3` the Grep/Glob tools shell out to). */
+	template: string;
+	sandboxIdleMs: number;
+	logger: WorkerLogger;
+}
+
+/** {@link createSandboxProvisioner} wired to the real E2B SDK. */
+export function createE2bSandboxProvisioner(
+	config: E2bSandboxProvisionerConfig,
+): SandboxProvisioner {
+	return createSandboxProvisioner({
+		sandboxIdleMs: config.sandboxIdleMs,
+		logger: config.logger,
+		connectSandbox: (sandboxId) =>
+			Sandbox.connect(sandboxId, {
+				apiKey: config.apiKey,
+				timeoutMs: config.sandboxIdleMs,
+			}),
+		createSandbox: (input) =>
+			Sandbox.create(config.template, {
+				apiKey: config.apiKey,
+				timeoutMs: config.sandboxIdleMs,
+				// Idle timeout pauses the workspace instead of killing it; the next
+				// turn's connect auto-resumes it with files intact (ADR-0007).
+				lifecycle: { onTimeout: "pause" },
+				metadata: {
+					userId: input.userId,
+					conversationId: input.conversationId,
+				},
+			}),
+	});
+}
+
+function toMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/apps/agent-worker/src/file-tools/file-tools.integration.test.ts
+++ b/apps/agent-worker/src/file-tools/file-tools.integration.test.ts
@@ -1,17 +1,16 @@
-import { afterEach, describe, expect, it } from "bun:test";
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { afterEach, describe, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import {
-	type FileToolLimits,
-	runGlobFileTool,
-	runGrepFileTool,
-	type SandboxFileClient,
-	type SandboxFileCommand,
-	type SandboxFileCommandResult,
-	type SandboxFileRead,
-	type SandboxFileWrite,
+import type {
+	FileToolLimits,
+	SandboxFileClient,
+	SandboxFileCommand,
+	SandboxFileCommandResult,
+	SandboxFileRead,
+	SandboxFileWrite,
 } from "./file-tools";
+import { runFileToolsContract } from "./testing";
 
 class LocalCommandSandboxFileClient implements SandboxFileClient {
 	async readFile(input: SandboxFileRead): Promise<string> {
@@ -69,12 +68,6 @@ afterEach(async () => {
 	}
 });
 
-function parseResult(result: { content: { text: string }[] }) {
-	const [first] = result.content;
-	if (!first) throw new Error("missing tool content");
-	return JSON.parse(first.text);
-}
-
 function boundOutput(
 	text: string,
 	maxBytes: number,
@@ -96,38 +89,11 @@ function boundOutput(
 describe("command-backed file tools", () => {
 	it("runs grep and glob against the real command path with bounded sorted results", async () => {
 		workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "mymemo-file-tools-"));
-		await mkdir(path.join(workspaceRoot, "src"));
-		await Bun.write(path.join(workspaceRoot, "notes.txt"), "alpha\nbeta\n");
-		await Bun.write(path.join(workspaceRoot, "src", "memo.txt"), "alpha\n");
-		await Bun.write(path.join(workspaceRoot, ".hidden.txt"), "alpha\n");
 
-		const context = {
+		await runFileToolsContract({
 			client: new LocalCommandSandboxFileClient(),
 			workspaceRoot,
 			limits,
-		};
-
-		const grepResult = await runGrepFileTool(
-			{ pattern: "alpha", maxResults: 10 },
-			context,
-		);
-		expect(grepResult.isError).toBeUndefined();
-		expect(parseResult(grepResult)).toEqual({
-			matches: [
-				{ path: "notes.txt", line: 1, column: 1, text: "alpha" },
-				{ path: "src/memo.txt", line: 1, column: 1, text: "alpha" },
-			],
-			truncated: false,
-		});
-
-		const globResult = await runGlobFileTool(
-			{ pattern: "**/*.txt", maxResults: 10 },
-			context,
-		);
-		expect(globResult.isError).toBeUndefined();
-		expect(parseResult(globResult)).toEqual({
-			paths: ["notes.txt", "src/memo.txt"],
-			truncated: false,
 		});
 	});
 });

--- a/apps/agent-worker/src/file-tools/file-tools.ts
+++ b/apps/agent-worker/src/file-tools/file-tools.ts
@@ -333,7 +333,7 @@ function isInsideWorkspace(
 	);
 }
 
-function takeUtf8Bytes(
+export function takeUtf8Bytes(
 	text: string,
 	maxBytes: number,
 ): { text: string; truncated: boolean } {

--- a/apps/agent-worker/src/file-tools/testing.ts
+++ b/apps/agent-worker/src/file-tools/testing.ts
@@ -1,0 +1,58 @@
+import { expect } from "bun:test";
+import type { FileToolContext, FileToolResult } from "./file-tools";
+import { runGlobFileTool, runGrepFileTool } from "./file-tools";
+
+/**
+ * The file-tools integration contract, shared by every real
+ * `SandboxFileClient` substrate (the local-command integration test and the
+ * live E2B file-client test): seeded through the client itself, the
+ * `rg`-backed Grep and `python3`-backed Glob return bounded, sorted,
+ * hidden-filtered results that are identical across substrates.
+ */
+export async function runFileToolsContract(
+	context: FileToolContext,
+): Promise<void> {
+	const root = context.workspaceRoot;
+	await context.client.writeFile({
+		path: `${root}/notes.txt`,
+		content: "alpha\nbeta\n",
+	});
+	await context.client.writeFile({
+		path: `${root}/src/memo.txt`,
+		content: "alpha\n",
+	});
+	await context.client.writeFile({
+		path: `${root}/.hidden.txt`,
+		content: "alpha\n",
+	});
+
+	const grepResult = await runGrepFileTool(
+		{ pattern: "alpha", maxResults: 10 },
+		context,
+	);
+	expect(grepResult.isError).toBeUndefined();
+	expect(parseToolResult(grepResult)).toEqual({
+		matches: [
+			{ path: "notes.txt", line: 1, column: 1, text: "alpha" },
+			{ path: "src/memo.txt", line: 1, column: 1, text: "alpha" },
+		],
+		truncated: false,
+	});
+
+	const globResult = await runGlobFileTool(
+		{ pattern: "**/*.txt", maxResults: 10 },
+		context,
+	);
+	expect(globResult.isError).toBeUndefined();
+	expect(parseToolResult(globResult)).toEqual({
+		paths: ["notes.txt", "src/memo.txt"],
+		truncated: false,
+	});
+}
+
+/** Parse the JSON payload out of a file-tool result's text content. */
+export function parseToolResult(result: FileToolResult): unknown {
+	const [first] = result.content;
+	if (!first) throw new Error("missing tool content");
+	return JSON.parse(first.text);
+}


### PR DESCRIPTION
Closes #230 (Milestone 9, Task 9.4 of #227).

## What changed

Every E2B side effect now lives behind the one new seam of this milestone, so later run orchestration (Task 9.5) can be tested with a fake and no credentials. All new code is under `apps/agent-worker/src/e2b/`:

- **`sandbox-provisioner.ts`** — `provisionForRun(...)` returns the plan-fixed shape `{ sandboxId, isNew, workspaceRoot, commandClient, fileClient, renew(), dispose() }`. Provisioning follows the paused-sandbox model (ADR-0007): pointer set and not tainted → `Sandbox.connect` (auto-resume, files intact); connect failure or a tainted pointer → fresh sandbox from the pinned template with `lifecycle: { onTimeout: "pause" }`. `dispose()` only stops renewal so the sandbox idle-pauses — the handle exposes no kill path, and a straggling `renew()` after dispose is inert. `createSandboxProvisioner` (logic, unit-tested over fakes) is wired to the real SDK by `createE2bSandboxProvisioner`.
- **`command-client.ts`** — the `E2BCommandClient` proven in the live Bash-tool test, promoted verbatim; the live test now imports the production class. A new unit test pins the outcome mapping (non-zero exit, backstop timeout, transport throw, kill/reap) that was previously only proven live.
- **`file-client.ts`** — the new `E2BFileClient` over the sandbox files API plus command execution: byte-capped reads, bounded command output, and non-zero exits returned as results (rg exits 1 on no matches) rather than throws.
- The file-tools integration contract moved to a shared helper (`file-tools/testing.ts`) so the local-command test and the new live E2B test prove identical Grep/Glob behavior; `takeUtf8Bytes` is exported from `file-tools.ts` for reuse.

Deliberately **not** here (per the task split): the DB-facing orchestration — runtime-row creation, fenced `updateRuntimeSandboxTx`, orphan recording, the renewal timer and abort linking — is Task 9.5, and the `WORKER_E2B_TEMPLATE`/`WORKER_SANDBOX_IDLE_MS` config keys are Task 9.6. The provisioner takes the pointer/taint state as caller input and reports `isNew` so the caller owns repointing.

## Verification

- 201 pass / 0 fail / 0 skip in apps/agent-worker — **including the live E2B tests**: `file-client.e2b.test.ts` provisions a real sandbox from the custom `mymemo-agent-sandbox` template (#236) through the real provisioner and proves rg-backed Grep, python3-backed Glob, a read/write round-trip through the tools, and `renew()` against the live API. Skipped without `E2B_API_KEY`; `WORKER_E2B_TEMPLATE` overrides the default template alias, matching `template:verify`.
- Connect-or-create, dispose/renew semantics, and both clients' API mapping are unit-tested with structural fakes (no credentials, no casts — the real `Sandbox` satisfies the narrow interfaces, which the compiling live tests prove).
- `tsc --noEmit` and Biome clean; agent-db (69) and chat-api (103) suites green.
- Two-axis code review (standards + spec) ran; its one hard finding (unawaited `.rejects` assertions) is fixed in this diff.

## Reviewer notes

- The connect fallback catches **any** connect error and provisions fresh (warn-logged with the reason). That is the spec's literal "connect failure → fresh sandbox"; the orphan-recording of the replaced sandbox is Task 9.5's fenced bookkeeping.
- `Sandbox.create` gets `metadata: { userId, conversationId }` — not in the spec, added so a stray sandbox is attributable during incident response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)