### PR TITLE
Connect production Redis Live preview lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,9 @@ jobs:
           # Pinned for reproducible CI — match the version the lockfile was
           # generated with. Bump deliberately alongside local upgrades.
           bun-version: 1.3.0
-      # The agent-worker file-tools integration test drives the real grep
-      # command path, which shells out to ripgrep; the runner image does not
-      # ship it.
-      - run: sudo apt-get update && sudo apt-get install -y ripgrep
+      # Integration tests drive real ripgrep and disposable Redis processes;
+      # the runner image does not ship either executable.
+      - run: sudo apt-get update && sudo apt-get install -y ripgrep redis-server
       - run: bun install --frozen-lockfile
       - run: bun run test
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,6 +190,10 @@ Optional:
 - `AGENT_EXPOSURE_BREAK_GLASS` (default: off) — operator break-glass for the agent exposure gate. When `true`, new agent work is allowed without Statsig (local dev, or an incident where Statsig is unavailable) and `STATSIG_SERVER_SECRET` is not required. When off (production default), the gate fails closed
 - `DB_PASSWORD` — spliced into `AGENT_DATABASE_URL` when it is passwordless (the form the platform injects)
 - `DB_SSL` (default: on; set `disable` for a local non-TLS Postgres)
+- `REDIS_URL` — optional authenticated `rediss://` secret for cursorless Live
+  preview. Missing, malformed, insecure, or unreachable configuration disables
+  only the Live lane; boot, health, and durable Postgres projection remain
+  operational. Never logged or passed into E2B
 
 ### agent-worker
 
@@ -214,6 +218,10 @@ Optional:
 - `WORKER_CLEANUP_INTERVAL_MS` (default: `300000`) — how often the worker-embedded orphan/deleted-conversation cleanup loop (Task 8.1, ADR-0007) attempts a pass; the pass is single-flighted across replicas by a Postgres advisory lock, so only one worker runs it at a time
 - `PORT` (default: `8080`) — `/health` endpoint port
 - `LOG_LEVEL` (default: `info`)
+- `REDIS_URL` — optional authenticated `rediss://` secret for cursorless Live
+  preview. Missing, malformed, insecure, or unreachable configuration disables
+  only the Live lane; boot, health, and Run execution remain operational. Never
+  logged or passed into E2B
 - `DB_PASSWORD` — spliced into `AGENT_DATABASE_URL` when passwordless; `DB_SSL` (default: on; `disable` for local non-TLS)
 
 ## Agent skills

--- a/apps/agent-worker/src/config/env.test.ts
+++ b/apps/agent-worker/src/config/env.test.ts
@@ -199,3 +199,25 @@ describe("loadWorkerConfigFromEnv — LoadDocuments caps", () => {
 		);
 	});
 });
+
+describe("loadWorkerConfigFromEnv — optional Live Redis lane", () => {
+	it("enables Live preview only for an authenticated TLS URL", () => {
+		const env = baseEnv();
+		env.REDIS_URL = "rediss://default:secret@redis.internal:6379";
+		expect(loadWorkerConfigFromEnv(env).liveTextRedisUrl).toBe(env.REDIS_URL);
+	});
+
+	it("degrades missing, malformed, or insecure Redis configuration", () => {
+		for (const redisUrl of [
+			undefined,
+			"not a URL",
+			"redis://default:secret@redis.internal:6379",
+			"rediss://redis.internal:6379",
+		]) {
+			const env = baseEnv();
+			env.REDIS_URL = redisUrl;
+			expect(() => loadWorkerConfigFromEnv(env)).not.toThrow();
+			expect(loadWorkerConfigFromEnv(env).liveTextRedisUrl).toBeUndefined();
+		}
+	});
+});

--- a/apps/agent-worker/src/config/env.ts
+++ b/apps/agent-worker/src/config/env.ts
@@ -1,3 +1,4 @@
+import { resolveLiveTextRedisUrl } from "@mymemo/live-text";
 import {
 	type BashToolLimits,
 	DEFAULT_BASH_TOOL_LIMITS,
@@ -46,6 +47,8 @@ export interface WorkerConfig {
 	 * Required so a misconfigured worker fails at boot, not per run.
 	 */
 	e2bTemplate: string;
+	/** Optional authenticated TLS Redis secret for best-effort Live preview. */
+	liveTextRedisUrl: string | undefined;
 	/** How long an unrenewed E2B sandbox stays active before idle-pausing. */
 	sandboxIdleMs: number;
 	/** Bounds for the model-facing workspace file tools. */
@@ -176,6 +179,7 @@ export function loadWorkerConfigFromEnv(env: Env): WorkerConfig {
 		},
 		e2bApiKey: env.E2B_API_KEY,
 		e2bTemplate: env.WORKER_E2B_TEMPLATE,
+		liveTextRedisUrl: resolveLiveTextRedisUrl(env.REDIS_URL),
 		sandboxIdleMs: positiveIntOr(
 			env.WORKER_SANDBOX_IDLE_MS,
 			DEFAULT_SANDBOX_IDLE_MS,

--- a/apps/agent-worker/src/index.test.ts
+++ b/apps/agent-worker/src/index.test.ts
@@ -9,9 +9,9 @@ describe("agent-worker production composition", () => {
 		const source = readFileSync(new URL("./index.ts", import.meta.url), "utf8");
 
 		expect(source).toContain("const startRunQuery = createStartRunQuery({");
-		expect(source).toContain(
-			"processor: createSdkRunProcessor({ startRunQuery, logger })",
-		);
+		expect(source).toContain("processor: createSdkRunProcessor({");
+		expect(source).toContain("liveTextPublisher: liveTextTransport");
+		expect(source).toContain("await liveTextTransport?.close()");
 		expect(source).not.toContain("syntheticProcessor");
 	});
 });

--- a/apps/agent-worker/src/index.ts
+++ b/apps/agent-worker/src/index.ts
@@ -10,6 +10,7 @@ import { loadWorkerConfigFromEnv } from "./config/env";
 import { createDocumentSearch } from "./documents/client";
 import { createE2bSandboxProvisioner } from "./e2b/sandbox-provisioner";
 import { startHealthServer } from "./health";
+import { createWorkerLiveTextTransport } from "./live-text";
 import { createLogger } from "./logger";
 import { buildModelClientConfig } from "./model-client";
 import { RunLoop } from "./run-loop";
@@ -26,6 +27,10 @@ import { generateWorkerId } from "./worker-id";
 const config = loadWorkerConfigFromEnv(Bun.env);
 const logger = createLogger(config.logLevel);
 const workerId = generateWorkerId();
+const liveTextTransport = createWorkerLiveTextTransport(
+	config.liveTextRedisUrl,
+	logger,
+);
 // Verify the native CLI before constructing a run loop: a missing or wrong-libc
 // binary must crash boot before this process can claim work.
 const pathToClaudeCodeExecutable = resolveAndVerifyClaudeCodeExecutable();
@@ -81,7 +86,11 @@ const startRunQuery = createStartRunQuery({
 const runLoop = new RunLoop({
 	db,
 	worker,
-	processor: createSdkRunProcessor({ startRunQuery, logger }),
+	processor: createSdkRunProcessor({
+		startRunQuery,
+		logger,
+		liveTextPublisher: liveTextTransport,
+	}),
 	heartbeatIntervalMs: config.heartbeatIntervalMs,
 	logger,
 });
@@ -117,6 +126,7 @@ async function handleShutdownSignal(signal: NodeJS.Signals): Promise<void> {
 	logger.info({ message: "Received shutdown signal", signal, workerId });
 	cleanupLoop.stop();
 	await runLoop.stop();
+	await liveTextTransport?.close().catch(() => {});
 	server.stop();
 	logger.info({ message: "agent-worker stopped", workerId });
 	process.exit(0);

--- a/apps/agent-worker/src/live-text.test.ts
+++ b/apps/agent-worker/src/live-text.test.ts
@@ -1,0 +1,35 @@
+import { expect, it } from "bun:test";
+import { createWorkerLiveTextTransport } from "./live-text";
+
+const logger = {
+	info() {},
+	warn() {},
+};
+
+it("keeps the worker Live lane disabled without valid Redis configuration", () => {
+	const signals: unknown[] = [];
+	const recordingLogger = {
+		info(event: unknown) {
+			signals.push(event);
+		},
+		warn() {},
+	};
+	expect(
+		createWorkerLiveTextTransport(undefined, recordingLogger),
+	).toBeUndefined();
+	expect(signals).toEqual([
+		{
+			message: "Live preview Redis transport state changed",
+			signal: "disabled",
+		},
+	]);
+});
+
+it("constructs the lazy production publisher when Redis is configured", async () => {
+	const transport = createWorkerLiveTextTransport(
+		"rediss://default:secret@redis.internal:6379",
+		logger,
+	);
+	expect(transport).toBeDefined();
+	await transport?.close();
+});

--- a/apps/agent-worker/src/live-text.ts
+++ b/apps/agent-worker/src/live-text.ts
@@ -1,0 +1,39 @@
+import {
+	createRedisLiveTextTransport,
+	type LiveTextTransport,
+	type RedisLiveTextSignal,
+} from "@mymemo/live-text";
+
+interface LiveTextLogger {
+	info(event: Record<string, unknown>): void;
+	warn(event: Record<string, unknown>): void;
+}
+
+/** Select the lazy production publisher only for validated Redis config. */
+export function createWorkerLiveTextTransport(
+	redisUrl: string | undefined,
+	logger: LiveTextLogger,
+): LiveTextTransport | undefined {
+	if (redisUrl === undefined) {
+		try {
+			logger.info({
+				message: "Live preview Redis transport state changed",
+				signal: "disabled",
+			});
+		} catch {
+			// Telemetry is optional and must never affect worker boot.
+		}
+		return undefined;
+	}
+	return createRedisLiveTextTransport({
+		url: redisUrl,
+		onSignal: (signal: RedisLiveTextSignal) => {
+			const event = {
+				message: "Live preview Redis transport state changed",
+				signal,
+			};
+			if (signal === "recovered") logger.info(event);
+			else logger.warn(event);
+		},
+	});
+}

--- a/apps/chat-api/src/config/env.test.ts
+++ b/apps/chat-api/src/config/env.test.ts
@@ -125,3 +125,25 @@ describe("loadApiConfigFromEnv — split-runtime core", () => {
 		expect(config.databaseUrl).toContain("mymemo_agent");
 	});
 });
+
+describe("loadApiConfigFromEnv — optional Live Redis lane", () => {
+	it("enables Live preview only for an authenticated TLS URL", () => {
+		const env = baseEnv();
+		env.REDIS_URL = "rediss://default:secret@redis.internal:6379";
+		expect(loadApiConfigFromEnv(env).liveTextRedisUrl).toBe(env.REDIS_URL);
+	});
+
+	it("degrades missing, malformed, or insecure Redis configuration", () => {
+		for (const redisUrl of [
+			undefined,
+			"not a URL",
+			"redis://default:secret@redis.internal:6379",
+			"rediss://redis.internal:6379",
+		]) {
+			const env = baseEnv();
+			env.REDIS_URL = redisUrl;
+			expect(() => loadApiConfigFromEnv(env)).not.toThrow();
+			expect(loadApiConfigFromEnv(env).liveTextRedisUrl).toBeUndefined();
+		}
+	});
+});

--- a/apps/chat-api/src/config/env.ts
+++ b/apps/chat-api/src/config/env.ts
@@ -1,3 +1,5 @@
+import { resolveLiveTextRedisUrl } from "@mymemo/live-text";
+
 export type ChatMessagesScope = "general" | "collection" | "document";
 
 /** Subset of the process environment the API reads. */
@@ -49,6 +51,8 @@ export interface ApiConfig {
 	 * Statsig secret is required. Identity-independent and explicit.
 	 */
 	agentExposureBreakGlass: boolean;
+	/** Optional authenticated TLS Redis secret for best-effort Live preview. */
+	liveTextRedisUrl: string | undefined;
 }
 
 /**
@@ -129,5 +133,6 @@ export function loadApiConfigFromEnv(env: Env): ApiConfig {
 		databaseUrl,
 		statsigServerSecret: env.STATSIG_SERVER_SECRET,
 		agentExposureBreakGlass,
+		liveTextRedisUrl: resolveLiveTextRedisUrl(env.REDIS_URL),
 	};
 }

--- a/apps/chat-api/src/deps.test.ts
+++ b/apps/chat-api/src/deps.test.ts
@@ -1,0 +1,31 @@
+import { expect, it } from "bun:test";
+import { disabledLiveTextSubscriber } from "@mymemo/live-text";
+import type { ApiConfig } from "./config/env";
+import { createDeps } from "./deps";
+
+function config(liveTextRedisUrl: string | undefined): ApiConfig {
+	return {
+		logLevel: "silent",
+		databaseUrl: "postgresql://u:p@localhost:5432/mymemo_agent",
+		statsigServerSecret: "statsig-test",
+		agentExposureBreakGlass: false,
+		liveTextRedisUrl,
+	};
+}
+
+it("keeps the chat-api Live lane disabled without valid Redis configuration", () => {
+	const signals: string[] = [];
+	const deps = createDeps(config(undefined), (signal) => signals.push(signal));
+	expect(deps.liveTextSubscriber).toBe(disabledLiveTextSubscriber);
+	expect(deps.closeLiveText).toBeUndefined();
+	expect(signals).toEqual(["disabled"]);
+});
+
+it("constructs the lazy production subscriber when Redis is configured", async () => {
+	const deps = createDeps(
+		config("rediss://default:secret@redis.internal:6379"),
+	);
+	expect(deps.liveTextSubscriber).not.toBe(disabledLiveTextSubscriber);
+	expect(deps.closeLiveText).toBeFunction();
+	await deps.closeLiveText?.();
+});

--- a/apps/chat-api/src/deps.ts
+++ b/apps/chat-api/src/deps.ts
@@ -1,6 +1,9 @@
 import {
+	createRedisLiveTextTransport,
 	disabledLiveTextSubscriber,
 	type LiveTextSubscriber,
+	type LiveTextTransport,
+	type RedisLiveTextSignal,
 } from "@mymemo/live-text";
 import type { Env as PinoEnv } from "hono-pino";
 import type { ApiConfig } from "./config/env";
@@ -39,6 +42,8 @@ export interface AppDeps {
 	runNotifier: RunNotifier;
 	/** Optional ephemeral Assistant-text preview lane. */
 	liveTextSubscriber: LiveTextSubscriber;
+	/** Close optional Live transport resources during service shutdown. */
+	closeLiveText?: () => Promise<void>;
 	/**
 	 * Server-side gate controlling who may create new agent work. Consulted on
 	 * the new-work paths (conversation create, `user.message`) after identity is
@@ -50,20 +55,43 @@ export interface AppDeps {
 /** Hono environment: pino logger vars plus the injected `AppDeps`. */
 export type AppEnv = PinoEnv & { Variables: { deps: AppDeps } };
 
-export function createDeps(config: ApiConfig): AppDeps {
+export type LiveTextRuntimeSignal = RedisLiveTextSignal | "disabled";
+
+export function createDeps(
+	config: ApiConfig,
+	onLiveTextSignal?: (signal: LiveTextRuntimeSignal) => void,
+): AppDeps {
 	// One Drizzle pool over the writable DB, shared by every store.
 	const database = createDatabase(config.databaseUrl);
 	const conversationStore = new PostgresConversationStore(database);
 	const runStore = new PostgresRunStore(database);
 	const runEventReader = new DrizzleRunEventReader(database);
 	const runNotifier = new PostgresRunNotifier(config.databaseUrl);
+	const emitLiveTextSignal = (signal: LiveTextRuntimeSignal) => {
+		try {
+			onLiveTextSignal?.(signal);
+		} catch {
+			// Telemetry is optional and must never affect boot or request handling.
+		}
+	};
+	const liveTextTransport: LiveTextTransport | undefined =
+		config.liveTextRedisUrl === undefined
+			? undefined
+			: createRedisLiveTextTransport({
+					url: config.liveTextRedisUrl,
+					onSignal: emitLiveTextSignal,
+				});
+	if (!liveTextTransport) emitLiveTextSignal("disabled");
 	return {
 		config,
 		conversationStore,
 		runStore,
 		runEventReader,
 		runNotifier,
-		liveTextSubscriber: disabledLiveTextSubscriber,
+		liveTextSubscriber: liveTextTransport ?? disabledLiveTextSubscriber,
+		closeLiveText: liveTextTransport
+			? () => liveTextTransport.close()
+			: undefined,
 		exposureGate: createExposureGate(config),
 	};
 }

--- a/apps/chat-api/src/features/run-events/project-run.test.ts
+++ b/apps/chat-api/src/features/run-events/project-run.test.ts
@@ -649,6 +649,56 @@ describe("projectRun", () => {
 		expect(signals).toEqual(["malformed_message"]);
 	});
 
+	it("drops an adapter-rejected wire message before it can reach SSE", async () => {
+		let reported = false;
+		const signals: string[] = [];
+		const reader = new ScriptedReader([
+			[
+				{
+					seq: 1,
+					type: RunEventType.Started,
+					payload: { conversationId: "conv-1", runId: "run-1" },
+				},
+			],
+			[
+				{
+					seq: 2,
+					type: RunEventType.AssistantText,
+					payload: { messageId: "message-1", text: "durable" },
+				},
+				{ seq: 3, type: RunEventType.Done, payload: {} },
+			],
+		]);
+
+		const projected = frames(
+			await drain(
+				projectRun("run-1", 0, {
+					reader,
+					notifier: new InstantNotifier(),
+					liveSubscription: {
+						readAvailable: () => [],
+						readDroppedMessages: () => {
+							if (reported) return emptyDropReport();
+							reported = true;
+							return { type: "invalid_wire_message" };
+						},
+						waitForMessage: async () => true,
+						close: async () => {},
+					},
+					onLiveTextSignal: (signal) => signals.push(signal),
+				}),
+			),
+		);
+
+		expect(projected).toEqual([
+			{ type: "conversation_id", conversationId: "conv-1" },
+			{ type: "run_id", runId: "run-1" },
+			{ type: "text_commit", messageId: "message-1", text: "durable" },
+			{ type: "done" },
+		]);
+		expect(signals).toEqual(["malformed_message"]);
+	});
+
 	it("suppresses nonzero first indexes and mid-message gaps", async () => {
 		const liveText = new InMemoryLiveTextTransport();
 		const liveSubscription = await liveText.subscribe("run-1");

--- a/apps/chat-api/src/features/run-events/project-run.ts
+++ b/apps/chat-api/src/features/run-events/project-run.ts
@@ -330,7 +330,11 @@ async function produceRun(
 				try {
 					const subscription = liveSubscription;
 					const droppedMessages = subscription.readDroppedMessages();
-					if (droppedMessages.type === "tracking_overflow") {
+					if (droppedMessages.type === "invalid_wire_message") {
+						emitSignal("malformed_message");
+						disableLiveForRun();
+						available = [];
+					} else if (droppedMessages.type === "tracking_overflow") {
 						emitSignal("queue_overflow");
 						disableLiveForRun();
 						available = [];

--- a/apps/chat-api/src/features/run-events/redis-live-text.integration.test.ts
+++ b/apps/chat-api/src/features/run-events/redis-live-text.integration.test.ts
@@ -1,0 +1,361 @@
+import { expect, it } from "bun:test";
+import { createServer } from "node:net";
+import { createRedisLiveTextTransport } from "@mymemo/live-text";
+import { eq } from "drizzle-orm";
+import { runEvents, runs } from "@/db/schema";
+import { createTestDatabase } from "@/db/testing";
+import { createQueuedRunStartedTx } from "@/features/run-store";
+import type { WorkerLogger } from "../../../../agent-worker/src/logger";
+import { RunLoop } from "../../../../agent-worker/src/run-loop";
+import type { SupervisedQuery } from "../../../../agent-worker/src/sdk/agent-stream";
+import { createSdkRunProcessor } from "../../../../agent-worker/src/sdk/run-processor";
+import {
+	assistantBlock,
+	streamEvent,
+} from "../../../../agent-worker/src/sdk/testing/sdk-message-fixtures";
+import { Worker } from "../../../../agent-worker/src/worker";
+import { type ProjectedFrame, projectRun } from "./project-run";
+import { DrizzleRunEventReader } from "./run-event-reader";
+import { RunEventType } from "./run-event-types";
+import type { RunNotifier, RunSubscription } from "./run-notifier";
+
+class PollingNotifier implements RunNotifier {
+	async subscribe(): Promise<RunSubscription> {
+		return {
+			waitForWakeup: async () => Bun.sleep(10),
+			close: async () => {},
+		};
+	}
+}
+
+function deferred(): { promise: Promise<void>; resolve(): void } {
+	let resolve: () => void = () => {};
+	const promise = new Promise<void>((done) => {
+		resolve = done;
+	});
+	return { promise, resolve };
+}
+
+function controlledTextQuery(options: {
+	continueAfterFirstDelta: Promise<void>;
+	continueAfterSecondDelta: Promise<void>;
+}): SupervisedQuery {
+	const query = {
+		async interrupt() {},
+		async *[Symbol.asyncIterator]() {
+			yield streamEvent({
+				type: "message_start",
+				message: { id: "provider-message-1", content: [] },
+			});
+			yield streamEvent({
+				type: "content_block_start",
+				index: 0,
+				content_block: { type: "text", text: "" },
+			});
+			yield streamEvent({
+				type: "content_block_delta",
+				index: 0,
+				delta: { type: "text_delta", text: "hel" },
+			});
+			await options.continueAfterFirstDelta;
+			yield streamEvent({
+				type: "content_block_delta",
+				index: 0,
+				delta: { type: "text_delta", text: "lo" },
+			});
+			await options.continueAfterSecondDelta;
+			yield assistantBlock("provider-message-1", {
+				type: "text",
+				text: "hello",
+			});
+			yield streamEvent({ type: "content_block_stop", index: 0 });
+			yield streamEvent({ type: "message_stop" });
+		},
+	};
+	return query;
+}
+
+async function freePort(): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const server = createServer();
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			const address = server.address();
+			if (!address || typeof address === "string") {
+				server.close();
+				reject(new Error("failed to allocate Redis test port"));
+				return;
+			}
+			server.close((error) => (error ? reject(error) : resolve(address.port)));
+		});
+	});
+}
+
+type RedisProcess = ReturnType<typeof Bun.spawn>;
+
+async function waitUntil(
+	condition: () => boolean | Promise<boolean>,
+	timeoutMs = 3_000,
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (!(await condition())) {
+		if (Date.now() >= deadline) throw new Error("condition timed out");
+		await Bun.sleep(20);
+	}
+}
+
+async function within<T>(promise: Promise<T>, label: string): Promise<T> {
+	return Promise.race([
+		promise,
+		Bun.sleep(3_000).then(() => {
+			throw new Error(`${label} timed out`);
+		}),
+	]);
+}
+
+async function startRedis(port: number): Promise<RedisProcess> {
+	const process = Bun.spawn(
+		[
+			"redis-server",
+			"--bind",
+			"127.0.0.1",
+			"--port",
+			String(port),
+			"--save",
+			"",
+			"--appendonly",
+			"no",
+		],
+		{ stdout: "ignore", stderr: "ignore" },
+	);
+	await waitUntil(async () => {
+		const ping = Bun.spawn(
+			["redis-cli", "-h", "127.0.0.1", "-p", String(port), "ping"],
+			{ stdout: "ignore", stderr: "ignore" },
+		);
+		return (await ping.exited) === 0;
+	});
+	return process;
+}
+
+async function stopRedis(process: RedisProcess): Promise<void> {
+	if (process.exitCode !== null) return;
+	process.kill("SIGTERM");
+	await process.exited;
+}
+
+async function consumeRemaining(
+	iterator: AsyncIterator<ProjectedFrame>,
+): Promise<ProjectedFrame[]> {
+	const projected: ProjectedFrame[] = [];
+	for (;;) {
+		const next = await iterator.next();
+		if (next.done) return projected;
+		projected.push(next.value);
+	}
+}
+
+const silentLogger: WorkerLogger = { info() {}, warn() {}, error() {} };
+
+async function runWorkerThroughRedis(options: {
+	stopAfterFirstDelta: boolean;
+}) {
+	const tdb = await createTestDatabase();
+	const port = await freePort();
+	const redis = await startRedis(port);
+	const url = `redis://127.0.0.1:${port}`;
+	const workerTransport = createRedisLiveTextTransport({
+		url,
+		operationTimeoutMs: 250,
+	});
+	const chatApiTransport = createRedisLiveTextTransport({ url });
+	const firstDeltaObserved = deferred();
+	const secondDeltaMayFinish = deferred();
+	const publisherFailed = deferred();
+	const logger: WorkerLogger = {
+		...silentLogger,
+		warn(event) {
+			if (event.signal === "publisher_failure") publisherFailed.resolve();
+		},
+	};
+
+	try {
+		await createQueuedRunStartedTx(tdb.db, {
+			runId: "run-1",
+			conversation: {
+				userId: "user-1",
+				conversationId: "conversation-1",
+				scope: "general",
+				collectionId: null,
+				summaryId: null,
+			},
+			message: "hello",
+		});
+
+		const liveSubscription = await chatApiTransport.subscribe("run-1");
+		const notifier = new PollingNotifier();
+		const iterator = projectRun("run-1", 0, {
+			reader: new DrizzleRunEventReader(tdb.db),
+			notifier,
+			liveSubscription,
+		})[Symbol.asyncIterator]();
+		const projected: ProjectedFrame[] = [];
+		projected.push(
+			(await within(iterator.next(), "conversation frame"))
+				.value as ProjectedFrame,
+		);
+		projected.push(
+			(await within(iterator.next(), "Run frame")).value as ProjectedFrame,
+		);
+
+		const worker = new Worker({
+			workerId: "worker-1",
+			maxConcurrentRuns: 1,
+			shutdownTimeoutMs: 1_000,
+			logger,
+		});
+		const loop = new RunLoop({
+			db: tdb.db,
+			worker,
+			processor: createSdkRunProcessor({
+				startRunQuery: async () =>
+					controlledTextQuery({
+						continueAfterFirstDelta: firstDeltaObserved.promise,
+						continueAfterSecondDelta: secondDeltaMayFinish.promise,
+					}),
+				logger,
+				liveTextPublisher: workerTransport,
+			}),
+			heartbeatIntervalMs: 15_000,
+			logger,
+		});
+
+		await loop.tick();
+		projected.push(
+			(await within(iterator.next(), "first Live delta"))
+				.value as ProjectedFrame,
+		);
+		if (options.stopAfterFirstDelta) await stopRedis(redis);
+		firstDeltaObserved.resolve();
+
+		if (options.stopAfterFirstDelta) {
+			await within(publisherFailed.promise, "failed Redis publication");
+			secondDeltaMayFinish.resolve();
+		} else {
+			projected.push(
+				(await within(iterator.next(), "second Live delta"))
+					.value as ProjectedFrame,
+			);
+			secondDeltaMayFinish.resolve();
+		}
+
+		await within(worker.drain(), "worker drain");
+		const durableRows = await tdb.db
+			.select()
+			.from(runEvents)
+			.where(eq(runEvents.runId, "run-1"))
+			.orderBy(runEvents.seq);
+		if (durableRows.at(-1)?.type !== RunEventType.Done) {
+			throw new Error(
+				`worker did not terminalize done: ${durableRows.map((row) => row.type).join(",")}`,
+			);
+		}
+		projected.push(
+			...(await within(consumeRemaining(iterator), "durable projection")),
+		);
+
+		const [run] = await tdb.db
+			.select()
+			.from(runs)
+			.where(eq(runs.runId, "run-1"));
+		return { projected, run, events: durableRows };
+	} finally {
+		firstDeltaObserved.resolve();
+		secondDeltaMayFinish.resolve();
+		publisherFailed.resolve();
+		await Promise.all([workerTransport.close(), chatApiTransport.close()]);
+		await stopRedis(redis);
+		await tdb.close();
+	}
+}
+
+it("runs worker publication through Redis into cursorless preview and an exact durable commit", async () => {
+	const { projected, run, events } = await runWorkerThroughRedis({
+		stopAfterFirstDelta: false,
+	});
+	const [conversation, runFrame, firstDelta, secondDelta, commit, done] =
+		projected;
+	if (firstDelta?.frame.type !== "text_delta") {
+		throw new Error("expected the first worker preview delta");
+	}
+	expect(conversation).toMatchObject({
+		id: undefined,
+		frame: { type: "conversation_id", conversationId: "conversation-1" },
+	});
+	expect(runFrame).toMatchObject({
+		id: "1",
+		frame: { type: "run_id", runId: "run-1" },
+	});
+	expect(firstDelta.id).toBeUndefined();
+	expect(firstDelta.frame).toMatchObject({
+		type: "text_delta",
+		deltaIndex: 0,
+		text: "hel",
+	});
+	expect(secondDelta?.id).toBeUndefined();
+	expect(secondDelta?.frame).toMatchObject({
+		type: "text_delta",
+		deltaIndex: 1,
+		text: "lo",
+	});
+	expect(commit).toMatchObject({
+		id: "2",
+		frame: {
+			type: "text_commit",
+			messageId: firstDelta.frame.messageId,
+			text: "hello",
+		},
+	});
+	expect(done).toMatchObject({ id: "3", frame: { type: "done" } });
+	expect(run?.status).toBe("done");
+	expect(events.map((event) => event.type)).toEqual([
+		RunEventType.Started,
+		RunEventType.AssistantText,
+		RunEventType.Done,
+	]);
+}, 20_000);
+
+it("keeps the active Run done from Postgres when Redis fails on its next publication", async () => {
+	const { projected, run, events } = await runWorkerThroughRedis({
+		stopAfterFirstDelta: true,
+	});
+	const deltas = projected.filter(({ frame }) => frame.type === "text_delta");
+	const commit = projected.find(({ frame }) => frame.type === "text_commit");
+	expect(deltas).toHaveLength(1);
+	const firstDelta = deltas[0];
+	if (firstDelta?.frame.type !== "text_delta") {
+		throw new Error("expected one surviving worker preview delta");
+	}
+	expect(firstDelta.id).toBeUndefined();
+	expect(firstDelta.frame).toMatchObject({
+		type: "text_delta",
+		deltaIndex: 0,
+		text: "hel",
+	});
+	expect(commit).toMatchObject({
+		id: "2",
+		frame: {
+			type: "text_commit",
+			messageId: firstDelta.frame.messageId,
+			text: "hello",
+		},
+	});
+	expect(projected.at(-1)).toMatchObject({
+		id: "3",
+		frame: { type: "done" },
+	});
+	expect(projected.some(({ frame }) => frame.type === "error")).toBe(false);
+	expect(run?.status).toBe("done");
+	expect(events.at(-2)?.payload).toMatchObject({ text: "hello" });
+	expect(events.at(-1)?.type).toBe(RunEventType.Done);
+}, 20_000);

--- a/apps/chat-api/src/index.ts
+++ b/apps/chat-api/src/index.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { requestId } from "hono/request-id";
 import { pinoLogger } from "hono-pino";
+import pino from "pino";
 import { type ApiConfig, loadApiConfigFromEnv } from "./config/env";
 import { type AppDeps, type AppEnv, createDeps } from "./deps";
 import routes from "./routes";
@@ -31,5 +32,31 @@ export function createApp(
 }
 
 // Entrypoint: the only place that reads the environment. `bun run src/index.ts`
-// serves this default export.
-export default createApp(loadApiConfigFromEnv(Bun.env));
+// serves this default export. Redis remains lazy and optional; the signal hook
+// only guarantees that any resources opened by active Live subscriptions are
+// closed before the process exits.
+const productionConfig = loadApiConfigFromEnv(Bun.env);
+const productionLogger = pino({ level: productionConfig.logLevel });
+const productionDeps = createDeps(productionConfig, (signal) => {
+	const event = {
+		message: "Live preview Redis transport state changed",
+		signal,
+	};
+	if (signal === "disabled" || signal === "recovered") {
+		productionLogger.info(event);
+	} else {
+		productionLogger.warn(event);
+	}
+});
+const productionApp = createApp(productionConfig, productionDeps);
+let shuttingDown = false;
+async function closeProductionLiveText(): Promise<void> {
+	if (shuttingDown) return;
+	shuttingDown = true;
+	await productionDeps.closeLiveText?.().catch(() => {});
+	process.exit(0);
+}
+process.once("SIGINT", () => void closeProductionLiveText());
+process.once("SIGTERM", () => void closeProductionLiveText());
+
+export default productionApp;

--- a/bun.lock
+++ b/bun.lock
@@ -88,6 +88,7 @@
       "name": "@mymemo/live-text",
       "version": "0.1.0",
       "dependencies": {
+        "redis": "^5.12.1",
         "zod": "^4.1.12",
       },
       "devDependencies": {
@@ -267,6 +268,16 @@
 
     "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
 
+    "@redis/bloom": ["@redis/bloom@5.12.1", "", { "peerDependencies": { "@redis/client": "^5.12.1" } }, "sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA=="],
+
+    "@redis/client": ["@redis/client@5.12.1", "", { "dependencies": { "cluster-key-slot": "1.1.2" }, "peerDependencies": { "@node-rs/xxhash": "^1.1.0", "@opentelemetry/api": ">=1 <2" }, "optionalPeers": ["@node-rs/xxhash", "@opentelemetry/api"] }, "sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA=="],
+
+    "@redis/json": ["@redis/json@5.12.1", "", { "peerDependencies": { "@redis/client": "^5.12.1" } }, "sha512-eOze75esLve4vfqDel7aMX08CNaiLLQS2fV8mpRN9NxPe1rVR4vQyYiW/OgtGUysF6QOr9ANhfxABKNOJfXdKg=="],
+
+    "@redis/search": ["@redis/search@5.12.1", "", { "peerDependencies": { "@redis/client": "^5.12.1" } }, "sha512-ItlxbxC9cKI6IU1TLWoczwJCRb6TdmkEpWv05UrPawqaAnWGRu3rcIqsc5vN483T2fSociuyV1UkWIL5I4//2w=="],
+
+    "@redis/time-series": ["@redis/time-series@5.12.1", "", { "peerDependencies": { "@redis/client": "^5.12.1" } }, "sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ=="],
+
     "@scalar/core": ["@scalar/core@0.3.45", "", { "dependencies": { "@scalar/types": "0.6.10" } }, "sha512-f3jyzColUUcu3eYfjslgNjG2JABuFU8WR3P7a9GevMpisW3skWUqVVffyC1P4w4i9TVRk9FUjYEtGeP10Rw9lQ=="],
 
     "@scalar/helpers": ["@scalar/helpers@0.2.18", "", {}, "sha512-w1d4tpNEVZ293oB2BAgLrS0kVPUtG3eByNmOCJA5eK9vcT4D3cmsGtWjUaaqit0BQCsBFHK51rasGvSWnApYTw=="],
@@ -358,6 +369,8 @@
     "chat-api": ["chat-api@workspace:apps/chat-api"],
 
     "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
+
+    "cluster-key-slot": ["cluster-key-slot@1.1.2", "", {}, "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="],
 
     "compare-versions": ["compare-versions@6.1.1", "", {}, "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg=="],
 
@@ -578,6 +591,8 @@
     "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
     "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
+
+    "redis": ["redis@5.12.1", "", { "dependencies": { "@redis/bloom": "5.12.1", "@redis/client": "5.12.1", "@redis/json": "5.12.1", "@redis/search": "5.12.1", "@redis/time-series": "5.12.1" } }, "sha512-LDsoVvb/CpoV9EN3FXvgvSHNJWuCIzl9MiO3ppOevuGLpSGJhwfQjpEwfFJcQvNSddHADDdZaWx0HnmMxRXG7g=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 

--- a/docs/adr/0008-token-streaming-redis-live-lane.md
+++ b/docs/adr/0008-token-streaming-redis-live-lane.md
@@ -3,10 +3,10 @@
 Status: accepted (2026-07-10); implementation in progress
 
 The durable-message increment, private Redis infrastructure, transport-neutral
-Live preview path, and loss-tolerance rules are implemented. The worker appends
-one `assistant_text` event per complete Assistant message, and chat-api projects
-it as the authoritative, replayable `text_commit`. Production Redis adapters,
-live-lane observability, and end-to-end cutover proof remain to be implemented.
+Live preview path, loss-tolerance rules, and production Redis adapters are
+implemented. The worker appends one `assistant_text` event per complete
+Assistant message, and chat-api projects it as the authoritative, replayable
+`text_commit`. Coordinated client rollout remains a release concern.
 
 Smooth token streaming cannot use the durable tier for every fragment: one
 `text_delta` per token would mean hundreds of fenced `appendRunEventTx` and
@@ -203,8 +203,8 @@ the specification and its tests.
 ## Consequences
 
 - Infrastructure includes a private, authenticated, TLS-protected Redis instance
-  reachable only by the trusted services. Production adapter composition still
-  needs to connect worker publication and chat-api subscription to that instance.
+  reachable only by the trusted services. The worker publisher and chat-api
+  subscriber connect to it through optional, lazy production adapters.
 - Knowingly breaks the "run-event replay is the only SSE source" exit criterion
   for the **live** path only; replay stays a pure projection. This is the
   accepted trade recorded here.
@@ -215,8 +215,8 @@ the specification and its tests.
   coordinated hard cutover: no legacy payload detection, dual emission, or
   compatibility window. The old meaning of `text_delta` as a complete durable
   assistant message is not preserved.
-- The durable envelope assembler, private Redis infrastructure, in-memory
-  transport/projector slice, and loss-tolerance increment are implemented. The
-  production Redis adapters, observability, and end-to-end cutover proof remain.
+- The durable envelope assembler, private Redis infrastructure, in-memory and
+  production transports, projector slice, loss-tolerance increment, and
+  disposable-Redis cutover proof are implemented.
   Production implementation must retain the live partial-message spike and
   deterministic envelope-assembler cases as conformance tests.

--- a/packages/live-text/package.json
+++ b/packages/live-text/package.json
@@ -10,6 +10,7 @@
 		"check": "biome check --write"
 	},
 	"dependencies": {
+		"redis": "^5.12.1",
 		"zod": "^4.1.12"
 	},
 	"devDependencies": {

--- a/packages/live-text/src/index.test.ts
+++ b/packages/live-text/src/index.test.ts
@@ -3,7 +3,29 @@ import {
 	InMemoryLiveTextTransport,
 	LIVE_TEXT_MAX_CHUNK_LENGTH,
 	LiveTextMessageSchema,
+	resolveLiveTextRedisUrl,
 } from "./index";
+
+describe("resolveLiveTextRedisUrl", () => {
+	it("accepts only an authenticated TLS Redis URL", () => {
+		expect(
+			resolveLiveTextRedisUrl("rediss://default:secret@redis.internal:6379"),
+		).toBe("rediss://default:secret@redis.internal:6379");
+		expect(
+			resolveLiveTextRedisUrl("rediss://:secret@redis.internal:6379"),
+		).toBe("rediss://:secret@redis.internal:6379");
+		for (const invalid of [
+			undefined,
+			"",
+			"not a URL",
+			"redis://default:secret@redis.internal:6379",
+			"rediss://redis.internal:6379",
+			"rediss://default@redis.internal:6379",
+		]) {
+			expect(resolveLiveTextRedisUrl(invalid)).toBeUndefined();
+		}
+	});
+});
 
 describe("LiveTextMessageSchema", () => {
 	it("accepts the bounded provisional wire message and rejects extra or oversized data", () => {

--- a/packages/live-text/src/index.ts
+++ b/packages/live-text/src/index.ts
@@ -1,7 +1,30 @@
+import { createClient } from "redis";
 import { z } from "zod";
 
 export const LIVE_TEXT_MAX_CHUNK_LENGTH = 16_384;
+export const LIVE_TEXT_MAX_WIRE_BYTES = 100_000;
 const LIVE_TEXT_MAX_ID_LENGTH = 128;
+
+/**
+ * Resolve the optional production Live-lane secret. Invalid configuration is
+ * deliberately indistinguishable from missing configuration to callers: both
+ * disable only Live preview and must never fail service boot. The returned URL
+ * is authenticated and TLS-only, but remains a secret and must not be logged.
+ */
+export function resolveLiveTextRedisUrl(
+	raw: string | undefined,
+): string | undefined {
+	if (!raw) return undefined;
+	try {
+		const url = new URL(raw);
+		if (url.protocol !== "rediss:" || !url.hostname || !url.password) {
+			return undefined;
+		}
+		return raw;
+	} catch {
+		return undefined;
+	}
+}
 
 export const LiveTextMessageSchema = z
 	.object({
@@ -16,7 +39,8 @@ export type LiveTextMessage = z.infer<typeof LiveTextMessageSchema>;
 
 export type LiveTextDropReport =
 	| { type: "message_ids"; messageIds: string[] }
-	| { type: "tracking_overflow" };
+	| { type: "tracking_overflow" }
+	| { type: "invalid_wire_message" };
 
 export interface LiveTextPublisher {
 	publish(
@@ -39,17 +63,24 @@ export interface LiveTextSubscriber {
 	subscribe(runId: string): Promise<LiveTextSubscription>;
 }
 
-class InMemoryLiveTextSubscription implements LiveTextSubscription {
+export interface LiveTextTransport
+	extends LiveTextPublisher,
+		LiveTextSubscriber {
+	close(): Promise<void>;
+}
+
+class BufferedLiveTextSubscription implements LiveTextSubscription {
 	readonly #buffer: LiveTextMessage[] = [];
 	readonly #droppedMessageIds = new Set<string>();
 	readonly #waiters = new Set<(available: boolean) => void>();
 	#droppedMessageIdsOverflowed = false;
+	#invalidWireMessageDropped = false;
 	#closed = false;
 
 	constructor(
 		readonly runId: string,
 		private readonly maxBufferedMessages: number,
-		private readonly onClose: () => void,
+		private readonly onClose: () => void | Promise<void>,
 	) {}
 
 	enqueue(message: LiveTextMessage): void {
@@ -75,6 +106,13 @@ class InMemoryLiveTextSubscription implements LiveTextSubscription {
 		this.#waiters.clear();
 	}
 
+	dropInvalidWireMessage(): void {
+		if (this.#closed) return;
+		this.#invalidWireMessageDropped = true;
+		for (const wake of this.#waiters) wake(true);
+		this.#waiters.clear();
+	}
+
 	readAvailable(): LiveTextMessage[] {
 		if (this.#closed) return [];
 		return this.#buffer.splice(0);
@@ -82,6 +120,10 @@ class InMemoryLiveTextSubscription implements LiveTextSubscription {
 
 	readDroppedMessages(): LiveTextDropReport {
 		if (this.#closed) return { type: "message_ids", messageIds: [] };
+		if (this.#invalidWireMessageDropped) {
+			this.#invalidWireMessageDropped = false;
+			return { type: "invalid_wire_message" };
+		}
 		if (this.#droppedMessageIdsOverflowed) {
 			this.#droppedMessageIdsOverflowed = false;
 			this.#droppedMessageIds.clear();
@@ -125,20 +167,20 @@ class InMemoryLiveTextSubscription implements LiveTextSubscription {
 		this.#buffer.length = 0;
 		this.#droppedMessageIds.clear();
 		this.#droppedMessageIdsOverflowed = false;
+		this.#invalidWireMessageDropped = false;
 		for (const wake of this.#waiters) wake(false);
 		this.#waiters.clear();
-		this.onClose();
+		await this.onClose();
 	}
 }
 
 /** Deterministic process-local transport used by integration tests. */
-export class InMemoryLiveTextTransport
-	implements LiveTextPublisher, LiveTextSubscriber
-{
+export class InMemoryLiveTextTransport implements LiveTextTransport {
 	readonly #subscriptions = new Map<
 		string,
-		Set<InMemoryLiveTextSubscription>
+		Set<BufferedLiveTextSubscription>
 	>();
+	#closed = false;
 
 	constructor(private readonly maxBufferedMessages = 64) {
 		if (!Number.isSafeInteger(maxBufferedMessages) || maxBufferedMessages < 1) {
@@ -150,6 +192,7 @@ export class InMemoryLiveTextTransport
 		message: LiveTextMessage,
 		options: { signal?: AbortSignal } = {},
 	): Promise<void> {
+		if (this.#closed) throw new Error("Live text transport is closed");
 		if (options.signal?.aborted) return;
 		const parsed = LiveTextMessageSchema.parse(message);
 		if (options.signal?.aborted) return;
@@ -159,11 +202,12 @@ export class InMemoryLiveTextTransport
 	}
 
 	async subscribe(runId: string): Promise<LiveTextSubscription> {
+		if (this.#closed) throw new Error("Live text transport is closed");
 		const parsedRunId = LiveTextMessageSchema.shape.runId.parse(runId);
 		const subscriptions = this.#subscriptions.get(parsedRunId) ?? new Set();
 		this.#subscriptions.set(parsedRunId, subscriptions);
-		let subscription: InMemoryLiveTextSubscription;
-		subscription = new InMemoryLiveTextSubscription(
+		let subscription: BufferedLiveTextSubscription;
+		subscription = new BufferedLiveTextSubscription(
 			parsedRunId,
 			this.maxBufferedMessages,
 			() => {
@@ -174,6 +218,266 @@ export class InMemoryLiveTextTransport
 		subscriptions.add(subscription);
 		return subscription;
 	}
+
+	async close(): Promise<void> {
+		if (this.#closed) return;
+		this.#closed = true;
+		const subscriptions = [...this.#subscriptions.values()].flatMap((set) => [
+			...set,
+		]);
+		await Promise.all(
+			subscriptions.map((subscription) => subscription.close()),
+		);
+		this.#subscriptions.clear();
+	}
+}
+
+export type RedisLiveTextSignal =
+	| "degraded"
+	| "recovered"
+	| "invalid_message"
+	| "oversized_message";
+
+export interface RedisLiveTextTransportOptions {
+	/** Authenticated rediss:// production secret, or redis:// in disposable tests. */
+	url: string;
+	maxBufferedMessages?: number;
+	operationTimeoutMs?: number;
+	reconnectMaxDelayMs?: number;
+	onSignal?: (signal: RedisLiveTextSignal) => void;
+}
+
+type RedisClient = ReturnType<typeof createClient>;
+
+const DEFAULT_REDIS_OPERATION_TIMEOUT_MS = 250;
+const DEFAULT_REDIS_RECONNECT_MAX_DELAY_MS = 3_000;
+
+/** Exact per-Run Pub/Sub channel fixed by ADR-0008. */
+export function liveTextChannel(runId: string): string {
+	return `run:${LiveTextMessageSchema.shape.runId.parse(runId)}`;
+}
+
+function timeoutAfter(ms: number): {
+	promise: Promise<never>;
+	cancel(): void;
+} {
+	let timer: ReturnType<typeof setTimeout>;
+	return {
+		promise: new Promise((_, reject) => {
+			timer = setTimeout(
+				() => reject(new Error("Live text Redis operation timed out")),
+				ms,
+			);
+		}),
+		cancel: () => clearTimeout(timer),
+	};
+}
+
+/**
+ * Lazy, best-effort Redis Pub/Sub adapter. No connection is made at
+ * construction time, so Redis can never become a boot or readiness dependency.
+ */
+class RedisLiveTextTransport implements LiveTextTransport {
+	readonly #url: string;
+	readonly #maxBufferedMessages: number;
+	readonly #operationTimeoutMs: number;
+	readonly #reconnectMaxDelayMs: number;
+	readonly #onSignal?: (signal: RedisLiveTextSignal) => void;
+	readonly #subscriptions = new Set<BufferedLiveTextSubscription>();
+	#publisher: RedisClient | undefined;
+	#degraded = false;
+	#closed = false;
+
+	constructor(options: RedisLiveTextTransportOptions) {
+		this.#url = options.url;
+		this.#maxBufferedMessages = options.maxBufferedMessages ?? 64;
+		this.#operationTimeoutMs =
+			options.operationTimeoutMs ?? DEFAULT_REDIS_OPERATION_TIMEOUT_MS;
+		this.#reconnectMaxDelayMs =
+			options.reconnectMaxDelayMs ?? DEFAULT_REDIS_RECONNECT_MAX_DELAY_MS;
+		this.#onSignal = options.onSignal;
+		if (
+			!Number.isSafeInteger(this.#maxBufferedMessages) ||
+			this.#maxBufferedMessages < 1
+		) {
+			throw new Error("maxBufferedMessages must be a positive integer");
+		}
+		if (
+			!Number.isSafeInteger(this.#operationTimeoutMs) ||
+			this.#operationTimeoutMs < 1
+		) {
+			throw new Error("operationTimeoutMs must be a positive integer");
+		}
+	}
+
+	async publish(
+		message: LiveTextMessage,
+		options: { signal?: AbortSignal } = {},
+	): Promise<void> {
+		if (this.#closed) throw new Error("Live text transport is closed");
+		if (options.signal?.aborted) return;
+		const parsed = LiveTextMessageSchema.parse(message);
+		const wireMessage = JSON.stringify(parsed);
+		if (Buffer.byteLength(wireMessage) > LIVE_TEXT_MAX_WIRE_BYTES) {
+			throw new Error("Live text wire message is too large");
+		}
+		const client = this.#publisher ?? this.#createClient();
+		this.#publisher = client;
+		try {
+			if (!client.isOpen) {
+				await this.#bounded(client.connect(), options.signal);
+			}
+			if (options.signal?.aborted) return;
+			await this.#bounded(
+				client.publish(liveTextChannel(parsed.runId), wireMessage),
+				options.signal,
+			);
+		} catch (error) {
+			this.#markDegraded();
+			if (this.#publisher === client) this.#publisher = undefined;
+			this.#destroy(client);
+			throw error;
+		}
+	}
+
+	async subscribe(runId: string): Promise<LiveTextSubscription> {
+		if (this.#closed) throw new Error("Live text transport is closed");
+		const parsedRunId = LiveTextMessageSchema.shape.runId.parse(runId);
+		const channel = liveTextChannel(parsedRunId);
+		const client = this.#createClient();
+		let subscription: BufferedLiveTextSubscription;
+		subscription = new BufferedLiveTextSubscription(
+			parsedRunId,
+			this.#maxBufferedMessages,
+			async () => {
+				this.#subscriptions.delete(subscription);
+				try {
+					if (client.isReady) {
+						await this.#bounded(client.unsubscribe(channel));
+					}
+				} catch {
+					this.#markDegraded();
+				} finally {
+					this.#destroy(client);
+				}
+			},
+		);
+		this.#subscriptions.add(subscription);
+		try {
+			await this.#bounded(client.connect());
+			await this.#bounded(
+				client.subscribe(channel, (wireMessage) => {
+					this.#acceptWireMessage(subscription, parsedRunId, wireMessage);
+				}),
+			);
+			return subscription;
+		} catch (error) {
+			this.#markDegraded();
+			await subscription.close();
+			throw error;
+		}
+	}
+
+	async close(): Promise<void> {
+		if (this.#closed) return;
+		this.#closed = true;
+		await Promise.all(
+			[...this.#subscriptions].map((subscription) => subscription.close()),
+		);
+		const publisher = this.#publisher;
+		this.#publisher = undefined;
+		if (publisher) this.#destroy(publisher);
+	}
+
+	#acceptWireMessage(
+		subscription: BufferedLiveTextSubscription,
+		runId: string,
+		wireMessage: string,
+	): void {
+		if (Buffer.byteLength(wireMessage) > LIVE_TEXT_MAX_WIRE_BYTES) {
+			this.#emitSignal("oversized_message");
+			subscription.dropInvalidWireMessage();
+			return;
+		}
+		try {
+			const parsed = LiveTextMessageSchema.safeParse(JSON.parse(wireMessage));
+			if (!parsed.success || parsed.data.runId !== runId) {
+				this.#emitSignal("invalid_message");
+				subscription.dropInvalidWireMessage();
+				return;
+			}
+			subscription.enqueue(parsed.data);
+		} catch {
+			this.#emitSignal("invalid_message");
+			subscription.dropInvalidWireMessage();
+		}
+	}
+
+	#createClient(): RedisClient {
+		const client = createClient({
+			url: this.#url,
+			socket: {
+				connectTimeout: this.#operationTimeoutMs,
+				reconnectStrategy: (retries) =>
+					Math.min(50 * 2 ** Math.min(retries, 10), this.#reconnectMaxDelayMs),
+			},
+		});
+		client.on("error", () => this.#markDegraded());
+		client.on("reconnecting", () => this.#markDegraded());
+		client.on("ready", () => this.#markRecovered());
+		return client;
+	}
+
+	async #bounded<T>(operation: Promise<T>, signal?: AbortSignal): Promise<T> {
+		const timeout = timeoutAfter(this.#operationTimeoutMs);
+		let onAbort: (() => void) | undefined;
+		const aborted = new Promise<never>((_, reject) => {
+			if (!signal) return;
+			onAbort = () => reject(new Error("Live text Redis operation aborted"));
+			if (signal.aborted) onAbort();
+			else signal.addEventListener("abort", onAbort, { once: true });
+		});
+		try {
+			return await Promise.race([operation, timeout.promise, aborted]);
+		} finally {
+			timeout.cancel();
+			if (onAbort) signal?.removeEventListener("abort", onAbort);
+		}
+	}
+
+	#destroy(client: RedisClient): void {
+		try {
+			client.destroy();
+		} catch {
+			// Cleanup is best-effort and must not fail a Run or service shutdown.
+		}
+	}
+
+	#markDegraded(): void {
+		if (this.#degraded) return;
+		this.#degraded = true;
+		this.#emitSignal("degraded");
+	}
+
+	#markRecovered(): void {
+		if (!this.#degraded) return;
+		this.#degraded = false;
+		this.#emitSignal("recovered");
+	}
+
+	#emitSignal(signal: RedisLiveTextSignal): void {
+		try {
+			this.#onSignal?.(signal);
+		} catch {
+			// Telemetry is optional and never receives credentials or payloads.
+		}
+	}
+}
+
+export function createRedisLiveTextTransport(
+	options: RedisLiveTextTransportOptions,
+): LiveTextTransport {
+	return new RedisLiveTextTransport(options);
 }
 
 export class LiveTextDisabledError extends Error {

--- a/packages/live-text/src/transport-contract.test.ts
+++ b/packages/live-text/src/transport-contract.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it } from "bun:test";
+import { createServer } from "node:net";
+import { createClient } from "redis";
+import {
+	createRedisLiveTextTransport,
+	InMemoryLiveTextTransport,
+	LIVE_TEXT_MAX_WIRE_BYTES,
+	type LiveTextPublisher,
+	type LiveTextSubscriber,
+	type LiveTextTransport,
+	liveTextChannel,
+} from "./index";
+
+interface ContractHarness {
+	publisher: LiveTextPublisher;
+	subscriber: LiveTextSubscriber;
+	close(): Promise<void>;
+	disconnect(): Promise<void>;
+	reconnect(): Promise<void>;
+}
+
+type ContractHarnessFactory = () => Promise<ContractHarness>;
+
+async function waitUntil(
+	condition: () => boolean | Promise<boolean>,
+	timeoutMs = 3_000,
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (!(await condition())) {
+		if (Date.now() >= deadline) throw new Error("condition timed out");
+		await Bun.sleep(20);
+	}
+}
+
+async function collectMessages(
+	subscription: Awaited<ReturnType<LiveTextSubscriber["subscribe"]>>,
+	count: number,
+): Promise<string[]> {
+	const texts: string[] = [];
+	await waitUntil(async () => {
+		await subscription.waitForMessage({ timeoutMs: 100 });
+		texts.push(...subscription.readAvailable().map((message) => message.text));
+		return texts.length >= count;
+	});
+	return texts;
+}
+
+function liveTextTransportContract(
+	name: string,
+	createHarness: ContractHarnessFactory,
+): void {
+	describe(name, () => {
+		it("isolates Runs, preserves publisher order, and fans out to subscribers", async () => {
+			const harness = await createHarness();
+			const runOneA = await harness.subscriber.subscribe("run-1");
+			const runOneB = await harness.subscriber.subscribe("run-1");
+			const runTwo = await harness.subscriber.subscribe("run-2");
+			try {
+				for (const [deltaIndex, text] of ["one", "two", "three"].entries()) {
+					await harness.publisher.publish({
+						runId: "run-1",
+						messageId: "message-1",
+						deltaIndex,
+						text,
+					});
+				}
+				const expected = ["one", "two", "three"];
+				expect(await collectMessages(runOneA, 3)).toEqual(expected);
+				expect(await collectMessages(runOneB, 3)).toEqual(expected);
+				expect(runTwo.readAvailable()).toEqual([]);
+			} finally {
+				await Promise.all([runOneA.close(), runOneB.close(), runTwo.close()]);
+				await harness.close();
+			}
+		});
+
+		it("unsubscribes independently and releases pending work on cleanup", async () => {
+			const harness = await createHarness();
+			const closed = await harness.subscriber.subscribe("run-1");
+			const active = await harness.subscriber.subscribe("run-1");
+			const waiting = closed.waitForMessage();
+			await closed.close();
+			expect(await waiting).toBe(false);
+
+			await harness.publisher.publish({
+				runId: "run-1",
+				messageId: "message-1",
+				deltaIndex: 0,
+				text: "only active receives this",
+			});
+			await active.waitForMessage({ timeoutMs: 1_000 });
+			expect(closed.readAvailable()).toEqual([]);
+			expect(active.readAvailable()).toHaveLength(1);
+
+			const activeWait = active.waitForMessage();
+			await harness.close();
+			expect(await activeWait).toBe(false);
+			await expect(harness.subscriber.subscribe("run-2")).rejects.toThrow();
+		});
+
+		it("recovers an established lane after a connection outage", async () => {
+			const harness = await createHarness();
+			const subscription = await harness.subscriber.subscribe("run-1");
+			try {
+				await harness.publisher.publish({
+					runId: "run-1",
+					messageId: "before",
+					deltaIndex: 0,
+					text: "before",
+				});
+				await subscription.waitForMessage({ timeoutMs: 1_000 });
+				expect(subscription.readAvailable()).toHaveLength(1);
+
+				await harness.disconnect();
+				await harness.reconnect();
+				await waitUntil(async () => {
+					try {
+						await harness.publisher.publish({
+							runId: "run-1",
+							messageId: "after",
+							deltaIndex: 0,
+							text: "after",
+						});
+						await subscription.waitForMessage({ timeoutMs: 100 });
+						return subscription
+							.readAvailable()
+							.some((message) => message.text === "after");
+					} catch {
+						return false;
+					}
+				}, 5_000);
+			} finally {
+				await subscription.close();
+				await harness.close();
+			}
+		}, 10_000);
+	});
+}
+
+liveTextTransportContract("in-memory Live transport contract", async () => {
+	const transport: LiveTextTransport = new InMemoryLiveTextTransport();
+	let connected = true;
+	return {
+		publisher: {
+			publish(message, options) {
+				if (!connected) return Promise.reject(new Error("disconnected"));
+				return transport.publish(message, options);
+			},
+		},
+		subscriber: transport,
+		close: () => transport.close(),
+		disconnect: async () => {
+			connected = false;
+		},
+		reconnect: async () => {
+			connected = true;
+		},
+	};
+});
+
+async function freePort(): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const server = createServer();
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			const address = server.address();
+			if (!address || typeof address === "string") {
+				server.close();
+				reject(new Error("failed to allocate Redis test port"));
+				return;
+			}
+			server.close((error) => (error ? reject(error) : resolve(address.port)));
+		});
+	});
+}
+
+type RedisProcess = ReturnType<typeof Bun.spawn>;
+
+async function startRedis(port: number): Promise<RedisProcess> {
+	const process = Bun.spawn(
+		[
+			"redis-server",
+			"--bind",
+			"127.0.0.1",
+			"--port",
+			String(port),
+			"--save",
+			"",
+			"--appendonly",
+			"no",
+		],
+		{ stdout: "ignore", stderr: "ignore" },
+	);
+	await waitUntil(async () => {
+		const ping = Bun.spawn(
+			["redis-cli", "-h", "127.0.0.1", "-p", String(port), "ping"],
+			{ stdout: "pipe", stderr: "ignore" },
+		);
+		return (await ping.exited) === 0;
+	});
+	return process;
+}
+
+async function stopRedis(process: RedisProcess): Promise<void> {
+	process.kill("SIGTERM");
+	await process.exited;
+}
+
+liveTextTransportContract(
+	"disposable Redis Live transport contract",
+	async () => {
+		const port = await freePort();
+		let server = await startRedis(port);
+		const transport = createRedisLiveTextTransport({
+			url: `redis://127.0.0.1:${port}`,
+			operationTimeoutMs: 250,
+			reconnectMaxDelayMs: 100,
+		});
+		return {
+			publisher: transport,
+			subscriber: transport,
+			close: async () => {
+				await transport.close();
+				if (server.exitCode === null) await stopRedis(server);
+			},
+			disconnect: async () => {
+				await stopRedis(server);
+			},
+			reconnect: async () => {
+				server = await startRedis(port);
+			},
+		};
+	},
+);
+
+it("drops invalid and oversized Redis messages with payload-free signals", async () => {
+	const port = await freePort();
+	const server = await startRedis(port);
+	const url = `redis://127.0.0.1:${port}`;
+	const signals: string[] = [];
+	const transport = createRedisLiveTextTransport({
+		url,
+		onSignal: (signal) => signals.push(signal),
+	});
+	const rawPublisher = createClient({ url });
+	try {
+		const subscription = await transport.subscribe("run-1");
+		await rawPublisher.connect();
+		await rawPublisher.publish(liveTextChannel("run-1"), "not json");
+		await subscription.waitForMessage({ timeoutMs: 1_000 });
+		expect(subscription.readAvailable()).toEqual([]);
+		expect(subscription.readDroppedMessages()).toEqual({
+			type: "invalid_wire_message",
+		});
+
+		await rawPublisher.publish(
+			liveTextChannel("run-1"),
+			"x".repeat(LIVE_TEXT_MAX_WIRE_BYTES + 1),
+		);
+		await subscription.waitForMessage({ timeoutMs: 1_000 });
+		expect(subscription.readAvailable()).toEqual([]);
+		expect(subscription.readDroppedMessages()).toEqual({
+			type: "invalid_wire_message",
+		});
+		expect(signals).toEqual(["invalid_message", "oversized_message"]);
+		await subscription.close();
+	} finally {
+		if (rawPublisher.isOpen) rawPublisher.destroy();
+		await transport.close();
+		await stopRedis(server);
+	}
+}, 10_000);


### PR DESCRIPTION
## Summary

- add the production Redis Pub/Sub publisher/subscriber with per-Run channels, runtime-validated bounded wire messages, bounded reconnect backoff, and lifecycle cleanup
- select the Redis lane only for authenticated TLS configuration while preserving disabled/degraded Postgres fallback and payload-free telemetry
- add shared in-memory and disposable-Redis contract coverage plus a real RunLoop → Redis → chat-api projector integration

## Why

The transport-neutral Live preview path was already proven, but production worker publication and chat-api subscription were not connected to the private Redis lane. This completes that connection without making Redis a boot, readiness, health, or Run-success dependency.

## Impact

Assistant preview deltas can now flow cursorlessly through Redis in production. Exact durable `text_commit` frames and terminal outcomes continue to come from Postgres, including when Redis is unavailable or fails during a Run.

## Validation

- `bun test` (repository-wide)
- TypeScript checks for `packages/live-text`, `apps/chat-api`, and `apps/agent-worker`
- disposable real-Redis contract suite: isolation, ordering, fan-out, unsubscribe, reconnect, cleanup, invalid/oversized payload rejection
- RunLoop/PGlite integration proving preview → exact durable commit and mid-Run Redis failure fallback
- two-axis Standards and Spec review

Closes #248