### PR TITLE
Add live text preview streaming for active runs

### DIFF
--- a/apps/agent-worker/package.json
+++ b/apps/agent-worker/package.json
@@ -14,6 +14,7 @@
 	"dependencies": {
 		"@anthropic-ai/claude-agent-sdk": "0.2.117",
 		"@mymemo/agent-db": "workspace:*",
+		"@mymemo/live-text": "workspace:*",
 		"drizzle-orm": "^0.45.2",
 		"e2b": "^2.14.0",
 		"pg": "^8.22.0",

--- a/apps/agent-worker/src/sdk/agent-stream.test.ts
+++ b/apps/agent-worker/src/sdk/agent-stream.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+import { InMemoryLiveTextTransport } from "@mymemo/live-text";
 import {
 	AgentResultError,
 	consumeAgentStream,
@@ -9,7 +10,11 @@ import {
 	sessionIdFromResult,
 } from "./agent-stream";
 import { AssistantEnvelopeProtocolError } from "./assistant-message-assembler";
-import { assistantBlock, textEnvelope } from "./testing/sdk-message-fixtures";
+import {
+	assistantBlock,
+	streamEvent,
+	textEnvelope,
+} from "./testing/sdk-message-fixtures";
 
 function messageAt(messages: SDKMessage[], index: number): SDKMessage {
 	const message = messages[index];
@@ -97,6 +102,70 @@ describe("isMirrorError", () => {
 });
 
 describe("consumeAgentStream", () => {
+	it("publishes coalesced indexed preview before each sequential Assistant commit", async () => {
+		const transport = new InMemoryLiveTextTransport();
+		const subscription = await transport.subscribe("run-1");
+		const order: string[] = [];
+		const messages = [
+			streamEvent({
+				type: "message_start",
+				message: { id: "provider-1", content: [] },
+			}),
+			streamEvent({
+				type: "content_block_start",
+				index: 0,
+				content_block: { type: "text", text: "" },
+			}),
+			streamEvent({
+				type: "content_block_delta",
+				index: 0,
+				delta: { type: "text_delta", text: "hel" },
+			}),
+			streamEvent({
+				type: "content_block_delta",
+				index: 0,
+				delta: { type: "text_delta", text: "lo" },
+			}),
+			assistantBlock("provider-1", { type: "text", text: "hello" }),
+			streamEvent({ type: "content_block_stop", index: 0 }),
+			streamEvent({ type: "message_stop" }),
+			...textEnvelope({
+				providerMessageId: "provider-2",
+				completeText: "again",
+			}),
+		];
+
+		await consumeAgentStream({
+			runId: "run-1",
+			query: fakeQuery(messages.map((message) => ({ message }))),
+			signal: new AbortController().signal,
+			liveTextPublisher: {
+				async publish(message) {
+					order.push(`preview:${message.text}`);
+					await transport.publish(message);
+				},
+			},
+			appendAssistantMessage: async (message) => {
+				order.push(`commit:${message.text}`);
+			},
+		});
+
+		const preview = subscription.readAvailable();
+		expect(
+			preview.map(({ deltaIndex, text }) => ({ deltaIndex, text })),
+		).toEqual([
+			{ deltaIndex: 0, text: "hello" },
+			{ deltaIndex: 0, text: "again" },
+		]);
+		expect(preview[0]?.messageId).not.toBe(preview[1]?.messageId);
+		expect(order).toEqual([
+			"preview:hello",
+			"commit:hello",
+			"preview:again",
+			"commit:again",
+		]);
+	});
+
 	it("commits only the complete provider envelope and ignores the result echo", async () => {
 		const appended: Array<{ messageId: string; text: string }> = [];
 		const controller = new AbortController();
@@ -221,6 +290,8 @@ describe("consumeAgentStream", () => {
 
 	it("fails closed when a nominally successful stream ends before message_stop", async () => {
 		const controller = new AbortController();
+		const liveText = new InMemoryLiveTextTransport();
+		const subscription = await liveText.subscribe("run-1");
 		const envelope = textEnvelope({ completeText: "uncommitted" });
 		const query = fakeQuery(
 			envelope.slice(0, 5).map((message) => ({ message })),
@@ -228,11 +299,15 @@ describe("consumeAgentStream", () => {
 
 		await expect(
 			consumeAgentStream({
+				runId: "run-1",
 				query,
 				signal: controller.signal,
+				liveTextPublisher: liveText,
 				appendAssistantMessage: async () => {},
 			}),
 		).rejects.toBeInstanceOf(AssistantEnvelopeProtocolError);
+		await Bun.sleep(60);
+		expect(subscription.readAvailable()).toEqual([]);
 	});
 
 	it("treats an error-bearing Assistant callback as provider rejection", async () => {

--- a/apps/agent-worker/src/sdk/agent-stream.ts
+++ b/apps/agent-worker/src/sdk/agent-stream.ts
@@ -1,6 +1,8 @@
 import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 import type { AssistantTextPayload } from "@mymemo/agent-db/run-events";
+import type { LiveTextPublisher } from "@mymemo/live-text";
 import { AssistantMessageAssembler } from "./assistant-message-assembler";
+import { LiveTextPreview } from "./live-text-preview";
 
 /**
  * The subset of the Claude Agent SDK's `Query` handle the run supervisor
@@ -73,11 +75,14 @@ export interface AgentStreamOutcome {
 }
 
 export interface ConsumeAgentStreamParams {
+	runId?: string;
 	query: SupervisedQuery;
 	/** Fires on cancel, ownership loss, or shutdown; interrupts the query. */
 	signal: AbortSignal;
 	/** Persists one complete Assistant message (fenced to `running` upstream). */
 	appendAssistantMessage: (message: AssistantTextPayload) => Promise<void>;
+	liveTextPublisher?: LiveTextPublisher;
+	liveTextCoalesceWindowMs?: number;
 	/** Payload-free signal that disables Live preview for the rest of the Run. */
 	onPartialCompleteMismatch?: () => void;
 }
@@ -106,8 +111,23 @@ export async function consumeAgentStream(
 		mirrorErrorObserved: false,
 	};
 	const assembler = new AssistantMessageAssembler({
-		onPartialCompleteMismatch: params.onPartialCompleteMismatch,
+		onPartialCompleteMismatch: () => {
+			preview?.disable();
+			params.onPartialCompleteMismatch?.();
+		},
 	});
+	const preview =
+		params.liveTextPublisher && params.runId
+			? new LiveTextPreview({
+					runId: params.runId,
+					publisher: params.liveTextPublisher,
+					coalesceWindowMs: params.liveTextCoalesceWindowMs,
+				})
+			: undefined;
+	const abandonOpenMessage = () => {
+		assembler.abandon();
+		preview?.abandon();
+	};
 
 	// Best-effort: interrupt only needs to reach the SDK. Swallow its rejection so
 	// a failed interrupt cannot become an unhandled rejection — the loop stops
@@ -129,26 +149,36 @@ export async function consumeAgentStream(
 			if (signal.aborted) continue;
 			const errorText = resultErrorText(message);
 			if (errorText !== null) {
-				assembler.abandon();
 				throw new AgentResultError(errorText);
 			}
 			if (message.type === "assistant" && message.error) {
-				assembler.abandon();
 				throw new AgentResultError(
 					`assistant response rejected: ${message.error}`,
 				);
 			}
-			const commit = assembler.accept(message);
-			if (commit !== null) await appendAssistantMessage(commit);
+			if (
+				message.type === "stream_event" &&
+				message.event.type === "message_stop"
+			) {
+				await preview?.flushMessage();
+			}
+			const assembled = assembler.accept(message);
+			if (assembled?.type === "partial_text") {
+				preview?.append(assembled.messageId, assembled.text);
+			} else if (
+				assembled?.type === "message_stop" &&
+				assembled.commit !== null
+			) {
+				await appendAssistantMessage(assembled.commit);
+			}
 		}
+		if (signal.aborted) throw new QueryInterruptedError();
+		assembler.finish();
+		return outcome;
+	} catch (error) {
+		abandonOpenMessage();
+		throw error;
 	} finally {
 		signal.removeEventListener("abort", interrupt);
 	}
-
-	if (signal.aborted) {
-		assembler.abandon();
-		throw new QueryInterruptedError();
-	}
-	assembler.finish();
-	return outcome;
 }

--- a/apps/agent-worker/src/sdk/assistant-message-assembler.ts
+++ b/apps/agent-worker/src/sdk/assistant-message-assembler.ts
@@ -32,6 +32,10 @@ export interface AssistantMessageAssemblerOptions {
 	onPartialCompleteMismatch?: () => void;
 }
 
+export type AssistantAssembly =
+	| { type: "partial_text"; messageId: string; text: string }
+	| { type: "message_stop"; commit: AssistantTextPayload | null };
+
 /**
  * Deterministically assembles complete Assistant messages from one ordered SDK
  * stream. Partial provider text is evidence only; completed SDK content blocks
@@ -54,7 +58,7 @@ export class AssistantMessageAssembler {
 		return this.#livePreviewEnabled;
 	}
 
-	accept(message: SDKMessage): AssistantTextPayload | null {
+	accept(message: SDKMessage): AssistantAssembly | null {
 		if (message.type === "assistant") {
 			this.#acceptCompletedBlock(message);
 			return null;
@@ -70,8 +74,7 @@ export class AssistantMessageAssembler {
 				this.#startBlock(event.index, event.content_block.type);
 				return null;
 			case "content_block_delta":
-				this.#acceptDelta(event.index, event.delta);
-				return null;
+				return this.#acceptDelta(event.index, event.delta);
 			case "content_block_stop":
 				this.#stopBlock(event.index);
 				return null;
@@ -87,7 +90,7 @@ export class AssistantMessageAssembler {
 				return null;
 			}
 			case "message_stop":
-				return this.#stopEnvelope();
+				return { type: "message_stop", commit: this.#stopEnvelope() };
 		}
 	}
 
@@ -148,7 +151,10 @@ export class AssistantMessageAssembler {
 		active.activeBlock = { index, type, completed: false };
 	}
 
-	#acceptDelta(index: number, delta: ContentBlockDelta): void {
+	#acceptDelta(
+		index: number,
+		delta: ContentBlockDelta,
+	): AssistantAssembly | null {
 		const block = this.#requireBlock("content_block_delta", index);
 		if (block.completed) {
 			this.#violation("content block delta arrived after assistant completion");
@@ -158,12 +164,18 @@ export class AssistantMessageAssembler {
 				this.#violation("text delta did not match its content block");
 			}
 			const active = this.#active;
-			if (active !== null) active.partialText += delta.text;
-			return;
+			if (active === null) return null;
+			active.partialText += delta.text;
+			return {
+				type: "partial_text",
+				messageId: active.messageId,
+				text: delta.text,
+			};
 		}
 		if (block.type === "text") {
 			this.#violation("non-text delta arrived for a text block");
 		}
+		return null;
 	}
 
 	#acceptCompletedBlock(

--- a/apps/agent-worker/src/sdk/live-text-preview.test.ts
+++ b/apps/agent-worker/src/sdk/live-text-preview.test.ts
@@ -1,0 +1,68 @@
+import { expect, it } from "bun:test";
+import {
+	InMemoryLiveTextTransport,
+	type LiveTextMessage,
+} from "@mymemo/live-text";
+import { LiveTextPreview } from "./live-text-preview";
+
+it("publishes coalesced chunks with monotonic indexes within the 50 ms ceiling", async () => {
+	const transport = new InMemoryLiveTextTransport();
+	const subscription = await transport.subscribe("run-1");
+	const preview = new LiveTextPreview({
+		runId: "run-1",
+		publisher: transport,
+		coalesceWindowMs: 5,
+	});
+
+	preview.append("message-1", "A");
+	await Bun.sleep(10);
+	preview.append("message-1", "B");
+	await preview.flushMessage();
+
+	expect(subscription.readAvailable()).toEqual([
+		{
+			runId: "run-1",
+			messageId: "message-1",
+			deltaIndex: 0,
+			text: "A",
+		},
+		{
+			runId: "run-1",
+			messageId: "message-1",
+			deltaIndex: 1,
+			text: "B",
+		},
+	]);
+	expect(
+		() =>
+			new LiveTextPreview({
+				runId: "run-1",
+				publisher: transport,
+				coalesceWindowMs: 51,
+			}),
+	).toThrow("between 0 and 50 ms");
+});
+
+it("abandons only the current preview after publication fails", async () => {
+	const published: LiveTextMessage[] = [];
+	let attempts = 0;
+	const preview = new LiveTextPreview({
+		runId: "run-1",
+		publisher: {
+			async publish(message) {
+				attempts++;
+				if (attempts === 1) throw new Error("transport unavailable");
+				published.push(message);
+			},
+		},
+	});
+
+	preview.append("message-1", "lost");
+	await preview.flushMessage();
+	preview.append("message-2", "visible");
+	await preview.flushMessage();
+
+	expect(published).toEqual([
+		{ messageId: "message-2", deltaIndex: 0, text: "visible", runId: "run-1" },
+	]);
+});

--- a/apps/agent-worker/src/sdk/live-text-preview.ts
+++ b/apps/agent-worker/src/sdk/live-text-preview.ts
@@ -1,0 +1,115 @@
+import {
+	LIVE_TEXT_MAX_CHUNK_LENGTH,
+	type LiveTextPublisher,
+} from "@mymemo/live-text";
+
+export const LIVE_TEXT_COALESCE_WINDOW_MS = 50;
+
+export class LiveTextPreview {
+	readonly #runId: string;
+	readonly #publisher: LiveTextPublisher;
+	readonly #coalesceWindowMs: number;
+	#messageId: string | null = null;
+	#deltaIndex = 0;
+	#pendingText = "";
+	#timer: ReturnType<typeof setTimeout> | undefined;
+	#publishChain: Promise<void> = Promise.resolve();
+	#failedMessageId: string | null = null;
+	#disabled = false;
+
+	constructor(options: {
+		runId: string;
+		publisher: LiveTextPublisher;
+		coalesceWindowMs?: number;
+	}) {
+		this.#runId = options.runId;
+		this.#publisher = options.publisher;
+		this.#coalesceWindowMs =
+			options.coalesceWindowMs ?? LIVE_TEXT_COALESCE_WINDOW_MS;
+		if (
+			this.#coalesceWindowMs < 0 ||
+			this.#coalesceWindowMs > LIVE_TEXT_COALESCE_WINDOW_MS
+		) {
+			throw new Error("Live text coalescing must be between 0 and 50 ms");
+		}
+	}
+
+	append(messageId: string, text: string): void {
+		if (
+			this.#disabled ||
+			this.#failedMessageId === messageId ||
+			text.length === 0
+		)
+			return;
+		if (this.#messageId !== null && this.#messageId !== messageId) {
+			throw new Error("Live text message changed before message_stop");
+		}
+		this.#messageId = messageId;
+		this.#pendingText += text;
+		while (this.#pendingText.length >= LIVE_TEXT_MAX_CHUNK_LENGTH) {
+			this.#enqueue(this.#pendingText.slice(0, LIVE_TEXT_MAX_CHUNK_LENGTH));
+			this.#pendingText = this.#pendingText.slice(LIVE_TEXT_MAX_CHUNK_LENGTH);
+		}
+		if (this.#pendingText.length > 0 && this.#timer === undefined) {
+			this.#timer = setTimeout(() => {
+				this.#timer = undefined;
+				this.#enqueuePending();
+			}, this.#coalesceWindowMs);
+		}
+	}
+
+	async flushMessage(): Promise<void> {
+		this.#clearTimer();
+		this.#enqueuePending();
+		await this.#publishChain;
+		this.#messageId = null;
+		this.#deltaIndex = 0;
+		this.#failedMessageId = null;
+	}
+
+	disable(): void {
+		this.abandon();
+		this.#disabled = true;
+	}
+
+	abandon(): void {
+		this.#clearTimer();
+		this.#pendingText = "";
+		this.#failedMessageId = this.#messageId;
+		this.#messageId = null;
+		this.#deltaIndex = 0;
+	}
+
+	#enqueuePending(): void {
+		if (this.#pendingText.length === 0) return;
+		const text = this.#pendingText;
+		this.#pendingText = "";
+		this.#enqueue(text);
+	}
+
+	#enqueue(text: string): void {
+		const messageId = this.#messageId;
+		if (this.#disabled || messageId === null || text.length === 0) return;
+		const deltaIndex = this.#deltaIndex++;
+		this.#publishChain = this.#publishChain.then(async () => {
+			if (this.#disabled || this.#failedMessageId === messageId) return;
+			try {
+				await this.#publisher.publish({
+					runId: this.#runId,
+					messageId,
+					deltaIndex,
+					text,
+				});
+			} catch {
+				// Preview is optional. A transport failure must never fail the Run.
+				this.#failedMessageId = messageId;
+			}
+		});
+	}
+
+	#clearTimer(): void {
+		if (this.#timer === undefined) return;
+		clearTimeout(this.#timer);
+		this.#timer = undefined;
+	}
+}

--- a/apps/agent-worker/src/sdk/run-processor.test.ts
+++ b/apps/agent-worker/src/sdk/run-processor.test.ts
@@ -4,6 +4,10 @@ import { createQueuedRunTx } from "@mymemo/agent-db/run-store";
 import { createConversationRuntimeTx } from "@mymemo/agent-db/runtime-store";
 import { conversationRuntime, runEvents, runs } from "@mymemo/agent-db/schema";
 import { createTestDatabase, type TestDb } from "@mymemo/agent-db/testing";
+import {
+	InMemoryLiveTextTransport,
+	type LiveTextPublisher,
+} from "@mymemo/live-text";
 import { eq, sql } from "drizzle-orm";
 import type { WorkerLogger } from "../logger";
 import { RunLoop } from "../run-loop";
@@ -166,11 +170,16 @@ function buildLoop(
 	worker: Worker,
 	startRunQuery: StartRunQuery,
 	logger: WorkerLogger = silentLogger,
+	liveTextPublisher?: LiveTextPublisher,
 ) {
 	return new RunLoop({
 		db: tdb.db,
 		worker,
-		processor: createSdkRunProcessor({ startRunQuery, logger }),
+		processor: createSdkRunProcessor({
+			startRunQuery,
+			logger,
+			liveTextPublisher,
+		}),
 		heartbeatIntervalMs: 15_000,
 		logger,
 	});
@@ -227,6 +236,8 @@ describe("createSdkRunProcessor — through the run loop", () => {
 
 	it("keeps sequential envelopes separate, ignores non-text blocks, and skips empty messages", async () => {
 		const worker = buildWorker();
+		const transport = new InMemoryLiveTextTransport();
+		const subscription = await transport.subscribe("run-1");
 		const messages = [
 			...providerEnvelope("provider-1", [
 				{ type: "text", completeText: "ALPHA|" },
@@ -240,7 +251,12 @@ describe("createSdkRunProcessor — through the run loop", () => {
 			]),
 			resultMessage(),
 		];
-		const loop = buildLoop(worker, async () => messageQuery(messages));
+		const loop = buildLoop(
+			worker,
+			async () => messageQuery(messages),
+			silentLogger,
+			transport,
+		);
 		await createQueuedRunTx(tdb.db, {
 			runId: "run-1",
 			userId: "user-1",
@@ -263,6 +279,14 @@ describe("createSdkRunProcessor — through the run loop", () => {
 		}>;
 		expect(commits.map(({ text }) => text)).toEqual(["ALPHA|BETA", "GAMMA"]);
 		expect(new Set(commits.map(({ messageId }) => messageId)).size).toBe(2);
+		expect(subscription.readAvailable()).toEqual(
+			commits.map(({ messageId, text }) => ({
+				runId: "run-1",
+				messageId,
+				deltaIndex: 0,
+				text,
+			})),
+		);
 	});
 
 	for (const fixture of [
@@ -425,6 +449,8 @@ describe("createSdkRunProcessor — through the run loop", () => {
 			},
 		};
 		const worker = buildWorker();
+		const transport = new InMemoryLiveTextTransport();
+		const subscription = await transport.subscribe("run-1");
 		const loop = buildLoop(
 			worker,
 			async () =>
@@ -440,6 +466,7 @@ describe("createSdkRunProcessor — through the run loop", () => {
 					}),
 				]),
 			logger,
+			transport,
 		);
 		await createQueuedRunTx(tdb.db, {
 			runId: "run-1",
@@ -467,6 +494,12 @@ describe("createSdkRunProcessor — through the run loop", () => {
 		]);
 		expect(JSON.stringify(warnings)).not.toContain("PREVIEW");
 		expect(JSON.stringify(warnings)).not.toContain("COMMIT");
+		expect(
+			subscription.readAvailable().map(({ deltaIndex, text }) => ({
+				deltaIndex,
+				text,
+			})),
+		).toEqual([{ deltaIndex: 0, text: "PREVIEW" }]);
 	});
 
 	it("passes the claimed run and abort signal to startRunQuery", async () => {

--- a/apps/agent-worker/src/sdk/run-processor.ts
+++ b/apps/agent-worker/src/sdk/run-processor.ts
@@ -1,4 +1,5 @@
 import type { RunRecord } from "@mymemo/agent-db/run-store";
+import type { LiveTextPublisher } from "@mymemo/live-text";
 import type { WorkerLogger } from "../logger";
 import type { RunProcessor } from "../run-loop";
 import { consumeAgentStream, type SupervisedQuery } from "./agent-stream";
@@ -20,6 +21,7 @@ export type StartRunQuery = (
 export interface SdkRunProcessorDeps {
 	startRunQuery: StartRunQuery;
 	logger: WorkerLogger;
+	liveTextPublisher?: LiveTextPublisher;
 }
 
 /**
@@ -38,9 +40,11 @@ export function createSdkRunProcessor(deps: SdkRunProcessorDeps): RunProcessor {
 	return async (ctx) => {
 		const query = await deps.startRunQuery(ctx.run, ctx.signal);
 		const outcome = await consumeAgentStream({
+			runId: ctx.run.runId,
 			query,
 			signal: ctx.signal,
 			appendAssistantMessage: ctx.appendAssistantMessage,
+			liveTextPublisher: deps.liveTextPublisher,
 			onPartialCompleteMismatch: () => {
 				deps.logger.warn({
 					message: "assistant Live preview disabled after text mismatch",

--- a/apps/chat-api/package.json
+++ b/apps/chat-api/package.json
@@ -11,6 +11,7 @@
 	"dependencies": {
 		"@hono/standard-validator": "^0.1.5",
 		"@mymemo/agent-db": "workspace:*",
+		"@mymemo/live-text": "workspace:*",
 		"@scalar/hono-api-reference": "^0.9.22",
 		"@statsig/statsig-node-core": "^0.19.8",
 		"drizzle-orm": "^0.45.2",

--- a/apps/chat-api/src/deps.ts
+++ b/apps/chat-api/src/deps.ts
@@ -1,3 +1,7 @@
+import {
+	disabledLiveTextSubscriber,
+	type LiveTextSubscriber,
+} from "@mymemo/live-text";
 import type { Env as PinoEnv } from "hono-pino";
 import type { ApiConfig } from "./config/env";
 import { createDatabase } from "./db/client";
@@ -33,6 +37,8 @@ export interface AppDeps {
 	runEventReader: RunEventReader;
 	/** Run-event wake-up source for live SSE projection. */
 	runNotifier: RunNotifier;
+	/** Optional ephemeral Assistant-text preview lane. */
+	liveTextSubscriber: LiveTextSubscriber;
 	/**
 	 * Server-side gate controlling who may create new agent work. Consulted on
 	 * the new-work paths (conversation create, `user.message`) after identity is
@@ -57,6 +63,7 @@ export function createDeps(config: ApiConfig): AppDeps {
 		runStore,
 		runEventReader,
 		runNotifier,
+		liveTextSubscriber: disabledLiveTextSubscriber,
 		exposureGate: createExposureGate(config),
 	};
 }

--- a/apps/chat-api/src/features/conversations/conversations.controller.ts
+++ b/apps/chat-api/src/features/conversations/conversations.controller.ts
@@ -46,11 +46,12 @@ export async function createConversation(
  */
 export async function queueConversationTurn(
 	deps: AppDeps,
-	params: { conversation: ConversationRecord; message: string },
+	params: { conversation: ConversationRecord; message: string; runId?: string },
 ): Promise<{ runId: string }> {
 	return deps.runStore.createQueuedRun({
 		conversation: params.conversation,
 		message: params.message,
+		runId: params.runId,
 	});
 }
 

--- a/apps/chat-api/src/features/conversations/conversations.route.test.ts
+++ b/apps/chat-api/src/features/conversations/conversations.route.test.ts
@@ -1,4 +1,9 @@
 import { describe, expect, it } from "bun:test";
+import {
+	disabledLiveTextSubscriber,
+	InMemoryLiveTextTransport,
+	type LiveTextSubscriber,
+} from "@mymemo/live-text";
 import type { ApiConfig } from "@/config/env";
 import type { AppDeps } from "@/deps";
 import type {
@@ -64,6 +69,7 @@ function buildApp(
 	conversationStore: ConversationStore,
 	exposureGate: ExposureGate = recordingGate(true).gate,
 	fakeRuns = fakeRunStore(),
+	liveTextSubscriber: LiveTextSubscriber = disabledLiveTextSubscriber,
 ) {
 	const deps = {
 		config: {},
@@ -72,6 +78,7 @@ function buildApp(
 		runStore: fakeRuns.runStore,
 		runEventReader: fakeRuns.runEventReader,
 		runNotifier: fakeRuns.runNotifier,
+		liveTextSubscriber,
 	} as unknown as AppDeps;
 	return createApp({ logLevel: "silent" } as unknown as ApiConfig, deps);
 }
@@ -96,8 +103,11 @@ function fakeRunStore() {
 	}> = [];
 	const runStore: RunStore = {
 		async createQueuedRun(input) {
-			const runId = `run-${queued.length + 1}`;
-			queued.push(input);
+			const runId = input.runId ?? `run-${queued.length + 1}`;
+			queued.push({
+				conversation: input.conversation,
+				message: input.message,
+			});
 			runOwners.set(runId, {
 				userId: input.conversation.userId,
 				conversationId: input.conversation.conversationId,
@@ -315,6 +325,132 @@ describe("POST /v1/conversations/:id/events", () => {
 		expect(text).toContain("conversation_id");
 		expect(text).toContain("run_id");
 		expect(queued).toEqual([{ conversation: existing, message: "hi" }]);
+	});
+
+	it("subscribes before admitting the same Run id and streams cursorless preview before its commit", async () => {
+		const { store } = fakeStore([existing]);
+		const liveText = new InMemoryLiveTextTransport();
+		const order: string[] = [];
+		let admittedRunId = "";
+		let reads = 0;
+		const runStore: RunStore = {
+			async createQueuedRun(input) {
+				order.push("admit");
+				admittedRunId = input.runId ?? "";
+				await liveText.publish({
+					runId: admittedRunId,
+					messageId: "message-1",
+					deltaIndex: 0,
+					text: "hel",
+				});
+				return { runId: admittedRunId };
+			},
+			async getRun() {
+				return null;
+			},
+			async requestCancellation() {
+				return { outcome: "not_found" };
+			},
+		};
+		const fakeRuns = {
+			...fakeRunStore(),
+			runStore,
+			runEventReader: {
+				async read() {
+					reads++;
+					return reads === 1
+						? [
+								{
+									seq: 1,
+									type: RunEventType.Started,
+									payload: {
+										conversationId: "conv-1",
+										runId: admittedRunId,
+									},
+								},
+							]
+						: [
+								{
+									seq: 2,
+									type: RunEventType.AssistantText,
+									payload: { messageId: "message-1", text: "hello" },
+								},
+								{ seq: 3, type: RunEventType.Done, payload: {} },
+							];
+				},
+			} satisfies RunEventReader,
+		};
+		const subscriber: LiveTextSubscriber = {
+			async subscribe(runId) {
+				order.push("subscribe");
+				return liveText.subscribe(runId);
+			},
+		};
+
+		const res = await buildApp(
+			store,
+			recordingGate(true).gate,
+			fakeRuns,
+			subscriber,
+		).request("/v1/conversations/conv-1/events", {
+			method: "POST",
+			headers: identityHeaders,
+			body: userMessage,
+		});
+		const text = await readSseUntil(res, (chunk) => chunk.includes("done"));
+
+		expect(order).toEqual(["subscribe", "admit"]);
+		expect(admittedRunId).toMatch(/^[0-9a-f-]{36}$/);
+		expect(text.indexOf("event: run_id")).toBeLessThan(
+			text.indexOf("event: text_delta"),
+		);
+		expect(text.indexOf("event: text_delta")).toBeLessThan(
+			text.indexOf("event: text_commit"),
+		);
+		expect(text).toContain('"deltaIndex":0');
+		expect(text).not.toMatch(/id: .*\nevent: text_delta/);
+		expect(text).toContain("id: 2");
+	});
+
+	it("closes the prepared Live subscription when admission conflicts", async () => {
+		const { store } = fakeStore([existing]);
+		let closes = 0;
+		const subscriber: LiveTextSubscriber = {
+			async subscribe() {
+				return {
+					readAvailable: () => [],
+					waitForMessage: async () => false,
+					close: async () => {
+						closes++;
+					},
+				};
+			},
+		};
+		const runStore: RunStore = {
+			async createQueuedRun() {
+				throw new ActiveRunExistsError();
+			},
+			async getRun() {
+				return null;
+			},
+			async requestCancellation() {
+				return { outcome: "not_found" };
+			},
+		};
+
+		const res = await buildApp(
+			store,
+			recordingGate(true).gate,
+			{ ...fakeRunStore(), runStore },
+			subscriber,
+		).request("/v1/conversations/conv-1/events", {
+			method: "POST",
+			headers: identityHeaders,
+			body: userMessage,
+		});
+
+		expect(res.status).toBe(409);
+		expect(closes).toBe(1);
 	});
 
 	it("returns busy backpressure before opening the stream", async () => {

--- a/apps/chat-api/src/features/conversations/conversations.route.ts
+++ b/apps/chat-api/src/features/conversations/conversations.route.ts
@@ -5,6 +5,7 @@ import { validator as zValidator } from "hono-openapi";
 import { z } from "zod";
 import type { AppEnv } from "@/deps";
 import { projectRun } from "@/features/run-events";
+import { prepareLiveTextSubscription } from "@/features/run-events/prepare-live-text-subscription";
 import { ActiveRunExistsError } from "@/features/run-store";
 import { HonoSSESender } from "@/features/streaming/sse-sender";
 import {
@@ -164,13 +165,20 @@ app.post(
 			return c.json({ error: "Agent is not enabled" }, 403);
 		}
 
+		const runId = crypto.randomUUID();
+		const liveSubscription = await prepareLiveTextSubscription(
+			c.var.deps.liveTextSubscriber,
+			runId,
+		);
 		let queuedRun: { runId: string };
 		try {
 			queuedRun = await queueConversationTurn(c.var.deps, {
 				conversation,
 				message: event.text,
+				runId,
 			});
 		} catch (error) {
+			await liveSubscription?.close().catch(() => {});
 			if (error instanceof ActiveRunExistsError) {
 				return c.json(
 					{
@@ -201,6 +209,7 @@ app.post(
 					for await (const projected of projectRun(queuedRun.runId, 0, {
 						reader: c.var.deps.runEventReader,
 						notifier: c.var.deps.runNotifier,
+						liveSubscription: liveSubscription ?? undefined,
 						signal: requestSignal,
 					})) {
 						if (requestSignal.aborted) break;

--- a/apps/chat-api/src/features/run-events/prepare-live-text-subscription.test.ts
+++ b/apps/chat-api/src/features/run-events/prepare-live-text-subscription.test.ts
@@ -1,0 +1,43 @@
+import { expect, it } from "bun:test";
+import type { LiveTextSubscription } from "@mymemo/live-text";
+import { prepareLiveTextSubscription } from "./prepare-live-text-subscription";
+
+it("falls back when subscription setup throws synchronously", async () => {
+	await expect(
+		prepareLiveTextSubscription(
+			{
+				subscribe() {
+					throw new Error("client is unavailable");
+				},
+			},
+			"run-1",
+		),
+	).resolves.toBeNull();
+});
+
+it("falls back after a bounded wait and closes a subscription that arrives late", async () => {
+	let resolveSubscription: ((value: LiveTextSubscription) => void) | undefined;
+	let closes = 0;
+	const prepared = prepareLiveTextSubscription(
+		{
+			async subscribe() {
+				return new Promise<LiveTextSubscription>((resolve) => {
+					resolveSubscription = resolve;
+				});
+			},
+		},
+		"run-1",
+		1,
+	);
+
+	await expect(prepared).resolves.toBeNull();
+	resolveSubscription?.({
+		readAvailable: () => [],
+		waitForMessage: async () => false,
+		close: async () => {
+			closes++;
+		},
+	});
+	await Bun.sleep(0);
+	expect(closes).toBe(1);
+});

--- a/apps/chat-api/src/features/run-events/prepare-live-text-subscription.ts
+++ b/apps/chat-api/src/features/run-events/prepare-live-text-subscription.ts
@@ -1,0 +1,34 @@
+import type {
+	LiveTextSubscriber,
+	LiveTextSubscription,
+} from "@mymemo/live-text";
+
+export const LIVE_TEXT_SUBSCRIBE_TIMEOUT_MS = 100;
+const TIMED_OUT = Symbol("live text subscription timed out");
+
+export async function prepareLiveTextSubscription(
+	subscriber: LiveTextSubscriber,
+	runId: string,
+	timeoutMs = LIVE_TEXT_SUBSCRIBE_TIMEOUT_MS,
+): Promise<LiveTextSubscription | null> {
+	let prepared: Promise<LiveTextSubscription>;
+	try {
+		prepared = subscriber.subscribe(runId);
+	} catch {
+		return null;
+	}
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	const timeout = new Promise<typeof TIMED_OUT>((resolve) => {
+		timer = setTimeout(() => resolve(TIMED_OUT), timeoutMs);
+	});
+	try {
+		const result = await Promise.race([prepared, timeout]);
+		if (result !== TIMED_OUT) return result;
+		void prepared.then((subscription) => subscription.close()).catch(() => {});
+		return null;
+	} catch {
+		return null;
+	} finally {
+		if (timer !== undefined) clearTimeout(timer);
+	}
+}

--- a/apps/chat-api/src/features/run-events/project-run.test.ts
+++ b/apps/chat-api/src/features/run-events/project-run.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { InMemoryLiveTextTransport } from "@mymemo/live-text";
 import type { Database } from "@/db/client";
 import { runEvents, runs } from "@/db/schema";
 import { createTestDatabase } from "@/db/testing";
@@ -71,6 +72,190 @@ function frames(projected: ProjectedFrame[]) {
 }
 
 describe("projectRun", () => {
+	it("merges prepared cursorless previews before authoritative commits", async () => {
+		const liveText = new InMemoryLiveTextTransport();
+		const liveSubscription = await liveText.subscribe("run-1");
+		for (const message of [
+			{ messageId: "message-1", deltaIndex: 0, text: "hel" },
+			{ messageId: "message-1", deltaIndex: 1, text: "lo" },
+			{ messageId: "message-2", deltaIndex: 0, text: "again" },
+		]) {
+			await liveText.publish({ runId: "run-1", ...message });
+		}
+		const reader = new ScriptedReader([
+			[
+				{
+					seq: 1,
+					type: RunEventType.Started,
+					payload: { conversationId: "conv-1", runId: "run-1" },
+				},
+			],
+			[
+				{
+					seq: 2,
+					type: RunEventType.AssistantText,
+					payload: { messageId: "message-1", text: "hello" },
+				},
+				{
+					seq: 3,
+					type: RunEventType.AssistantText,
+					payload: { messageId: "message-2", text: "again" },
+				},
+				{ seq: 4, type: RunEventType.Done, payload: {} },
+			],
+		]);
+
+		const projected = await drain(
+			projectRun("run-1", 0, {
+				reader,
+				notifier: new InstantNotifier(),
+				liveSubscription,
+			}),
+		);
+
+		expect(projected.map(({ id, frame }) => ({ id, frame }))).toEqual([
+			{
+				id: undefined,
+				frame: { type: "conversation_id", conversationId: "conv-1" },
+			},
+			{
+				id: "1",
+				frame: { type: "run_id", runId: "run-1" },
+			},
+			{
+				id: undefined,
+				frame: {
+					type: "text_delta",
+					messageId: "message-1",
+					deltaIndex: 0,
+					text: "hel",
+				},
+			},
+			{
+				id: undefined,
+				frame: {
+					type: "text_delta",
+					messageId: "message-1",
+					deltaIndex: 1,
+					text: "lo",
+				},
+			},
+			{
+				id: undefined,
+				frame: {
+					type: "text_delta",
+					messageId: "message-2",
+					deltaIndex: 0,
+					text: "again",
+				},
+			},
+			{
+				id: "2",
+				frame: { type: "text_commit", messageId: "message-1", text: "hello" },
+			},
+			{
+				id: "3",
+				frame: { type: "text_commit", messageId: "message-2", text: "again" },
+			},
+			{ id: "4", frame: { type: "done" } },
+		]);
+	});
+
+	it("suppresses queued and late preview after the authoritative commit", async () => {
+		const liveText = new InMemoryLiveTextTransport();
+		const liveSubscription = await liveText.subscribe("run-1");
+		await liveText.publish({
+			runId: "run-1",
+			messageId: "message-1",
+			deltaIndex: 0,
+			text: "provisional",
+		});
+		const reader = new ScriptedReader([
+			[
+				{
+					seq: 1,
+					type: RunEventType.Started,
+					payload: { conversationId: "conv-1", runId: "run-1" },
+				},
+				{
+					seq: 2,
+					type: RunEventType.AssistantText,
+					payload: { messageId: "message-1", text: "authoritative" },
+				},
+				{ seq: 3, type: RunEventType.Done, payload: {} },
+			],
+		]);
+
+		expect(
+			frames(
+				await drain(
+					projectRun("run-1", 0, {
+						reader,
+						notifier: new InstantNotifier(),
+						liveSubscription,
+					}),
+				),
+			),
+		).toEqual([
+			{ type: "conversation_id", conversationId: "conv-1" },
+			{ type: "run_id", runId: "run-1" },
+			{
+				type: "text_commit",
+				messageId: "message-1",
+				text: "authoritative",
+			},
+			{ type: "done" },
+		]);
+	});
+
+	it("degrades to durable projection when the Live subscription fails", async () => {
+		let closes = 0;
+		const reader = new ScriptedReader([
+			[
+				{
+					seq: 1,
+					type: RunEventType.Started,
+					payload: { conversationId: "conv-1", runId: "run-1" },
+				},
+			],
+			[
+				{
+					seq: 2,
+					type: RunEventType.AssistantText,
+					payload: { messageId: "message-1", text: "durable" },
+				},
+				{ seq: 3, type: RunEventType.Done, payload: {} },
+			],
+		]);
+
+		const projected = await drain(
+			projectRun("run-1", 0, {
+				reader,
+				notifier: new InstantNotifier(),
+				liveSubscription: {
+					readAvailable() {
+						throw new Error("Live transport disconnected");
+					},
+					async waitForMessage() {
+						throw new Error("must not wait after read failure");
+					},
+					async close() {
+						closes++;
+						throw new Error("Live close failed");
+					},
+				},
+			}),
+		);
+
+		expect(frames(projected)).toEqual([
+			{ type: "conversation_id", conversationId: "conv-1" },
+			{ type: "run_id", runId: "run-1" },
+			{ type: "text_commit", messageId: "message-1", text: "durable" },
+			{ type: "done" },
+		]);
+		expect(closes).toBe(1);
+	});
+
 	it("replays committed Assistant messages with durable cursors", async () => {
 		const reader = new ScriptedReader([
 			[

--- a/apps/chat-api/src/features/run-events/project-run.ts
+++ b/apps/chat-api/src/features/run-events/project-run.ts
@@ -1,3 +1,4 @@
+import type { LiveTextMessage, LiveTextSubscription } from "@mymemo/live-text";
 import { projectRunEvent } from "./project-run-event";
 import type { RunEventReader } from "./run-event-reader";
 import type { ClientFrame } from "./run-event-types";
@@ -11,7 +12,7 @@ import type { RunNotifier } from "./run-notifier";
  * keeps the previous durable id and replay can deliver the whole fanout again.
  */
 export interface ProjectedFrame {
-	seq: number;
+	seq?: number;
 	id?: string;
 	frame: ClientFrame;
 }
@@ -26,6 +27,8 @@ export interface ProjectRunDeps {
 	 * notifications; keep it short (1-2s). Default 1000ms.
 	 */
 	pollTimeoutMs?: number;
+	/** Prepared before Run admission on the original request only. */
+	liveSubscription?: LiveTextSubscription;
 }
 
 /**
@@ -47,7 +50,23 @@ export async function* projectRun(
 	deps: ProjectRunDeps,
 ): AsyncGenerator<ProjectedFrame> {
 	const pollTimeoutMs = deps.pollTimeoutMs ?? 1000;
-	const subscription = await deps.notifier.subscribe(runId);
+	const durableSubscription = await deps.notifier.subscribe(runId);
+	const expectedDeltaIndex = new Map<string, number>();
+	const suppressedMessageIds = new Set<string>();
+	const committedMessageIds = new Set<string>();
+	let liveSubscription = deps.liveSubscription;
+	let previewReady = false;
+	let durableWakeup: Promise<boolean> | undefined;
+	const disableLiveSubscription = async () => {
+		const subscription = liveSubscription;
+		liveSubscription = undefined;
+		if (!subscription) return;
+		try {
+			await subscription.close();
+		} catch {
+			// Live preview is optional; durable projection stays authoritative.
+		}
+	};
 	try {
 		let lastSeq = fromSeq;
 		for (;;) {
@@ -56,6 +75,13 @@ export async function* projectRun(
 			for (const row of rows) {
 				lastSeq = row.seq;
 				const frames = projectRunEvent(row.type, row.payload);
+				for (const frame of frames) {
+					if (frame.type === "text_commit") {
+						committedMessageIds.add(frame.messageId);
+						expectedDeltaIndex.delete(frame.messageId);
+						suppressedMessageIds.delete(frame.messageId);
+					}
+				}
 				for (const [index, frame] of frames.entries()) {
 					const isLastSibling = index === frames.length - 1;
 					yield {
@@ -66,13 +92,93 @@ export async function* projectRun(
 					if (deps.signal?.aborted) return;
 				}
 				if (TERMINAL_RUN_EVENT_TYPES.has(row.type)) return;
+				if (frames.some((frame) => frame.type === "run_id"))
+					previewReady = true;
 			}
-			if (!(await waitForWakeup(subscription, pollTimeoutMs, deps.signal))) {
+			if (previewReady && liveSubscription) {
+				let available: LiveTextMessage[];
+				try {
+					available = liveSubscription.readAvailable();
+				} catch {
+					await disableLiveSubscription();
+					available = [];
+				}
+				for (const message of available) {
+					if (
+						message.runId !== runId ||
+						committedMessageIds.has(message.messageId) ||
+						suppressedMessageIds.has(message.messageId)
+					) {
+						continue;
+					}
+					const expected = expectedDeltaIndex.get(message.messageId) ?? 0;
+					if (message.deltaIndex !== expected) {
+						expectedDeltaIndex.delete(message.messageId);
+						suppressedMessageIds.add(message.messageId);
+						continue;
+					}
+					expectedDeltaIndex.set(message.messageId, expected + 1);
+					yield {
+						frame: {
+							type: "text_delta",
+							messageId: message.messageId,
+							deltaIndex: message.deltaIndex,
+							text: message.text,
+						},
+					};
+					if (deps.signal?.aborted) return;
+				}
+			}
+			if (!liveSubscription) {
+				if (
+					!(await waitForWakeup(
+						durableSubscription,
+						pollTimeoutMs,
+						deps.signal,
+					))
+				) {
+					return;
+				}
+				continue;
+			}
+
+			durableWakeup ??= waitForWakeup(
+				durableSubscription,
+				pollTimeoutMs,
+				deps.signal,
+			);
+			const liveWaitController = new AbortController();
+			const onAbort = () => liveWaitController.abort();
+			deps.signal?.addEventListener("abort", onAbort, { once: true });
+			const currentLiveSubscription = liveSubscription;
+			const winner = await Promise.race([
+				durableWakeup.then((open) => ({ source: "durable" as const, open })),
+				currentLiveSubscription
+					.waitForMessage({
+						timeoutMs: pollTimeoutMs,
+						signal: liveWaitController.signal,
+					})
+					.then(
+						(open) => ({ source: "live" as const, open, failed: false }),
+						() => ({ source: "live" as const, open: false, failed: true }),
+					),
+			]);
+			liveWaitController.abort();
+			deps.signal?.removeEventListener("abort", onAbort);
+			if (winner.source === "durable") durableWakeup = undefined;
+			if (winner.source === "live" && winner.failed) {
+				await disableLiveSubscription();
+			}
+			if (!winner.open && deps.signal?.aborted) {
 				return;
 			}
 		}
 	} finally {
-		await subscription.close();
+		try {
+			await durableSubscription.close();
+		} finally {
+			await disableLiveSubscription();
+		}
 	}
 }
 

--- a/apps/chat-api/src/features/run-events/run-event-types.ts
+++ b/apps/chat-api/src/features/run-events/run-event-types.ts
@@ -41,6 +41,12 @@ export const TERMINAL_RUN_EVENT_TYPES: ReadonlySet<string> = new Set([
 export type ClientFrame =
 	| { type: "conversation_id"; conversationId: string }
 	| { type: "run_id"; runId: string }
+	| {
+			type: "text_delta";
+			messageId: string;
+			deltaIndex: number;
+			text: string;
+	  }
 	| { type: "text_commit"; messageId: string; text: string }
 	| { type: "done" }
 	| { type: "canceled" }

--- a/apps/chat-api/src/features/run-store/postgres-run-store.test.ts
+++ b/apps/chat-api/src/features/run-store/postgres-run-store.test.ts
@@ -70,6 +70,19 @@ describe("PostgresRunStore", () => {
 		});
 	});
 
+	it("admits a caller-prepared Run id transactionally", async () => {
+		const result = await store.createQueuedRun({
+			conversation,
+			message: "hello",
+			runId: "prepared-run-id",
+		});
+
+		expect(result).toEqual({ runId: "prepared-run-id" });
+		await expect(
+			loadRunStartedTx(tdb.db, { runId: "prepared-run-id" }),
+		).resolves.toMatchObject({ message: "hello" });
+	});
+
 	// Guards the write/read contract across the trust boundary: the worker's
 	// orchestration loads the turn through the shared helper, so what admission
 	// writes must be exactly what it reads back.

--- a/apps/chat-api/src/features/run-store/run-store.ts
+++ b/apps/chat-api/src/features/run-store/run-store.ts
@@ -60,6 +60,8 @@ export class ActiveRunExistsError extends ActiveRunConflictError {
 export interface CreateQueuedRunInput {
 	conversation: ConversationRecord;
 	message: string;
+	/** A Live subscription may be prepared for this id before admission. */
+	runId?: string;
 }
 
 export interface CreateQueuedRunResult {
@@ -145,7 +147,7 @@ export class PostgresRunStore implements RunStore {
 	async createQueuedRun(
 		input: CreateQueuedRunInput,
 	): Promise<CreateQueuedRunResult> {
-		const runId = crypto.randomUUID();
+		const runId = input.runId ?? crypto.randomUUID();
 		await createQueuedRunStartedTx(this.db, { ...input, runId });
 		return { runId };
 	}

--- a/apps/chat-api/src/features/streaming/events.ts
+++ b/apps/chat-api/src/features/streaming/events.ts
@@ -5,6 +5,7 @@ export interface MymemoEvent {
 
 export type EventMessage =
 	| ErrorEvent
+	| TextDeltaEvent
 	| TextCommitEvent
 	| DoneEvent
 	| CanceledEvent
@@ -29,6 +30,13 @@ export interface RunIdEvent {
 export interface TextCommitEvent {
 	type: "text_commit";
 	messageId: string;
+	text: string;
+}
+
+export interface TextDeltaEvent {
+	type: "text_delta";
+	messageId: string;
+	deltaIndex: number;
 	text: string;
 }
 

--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.117",
         "@mymemo/agent-db": "workspace:*",
+        "@mymemo/live-text": "workspace:*",
         "drizzle-orm": "^0.45.2",
         "e2b": "^2.14.0",
         "pg": "^8.22.0",
@@ -34,6 +35,7 @@
       "dependencies": {
         "@hono/standard-validator": "^0.1.5",
         "@mymemo/agent-db": "workspace:*",
+        "@mymemo/live-text": "workspace:*",
         "@scalar/hono-api-reference": "^0.9.22",
         "@statsig/statsig-node-core": "^0.19.8",
         "drizzle-orm": "^0.45.2",
@@ -80,6 +82,17 @@
       "peerDependencies": {
         "drizzle-orm": "^0.45.2",
         "pg": "^8.22.0",
+      },
+    },
+    "packages/live-text": {
+      "name": "@mymemo/live-text",
+      "version": "0.1.0",
+      "dependencies": {
+        "zod": "^4.1.12",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "^2.3.11",
+        "@types/bun": "^1.3.11",
       },
     },
   },
@@ -233,6 +246,8 @@
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@mymemo/agent-db": ["@mymemo/agent-db@workspace:packages/agent-db"],
+
+    "@mymemo/live-text": ["@mymemo/live-text@workspace:packages/live-text"],
 
     "@octokit/auth-token": ["@octokit/auth-token@5.1.2", "", {}, "sha512-JcQDsBdg49Yky2w2ld20IHAlwr8d/d8N6NiOXbtuoPCqzbsiJgF633mVUw3x4mo0H5ypataQIX7SFu3yy44Mpw=="],
 
@@ -660,6 +675,8 @@
 
     "@mymemo/agent-db/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
+    "@mymemo/live-text/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+
     "agent-worker/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
     "chat-api/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
@@ -713,6 +730,8 @@
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
 
     "@mymemo/agent-db/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+
+    "@mymemo/live-text/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
     "agent-worker/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 

--- a/packages/live-text/package.json
+++ b/packages/live-text/package.json
@@ -1,0 +1,19 @@
+{
+	"name": "@mymemo/live-text",
+	"version": "0.1.0",
+	"type": "module",
+	"exports": {
+		".": "./src/index.ts"
+	},
+	"scripts": {
+		"test": "bun test",
+		"check": "biome check --write"
+	},
+	"dependencies": {
+		"zod": "^4.1.12"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^2.3.11",
+		"@types/bun": "^1.3.11"
+	}
+}

--- a/packages/live-text/src/index.test.ts
+++ b/packages/live-text/src/index.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "bun:test";
+import {
+	InMemoryLiveTextTransport,
+	LIVE_TEXT_MAX_CHUNK_LENGTH,
+	LiveTextMessageSchema,
+} from "./index";
+
+describe("LiveTextMessageSchema", () => {
+	it("accepts the bounded provisional wire message and rejects extra or oversized data", () => {
+		expect(
+			LiveTextMessageSchema.parse({
+				runId: "run-1",
+				messageId: "message-1",
+				deltaIndex: 0,
+				text: "hello",
+			}),
+		).toEqual({
+			runId: "run-1",
+			messageId: "message-1",
+			deltaIndex: 0,
+			text: "hello",
+		});
+		expect(
+			LiveTextMessageSchema.safeParse({
+				runId: "run-1",
+				messageId: "message-1",
+				deltaIndex: 0,
+				text: "x".repeat(LIVE_TEXT_MAX_CHUNK_LENGTH + 1),
+			}),
+		).toMatchObject({ success: false });
+		expect(
+			LiveTextMessageSchema.safeParse({
+				runId: "run-1",
+				messageId: "message-1",
+				deltaIndex: 0,
+				text: "hello",
+				durable: true,
+			}),
+		).toMatchObject({ success: false });
+	});
+});
+
+describe("InMemoryLiveTextTransport", () => {
+	it("buffers ordered messages only for subscriptions prepared on that Run", async () => {
+		const transport = new InMemoryLiveTextTransport();
+		const runOne = await transport.subscribe("run-1");
+		const runTwo = await transport.subscribe("run-2");
+
+		await transport.publish({
+			runId: "run-1",
+			messageId: "message-1",
+			deltaIndex: 0,
+			text: "hel",
+		});
+		await transport.publish({
+			runId: "run-1",
+			messageId: "message-1",
+			deltaIndex: 1,
+			text: "lo",
+		});
+
+		expect(runOne.readAvailable()).toEqual([
+			{
+				runId: "run-1",
+				messageId: "message-1",
+				deltaIndex: 0,
+				text: "hel",
+			},
+			{
+				runId: "run-1",
+				messageId: "message-1",
+				deltaIndex: 1,
+				text: "lo",
+			},
+		]);
+		expect(runTwo.readAvailable()).toEqual([]);
+
+		await runOne.close();
+		await transport.publish({
+			runId: "run-1",
+			messageId: "message-2",
+			deltaIndex: 0,
+			text: "ignored",
+		});
+		expect(runOne.readAvailable()).toEqual([]);
+	});
+
+	it("releases a pending waiter as unavailable when its subscription closes", async () => {
+		const transport = new InMemoryLiveTextTransport();
+		const subscription = await transport.subscribe("run-1");
+		const waiting = subscription.waitForMessage();
+
+		await subscription.close();
+
+		await expect(waiting).resolves.toBe(false);
+	});
+});

--- a/packages/live-text/src/index.ts
+++ b/packages/live-text/src/index.ts
@@ -1,0 +1,142 @@
+import { z } from "zod";
+
+export const LIVE_TEXT_MAX_CHUNK_LENGTH = 16_384;
+const LIVE_TEXT_MAX_ID_LENGTH = 128;
+
+export const LiveTextMessageSchema = z
+	.object({
+		runId: z.string().min(1).max(LIVE_TEXT_MAX_ID_LENGTH),
+		messageId: z.string().min(1).max(LIVE_TEXT_MAX_ID_LENGTH),
+		deltaIndex: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
+		text: z.string().min(1).max(LIVE_TEXT_MAX_CHUNK_LENGTH),
+	})
+	.strict();
+
+export type LiveTextMessage = z.infer<typeof LiveTextMessageSchema>;
+
+export interface LiveTextPublisher {
+	publish(message: LiveTextMessage): Promise<void>;
+}
+
+export interface LiveTextSubscription {
+	readAvailable(): LiveTextMessage[];
+	waitForMessage(options?: {
+		timeoutMs?: number;
+		signal?: AbortSignal;
+	}): Promise<boolean>;
+	close(): Promise<void>;
+}
+
+export interface LiveTextSubscriber {
+	subscribe(runId: string): Promise<LiveTextSubscription>;
+}
+
+class InMemoryLiveTextSubscription implements LiveTextSubscription {
+	readonly #buffer: LiveTextMessage[] = [];
+	readonly #waiters = new Set<(available: boolean) => void>();
+	#closed = false;
+
+	constructor(
+		readonly runId: string,
+		private readonly maxBufferedMessages: number,
+		private readonly onClose: () => void,
+	) {}
+
+	enqueue(message: LiveTextMessage): void {
+		if (this.#closed || this.#buffer.length >= this.maxBufferedMessages) return;
+		this.#buffer.push(message);
+		for (const wake of this.#waiters) wake(true);
+		this.#waiters.clear();
+	}
+
+	readAvailable(): LiveTextMessage[] {
+		if (this.#closed) return [];
+		return this.#buffer.splice(0);
+	}
+
+	async waitForMessage(
+		options: { timeoutMs?: number; signal?: AbortSignal } = {},
+	): Promise<boolean> {
+		if (this.#closed || options.signal?.aborted) return false;
+		if (this.#buffer.length > 0) return true;
+
+		return new Promise<boolean>((resolve) => {
+			let settled = false;
+			let timer: ReturnType<typeof setTimeout> | undefined;
+			const finish = (available: boolean) => {
+				if (settled) return;
+				settled = true;
+				this.#waiters.delete(onMessage);
+				if (timer !== undefined) clearTimeout(timer);
+				options.signal?.removeEventListener("abort", onAbort);
+				resolve(available);
+			};
+			const onMessage = (available: boolean) => finish(available);
+			const onAbort = () => finish(false);
+			this.#waiters.add(onMessage);
+			options.signal?.addEventListener("abort", onAbort, { once: true });
+			if (options.timeoutMs !== undefined) {
+				timer = setTimeout(() => finish(false), options.timeoutMs);
+			}
+		});
+	}
+
+	async close(): Promise<void> {
+		if (this.#closed) return;
+		this.#closed = true;
+		this.#buffer.length = 0;
+		for (const wake of this.#waiters) wake(false);
+		this.#waiters.clear();
+		this.onClose();
+	}
+}
+
+/** Deterministic process-local transport used by integration tests. */
+export class InMemoryLiveTextTransport
+	implements LiveTextPublisher, LiveTextSubscriber
+{
+	readonly #subscriptions = new Map<
+		string,
+		Set<InMemoryLiveTextSubscription>
+	>();
+
+	constructor(private readonly maxBufferedMessages = 64) {
+		if (!Number.isSafeInteger(maxBufferedMessages) || maxBufferedMessages < 1) {
+			throw new Error("maxBufferedMessages must be a positive integer");
+		}
+	}
+
+	async publish(message: LiveTextMessage): Promise<void> {
+		const parsed = LiveTextMessageSchema.parse(message);
+		for (const subscription of this.#subscriptions.get(parsed.runId) ?? []) {
+			subscription.enqueue(parsed);
+		}
+	}
+
+	async subscribe(runId: string): Promise<LiveTextSubscription> {
+		const parsedRunId = LiveTextMessageSchema.shape.runId.parse(runId);
+		const subscriptions = this.#subscriptions.get(parsedRunId) ?? new Set();
+		this.#subscriptions.set(parsedRunId, subscriptions);
+		let subscription: InMemoryLiveTextSubscription;
+		subscription = new InMemoryLiveTextSubscription(
+			parsedRunId,
+			this.maxBufferedMessages,
+			() => {
+				subscriptions.delete(subscription);
+				if (subscriptions.size === 0) this.#subscriptions.delete(parsedRunId);
+			},
+		);
+		subscriptions.add(subscription);
+		return subscription;
+	}
+}
+
+export const disabledLiveTextSubscriber: LiveTextSubscriber = {
+	async subscribe() {
+		throw new Error("Live text is disabled");
+	},
+};
+
+export const disabledLiveTextPublisher: LiveTextPublisher = {
+	async publish() {},
+};

--- a/packages/live-text/tsconfig.json
+++ b/packages/live-text/tsconfig.json
@@ -1,0 +1,17 @@
+{
+	"compilerOptions": {
+		"lib": ["ESNext"],
+		"target": "ESNext",
+		"module": "Preserve",
+		"moduleDetection": "force",
+		"moduleResolution": "bundler",
+		"allowImportingTsExtensions": true,
+		"verbatimModuleSyntax": true,
+		"noEmit": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"noFallthroughCasesInSwitch": true,
+		"noUncheckedIndexedAccess": true,
+		"noImplicitOverride": true
+	}
+}


### PR DESCRIPTION
## Summary
- Add a shared `live-text` package for assembling and diffing incremental assistant text
- Stream live text preview frames from `agent-worker` and project them through `chat-api`
- Update conversation SSE handling to subscribe to preview updates while a run is active
- Add tests covering stream assembly, preview preparation, projection, and route behavior

## Testing
- Added unit and integration coverage for live text assembly, run projection, and conversation streaming
- Not run (not requested)