### PR TITLE
Upgrade AWS credentials action to v6 in release deploy workflow

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -60,7 +60,7 @@ jobs:
           terraform_wrapper: false
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/mymemo-agent-github-actions-deploy
           aws-region: ${{ env.AWS_REGION }}


### PR DESCRIPTION
## Summary
- Update the release deploy GitHub Actions workflow to use `aws-actions/configure-aws-credentials` v6
- Keep the existing role assumption and region configuration unchanged

## Testing
- Not run (not requested)