### PR TITLE
Add disposable Redis live preview lane to Terraform

### DIFF
--- a/infra/bootstrap-iam/main.tf
+++ b/infra/bootstrap-iam/main.tf
@@ -91,6 +91,7 @@ data "aws_iam_policy_document" "github_actions_deploy" {
       "ec2:RevokeSecurityGroupEgress",
       "ec2:RevokeSecurityGroupIngress",
       "ecs:*",
+      "elasticache:*",
       "elasticloadbalancing:*",
       "logs:*",
       "rds:*",

--- a/infra/terraform/.terraform.lock.hcl
+++ b/infra/terraform/.terraform.lock.hcl
@@ -23,3 +23,24 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.7"
+  hashes = [
+    "h1:o0s5Mk9NXMP60nlheO1r0LsDGGratFb3oL0t7bD2QnM=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -27,6 +27,7 @@ the direct remote-state output is absent and the fallback input is present.
 - ECR repositories for `mymemo-agent-chat-api` and `mymemo-agent-worker` in the
   separate `infra/ecr` Terraform root
 - dedicated RDS Postgres instance for writable agent state
+- single-node ElastiCache Redis replication group for disposable live previews
 - ECS Fargate task definitions and services for chat-api and agent-worker
 - agent DB migration task definition
 - service security group inside the shared VPC
@@ -42,6 +43,13 @@ receives `AGENT_DATABASE_URL` without a password plus `DB_PASSWORD` from the
 RDS-managed secret. This is the writable agent state database for conversations,
 leases, run state, and migrations. It is separate from the read-only KB database
 URL used by `agent-worker`.
+
+Terraform also generates the live preview cache authentication token and stores
+the complete `rediss://` connection URL in the Terraform-managed
+`<name_prefix>-<environment>-REDIS_URL` Secrets Manager secret. ECS injects that
+secret as `REDIS_URL` into `chat-api` and `agent-worker` only. It is not added to
+the migration task or any E2B sandbox configuration, and neither the credential
+nor the complete URL is exposed as a Terraform output.
 
 Other secret values are not committed. Terraform resolves conventional Secrets
 Manager names to ARNs at plan/apply time, and ECS task definitions consume those
@@ -68,6 +76,27 @@ Replace it with a read-only KB role before broad exposure.
 validates that variable when `SANDBOX_PROVIDER=e2b`. The final split-runtime
 boundary should remove that from chat-api once sandbox creation moves fully to
 `agent-worker`.
+
+## Redis Live Preview Lane
+
+The Redis cache is transport infrastructure for provisional Assistant text,
+not a source of truth. It is a single small node with no replicas, Multi-AZ
+failover, automatic snapshots, final snapshot, or backup retention. The cache
+is reachable on its TLS port only from a dedicated client security group
+attached to the trusted `chat-api` and `agent-worker` services; the migration
+task does not receive that group. ElastiCache does not receive a public address
+or a public ingress rule. Authentication and in-transit encryption are
+mandatory.
+
+Before the first cache plan in an existing environment, reapply
+`infra/bootstrap-iam` with the admin profile as shown below. That updates the
+GitHub Actions deploy role with the ElastiCache permissions used by this root.
+
+Redis availability must not participate in chat-api or agent-worker readiness.
+Missing, invalid, or unreachable Redis configuration must degrade only live
+previews and must not prevent either service from booting or staying healthy.
+The durable Postgres path remains sufficient for successful Runs, durable
+Assistant messages, terminal Outcomes, and replay.
 
 ## Release Deploy Config
 

--- a/infra/terraform/ecs.tf
+++ b/infra/terraform/ecs.tf
@@ -123,7 +123,7 @@ resource "aws_ecs_service" "chat_api" {
 
   network_configuration {
     subnets          = local.shared_ecs_subnet_ids
-    security_groups  = [aws_security_group.services.id]
+    security_groups  = [aws_security_group.services.id, aws_security_group.live_redis_clients.id]
     assign_public_ip = var.assign_public_ip
   }
 
@@ -147,7 +147,7 @@ resource "aws_ecs_service" "agent_worker" {
 
   network_configuration {
     subnets          = local.shared_ecs_subnet_ids
-    security_groups  = [aws_security_group.services.id]
+    security_groups  = [aws_security_group.services.id, aws_security_group.live_redis_clients.id]
     assign_public_ip = var.assign_public_ip
   }
 

--- a/infra/terraform/examples/prod.tfvars.example
+++ b/infra/terraform/examples/prod.tfvars.example
@@ -33,6 +33,11 @@ openrouter_base_url       = "https://openrouter.ai/api"
 openrouter_default_model  = "anthropic/claude-sonnet-4"
 worker_max_concurrent_runs = 2
 
+# Disposable Pub/Sub only: one small node, with replication and backups disabled
+# in redis.tf.
+live_redis_node_type      = "cache.t4g.micro"
+live_redis_engine_version = "7.1"
+
 # Agent-owned writable Postgres. This Terraform root always creates a dedicated
 # RDS instance. The password is generated and stored by RDS in AWS Secrets
 # Manager; ECS receives AGENT_DATABASE_URL without a password plus a DB_PASSWORD

--- a/infra/terraform/locals.tf
+++ b/infra/terraform/locals.tf
@@ -30,6 +30,7 @@ locals {
 
   agent_db_password_secret_arn      = "${aws_db_instance.agent.master_user_secret[0].secret_arn}:password::"
   agent_db_password_base_secret_arn = aws_db_instance.agent.master_user_secret[0].secret_arn
+  live_redis_url_secret_arn         = aws_secretsmanager_secret.live_redis_url.arn
 
   kb_database_url_secret_name    = coalesce(var.kb_database_url_secret_name, "${local.common_name}-KB_DATABASE_URL")
   statsig_server_secret_name     = coalesce(var.statsig_server_secret_name, "${local.common_name}-STATSIG_SERVER_SECRET")
@@ -47,6 +48,7 @@ locals {
     local.statsig_server_secret_arn,
     local.openrouter_api_key_secret_arn,
     local.e2b_api_key_secret_arn,
+    local.live_redis_url_secret_arn,
   ]))
 
   agent_db_password_secret = [
@@ -66,6 +68,7 @@ locals {
   chat_api_secrets = concat([
     { name = "STATSIG_SERVER_SECRET", valueFrom = local.statsig_server_secret_arn },
     { name = "E2B_API_KEY", valueFrom = local.e2b_api_key_secret_arn },
+    { name = "REDIS_URL", valueFrom = local.live_redis_url_secret_arn },
   ], local.agent_db_password_secret)
 
   agent_worker_environment = concat([
@@ -84,5 +87,6 @@ locals {
     { name = "KB_DATABASE_URL", valueFrom = local.kb_database_url_secret_arn },
     { name = "OPENROUTER_API_KEY", valueFrom = local.openrouter_api_key_secret_arn },
     { name = "E2B_API_KEY", valueFrom = local.e2b_api_key_secret_arn },
+    { name = "REDIS_URL", valueFrom = local.live_redis_url_secret_arn },
   ], local.agent_db_password_secret)
 }

--- a/infra/terraform/prod.tfvars
+++ b/infra/terraform/prod.tfvars
@@ -30,6 +30,11 @@ openrouter_base_url        = "https://openrouter.ai/api"
 openrouter_default_model   = "anthropic/claude-sonnet-4"
 worker_max_concurrent_runs = 2
 
+# Disposable Pub/Sub only: one small node, with replication and backups disabled
+# in redis.tf.
+live_redis_node_type      = "cache.t4g.micro"
+live_redis_engine_version = "7.1"
+
 agent_database_name               = "mymemo_agent"
 agent_database_username           = "mymemo_agent"
 agent_db_instance_class           = "db.t4g.micro"

--- a/infra/terraform/redis.tf
+++ b/infra/terraform/redis.tf
@@ -1,0 +1,68 @@
+resource "aws_security_group" "live_redis" {
+  name        = "${local.common_name}-live-redis"
+  description = "Private Redis live preview lane for trusted agent services"
+  vpc_id      = local.shared_vpc_id
+}
+
+resource "aws_security_group" "live_redis_clients" {
+  name        = "${local.common_name}-live-redis-clients"
+  description = "chat-api and agent-worker clients of the Redis live preview lane"
+  vpc_id      = local.shared_vpc_id
+}
+
+resource "aws_security_group_rule" "live_redis_from_services" {
+  type                     = "ingress"
+  description              = "Trusted agent services to the Redis live preview lane"
+  security_group_id        = aws_security_group.live_redis.id
+  source_security_group_id = aws_security_group.live_redis_clients.id
+  from_port                = var.live_redis_port
+  to_port                  = var.live_redis_port
+  protocol                 = "tcp"
+}
+
+resource "aws_elasticache_subnet_group" "live" {
+  name       = "${local.common_name}-live"
+  subnet_ids = local.shared_ecs_subnet_ids
+}
+
+resource "random_password" "live_redis" {
+  length  = 64
+  special = false
+}
+
+resource "aws_elasticache_replication_group" "live" {
+  replication_group_id = substr(replace("${local.common_name}-live", "_", "-"), 0, 40)
+  description          = "Disposable Redis Pub/Sub lane for live assistant text previews"
+
+  engine         = "redis"
+  engine_version = var.live_redis_engine_version
+  node_type      = var.live_redis_node_type
+  port           = var.live_redis_port
+
+  num_cache_clusters         = 1
+  automatic_failover_enabled = false
+  multi_az_enabled           = false
+
+  subnet_group_name  = aws_elasticache_subnet_group.live.name
+  security_group_ids = [aws_security_group.live_redis.id]
+
+  at_rest_encryption_enabled = true
+  transit_encryption_enabled = true
+  transit_encryption_mode    = "required"
+  auth_token                 = random_password.live_redis.result
+  auth_token_update_strategy = "SET"
+
+  snapshot_retention_limit = 0
+  apply_immediately        = true
+}
+
+resource "aws_secretsmanager_secret" "live_redis_url" {
+  name                    = "${local.common_name}-REDIS_URL"
+  description             = "Authenticated TLS URL for the ephemeral Redis live preview lane"
+  recovery_window_in_days = 7
+}
+
+resource "aws_secretsmanager_secret_version" "live_redis_url" {
+  secret_id     = aws_secretsmanager_secret.live_redis_url.id
+  secret_string = "rediss://default:${urlencode(random_password.live_redis.result)}@${aws_elasticache_replication_group.live.primary_endpoint_address}:${var.live_redis_port}"
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -108,6 +108,24 @@ variable "agent_worker_port" {
   default     = 8080
 }
 
+variable "live_redis_port" {
+  description = "TLS port for the disposable Redis live preview lane."
+  type        = number
+  default     = 6379
+}
+
+variable "live_redis_node_type" {
+  description = "ElastiCache node type for ephemeral Pub/Sub traffic."
+  type        = string
+  default     = "cache.t4g.micro"
+}
+
+variable "live_redis_engine_version" {
+  description = "Redis engine version for the ephemeral live preview lane."
+  type        = string
+  default     = "7.1"
+}
+
 variable "assign_public_ip" {
   description = "Inherited existing-network constraint: current mymemo-service ECS subnets are public/default subnets with no NAT/VPC endpoint egress path, so agent ECS tasks need public IPs."
   type        = bool

--- a/infra/terraform/versions.tf
+++ b/infra/terraform/versions.tf
@@ -6,6 +6,11 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
+
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.7"
+    }
   }
 
   backend "s3" {

--- a/scripts/deploy-config.test.ts
+++ b/scripts/deploy-config.test.ts
@@ -52,6 +52,52 @@ describe("agent deployment config", () => {
 		expect(combined).toContain("shared_ecs_subnet_ids");
 	});
 
+	it("provisions the disposable Redis live lane inside the trusted service network", () => {
+		const redisConfig = readFileSync(join(terraformDir, "redis.tf"), "utf8");
+		const locals = readFileSync(join(terraformDir, "locals.tf"), "utf8");
+		const ecsConfig = readFileSync(join(terraformDir, "ecs.tf"), "utf8");
+		const migrationStart = ecsConfig.indexOf(
+			'resource "aws_ecs_task_definition" "agent_migration"',
+		);
+		const migrationEnd = ecsConfig.indexOf(
+			'resource "aws_ecs_service" "chat_api"',
+			migrationStart,
+		);
+		const migrationConfig = ecsConfig.slice(migrationStart, migrationEnd);
+
+		expect(redisConfig).toContain('resource "aws_elasticache_replication_group" "live"');
+		expect(redisConfig).toMatch(/num_cache_clusters\s*=\s*1/);
+		expect(redisConfig).toMatch(/automatic_failover_enabled\s*=\s*false/);
+		expect(redisConfig).toMatch(/multi_az_enabled\s*=\s*false/);
+		expect(redisConfig).toMatch(/snapshot_retention_limit\s*=\s*0/);
+		expect(redisConfig).toMatch(/transit_encryption_enabled\s*=\s*true/);
+		expect(redisConfig).toMatch(/transit_encryption_mode\s*=\s*"required"/);
+		expect(redisConfig).toMatch(/at_rest_encryption_enabled\s*=\s*true/);
+		expect(redisConfig).toMatch(/auth_token\s*=\s*random_password\.live_redis\.result/);
+		expect(redisConfig).toContain("subnet_ids = local.shared_ecs_subnet_ids");
+		expect(redisConfig).toContain(
+			"source_security_group_id = aws_security_group.live_redis_clients.id",
+		);
+		expect(redisConfig).toContain('resource "aws_secretsmanager_secret" "live_redis_url"');
+		expect(redisConfig).toContain(
+			'"rediss://default:${urlencode(random_password.live_redis.result)}@',
+		);
+		expect(locals.match(/name\s*=\s*"REDIS_URL"/g)).toHaveLength(2);
+		expect(ecsConfig.match(/aws_security_group\.live_redis_clients\.id/g)).toHaveLength(2);
+		expect(migrationConfig).toContain("secrets = local.agent_db_password_secret");
+	});
+
+	it("documents the Redis live lane as optional transport infrastructure", () => {
+		const readme = readFileSync(join(terraformDir, "README.md"), "utf8");
+
+		expect(readme).toContain(
+			"Redis availability must not participate in chat-api or agent-worker readiness",
+		);
+		expect(readme).toContain(
+			"The durable Postgres path remains sufficient for successful Runs",
+		);
+	});
+
 	it("example tfvars include required deploy inputs and optional secret-name overrides", () => {
 		for (const required of [
 			"assign_public_ip",
@@ -62,6 +108,8 @@ describe("agent deployment config", () => {
 			"statsig_server_secret_name",
 			"openrouter_api_key_secret_name",
 			"e2b_api_key_secret_name",
+			"live_redis_node_type",
+			"live_redis_engine_version",
 		]) {
 			expect(exampleTfvars).toContain(required);
 		}


### PR DESCRIPTION
## Summary
- Provision a single-node ElastiCache Redis lane for disposable live preview traffic.
- Wire `REDIS_URL` into `chat-api` and `agent-worker` via Terraform-managed Secrets Manager.
- Update ECS networking and IAM bootstrap permissions so the trusted services can reach and manage the cache.
- Document the operational constraints and add tests covering the new infra shape.

## Testing
- Added Terraform config assertions for the Redis resource, secret wiring, and service security-group attachment.
- Added README coverage for the non-durable, non-readiness role of the Redis lane.
- Not run (not requested).