### PR TITLE
Add Redis-backed live text preview with telemetry and deployment wiring

### DIFF
--- a/apps/agent-worker/src/index.ts
+++ b/apps/agent-worker/src/index.ts
@@ -132,6 +132,7 @@ async function handleShutdownSignal(signal: NodeJS.Signals): Promise<void> {
 	cleanupLoop.stop();
 	await runLoop.stop();
 	await liveTextTransport?.close().catch(() => {});
+	liveTextTelemetry.close();
 	server.stop();
 	logger.info({ message: "agent-worker stopped", workerId });
 	process.exit(0);

--- a/apps/agent-worker/src/index.ts
+++ b/apps/agent-worker/src/index.ts
@@ -10,7 +10,10 @@ import { loadWorkerConfigFromEnv } from "./config/env";
 import { createDocumentSearch } from "./documents/client";
 import { createE2bSandboxProvisioner } from "./e2b/sandbox-provisioner";
 import { startHealthServer } from "./health";
-import { createWorkerLiveTextTransport } from "./live-text";
+import {
+	createWorkerLiveTextTelemetry,
+	createWorkerLiveTextTransport,
+} from "./live-text";
 import { createLogger } from "./logger";
 import { buildModelClientConfig } from "./model-client";
 import { RunLoop } from "./run-loop";
@@ -27,9 +30,10 @@ import { generateWorkerId } from "./worker-id";
 const config = loadWorkerConfigFromEnv(Bun.env);
 const logger = createLogger(config.logLevel);
 const workerId = generateWorkerId();
+const liveTextTelemetry = createWorkerLiveTextTelemetry(logger);
 const liveTextTransport = createWorkerLiveTextTransport(
 	config.liveTextRedisUrl,
-	logger,
+	liveTextTelemetry,
 );
 // Verify the native CLI before constructing a run loop: a missing or wrong-libc
 // binary must crash boot before this process can claim work.
@@ -90,6 +94,7 @@ const runLoop = new RunLoop({
 		startRunQuery,
 		logger,
 		liveTextPublisher: liveTextTransport,
+		liveTextTelemetry,
 	}),
 	heartbeatIntervalMs: config.heartbeatIntervalMs,
 	logger,

--- a/apps/agent-worker/src/live-text.test.ts
+++ b/apps/agent-worker/src/live-text.test.ts
@@ -2,6 +2,8 @@ import { expect, it } from "bun:test";
 import {
 	createWorkerLiveTextTelemetry,
 	createWorkerLiveTextTransport,
+	reportWorkerLiveTextPreviewSignal,
+	reportWorkerLiveTextRuntimeSignal,
 } from "./live-text";
 
 const logger = {
@@ -41,4 +43,63 @@ it("constructs the lazy production publisher when Redis is configured", async ()
 	);
 	expect(transport).toBeDefined();
 	await transport?.close();
+});
+
+it("maps every worker Live path to bounded payload-free signals", () => {
+	const events: Record<string, unknown>[] = [];
+	const telemetry = createWorkerLiveTextTelemetry({
+		info: (event) => events.push(event),
+		warn: (event) => events.push(event),
+	});
+
+	for (const signal of [
+		"degraded",
+		"recovered",
+		"invalid_message",
+		"oversized_message",
+	] as const) {
+		reportWorkerLiveTextRuntimeSignal(telemetry, signal);
+	}
+	for (const signal of [
+		{ type: "attempted" },
+		{ type: "delivered" },
+		{ type: "dropped", reason: "publisher_failure" },
+		{ type: "dropped", reason: "queue_overflow" },
+		{ type: "dropped", reason: "mismatch" },
+		{ type: "dropped", reason: "run_aborted" },
+		{ type: "dropped", reason: "run_ended" },
+		{ type: "recovered", reason: "publisher_failure" },
+		{ type: "recovered", reason: "queue_overflow" },
+	] as const) {
+		reportWorkerLiveTextPreviewSignal(telemetry, signal);
+	}
+
+	expect(
+		events.map(({ signal, reason, outcome }) => ({ signal, reason, outcome })),
+	).toEqual([
+		{ signal: "degraded", reason: "redis_connection", outcome: undefined },
+		{ signal: "recovered", reason: "redis_connection", outcome: undefined },
+		{ signal: "malformed", reason: "adapter_message", outcome: "dropped" },
+		{ signal: "malformed", reason: "adapter_message", outcome: "dropped" },
+		{
+			signal: "attempted",
+			reason: "message_publication",
+			outcome: "attempted",
+		},
+		{
+			signal: "delivered",
+			reason: "message_publication",
+			outcome: "delivered",
+		},
+		{ signal: "dropped", reason: "publisher", outcome: "dropped" },
+		{ signal: "queue_overflow", reason: "worker_queue", outcome: "dropped" },
+		{ signal: "dropped", reason: "partial_complete", outcome: "dropped" },
+		{ signal: "dropped", reason: "run_aborted", outcome: "dropped" },
+		{ signal: "dropped", reason: "run_ended", outcome: "dropped" },
+	]);
+	expect(events.every(({ service }) => service === "agent-worker")).toBe(true);
+	expect(JSON.stringify(events)).not.toContain("preview text");
+	expect(JSON.stringify(events)).not.toContain("run-1");
+	expect(JSON.stringify(events)).not.toContain("message-1");
+	telemetry.close();
 });

--- a/apps/agent-worker/src/live-text.test.ts
+++ b/apps/agent-worker/src/live-text.test.ts
@@ -96,6 +96,8 @@ it("maps every worker Live path to bounded payload-free signals", () => {
 		{ signal: "dropped", reason: "partial_complete", outcome: "dropped" },
 		{ signal: "dropped", reason: "run_aborted", outcome: "dropped" },
 		{ signal: "dropped", reason: "run_ended", outcome: "dropped" },
+		{ signal: "recovered", reason: "publisher", outcome: undefined },
+		{ signal: "recovered", reason: "worker_queue", outcome: undefined },
 	]);
 	expect(events.every(({ service }) => service === "agent-worker")).toBe(true);
 	expect(JSON.stringify(events)).not.toContain("preview text");

--- a/apps/agent-worker/src/live-text.test.ts
+++ b/apps/agent-worker/src/live-text.test.ts
@@ -1,5 +1,8 @@
 import { expect, it } from "bun:test";
-import { createWorkerLiveTextTransport } from "./live-text";
+import {
+	createWorkerLiveTextTelemetry,
+	createWorkerLiveTextTransport,
+} from "./live-text";
 
 const logger = {
 	info() {},
@@ -15,12 +18,18 @@ it("keeps the worker Live lane disabled without valid Redis configuration", () =
 		warn() {},
 	};
 	expect(
-		createWorkerLiveTextTransport(undefined, recordingLogger),
+		createWorkerLiveTextTransport(
+			undefined,
+			createWorkerLiveTextTelemetry(recordingLogger),
+		),
 	).toBeUndefined();
 	expect(signals).toEqual([
 		{
-			message: "Live preview Redis transport state changed",
+			message: "Live preview signal",
+			service: "agent-worker",
 			signal: "disabled",
+			reason: "configuration",
+			count: 1,
 		},
 	]);
 });
@@ -28,7 +37,7 @@ it("keeps the worker Live lane disabled without valid Redis configuration", () =
 it("constructs the lazy production publisher when Redis is configured", async () => {
 	const transport = createWorkerLiveTextTransport(
 		"rediss://default:secret@redis.internal:6379",
-		logger,
+		createWorkerLiveTextTelemetry(logger),
 	);
 	expect(transport).toBeDefined();
 	await transport?.close();

--- a/apps/agent-worker/src/live-text.ts
+++ b/apps/agent-worker/src/live-text.ts
@@ -55,6 +55,19 @@ export function reportWorkerLiveTextPreviewSignal(
 	}
 }
 
+export function reportWorkerLiveTextRuntimeSignal(
+	telemetry: LiveTextTelemetry,
+	signal: RedisLiveTextSignal,
+): void {
+	if (signal === "degraded") {
+		telemetry.degraded("redis_connection");
+	} else if (signal === "recovered") {
+		telemetry.recovered("redis_connection");
+	} else {
+		telemetry.record("malformed", "adapter_message", "dropped");
+	}
+}
+
 /** Select the lazy production publisher only for validated Redis config. */
 export function createWorkerLiveTextTransport(
 	redisUrl: string | undefined,
@@ -66,14 +79,7 @@ export function createWorkerLiveTextTransport(
 	}
 	return createRedisLiveTextTransport({
 		url: redisUrl,
-		onSignal: (signal: RedisLiveTextSignal) => {
-			if (signal === "degraded") {
-				telemetry.degraded("redis_connection");
-			} else if (signal === "recovered") {
-				telemetry.recovered("redis_connection");
-			} else {
-				telemetry.record("malformed", "adapter_message", "dropped");
-			}
-		},
+		onSignal: (signal: RedisLiveTextSignal) =>
+			reportWorkerLiveTextRuntimeSignal(telemetry, signal),
 	});
 }

--- a/apps/agent-worker/src/live-text.ts
+++ b/apps/agent-worker/src/live-text.ts
@@ -31,19 +31,16 @@ export function reportWorkerLiveTextPreviewSignal(
 		return;
 	}
 	if (signal.type === "recovered") {
-		telemetry.recovered(
-			signal.reason === "publisher_failure" ? "publisher" : "worker_queue",
-		);
+		// Per-message recovery is not service recovery. Redis transport state owns
+		// the process-wide degraded/recovered transition.
 		return;
 	}
 
 	switch (signal.reason) {
 		case "publisher_failure":
-			telemetry.degraded("publisher");
 			telemetry.record("dropped", "publisher", "dropped");
 			break;
 		case "queue_overflow":
-			telemetry.degraded("worker_queue");
 			telemetry.record("queue_overflow", "worker_queue", "dropped");
 			break;
 		case "mismatch":

--- a/apps/agent-worker/src/live-text.ts
+++ b/apps/agent-worker/src/live-text.ts
@@ -31,8 +31,10 @@ export function reportWorkerLiveTextPreviewSignal(
 		return;
 	}
 	if (signal.type === "recovered") {
-		// Per-message recovery is not service recovery. Redis transport state owns
-		// the process-wide degraded/recovered transition.
+		// Record the per-run transition without clearing process-wide Redis state.
+		telemetry.recordRecovery(
+			signal.reason === "publisher_failure" ? "publisher" : "worker_queue",
+		);
 		return;
 	}
 

--- a/apps/agent-worker/src/live-text.ts
+++ b/apps/agent-worker/src/live-text.ts
@@ -1,39 +1,82 @@
 import {
+	createLiveTextTelemetry,
 	createRedisLiveTextTransport,
+	type LiveTextTelemetry,
 	type LiveTextTransport,
 	type RedisLiveTextSignal,
 } from "@mymemo/live-text";
+import type { LiveTextPreviewSignal } from "./sdk/live-text-preview";
 
 interface LiveTextLogger {
 	info(event: Record<string, unknown>): void;
 	warn(event: Record<string, unknown>): void;
 }
 
+export function createWorkerLiveTextTelemetry(
+	logger: LiveTextLogger,
+): LiveTextTelemetry {
+	return createLiveTextTelemetry("agent-worker", logger);
+}
+
+export function reportWorkerLiveTextPreviewSignal(
+	telemetry: LiveTextTelemetry,
+	signal: LiveTextPreviewSignal,
+): void {
+	if (signal.type === "attempted") {
+		telemetry.record("attempted", "message_publication", "attempted");
+		return;
+	}
+	if (signal.type === "delivered") {
+		telemetry.record("delivered", "message_publication", "delivered");
+		return;
+	}
+	if (signal.type === "recovered") {
+		telemetry.recovered(
+			signal.reason === "publisher_failure" ? "publisher" : "worker_queue",
+		);
+		return;
+	}
+
+	switch (signal.reason) {
+		case "publisher_failure":
+			telemetry.degraded("publisher");
+			telemetry.record("dropped", "publisher", "dropped");
+			break;
+		case "queue_overflow":
+			telemetry.degraded("worker_queue");
+			telemetry.record("queue_overflow", "worker_queue", "dropped");
+			break;
+		case "mismatch":
+			telemetry.record("dropped", "partial_complete", "dropped");
+			break;
+		case "run_aborted":
+			telemetry.record("dropped", "run_aborted", "dropped");
+			break;
+		case "run_ended":
+			telemetry.record("dropped", "run_ended", "dropped");
+			break;
+	}
+}
+
 /** Select the lazy production publisher only for validated Redis config. */
 export function createWorkerLiveTextTransport(
 	redisUrl: string | undefined,
-	logger: LiveTextLogger,
+	telemetry: LiveTextTelemetry,
 ): LiveTextTransport | undefined {
 	if (redisUrl === undefined) {
-		try {
-			logger.info({
-				message: "Live preview Redis transport state changed",
-				signal: "disabled",
-			});
-		} catch {
-			// Telemetry is optional and must never affect worker boot.
-		}
+		telemetry.disabled("configuration");
 		return undefined;
 	}
 	return createRedisLiveTextTransport({
 		url: redisUrl,
 		onSignal: (signal: RedisLiveTextSignal) => {
-			const event = {
-				message: "Live preview Redis transport state changed",
-				signal,
-			};
-			if (signal === "recovered") logger.info(event);
-			else logger.warn(event);
+			if (signal === "degraded") {
+				telemetry.degraded("redis_connection");
+			} else if (signal === "recovered") {
+				telemetry.recovered("redis_connection");
+			} else {
+				telemetry.record("malformed", "adapter_message", "dropped");
+			}
 		},
 	});
 }

--- a/apps/agent-worker/src/sdk/live-text-preview.test.ts
+++ b/apps/agent-worker/src/sdk/live-text-preview.test.ts
@@ -16,16 +16,19 @@ function deferred<T>() {
 it("publishes coalesced chunks with monotonic indexes within the 50 ms ceiling", async () => {
 	const transport = new InMemoryLiveTextTransport();
 	const subscription = await transport.subscribe("run-1");
+	const signals: unknown[] = [];
 	const preview = new LiveTextPreview({
 		runId: "run-1",
 		publisher: transport,
 		coalesceWindowMs: 5,
+		onSignal: (signal) => signals.push(signal),
 	});
 
 	preview.append("message-1", "A");
 	await Bun.sleep(10);
 	preview.append("message-1", "B");
 	await preview.flushMessage();
+	await Bun.sleep(0);
 
 	expect(subscription.readAvailable()).toEqual([
 		{
@@ -41,6 +44,9 @@ it("publishes coalesced chunks with monotonic indexes within the 50 ms ceiling",
 			text: "B",
 		},
 	]);
+	expect(signals).toEqual([{ type: "attempted" }, { type: "delivered" }]);
+	expect(JSON.stringify(signals)).not.toContain("message-1");
+	expect(JSON.stringify(signals)).not.toContain("A");
 	expect(
 		() =>
 			new LiveTextPreview({
@@ -53,9 +59,11 @@ it("publishes coalesced chunks with monotonic indexes within the 50 ms ceiling",
 
 it("abandons only the current preview after publication fails", async () => {
 	const published: LiveTextMessage[] = [];
+	const signals: unknown[] = [];
 	let attempts = 0;
 	const preview = new LiveTextPreview({
 		runId: "run-1",
+		onSignal: (signal) => signals.push(signal),
 		publisher: {
 			async publish(message) {
 				attempts++;
@@ -69,10 +77,20 @@ it("abandons only the current preview after publication fails", async () => {
 	await preview.flushMessage();
 	preview.append("message-2", "visible");
 	await preview.flushMessage();
+	await Bun.sleep(0);
 
 	expect(published).toEqual([
 		{ messageId: "message-2", deltaIndex: 0, text: "visible", runId: "run-1" },
 	]);
+	expect(signals).toEqual([
+		{ type: "attempted" },
+		{ type: "dropped", reason: "publisher_failure" },
+		{ type: "attempted" },
+		{ type: "recovered", reason: "publisher_failure" },
+		{ type: "delivered" },
+	]);
+	expect(JSON.stringify(signals)).not.toContain("lost");
+	expect(JSON.stringify(signals)).not.toContain("visible");
 });
 
 it("does not wait for a stalled publisher when a message completes", async () => {
@@ -104,7 +122,7 @@ it("does not wait for a stalled publisher when a message completes", async () =>
 it("bounds queued publications and recovers on the next Assistant message", async () => {
 	const firstPublish = deferred<void>();
 	const published: LiveTextMessage[] = [];
-	const signals: string[] = [];
+	const signals: unknown[] = [];
 	let attempts = 0;
 	const preview = new LiveTextPreview({
 		runId: "run-1",
@@ -127,7 +145,13 @@ it("bounds queued publications and recovers on the next Assistant message", asyn
 	await preview.flushMessage();
 	await Bun.sleep(0);
 
-	expect(signals).toEqual(["queue_overflow", "recovered"]);
+	expect(signals).toEqual([
+		{ type: "attempted" },
+		{ type: "dropped", reason: "queue_overflow" },
+		{ type: "attempted" },
+		{ type: "recovered", reason: "queue_overflow" },
+		{ type: "delivered" },
+	]);
 	expect(published.map(({ messageId, text }) => ({ messageId, text }))).toEqual(
 		[
 			{ messageId: "message-1", text: "A".repeat(16_384) },

--- a/apps/agent-worker/src/sdk/live-text-preview.ts
+++ b/apps/agent-worker/src/sdk/live-text-preview.ts
@@ -6,10 +6,21 @@ import {
 export const LIVE_TEXT_COALESCE_WINDOW_MS = 50;
 export const LIVE_TEXT_MAX_QUEUED_MESSAGES = 32;
 
-export type LiveTextPreviewSignal =
+export type LiveTextPreviewDropReason =
+	| "mismatch"
 	| "publisher_failure"
 	| "queue_overflow"
-	| "recovered";
+	| "run_aborted"
+	| "run_ended";
+
+export type LiveTextPreviewSignal =
+	| { type: "attempted" }
+	| { type: "delivered" }
+	| { type: "dropped"; reason: LiveTextPreviewDropReason }
+	| {
+			type: "recovered";
+			reason: "publisher_failure" | "queue_overflow";
+	  };
 
 interface QueuedPreview {
 	messageId: string;
@@ -25,6 +36,9 @@ export class LiveTextPreview {
 	readonly #onSignal?: (signal: LiveTextPreviewSignal) => void;
 	readonly #queue: QueuedPreview[] = [];
 	readonly #failedMessageIds = new Set<string>();
+	readonly #attemptedMessageIds = new Set<string>();
+	readonly #completedMessageIds = new Set<string>();
+	readonly #resolvedMessageIds = new Set<string>();
 	#messageId: string | null = null;
 	#deltaIndex = 0;
 	#pendingText = "";
@@ -32,7 +46,7 @@ export class LiveTextPreview {
 	#publishing = false;
 	#publishController: AbortController | undefined;
 	#inFlightMessageId: string | null = null;
-	#degraded = false;
+	#degradedReason: "publisher_failure" | "queue_overflow" | undefined;
 	#disabled = false;
 	#closed = false;
 
@@ -75,6 +89,10 @@ export class LiveTextPreview {
 		if (this.#messageId !== null && this.#messageId !== messageId) {
 			throw new Error("Live text message changed before message_stop");
 		}
+		if (!this.#attemptedMessageIds.has(messageId)) {
+			this.#attemptedMessageIds.add(messageId);
+			this.#emitSignal({ type: "attempted" });
+		}
 		this.#messageId = messageId;
 		this.#pendingText += text;
 		while (this.#pendingText.length >= LIVE_TEXT_MAX_CHUNK_LENGTH) {
@@ -95,6 +113,10 @@ export class LiveTextPreview {
 		const completedMessageId = this.#messageId;
 		this.#messageId = null;
 		this.#deltaIndex = 0;
+		if (completedMessageId !== null) {
+			this.#completedMessageIds.add(completedMessageId);
+			this.#maybeMarkDelivered(completedMessageId);
+		}
 		if (
 			completedMessageId !== null &&
 			this.#inFlightMessageId !== completedMessageId
@@ -103,30 +125,19 @@ export class LiveTextPreview {
 		}
 	}
 
-	disable(): void {
+	disable(reason: LiveTextPreviewDropReason = "mismatch"): void {
 		this.#disabled = true;
-		this.#discardAll();
+		this.#discardAll(reason);
 	}
 
 	abandon(): void {
-		this.#clearTimer();
-		this.#pendingText = "";
-		const messageId = this.#messageId;
-		if (messageId !== null) {
-			this.#failedMessageIds.add(messageId);
-			this.#discardQueuedMessage(messageId);
-			if (this.#inFlightMessageId === messageId) {
-				this.#publishController?.abort();
-			}
-		}
-		this.#messageId = null;
-		this.#deltaIndex = 0;
+		this.#discardAll("run_aborted");
 	}
 
 	close(): void {
 		if (this.#closed) return;
 		this.#closed = true;
-		this.#discardAll();
+		this.#discardAll("run_ended");
 		this.#failedMessageIds.clear();
 	}
 
@@ -184,10 +195,11 @@ export class LiveTextPreview {
 					if (
 						!controller.signal.aborted &&
 						!this.#failedMessageIds.has(next.messageId) &&
-						this.#degraded
+						this.#degradedReason !== undefined
 					) {
-						this.#degraded = false;
-						this.#emitSignal("recovered");
+						const reason = this.#degradedReason;
+						this.#degradedReason = undefined;
+						this.#emitSignal({ type: "recovered", reason });
 					}
 				},
 				() => {
@@ -205,17 +217,21 @@ export class LiveTextPreview {
 				if (this.#messageId !== next.messageId) {
 					this.#failedMessageIds.delete(next.messageId);
 				}
+				this.#maybeMarkDelivered(next.messageId);
 				this.#pump();
 			});
 	}
 
-	#failMessage(messageId: string, signal: LiveTextPreviewSignal): void {
+	#failMessage(
+		messageId: string,
+		reason: "publisher_failure" | "queue_overflow",
+	): void {
 		if (this.#failedMessageIds.has(messageId)) return;
 		this.#failedMessageIds.add(messageId);
-		this.#degraded = true;
+		this.#degradedReason = reason;
 		if (this.#messageId === messageId) this.#pendingText = "";
 		this.#discardQueuedMessage(messageId);
-		this.#emitSignal(signal);
+		this.#markDropped(messageId, reason);
 	}
 
 	#emitSignal(signal: LiveTextPreviewSignal): void {
@@ -234,13 +250,41 @@ export class LiveTextPreview {
 		}
 	}
 
-	#discardAll(): void {
+	#discardAll(reason: LiveTextPreviewDropReason): void {
 		this.#clearTimer();
 		this.#pendingText = "";
 		this.#queue.length = 0;
 		this.#publishController?.abort();
 		this.#messageId = null;
 		this.#deltaIndex = 0;
+		for (const messageId of this.#attemptedMessageIds) {
+			this.#markDropped(messageId, reason);
+		}
+	}
+
+	#maybeMarkDelivered(messageId: string): void {
+		if (
+			!this.#completedMessageIds.has(messageId) ||
+			this.#failedMessageIds.has(messageId) ||
+			this.#resolvedMessageIds.has(messageId) ||
+			this.#inFlightMessageId === messageId ||
+			this.#queue.some((queued) => queued.messageId === messageId)
+		) {
+			return;
+		}
+		this.#resolvedMessageIds.add(messageId);
+		this.#emitSignal({ type: "delivered" });
+	}
+
+	#markDropped(messageId: string, reason: LiveTextPreviewDropReason): void {
+		if (
+			!this.#attemptedMessageIds.has(messageId) ||
+			this.#resolvedMessageIds.has(messageId)
+		) {
+			return;
+		}
+		this.#resolvedMessageIds.add(messageId);
+		this.#emitSignal({ type: "dropped", reason });
 	}
 
 	#clearTimer(): void {

--- a/apps/agent-worker/src/sdk/run-processor.test.ts
+++ b/apps/agent-worker/src/sdk/run-processor.test.ts
@@ -444,9 +444,16 @@ describe("createSdkRunProcessor — through the run loop", () => {
 		},
 	]) {
 		it(`fails the Run closed for ${fixture.name}`, async () => {
+			const warnings: Record<string, unknown>[] = [];
+			const logger: WorkerLogger = {
+				...silentLogger,
+				warn: (event) => warnings.push(event),
+			};
 			const worker = buildWorker();
-			const loop = buildLoop(worker, async () =>
-				messageQuery(fixture.messages),
+			const loop = buildLoop(
+				worker,
+				async () => messageQuery(fixture.messages),
+				logger,
 			);
 			await createQueuedRunTx(tdb.db, {
 				runId: "run-1",
@@ -461,6 +468,14 @@ describe("createSdkRunProcessor — through the run loop", () => {
 			const events = await readEvents("run-1");
 			expect(events.map((event) => event.type)).toEqual(["run_error"]);
 			expect(events[0]?.payload).toEqual({ message: "Run failed" });
+			expect(warnings).toContainEqual({
+				message: "Live preview signal",
+				service: "agent-worker",
+				signal: "impossible_ordering",
+				reason: "provider_envelope",
+				count: 1,
+			});
+			expect(JSON.stringify(warnings)).not.toContain("complete");
 		});
 	}
 
@@ -511,7 +526,19 @@ describe("createSdkRunProcessor — through the run loop", () => {
 		).toEqual(["COMMIT", "NEXT"]);
 		expect(warnings).toEqual([
 			{
-				message: "assistant Live preview disabled after text mismatch",
+				message: "Live preview signal",
+				service: "agent-worker",
+				signal: "dropped",
+				reason: "partial_complete",
+				outcome: "dropped",
+				count: 1,
+			},
+			{
+				message: "Live preview signal",
+				service: "agent-worker",
+				signal: "mismatch",
+				reason: "partial_complete",
+				count: 1,
 			},
 		]);
 		expect(JSON.stringify(warnings)).not.toContain("PREVIEW");
@@ -556,8 +583,19 @@ describe("createSdkRunProcessor — through the run loop", () => {
 		).toEqual(["authoritative answer"]);
 		expect(warnings).toEqual([
 			{
-				message: "Live preview transport state changed",
-				signal: "publisher_failure",
+				message: "Live preview signal",
+				service: "agent-worker",
+				signal: "degraded",
+				reason: "publisher",
+				count: 1,
+			},
+			{
+				message: "Live preview signal",
+				service: "agent-worker",
+				signal: "dropped",
+				reason: "publisher",
+				outcome: "dropped",
+				count: 1,
 			},
 		]);
 		expect(JSON.stringify(warnings)).not.toContain("authoritative answer");

--- a/apps/agent-worker/src/sdk/run-processor.test.ts
+++ b/apps/agent-worker/src/sdk/run-processor.test.ts
@@ -585,13 +585,6 @@ describe("createSdkRunProcessor — through the run loop", () => {
 			{
 				message: "Live preview signal",
 				service: "agent-worker",
-				signal: "degraded",
-				reason: "publisher",
-				count: 1,
-			},
-			{
-				message: "Live preview signal",
-				service: "agent-worker",
 				signal: "dropped",
 				reason: "publisher",
 				outcome: "dropped",

--- a/apps/agent-worker/src/sdk/run-processor.ts
+++ b/apps/agent-worker/src/sdk/run-processor.ts
@@ -1,8 +1,17 @@
 import type { RunRecord } from "@mymemo/agent-db/run-store";
-import type { LiveTextPublisher } from "@mymemo/live-text";
+import type { LiveTextPublisher, LiveTextTelemetry } from "@mymemo/live-text";
+import {
+	createWorkerLiveTextTelemetry,
+	reportWorkerLiveTextPreviewSignal,
+} from "../live-text";
 import type { WorkerLogger } from "../logger";
 import type { RunProcessor } from "../run-loop";
-import { consumeAgentStream, type SupervisedQuery } from "./agent-stream";
+import {
+	type AgentStreamOutcome,
+	consumeAgentStream,
+	type SupervisedQuery,
+} from "./agent-stream";
+import { AssistantEnvelopeProtocolError } from "./assistant-message-assembler";
 
 /**
  * Start a Claude Agent SDK query for one claimed run. This is the seam between
@@ -22,6 +31,7 @@ export interface SdkRunProcessorDeps {
 	startRunQuery: StartRunQuery;
 	logger: WorkerLogger;
 	liveTextPublisher?: LiveTextPublisher;
+	liveTextTelemetry?: LiveTextTelemetry;
 }
 
 /**
@@ -37,35 +47,30 @@ export interface SdkRunProcessorDeps {
  * reports the session to resume from next turn, and lets errors propagate.
  */
 export function createSdkRunProcessor(deps: SdkRunProcessorDeps): RunProcessor {
+	const telemetry =
+		deps.liveTextTelemetry ?? createWorkerLiveTextTelemetry(deps.logger);
 	return async (ctx) => {
-		if (!deps.liveTextPublisher) {
-			try {
-				deps.logger.info({ message: "Live preview disabled" });
-			} catch {
-				// Live telemetry must never change the Run outcome.
-			}
-		}
 		const query = await deps.startRunQuery(ctx.run, ctx.signal);
-		const outcome = await consumeAgentStream({
-			runId: ctx.run.runId,
-			query,
-			signal: ctx.signal,
-			appendAssistantMessage: ctx.appendAssistantMessage,
-			liveTextPublisher: deps.liveTextPublisher,
-			onLiveTextSignal: (signal) => {
-				const event = {
-					message: "Live preview transport state changed",
-					signal,
-				};
-				if (signal === "recovered") deps.logger.info(event);
-				else deps.logger.warn(event);
-			},
-			onPartialCompleteMismatch: () => {
-				deps.logger.warn({
-					message: "assistant Live preview disabled after text mismatch",
-				});
-			},
-		});
+		let outcome: AgentStreamOutcome;
+		try {
+			outcome = await consumeAgentStream({
+				runId: ctx.run.runId,
+				query,
+				signal: ctx.signal,
+				appendAssistantMessage: ctx.appendAssistantMessage,
+				liveTextPublisher: deps.liveTextPublisher,
+				onLiveTextSignal: (signal) =>
+					reportWorkerLiveTextPreviewSignal(telemetry, signal),
+				onPartialCompleteMismatch: () => {
+					telemetry.record("mismatch", "partial_complete");
+				},
+			});
+		} catch (error) {
+			if (error instanceof AssistantEnvelopeProtocolError) {
+				telemetry.record("impossible_ordering", "provider_envelope");
+			}
+			throw error;
+		}
 		return {
 			// Advance the conversation's resume pointer only when the SDK produced a
 			// session id and no `mirror_error` left the stored transcript unreliable

--- a/apps/chat-api/src/deps.test.ts
+++ b/apps/chat-api/src/deps.test.ts
@@ -1,5 +1,8 @@
 import { expect, it } from "bun:test";
-import { disabledLiveTextSubscriber } from "@mymemo/live-text";
+import {
+	createLiveTextTelemetry,
+	disabledLiveTextSubscriber,
+} from "@mymemo/live-text";
 import type { ApiConfig } from "./config/env";
 import { createDeps } from "./deps";
 
@@ -14,11 +17,23 @@ function config(liveTextRedisUrl: string | undefined): ApiConfig {
 }
 
 it("keeps the chat-api Live lane disabled without valid Redis configuration", () => {
-	const signals: string[] = [];
-	const deps = createDeps(config(undefined), (signal) => signals.push(signal));
+	const signals: Record<string, unknown>[] = [];
+	const telemetry = createLiveTextTelemetry("chat-api", {
+		info: (event) => signals.push(event),
+		warn: (event) => signals.push(event),
+	});
+	const deps = createDeps(config(undefined), telemetry);
 	expect(deps.liveTextSubscriber).toBe(disabledLiveTextSubscriber);
 	expect(deps.closeLiveText).toBeUndefined();
-	expect(signals).toEqual(["disabled"]);
+	expect(signals).toEqual([
+		{
+			message: "Live preview signal",
+			service: "chat-api",
+			signal: "disabled",
+			reason: "configuration",
+			count: 1,
+		},
+	]);
 });
 
 it("constructs the lazy production subscriber when Redis is configured", async () => {

--- a/apps/chat-api/src/deps.ts
+++ b/apps/chat-api/src/deps.ts
@@ -1,7 +1,9 @@
 import {
+	createLiveTextTelemetry,
 	createRedisLiveTextTransport,
 	disabledLiveTextSubscriber,
 	type LiveTextSubscriber,
+	type LiveTextTelemetry,
 	type LiveTextTransport,
 	type RedisLiveTextSignal,
 } from "@mymemo/live-text";
@@ -22,6 +24,7 @@ import {
 	type RunEventReader,
 	type RunNotifier,
 } from "./features/run-events";
+import { reportChatLiveTextRuntimeSignal } from "./features/run-events/live-text-telemetry";
 import { PostgresRunStore, type RunStore } from "./features/run-store";
 
 /**
@@ -42,6 +45,8 @@ export interface AppDeps {
 	runNotifier: RunNotifier;
 	/** Optional ephemeral Assistant-text preview lane. */
 	liveTextSubscriber: LiveTextSubscriber;
+	/** Cardinality-safe, payload-free Live-lane observability. */
+	liveTextTelemetry: LiveTextTelemetry;
 	/** Close optional Live transport resources during service shutdown. */
 	closeLiveText?: () => Promise<void>;
 	/**
@@ -59,7 +64,10 @@ export type LiveTextRuntimeSignal = RedisLiveTextSignal | "disabled";
 
 export function createDeps(
 	config: ApiConfig,
-	onLiveTextSignal?: (signal: LiveTextRuntimeSignal) => void,
+	liveTextTelemetry: LiveTextTelemetry = createLiveTextTelemetry("chat-api", {
+		info() {},
+		warn() {},
+	}),
 ): AppDeps {
 	// One Drizzle pool over the writable DB, shared by every store.
 	const database = createDatabase(config.databaseUrl);
@@ -68,11 +76,7 @@ export function createDeps(
 	const runEventReader = new DrizzleRunEventReader(database);
 	const runNotifier = new PostgresRunNotifier(config.databaseUrl);
 	const emitLiveTextSignal = (signal: LiveTextRuntimeSignal) => {
-		try {
-			onLiveTextSignal?.(signal);
-		} catch {
-			// Telemetry is optional and must never affect boot or request handling.
-		}
+		reportChatLiveTextRuntimeSignal(liveTextTelemetry, signal);
 	};
 	const liveTextTransport: LiveTextTransport | undefined =
 		config.liveTextRedisUrl === undefined
@@ -89,6 +93,7 @@ export function createDeps(
 		runEventReader,
 		runNotifier,
 		liveTextSubscriber: liveTextTransport ?? disabledLiveTextSubscriber,
+		liveTextTelemetry,
 		closeLiveText: liveTextTransport
 			? () => liveTextTransport.close()
 			: undefined,

--- a/apps/chat-api/src/features/conversations/conversations.route.test.ts
+++ b/apps/chat-api/src/features/conversations/conversations.route.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+	createLiveTextTelemetry,
 	disabledLiveTextSubscriber,
 	InMemoryLiveTextTransport,
 	type LiveTextSubscriber,
@@ -30,6 +31,10 @@ import {
 import type { InternalIdentity } from "./conversations.schema";
 
 const { createApp } = await import("@/index");
+const silentLiveTextTelemetry = createLiveTextTelemetry("chat-api", {
+	info() {},
+	warn() {},
+});
 
 /** In-memory ConversationStore for the HTTP layer. */
 function fakeStore(seed: ConversationRecord[] = []) {
@@ -83,6 +88,7 @@ function buildApp(
 		runEventReader: fakeRuns.runEventReader,
 		runNotifier: fakeRuns.runNotifier,
 		liveTextSubscriber,
+		liveTextTelemetry: silentLiveTextTelemetry,
 	} as unknown as AppDeps;
 	return createApp({ logLevel: "silent" } as unknown as ApiConfig, deps);
 }
@@ -431,6 +437,7 @@ describe("POST /v1/conversations/:id/events", () => {
 			runEventReader,
 			runNotifier: fakeRunStore().runNotifier,
 			liveTextSubscriber: subscriber,
+			liveTextTelemetry: silentLiveTextTelemetry,
 		} as unknown as AppDeps;
 		const res = await createApp(
 			{ logLevel: "silent" } as unknown as ApiConfig,

--- a/apps/chat-api/src/features/conversations/conversations.route.ts
+++ b/apps/chat-api/src/features/conversations/conversations.route.ts
@@ -5,6 +5,10 @@ import { validator as zValidator } from "hono-openapi";
 import { z } from "zod";
 import type { AppEnv } from "@/deps";
 import { projectRun } from "@/features/run-events";
+import {
+	reportChatLiveTextProjectionSignal,
+	reportChatLiveTextSetupSignal,
+} from "@/features/run-events/live-text-telemetry";
 import { prepareLiveTextSubscription } from "@/features/run-events/prepare-live-text-subscription";
 import { ActiveRunExistsError } from "@/features/run-store";
 import { HonoSSESender } from "@/features/streaming/sse-sender";
@@ -55,13 +59,6 @@ function lastEventIdFromContext(c: {
 
 function isTerminalRunStatus(status: string): boolean {
 	return status === "done" || status === "error" || status === "canceled";
-}
-
-function liveTextSignalHandler(
-	logger: { warn: (event: Record<string, unknown>) => void },
-	message: string,
-): (signal: string) => void {
-	return (signal) => logger.warn({ message, signal });
 }
 
 // POST /v1/conversations — create a conversation, freezing its document scope.
@@ -177,10 +174,8 @@ app.post(
 			c.var.deps.liveTextSubscriber,
 			runId,
 			{
-				onSignal: liveTextSignalHandler(
-					c.var.logger,
-					"Live preview setup state changed",
-				),
+				onSignal: (signal) =>
+					reportChatLiveTextSetupSignal(c.var.deps.liveTextTelemetry, signal),
 			},
 		);
 		let queuedRun: { runId: string };
@@ -224,10 +219,11 @@ app.post(
 						notifier: c.var.deps.runNotifier,
 						liveSubscription: liveSubscription ?? undefined,
 						signal: requestSignal,
-						onLiveTextSignal: liveTextSignalHandler(
-							c.var.logger,
-							"Live preview projection state changed",
-						),
+						onLiveTextSignal: (signal) =>
+							reportChatLiveTextProjectionSignal(
+								c.var.deps.liveTextTelemetry,
+								signal,
+							),
 					})) {
 						if (requestSignal.aborted) break;
 						await sender.send({
@@ -306,10 +302,11 @@ app.get(
 					c.var.deps.liveTextSubscriber,
 					runId,
 					{
-						onSignal: liveTextSignalHandler(
-							c.var.logger,
-							"Live preview setup state changed",
-						),
+						onSignal: (signal) =>
+							reportChatLiveTextSetupSignal(
+								c.var.deps.liveTextTelemetry,
+								signal,
+							),
 					},
 				);
 
@@ -333,10 +330,11 @@ app.get(
 						notifier: c.var.deps.runNotifier,
 						liveSubscription: liveSubscription ?? undefined,
 						signal: requestSignal,
-						onLiveTextSignal: liveTextSignalHandler(
-							c.var.logger,
-							"Live preview projection state changed",
-						),
+						onLiveTextSignal: (signal) =>
+							reportChatLiveTextProjectionSignal(
+								c.var.deps.liveTextTelemetry,
+								signal,
+							),
 					})) {
 						if (requestSignal.aborted) break;
 						await sender.send({

--- a/apps/chat-api/src/features/run-events/live-text-telemetry.test.ts
+++ b/apps/chat-api/src/features/run-events/live-text-telemetry.test.ts
@@ -18,7 +18,6 @@ it("maps every chat-api Live degradation path to bounded payload-free signals", 
 	reportChatLiveTextRuntimeSignal(telemetry, "recovered");
 	reportChatLiveTextRuntimeSignal(telemetry, "invalid_message");
 	reportChatLiveTextSetupSignal(telemetry, "subscription_timeout");
-	reportChatLiveTextSetupSignal(telemetry, "recovered");
 	for (const signal of [
 		"message_attempted",
 		"message_delivered",
@@ -26,7 +25,7 @@ it("maps every chat-api Live degradation path to bounded payload-free signals", 
 		"gap",
 		"malformed_message",
 		"queue_overflow",
-		"durable_backlog",
+		"slow_client",
 		"partial_complete_mismatch",
 		"impossible_ordering",
 	] as const) {
@@ -38,8 +37,7 @@ it("maps every chat-api Live degradation path to bounded payload-free signals", 
 		"degraded",
 		"recovered",
 		"malformed",
-		"degraded",
-		"recovered",
+		"dropped",
 		"attempted",
 		"delivered",
 		"dropped",

--- a/apps/chat-api/src/features/run-events/live-text-telemetry.test.ts
+++ b/apps/chat-api/src/features/run-events/live-text-telemetry.test.ts
@@ -17,7 +17,9 @@ it("maps every chat-api Live degradation path to bounded payload-free signals", 
 	reportChatLiveTextRuntimeSignal(telemetry, "degraded");
 	reportChatLiveTextRuntimeSignal(telemetry, "recovered");
 	reportChatLiveTextRuntimeSignal(telemetry, "invalid_message");
+	reportChatLiveTextRuntimeSignal(telemetry, "oversized_message");
 	reportChatLiveTextSetupSignal(telemetry, "subscription_timeout");
+	reportChatLiveTextSetupSignal(telemetry, "subscription_failure");
 	for (const signal of [
 		"message_attempted",
 		"message_delivered",
@@ -25,8 +27,13 @@ it("maps every chat-api Live degradation path to bounded payload-free signals", 
 		"gap",
 		"malformed_message",
 		"queue_overflow",
+		"reconciliation_overflow",
 		"slow_client",
 		"partial_complete_mismatch",
+		"subscriber_failure",
+		"duplicate_inconsistency",
+		"late_delta",
+		"terminal_open_preview",
 		"impossible_ordering",
 	] as const) {
 		reportChatLiveTextProjectionSignal(telemetry, signal);
@@ -37,6 +44,8 @@ it("maps every chat-api Live degradation path to bounded payload-free signals", 
 		"degraded",
 		"recovered",
 		"malformed",
+		"malformed",
+		"dropped",
 		"dropped",
 		"attempted",
 		"delivered",
@@ -44,8 +53,13 @@ it("maps every chat-api Live degradation path to bounded payload-free signals", 
 		"gap_detected",
 		"malformed",
 		"queue_overflow",
+		"queue_overflow",
 		"slow_client",
 		"mismatch",
+		"dropped",
+		"impossible_ordering",
+		"impossible_ordering",
+		"impossible_ordering",
 		"impossible_ordering",
 	]);
 	expect(events.every(({ service }) => service === "chat-api")).toBe(true);

--- a/apps/chat-api/src/features/run-events/live-text-telemetry.test.ts
+++ b/apps/chat-api/src/features/run-events/live-text-telemetry.test.ts
@@ -1,0 +1,57 @@
+import { expect, it } from "bun:test";
+import { createLiveTextTelemetry } from "@mymemo/live-text";
+import {
+	reportChatLiveTextProjectionSignal,
+	reportChatLiveTextRuntimeSignal,
+	reportChatLiveTextSetupSignal,
+} from "./live-text-telemetry";
+
+it("maps every chat-api Live degradation path to bounded payload-free signals", () => {
+	const events: Record<string, unknown>[] = [];
+	const telemetry = createLiveTextTelemetry("chat-api", {
+		info: (event) => events.push(event),
+		warn: (event) => events.push(event),
+	});
+
+	reportChatLiveTextRuntimeSignal(telemetry, "disabled");
+	reportChatLiveTextRuntimeSignal(telemetry, "degraded");
+	reportChatLiveTextRuntimeSignal(telemetry, "recovered");
+	reportChatLiveTextRuntimeSignal(telemetry, "invalid_message");
+	reportChatLiveTextSetupSignal(telemetry, "subscription_timeout");
+	reportChatLiveTextSetupSignal(telemetry, "recovered");
+	for (const signal of [
+		"message_attempted",
+		"message_delivered",
+		"message_dropped",
+		"gap",
+		"malformed_message",
+		"queue_overflow",
+		"durable_backlog",
+		"partial_complete_mismatch",
+		"impossible_ordering",
+	] as const) {
+		reportChatLiveTextProjectionSignal(telemetry, signal);
+	}
+
+	expect(events.map(({ signal }) => signal)).toEqual([
+		"disabled",
+		"degraded",
+		"recovered",
+		"malformed",
+		"degraded",
+		"recovered",
+		"attempted",
+		"delivered",
+		"dropped",
+		"gap_detected",
+		"malformed",
+		"queue_overflow",
+		"slow_client",
+		"mismatch",
+		"impossible_ordering",
+	]);
+	expect(events.every(({ service }) => service === "chat-api")).toBe(true);
+	expect(JSON.stringify(events)).not.toContain("preview text");
+	expect(JSON.stringify(events)).not.toContain("run-1");
+	expect(JSON.stringify(events)).not.toContain("message-1");
+});

--- a/apps/chat-api/src/features/run-events/live-text-telemetry.ts
+++ b/apps/chat-api/src/features/run-events/live-text-telemetry.ts
@@ -24,12 +24,9 @@ export function reportChatLiveTextSetupSignal(
 	if (signal === "disabled") {
 		telemetry.disabled("configuration");
 	} else if (signal === "subscription_timeout") {
-		telemetry.degraded("subscription_timeout");
+		telemetry.record("dropped", "subscription_timeout");
 	} else if (signal === "subscription_failure") {
-		telemetry.degraded("subscription");
-	} else {
-		telemetry.recovered("subscription_timeout");
-		telemetry.recovered("subscription");
+		telemetry.record("dropped", "subscription");
 	}
 }
 
@@ -59,14 +56,14 @@ export function reportChatLiveTextProjectionSignal(
 		case "reconciliation_overflow":
 			telemetry.record("queue_overflow", "reconciliation_state");
 			break;
-		case "durable_backlog":
-			telemetry.record("slow_client", "durable_backlog");
+		case "slow_client":
+			telemetry.record("slow_client", "connection_buffer");
 			break;
 		case "partial_complete_mismatch":
 			telemetry.record("mismatch", "partial_complete");
 			break;
 		case "subscriber_failure":
-			telemetry.degraded("subscription");
+			telemetry.record("dropped", "subscription");
 			break;
 		case "duplicate_inconsistency":
 			telemetry.record("impossible_ordering", "duplicate_delta");

--- a/apps/chat-api/src/features/run-events/live-text-telemetry.ts
+++ b/apps/chat-api/src/features/run-events/live-text-telemetry.ts
@@ -1,0 +1,84 @@
+import type { LiveTextTelemetry, RedisLiveTextSignal } from "@mymemo/live-text";
+import type { LiveTextSetupSignal } from "./prepare-live-text-subscription";
+import type { ProjectRunLiveTextSignal } from "./project-run";
+
+export function reportChatLiveTextRuntimeSignal(
+	telemetry: LiveTextTelemetry,
+	signal: RedisLiveTextSignal | "disabled",
+): void {
+	if (signal === "disabled") {
+		telemetry.disabled("configuration");
+	} else if (signal === "degraded") {
+		telemetry.degraded("redis_connection");
+	} else if (signal === "recovered") {
+		telemetry.recovered("redis_connection");
+	} else {
+		telemetry.record("malformed", "adapter_message", "dropped");
+	}
+}
+
+export function reportChatLiveTextSetupSignal(
+	telemetry: LiveTextTelemetry,
+	signal: LiveTextSetupSignal,
+): void {
+	if (signal === "disabled") {
+		telemetry.disabled("configuration");
+	} else if (signal === "subscription_timeout") {
+		telemetry.degraded("subscription_timeout");
+	} else if (signal === "subscription_failure") {
+		telemetry.degraded("subscription");
+	} else {
+		telemetry.recovered("subscription_timeout");
+		telemetry.recovered("subscription");
+	}
+}
+
+export function reportChatLiveTextProjectionSignal(
+	telemetry: LiveTextTelemetry,
+	signal: ProjectRunLiveTextSignal,
+): void {
+	switch (signal) {
+		case "message_attempted":
+			telemetry.record("attempted", "message_projection", "attempted");
+			break;
+		case "message_delivered":
+			telemetry.record("delivered", "message_projection", "delivered");
+			break;
+		case "message_dropped":
+			telemetry.record("dropped", "message_projection", "dropped");
+			break;
+		case "gap":
+			telemetry.record("gap_detected", "delta_gap");
+			break;
+		case "malformed_message":
+			telemetry.record("malformed", "adapter_message");
+			break;
+		case "queue_overflow":
+			telemetry.record("queue_overflow", "connection_buffer");
+			break;
+		case "reconciliation_overflow":
+			telemetry.record("queue_overflow", "reconciliation_state");
+			break;
+		case "durable_backlog":
+			telemetry.record("slow_client", "durable_backlog");
+			break;
+		case "partial_complete_mismatch":
+			telemetry.record("mismatch", "partial_complete");
+			break;
+		case "subscriber_failure":
+			telemetry.degraded("subscription");
+			break;
+		case "duplicate_inconsistency":
+			telemetry.record("impossible_ordering", "duplicate_delta");
+			break;
+		case "late_delta":
+			telemetry.record("impossible_ordering", "late_delta");
+			break;
+		case "terminal_open_preview":
+			telemetry.record("impossible_ordering", "terminal_preview");
+			break;
+		case "impossible_ordering":
+			telemetry.record("impossible_ordering", "transport_channel");
+			break;
+	}
+}

--- a/apps/chat-api/src/features/run-events/prepare-live-text-subscription.test.ts
+++ b/apps/chat-api/src/features/run-events/prepare-live-text-subscription.test.ts
@@ -67,7 +67,7 @@ it("falls back after a bounded wait and closes a subscription that arrives late"
 	expect(signals).toEqual(["subscription_timeout"]);
 });
 
-it("reports recovery when a subscription is prepared", async () => {
+it("does not mistake a healthy subscription attempt for outage recovery", async () => {
 	const signals: string[] = [];
 	const subscription: LiveTextSubscription = {
 		readAvailable: () => [],
@@ -83,5 +83,5 @@ it("reports recovery when a subscription is prepared", async () => {
 			{ onSignal: (signal) => signals.push(signal) },
 		),
 	).resolves.toBe(subscription);
-	expect(signals).toEqual(["recovered"]);
+	expect(signals).toEqual([]);
 });

--- a/apps/chat-api/src/features/run-events/prepare-live-text-subscription.test.ts
+++ b/apps/chat-api/src/features/run-events/prepare-live-text-subscription.test.ts
@@ -23,7 +23,7 @@ it("falls back when subscription setup throws synchronously", async () => {
 			},
 		),
 	).resolves.toBeNull();
-	expect(signals).toEqual(["degraded"]);
+	expect(signals).toEqual(["subscription_failure"]);
 });
 
 it("reports disabled configuration without surfacing an error", async () => {
@@ -40,6 +40,7 @@ it("reports disabled configuration without surfacing an error", async () => {
 it("falls back after a bounded wait and closes a subscription that arrives late", async () => {
 	let resolveSubscription: ((value: LiveTextSubscription) => void) | undefined;
 	let closes = 0;
+	const signals: string[] = [];
 	const prepared = prepareLiveTextSubscription(
 		{
 			async subscribe() {
@@ -49,7 +50,7 @@ it("falls back after a bounded wait and closes a subscription that arrives late"
 			},
 		},
 		"run-1",
-		{ timeoutMs: 1 },
+		{ timeoutMs: 1, onSignal: (signal) => signals.push(signal) },
 	);
 
 	await expect(prepared).resolves.toBeNull();
@@ -63,4 +64,24 @@ it("falls back after a bounded wait and closes a subscription that arrives late"
 	});
 	await Bun.sleep(0);
 	expect(closes).toBe(1);
+	expect(signals).toEqual(["subscription_timeout"]);
+});
+
+it("reports recovery when a subscription is prepared", async () => {
+	const signals: string[] = [];
+	const subscription: LiveTextSubscription = {
+		readAvailable: () => [],
+		readDroppedMessages: () => ({ type: "message_ids", messageIds: [] }),
+		waitForMessage: async () => false,
+		close: async () => {},
+	};
+
+	await expect(
+		prepareLiveTextSubscription(
+			{ subscribe: async () => subscription },
+			"run-1",
+			{ onSignal: (signal) => signals.push(signal) },
+		),
+	).resolves.toBe(subscription);
+	expect(signals).toEqual(["recovered"]);
 });

--- a/apps/chat-api/src/features/run-events/prepare-live-text-subscription.ts
+++ b/apps/chat-api/src/features/run-events/prepare-live-text-subscription.ts
@@ -9,7 +9,6 @@ const TIMED_OUT = Symbol("live text subscription timed out");
 
 export type LiveTextSetupSignal =
 	| "disabled"
-	| "recovered"
 	| "subscription_failure"
 	| "subscription_timeout";
 
@@ -51,10 +50,7 @@ export async function prepareLiveTextSubscription(
 	});
 	try {
 		const result = await Promise.race([prepared, timeout]);
-		if (result !== TIMED_OUT) {
-			emitSignal(options.onSignal, "recovered");
-			return result;
-		}
+		if (result !== TIMED_OUT) return result;
 		emitSignal(options.onSignal, "subscription_timeout");
 		void prepared.then((subscription) => subscription.close()).catch(() => {});
 		return null;

--- a/apps/chat-api/src/features/run-events/prepare-live-text-subscription.ts
+++ b/apps/chat-api/src/features/run-events/prepare-live-text-subscription.ts
@@ -7,7 +7,11 @@ import { LiveTextDisabledError } from "@mymemo/live-text";
 export const LIVE_TEXT_SUBSCRIBE_TIMEOUT_MS = 100;
 const TIMED_OUT = Symbol("live text subscription timed out");
 
-export type LiveTextSetupSignal = "degraded" | "disabled";
+export type LiveTextSetupSignal =
+	| "disabled"
+	| "recovered"
+	| "subscription_failure"
+	| "subscription_timeout";
 
 function emitSignal(
 	onSignal: ((signal: LiveTextSetupSignal) => void) | undefined,
@@ -35,7 +39,9 @@ export async function prepareLiveTextSubscription(
 	} catch (error) {
 		emitSignal(
 			options.onSignal,
-			error instanceof LiveTextDisabledError ? "disabled" : "degraded",
+			error instanceof LiveTextDisabledError
+				? "disabled"
+				: "subscription_failure",
 		);
 		return null;
 	}
@@ -45,14 +51,19 @@ export async function prepareLiveTextSubscription(
 	});
 	try {
 		const result = await Promise.race([prepared, timeout]);
-		if (result !== TIMED_OUT) return result;
-		emitSignal(options.onSignal, "degraded");
+		if (result !== TIMED_OUT) {
+			emitSignal(options.onSignal, "recovered");
+			return result;
+		}
+		emitSignal(options.onSignal, "subscription_timeout");
 		void prepared.then((subscription) => subscription.close()).catch(() => {});
 		return null;
 	} catch (error) {
 		emitSignal(
 			options.onSignal,
-			error instanceof LiveTextDisabledError ? "disabled" : "degraded",
+			error instanceof LiveTextDisabledError
+				? "disabled"
+				: "subscription_failure",
 		);
 		return null;
 	} finally {

--- a/apps/chat-api/src/features/run-events/project-run.test.ts
+++ b/apps/chat-api/src/features/run-events/project-run.test.ts
@@ -125,6 +125,7 @@ describe("projectRun", () => {
 	it("merges prepared cursorless previews before authoritative commits", async () => {
 		const liveText = new InMemoryLiveTextTransport();
 		const liveSubscription = await liveText.subscribe("run-1");
+		const signals: string[] = [];
 		for (const message of [
 			{ messageId: "message-1", deltaIndex: 0, text: "hel" },
 			{ messageId: "message-1", deltaIndex: 1, text: "lo" },
@@ -160,6 +161,7 @@ describe("projectRun", () => {
 				reader,
 				notifier: new InstantNotifier(),
 				liveSubscription,
+				onLiveTextSignal: (signal) => signals.push(signal),
 			}),
 		);
 
@@ -208,6 +210,12 @@ describe("projectRun", () => {
 				frame: { type: "text_commit", messageId: "message-2", text: "again" },
 			},
 			{ id: "4", frame: { type: "done" } },
+		]);
+		expect(signals).toEqual([
+			"message_attempted",
+			"message_attempted",
+			"message_delivered",
+			"message_delivered",
 		]);
 	});
 
@@ -589,7 +597,13 @@ describe("projectRun", () => {
 			{ type: "text_delta", messageId: "message-1", deltaIndex: 0, text: "a" },
 			{ type: "text_delta", messageId: "message-1", deltaIndex: 1, text: "b" },
 		]);
-		expect(signals).toEqual(["duplicate_inconsistency"]);
+		expect(signals).toEqual([
+			"message_attempted",
+			"message_attempted",
+			"message_dropped",
+			"duplicate_inconsistency",
+			"message_delivered",
+		]);
 	});
 
 	it("suppresses malformed preview for its message and continues durable projection", async () => {
@@ -747,7 +761,14 @@ describe("projectRun", () => {
 		expect(projected.filter((frame) => frame.type === "text_delta")).toEqual(
 			[],
 		);
-		expect(signals).toEqual(["gap", "gap"]);
+		expect(signals).toEqual([
+			"message_attempted",
+			"message_dropped",
+			"gap",
+			"message_attempted",
+			"message_dropped",
+			"gap",
+		]);
 		expect(
 			projected
 				.filter((frame) => frame.type === "text_commit")

--- a/apps/chat-api/src/features/run-events/project-run.test.ts
+++ b/apps/chat-api/src/features/run-events/project-run.test.ts
@@ -376,6 +376,7 @@ describe("projectRun", () => {
 				.map((frame) => frame.text),
 		).toEqual(["complete first", "complete second"]);
 		expect(signals).toContain("queue_overflow");
+		expect(signals).toContain("slow_client");
 	});
 
 	it("bounds reconciliation state even when the SSE consumer keeps up", async () => {
@@ -416,7 +417,7 @@ describe("projectRun", () => {
 						waitForMessage: async () => true,
 						close: async () => {},
 					},
-					maxPreviewQueueMessages: 2,
+					maxPreviewStateMessages: 2,
 					onLiveTextSignal: (signal) => signals.push(signal),
 				}),
 			),
@@ -473,7 +474,7 @@ describe("projectRun", () => {
 		expect(projected).toEqual([
 			{ type: "conversation_id", conversationId: "conv-1" },
 		]);
-		expect(signals).toContain("durable_backlog");
+		expect(signals).toEqual([]);
 		expect(closes).toBe(1);
 		expect(reader.limits).toEqual([1]);
 
@@ -525,7 +526,7 @@ describe("projectRun", () => {
 				projectRun("run-1", 0, {
 					reader,
 					notifier: new InstantNotifier(),
-					maxPreviewQueueMessages: 1,
+					maxPreviewStateMessages: 1,
 					liveSubscription: {
 						readAvailable: () => [],
 						readDroppedMessages: emptyDropReport,
@@ -1219,6 +1220,44 @@ describe("projectRun", () => {
 
 		expect(await pending).toEqual({ done: true, value: undefined });
 		expect(notifier.closed).toBe(1);
+	});
+
+	it("resolves an attempted preview as dropped when the client disconnects", async () => {
+		const liveText = new InMemoryLiveTextTransport();
+		const liveSubscription = await liveText.subscribe("run-1");
+		await liveText.publish({
+			runId: "run-1",
+			messageId: "message-1",
+			deltaIndex: 0,
+			text: "partial",
+		});
+		const controller = new AbortController();
+		const signals: string[] = [];
+		const gen = projectRun("run-1", 0, {
+			reader: new ScriptedReader([
+				[
+					{
+						seq: 1,
+						type: RunEventType.Started,
+						payload: { conversationId: "conv-1", runId: "run-1" },
+					},
+				],
+				[],
+			]),
+			notifier: new BlockingNotifier(),
+			liveSubscription,
+			signal: controller.signal,
+			onLiveTextSignal: (signal) => signals.push(signal),
+		});
+
+		expect((await gen.next()).value?.frame.type).toBe("conversation_id");
+		expect((await gen.next()).value?.frame.type).toBe("run_id");
+		expect((await gen.next()).value?.frame.type).toBe("text_delta");
+		const pending = gen.next();
+		controller.abort();
+		await pending;
+
+		expect(signals).toEqual(["message_attempted", "message_dropped"]);
 	});
 
 	it("maps run_canceled to canceled and closes (never error)", async () => {

--- a/apps/chat-api/src/features/run-events/project-run.test.ts
+++ b/apps/chat-api/src/features/run-events/project-run.test.ts
@@ -417,7 +417,7 @@ describe("projectRun", () => {
 						waitForMessage: async () => true,
 						close: async () => {},
 					},
-					maxPreviewStateMessages: 2,
+					maxPreviewStateEntries: 2,
 					onLiveTextSignal: (signal) => signals.push(signal),
 				}),
 			),
@@ -526,7 +526,7 @@ describe("projectRun", () => {
 				projectRun("run-1", 0, {
 					reader,
 					notifier: new InstantNotifier(),
-					maxPreviewStateMessages: 1,
+					maxPreviewStateEntries: 1,
 					liveSubscription: {
 						readAvailable: () => [],
 						readDroppedMessages: emptyDropReport,

--- a/apps/chat-api/src/features/run-events/project-run.ts
+++ b/apps/chat-api/src/features/run-events/project-run.ts
@@ -50,6 +50,9 @@ export type ProjectRunLiveTextSignal =
 	| "impossible_ordering"
 	| "late_delta"
 	| "malformed_message"
+	| "message_attempted"
+	| "message_delivered"
+	| "message_dropped"
 	| "partial_complete_mismatch"
 	| "queue_overflow"
 	| "reconciliation_overflow"
@@ -217,6 +220,7 @@ async function produceRun(
 	const previewStates = new Map<string, PreviewState>();
 	const suppressedMessageIds = new Set<string>();
 	const committedMessageIds = new Set<string>();
+	const activeOutcomeMessageIds = new Set<string>();
 	let liveSubscription = deps.liveSubscription;
 	let liveSubscriptionClose = Promise.resolve();
 	let previewReady = fromSeq > 0;
@@ -245,6 +249,9 @@ async function produceRun(
 	const suppressMessage = (messageId: string) => {
 		previewStates.delete(messageId);
 		output.purgePreview(messageId);
+		if (activeOutcomeMessageIds.delete(messageId)) {
+			emitSignal("message_dropped");
+		}
 		if (suppressedMessageIds.has(messageId)) return;
 		if (suppressedMessageIds.size >= maxPreviewQueueMessages) {
 			emitSignal("queue_overflow");
@@ -256,6 +263,10 @@ async function produceRun(
 		suppressedMessageIds.add(messageId);
 	};
 	const disableLiveForRun = () => {
+		for (const _messageId of activeOutcomeMessageIds) {
+			emitSignal("message_dropped");
+		}
+		activeOutcomeMessageIds.clear();
 		previewStates.clear();
 		suppressedMessageIds.clear();
 		output.clearPreview();
@@ -292,8 +303,16 @@ async function produceRun(
 							!suppressedMessageIds.has(frame.messageId) &&
 							state.chunks.join("") !== frame.text
 						) {
+							if (activeOutcomeMessageIds.delete(frame.messageId)) {
+								emitSignal("message_dropped");
+							}
 							emitSignal("partial_complete_mismatch");
 							disableLiveForRun();
+						} else if (
+							state &&
+							activeOutcomeMessageIds.delete(frame.messageId)
+						) {
+							emitSignal("message_delivered");
 						}
 						previewStates.delete(frame.messageId);
 						suppressedMessageIds.delete(frame.messageId);
@@ -372,6 +391,10 @@ async function produceRun(
 					}
 					if (suppressedMessageIds.has(message.messageId)) {
 						continue;
+					}
+					if (!activeOutcomeMessageIds.has(message.messageId)) {
+						activeOutcomeMessageIds.add(message.messageId);
+						emitSignal("message_attempted");
 					}
 					let state = previewStates.get(message.messageId);
 					if (!state) {

--- a/apps/chat-api/src/features/run-events/project-run.ts
+++ b/apps/chat-api/src/features/run-events/project-run.ts
@@ -35,7 +35,7 @@ export interface ProjectRunDeps {
 	/** Bound on provisional frames waiting for a slow SSE consumer. */
 	maxPreviewQueueMessages?: number;
 	/** Bound on per-message reconciliation state retained for the Live lane. */
-	maxPreviewStateMessages?: number;
+	maxPreviewStateEntries?: number;
 	/** Bound on durable frames before this replayable connection is ended. */
 	maxDurableQueueMessages?: number;
 	/** Payload-free, fixed-vocabulary Live preview degradation signal. */
@@ -43,7 +43,7 @@ export interface ProjectRunDeps {
 }
 
 export const DEFAULT_MAX_PREVIEW_QUEUE_MESSAGES = 64;
-export const DEFAULT_MAX_PREVIEW_STATE_MESSAGES = 64;
+export const DEFAULT_MAX_PREVIEW_STATE_ENTRIES = 64;
 export const DEFAULT_MAX_DURABLE_QUEUE_MESSAGES = 256;
 
 export type ProjectRunLiveTextSignal =
@@ -182,15 +182,15 @@ export async function* projectRun(
 		deps.maxPreviewQueueMessages ?? DEFAULT_MAX_PREVIEW_QUEUE_MESSAGES;
 	const maxDurableQueueMessages =
 		deps.maxDurableQueueMessages ?? DEFAULT_MAX_DURABLE_QUEUE_MESSAGES;
-	const maxPreviewStateMessages =
-		deps.maxPreviewStateMessages ?? DEFAULT_MAX_PREVIEW_STATE_MESSAGES;
+	const maxPreviewStateEntries =
+		deps.maxPreviewStateEntries ?? DEFAULT_MAX_PREVIEW_STATE_ENTRIES;
 	if (
 		!Number.isSafeInteger(maxPreviewQueueMessages) ||
 		maxPreviewQueueMessages < 1 ||
 		!Number.isSafeInteger(maxDurableQueueMessages) ||
 		maxDurableQueueMessages < 1 ||
-		!Number.isSafeInteger(maxPreviewStateMessages) ||
-		maxPreviewStateMessages < 1
+		!Number.isSafeInteger(maxPreviewStateEntries) ||
+		maxPreviewStateEntries < 1
 	) {
 		throw new Error("Projection queue bounds must be positive integers");
 	}
@@ -234,8 +234,8 @@ async function produceRun(
 	signal: AbortSignal,
 ): Promise<void> {
 	const pollTimeoutMs = deps.pollTimeoutMs ?? 1000;
-	const maxPreviewStateMessages =
-		deps.maxPreviewStateMessages ?? DEFAULT_MAX_PREVIEW_STATE_MESSAGES;
+	const maxPreviewStateEntries =
+		deps.maxPreviewStateEntries ?? DEFAULT_MAX_PREVIEW_STATE_ENTRIES;
 	const maxDurableQueueMessages =
 		deps.maxDurableQueueMessages ?? DEFAULT_MAX_DURABLE_QUEUE_MESSAGES;
 	const durableSubscription = await deps.notifier.subscribe(runId);
@@ -276,7 +276,7 @@ async function produceRun(
 		}
 		output.clearEmittedPreview(messageId);
 		if (suppressedMessageIds.has(messageId)) return;
-		if (suppressedMessageIds.size >= maxPreviewStateMessages) {
+		if (suppressedMessageIds.size >= maxPreviewStateEntries) {
 			emitSignal("queue_overflow");
 			suppressedMessageIds.clear();
 			output.clearPreview();
@@ -313,7 +313,7 @@ async function produceRun(
 						if (
 							liveSubscription &&
 							!committedMessageIds.has(frame.messageId) &&
-							committedMessageIds.size >= maxPreviewStateMessages
+							committedMessageIds.size >= maxPreviewStateEntries
 						) {
 							emitSignal("reconciliation_overflow");
 							committedMessageIds.clear();
@@ -431,7 +431,7 @@ async function produceRun(
 							emitSignal("gap");
 							continue;
 						}
-						if (previewStates.size >= maxPreviewStateMessages) {
+						if (previewStates.size >= maxPreviewStateEntries) {
 							emitSignal("queue_overflow");
 							disableLiveForRun();
 							break;
@@ -451,7 +451,7 @@ async function produceRun(
 						emitSignal("gap");
 						continue;
 					}
-					if (state.chunks.length >= maxPreviewStateMessages) {
+					if (state.chunks.length >= maxPreviewStateEntries) {
 						suppressMessage(message.messageId);
 						emitSignal("queue_overflow");
 						continue;

--- a/apps/chat-api/src/features/run-events/project-run.ts
+++ b/apps/chat-api/src/features/run-events/project-run.ts
@@ -34,6 +34,8 @@ export interface ProjectRunDeps {
 	liveSubscription?: LiveTextSubscription;
 	/** Bound on provisional frames waiting for a slow SSE consumer. */
 	maxPreviewQueueMessages?: number;
+	/** Bound on per-message reconciliation state retained for the Live lane. */
+	maxPreviewStateMessages?: number;
 	/** Bound on durable frames before this replayable connection is ended. */
 	maxDurableQueueMessages?: number;
 	/** Payload-free, fixed-vocabulary Live preview degradation signal. */
@@ -41,11 +43,11 @@ export interface ProjectRunDeps {
 }
 
 export const DEFAULT_MAX_PREVIEW_QUEUE_MESSAGES = 64;
+export const DEFAULT_MAX_PREVIEW_STATE_MESSAGES = 64;
 export const DEFAULT_MAX_DURABLE_QUEUE_MESSAGES = 256;
 
 export type ProjectRunLiveTextSignal =
 	| "duplicate_inconsistency"
-	| "durable_backlog"
 	| "gap"
 	| "impossible_ordering"
 	| "late_delta"
@@ -56,6 +58,7 @@ export type ProjectRunLiveTextSignal =
 	| "partial_complete_mismatch"
 	| "queue_overflow"
 	| "reconciliation_overflow"
+	| "slow_client"
 	| "subscriber_failure"
 	| "terminal_open_preview";
 
@@ -67,6 +70,7 @@ interface PreviewState {
 class ProjectionOutput {
 	readonly #durable: ProjectedFrame[] = [];
 	readonly #preview: ProjectedFrame[] = [];
+	readonly #emittedPreviewMessageIds = new Set<string>();
 	readonly #waiters = new Set<() => void>();
 	#finished = false;
 	#error: unknown;
@@ -103,6 +107,15 @@ class ProjectionOutput {
 		this.#preview.length = 0;
 	}
 
+	hasEmittedPreview(messageId: string): boolean {
+		return this.#emittedPreviewMessageIds.has(messageId);
+	}
+
+	clearEmittedPreview(messageId?: string): void {
+		if (messageId === undefined) this.#emittedPreviewMessageIds.clear();
+		else this.#emittedPreviewMessageIds.delete(messageId);
+	}
+
 	hasPreview(): boolean {
 		return this.#preview.length > 0;
 	}
@@ -118,7 +131,12 @@ class ProjectionOutput {
 			const durable = this.#durable.shift();
 			if (durable) return durable;
 			const preview = this.#preview.shift();
-			if (preview) return preview;
+			if (preview) {
+				if (preview.frame.type === "text_delta") {
+					this.#emittedPreviewMessageIds.add(preview.frame.messageId);
+				}
+				return preview;
+			}
 			if (this.#error !== undefined) throw this.#error;
 			if (this.#finished || signal.aborted) return undefined;
 			await new Promise<void>((resolve) => {
@@ -164,11 +182,15 @@ export async function* projectRun(
 		deps.maxPreviewQueueMessages ?? DEFAULT_MAX_PREVIEW_QUEUE_MESSAGES;
 	const maxDurableQueueMessages =
 		deps.maxDurableQueueMessages ?? DEFAULT_MAX_DURABLE_QUEUE_MESSAGES;
+	const maxPreviewStateMessages =
+		deps.maxPreviewStateMessages ?? DEFAULT_MAX_PREVIEW_STATE_MESSAGES;
 	if (
 		!Number.isSafeInteger(maxPreviewQueueMessages) ||
 		maxPreviewQueueMessages < 1 ||
 		!Number.isSafeInteger(maxDurableQueueMessages) ||
-		maxDurableQueueMessages < 1
+		maxDurableQueueMessages < 1 ||
+		!Number.isSafeInteger(maxPreviewStateMessages) ||
+		maxPreviewStateMessages < 1
 	) {
 		throw new Error("Projection queue bounds must be positive integers");
 	}
@@ -212,8 +234,8 @@ async function produceRun(
 	signal: AbortSignal,
 ): Promise<void> {
 	const pollTimeoutMs = deps.pollTimeoutMs ?? 1000;
-	const maxPreviewQueueMessages =
-		deps.maxPreviewQueueMessages ?? DEFAULT_MAX_PREVIEW_QUEUE_MESSAGES;
+	const maxPreviewStateMessages =
+		deps.maxPreviewStateMessages ?? DEFAULT_MAX_PREVIEW_STATE_MESSAGES;
 	const maxDurableQueueMessages =
 		deps.maxDurableQueueMessages ?? DEFAULT_MAX_DURABLE_QUEUE_MESSAGES;
 	const durableSubscription = await deps.notifier.subscribe(runId);
@@ -252,8 +274,9 @@ async function produceRun(
 		if (activeOutcomeMessageIds.delete(messageId)) {
 			emitSignal("message_dropped");
 		}
+		output.clearEmittedPreview(messageId);
 		if (suppressedMessageIds.has(messageId)) return;
-		if (suppressedMessageIds.size >= maxPreviewQueueMessages) {
+		if (suppressedMessageIds.size >= maxPreviewStateMessages) {
 			emitSignal("queue_overflow");
 			suppressedMessageIds.clear();
 			output.clearPreview();
@@ -270,6 +293,7 @@ async function produceRun(
 		previewStates.clear();
 		suppressedMessageIds.clear();
 		output.clearPreview();
+		output.clearEmittedPreview();
 		disableLiveSubscription();
 	};
 	try {
@@ -289,7 +313,7 @@ async function produceRun(
 						if (
 							liveSubscription &&
 							!committedMessageIds.has(frame.messageId) &&
-							committedMessageIds.size >= maxPreviewQueueMessages
+							committedMessageIds.size >= maxPreviewStateMessages
 						) {
 							emitSignal("reconciliation_overflow");
 							committedMessageIds.clear();
@@ -312,8 +336,13 @@ async function produceRun(
 							state &&
 							activeOutcomeMessageIds.delete(frame.messageId)
 						) {
-							emitSignal("message_delivered");
+							emitSignal(
+								output.hasEmittedPreview(frame.messageId)
+									? "message_delivered"
+									: "message_dropped",
+							);
 						}
+						output.clearEmittedPreview(frame.messageId);
 						previewStates.delete(frame.messageId);
 						suppressedMessageIds.delete(frame.messageId);
 					}
@@ -334,7 +363,6 @@ async function produceRun(
 							frame,
 						})
 					) {
-						emitSignal("durable_backlog");
 						disableLiveForRun();
 						return;
 					}
@@ -403,7 +431,7 @@ async function produceRun(
 							emitSignal("gap");
 							continue;
 						}
-						if (previewStates.size >= maxPreviewQueueMessages) {
+						if (previewStates.size >= maxPreviewStateMessages) {
 							emitSignal("queue_overflow");
 							disableLiveForRun();
 							break;
@@ -423,7 +451,7 @@ async function produceRun(
 						emitSignal("gap");
 						continue;
 					}
-					if (state.chunks.length >= maxPreviewQueueMessages) {
+					if (state.chunks.length >= maxPreviewStateMessages) {
 						suppressMessage(message.messageId);
 						emitSignal("queue_overflow");
 						continue;
@@ -440,6 +468,7 @@ async function produceRun(
 							},
 						})
 					) {
+						emitSignal("slow_client");
 						suppressMessage(message.messageId);
 						emitSignal("queue_overflow");
 					}
@@ -492,6 +521,7 @@ async function produceRun(
 			}
 		}
 	} finally {
+		disableLiveForRun();
 		try {
 			await durableSubscription.close();
 		} finally {

--- a/apps/chat-api/src/features/run-events/redis-live-text.integration.test.ts
+++ b/apps/chat-api/src/features/run-events/redis-live-text.integration.test.ts
@@ -175,7 +175,9 @@ async function runWorkerThroughRedis(options: {
 	const logger: WorkerLogger = {
 		...silentLogger,
 		warn(event) {
-			if (event.signal === "publisher_failure") publisherFailed.resolve();
+			if (event.signal === "dropped" && event.reason === "publisher") {
+				publisherFailed.resolve();
+			}
 		},
 	};
 

--- a/apps/chat-api/src/index.ts
+++ b/apps/chat-api/src/index.ts
@@ -48,6 +48,7 @@ async function closeProductionLiveText(): Promise<void> {
 	if (shuttingDown) return;
 	shuttingDown = true;
 	await productionDeps.closeLiveText?.().catch(() => {});
+	productionDeps.liveTextTelemetry.close();
 	process.exit(0);
 }
 process.once("SIGINT", () => void closeProductionLiveText());

--- a/apps/chat-api/src/index.ts
+++ b/apps/chat-api/src/index.ts
@@ -1,3 +1,4 @@
+import { createLiveTextTelemetry } from "@mymemo/live-text";
 import { Hono } from "hono";
 import { requestId } from "hono/request-id";
 import { pinoLogger } from "hono-pino";
@@ -37,17 +38,10 @@ export function createApp(
 // closed before the process exits.
 const productionConfig = loadApiConfigFromEnv(Bun.env);
 const productionLogger = pino({ level: productionConfig.logLevel });
-const productionDeps = createDeps(productionConfig, (signal) => {
-	const event = {
-		message: "Live preview Redis transport state changed",
-		signal,
-	};
-	if (signal === "disabled" || signal === "recovered") {
-		productionLogger.info(event);
-	} else {
-		productionLogger.warn(event);
-	}
-});
+const productionDeps = createDeps(
+	productionConfig,
+	createLiveTextTelemetry("chat-api", productionLogger),
+);
 const productionApp = createApp(productionConfig, productionDeps);
 let shuttingDown = false;
 async function closeProductionLiveText(): Promise<void> {

--- a/docs/runbooks/live-preview.md
+++ b/docs/runbooks/live-preview.md
@@ -12,8 +12,11 @@ The CloudWatch namespace `<name-prefix>-<environment>/LivePreview` contains:
 - `Signals`, dimensioned only by bounded `Service` and `Signal` values;
 - `MessageOutcomes`, dimensioned only by `Service` and `Outcome`; and
 - per-service alarms for repeated degradation, sustained dropped outcomes, and
-  sustained queue overflow. Each alarm requires two breaching 5-minute periods
-  out of three, so one short reconnect does not alarm by default.
+  sustained queue overflow; and
+- a cross-service alarm when both services report degradation.
+
+Each alarm requires two breaching 5-minute periods out of three, so one short
+reconnect does not alarm by default.
 
 Production must set `alarm_action_arns` to SNS topics with confirmed incident
 subscriptions. An empty list still creates visible CloudWatch alarms but does

--- a/docs/runbooks/live-preview.md
+++ b/docs/runbooks/live-preview.md
@@ -79,13 +79,16 @@ the reviewed plan:
 ```bash
 terraform -chdir=infra/terraform plan -var-file=prod.tfvars -var-file=generated.auto.tfvars -var="live_preview_enabled=false" -out=/tmp/live-preview-disable.tfplan
 terraform -chdir=infra/terraform apply /tmp/live-preview-disable.tfplan
+AWS_PROFILE=mymemo scripts/deploy/roll_ecs_services.sh
 ```
 
 Review the plan before apply. It should update the two trusted service task
 definitions only; it must not expose the Redis secret or introduce content- or
-identifier-bearing monitoring dimensions. After the ECS rollout, expect one
-`disabled` signal from each service and continue verifying `text_commit` plus
-terminal outcomes.
+identifier-bearing monitoring dimensions. The rollout command is required:
+Terraform registers the task definitions, while the ECS services intentionally
+ignore task-definition drift until that script updates them. After the rollout,
+expect one `disabled` signal from each service and continue verifying
+`text_commit` plus terminal outcomes.
 
 ## Restore the Redis lane
 
@@ -95,11 +98,13 @@ services to roll:
 ```bash
 terraform -chdir=infra/terraform plan -var-file=prod.tfvars -var-file=generated.auto.tfvars -var="live_preview_enabled=true" -out=/tmp/live-preview-restore.tfplan
 terraform -chdir=infra/terraform apply /tmp/live-preview-restore.tfplan
+AWS_PROFILE=mymemo scripts/deploy/roll_ecs_services.sh
 ```
 
-Run a new conversation turn. Confirm `attempted` and `delivered` outcomes in
-both services, one or more cursorless `text_delta` frames, the exact
-cursor-bearing `text_commit`, and `done`.
+The rollout is required for the same task-definition reason as disable. Then run
+a new conversation turn. Confirm `attempted` and `delivered` outcomes in both
+services, one or more cursorless `text_delta` frames, the exact cursor-bearing
+`text_commit`, and `done`.
 
 ## Recognize a Postgres-path incident
 

--- a/docs/runbooks/live-preview.md
+++ b/docs/runbooks/live-preview.md
@@ -1,0 +1,106 @@
+# Live preview operations
+
+Live preview is the optional Redis Pub/Sub path for provisional `text_delta`
+frames. Postgres `assistant_text` Run events, projected as cursor-bearing
+`text_commit` frames, remain authoritative. A Live alarm must not be used to
+fail `/health`, restart tasks, or decide a Run outcome.
+
+## Identify a Live-only incident
+
+The CloudWatch namespace `<name-prefix>-<environment>/LivePreview` contains:
+
+- `Signals`, dimensioned only by bounded `Service` and `Signal` values;
+- `MessageOutcomes`, dimensioned only by `Service` and `Outcome`; and
+- per-service alarms for repeated degradation, sustained dropped outcomes, and
+  sustained queue overflow. Each alarm requires two breaching 5-minute periods
+  out of three, so one short reconnect does not alarm by default.
+
+Use this Logs Insights query across the chat-api and agent-worker log groups:
+
+```text
+fields @timestamp, service, signal, reason, outcome, count
+| filter message = "Live preview signal"
+| stats sum(count) by bin(5m), service, signal, reason, outcome
+| sort bin(5m) desc
+```
+
+Interpret the bounded signals as follows:
+
+- `disabled`: `REDIS_URL` is intentionally absent or invalid for that service.
+- `degraded` without a later `recovered` for the same service and reason:
+  the Live path is still unavailable. A nearby `recovered` is a short reconnect.
+- `attempted`, `delivered`, and `dropped`: compare these outcomes per service.
+  `agent-worker` measures publication; `chat-api` measures projection and
+  reconciliation.
+- `gap_detected`, `malformed`, `queue_overflow`, `slow_client`, `mismatch`, or
+  `impossible_ordering`: the named loss-tolerance path suppressed provisional
+  data and waited for the durable commit.
+
+The events contain no Assistant text, provider/tool payload, Redis URL, user
+identity, Conversation id, Run id, or Assistant-message id. Do not add any of
+those as metric dimensions or Logs Insights grouping fields.
+
+## Confirm durable delivery still flows
+
+1. Check that both service `/health` endpoints remain healthy. This is expected
+   during a Live-only incident.
+2. Through an authorized conversation request or active-Run reconnect, confirm
+   that cursor-bearing `text_commit` frames and a terminal `done` still arrive.
+   Missing cursorless `text_delta` frames alone is a Live-only symptom.
+3. Confirm Postgres Run events continue to advance without reading their JSON
+   payloads:
+
+   ```sql
+   SELECT type, count(*)
+   FROM run_events
+   WHERE created_at >= now() - interval '15 minutes'
+   GROUP BY type
+   ORDER BY type;
+   ```
+
+   Continuing `assistant_text` and `run_done` events prove the authoritative
+   path is active.
+
+## Disable the Redis lane
+
+Use the Terraform kill switch; it removes `REDIS_URL` from both ECS task
+definitions while leaving Redis provisioned for a quick restore:
+
+```bash
+terraform -chdir=infra/terraform plan -var-file=prod.tfvars -var="live_preview_enabled=false"
+terraform -chdir=infra/terraform apply -var-file=prod.tfvars -var="live_preview_enabled=false"
+```
+
+Review the plan before apply. It should update the two trusted service task
+definitions only; it must not expose the Redis secret or introduce content- or
+identifier-bearing monitoring dimensions. After the ECS rollout, expect one
+`disabled` signal from each service and continue verifying `text_commit` plus
+terminal outcomes.
+
+## Restore the Redis lane
+
+Set the same variable back to `true`, review the plan, apply, and wait for both
+services to roll:
+
+```bash
+terraform -chdir=infra/terraform plan -var-file=prod.tfvars -var="live_preview_enabled=true"
+terraform -chdir=infra/terraform apply -var-file=prod.tfvars -var="live_preview_enabled=true"
+```
+
+Run a new conversation turn. Confirm `attempted` and `delivered` outcomes in
+both services, one or more cursorless `text_delta` frames, the exact
+cursor-bearing `text_commit`, and `done`.
+
+## Recognize a Postgres-path incident
+
+Treat the incident as authoritative-path failure, not Live degradation, if any
+of these are true:
+
+- `text_commit` or terminal frames stop even after Redis is disabled;
+- `assistant_text` / terminal Run-event counts stop advancing;
+- chat-api cannot read the Run event log, the worker cannot append or
+  terminalize, or either service health endpoint fails; or
+- clients receive durable transport errors rather than merely missing preview.
+
+Escalate through the database/service incident path. Do not tune Live alarms or
+restart Redis as a substitute for restoring Postgres delivery.

--- a/docs/runbooks/live-preview.md
+++ b/docs/runbooks/live-preview.md
@@ -15,6 +15,10 @@ The CloudWatch namespace `<name-prefix>-<environment>/LivePreview` contains:
   sustained queue overflow. Each alarm requires two breaching 5-minute periods
   out of three, so one short reconnect does not alarm by default.
 
+Production must set `alarm_action_arns` to SNS topics with confirmed incident
+subscriptions. An empty list still creates visible CloudWatch alarms but does
+not page an operator; do not call that configuration production-ready.
+
 Use this Logs Insights query across the chat-api and agent-worker log groups:
 
 ```text
@@ -28,7 +32,9 @@ Interpret the bounded signals as follows:
 
 - `disabled`: `REDIS_URL` is intentionally absent or invalid for that service.
 - `degraded` without a later `recovered` for the same service and reason:
-  the Live path is still unavailable. A nearby `recovered` is a short reconnect.
+  the Live path is still unavailable. Active degradation repeats a payload-free
+  heartbeat every five minutes so a prolonged outage can alarm; a nearby
+  `recovered` stops the heartbeat and is a short reconnect.
 - `attempted`, `delivered`, and `dropped`: compare these outcomes per service.
   `agent-worker` measures publication; `chat-api` measures projection and
   reconciliation.
@@ -66,9 +72,13 @@ those as metric dimensions or Logs Insights grouping fields.
 Use the Terraform kill switch; it removes `REDIS_URL` from both ECS task
 definitions while leaving Redis provisioned for a quick restore:
 
+First prepare `infra/terraform/generated.auto.tfvars` with the currently
+deployed image URIs as described in the Terraform README. Then save and apply
+the reviewed plan:
+
 ```bash
-terraform -chdir=infra/terraform plan -var-file=prod.tfvars -var="live_preview_enabled=false"
-terraform -chdir=infra/terraform apply -var-file=prod.tfvars -var="live_preview_enabled=false"
+terraform -chdir=infra/terraform plan -var-file=prod.tfvars -var-file=generated.auto.tfvars -var="live_preview_enabled=false" -out=/tmp/live-preview-disable.tfplan
+terraform -chdir=infra/terraform apply /tmp/live-preview-disable.tfplan
 ```
 
 Review the plan before apply. It should update the two trusted service task
@@ -83,8 +93,8 @@ Set the same variable back to `true`, review the plan, apply, and wait for both
 services to roll:
 
 ```bash
-terraform -chdir=infra/terraform plan -var-file=prod.tfvars -var="live_preview_enabled=true"
-terraform -chdir=infra/terraform apply -var-file=prod.tfvars -var="live_preview_enabled=true"
+terraform -chdir=infra/terraform plan -var-file=prod.tfvars -var-file=generated.auto.tfvars -var="live_preview_enabled=true" -out=/tmp/live-preview-restore.tfplan
+terraform -chdir=infra/terraform apply /tmp/live-preview-restore.tfplan
 ```
 
 Run a new conversation turn. Confirm `attempted` and `delivered` outcomes in

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -101,7 +101,9 @@ Assistant messages, terminal Outcomes, and replay.
 Set `live_preview_enabled=false` to omit `REDIS_URL` from both trusted service
 task definitions without deleting the cache. Live telemetry is converted into
 CloudWatch metrics with bounded service/signal/outcome dimensions; the alarms
-require repeated five-minute breaches and never feed service health. See
+detect both repeated per-service breaches and multiple services degrading in
+the same five-minute period, and never feed service health. Production must set
+`alarm_action_arns` to an SNS topic with a confirmed incident subscription. See
 [`docs/runbooks/live-preview.md`](../../docs/runbooks/live-preview.md) for
 diagnosis, disable, and restore procedures.
 

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -98,6 +98,13 @@ previews and must not prevent either service from booting or staying healthy.
 The durable Postgres path remains sufficient for successful Runs, durable
 Assistant messages, terminal Outcomes, and replay.
 
+Set `live_preview_enabled=false` to omit `REDIS_URL` from both trusted service
+task definitions without deleting the cache. Live telemetry is converted into
+CloudWatch metrics with bounded service/signal/outcome dimensions; the alarms
+require repeated five-minute breaches and never feed service health. See
+[`docs/runbooks/live-preview.md`](../../docs/runbooks/live-preview.md) for
+diagnosis, disable, and restore procedures.
+
 ## Release Deploy Config
 
 This repo owns its GitHub Actions deploy role in the one-time bootstrap root:

--- a/infra/terraform/cloudwatch.tf
+++ b/infra/terraform/cloudwatch.tf
@@ -8,6 +8,122 @@ resource "aws_cloudwatch_log_group" "agent_worker" {
   retention_in_days = var.log_retention_days
 }
 
+locals {
+  live_preview_log_groups = {
+    chat-api     = aws_cloudwatch_log_group.chat_api.name
+    agent-worker = aws_cloudwatch_log_group.agent_worker.name
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "live_preview_signals" {
+  for_each = local.live_preview_log_groups
+
+  name           = "${local.common_name}-${each.key}-live-preview-signals"
+  log_group_name = each.value
+  pattern        = "{ $.message = \"Live preview signal\" && $.service = \"${each.key}\" && $.signal = * }"
+
+  metric_transformation {
+    name      = "Signals"
+    namespace = "${local.common_name}/LivePreview"
+    value     = "$.count"
+    unit      = "Count"
+
+    dimensions = {
+      Service = "$.service"
+      Signal  = "$.signal"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "live_preview_outcomes" {
+  for_each = local.live_preview_log_groups
+
+  name           = "${local.common_name}-${each.key}-live-preview-outcomes"
+  log_group_name = each.value
+  pattern        = "{ $.message = \"Live preview signal\" && $.service = \"${each.key}\" && $.outcome = * }"
+
+  metric_transformation {
+    name      = "MessageOutcomes"
+    namespace = "${local.common_name}/LivePreview"
+    value     = "$.count"
+    unit      = "Count"
+
+    dimensions = {
+      Service = "$.service"
+      Outcome = "$.outcome"
+    }
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "live_preview_degraded" {
+  for_each = local.live_preview_log_groups
+
+  alarm_name          = "${local.common_name}-${each.key}-live-preview-degraded"
+  alarm_description   = "${each.key} repeatedly entered Live-only degradation; durable Postgres delivery and service health remain authoritative."
+  namespace           = "${local.common_name}/LivePreview"
+  metric_name         = "Signals"
+  statistic           = "Sum"
+  period              = 300
+  evaluation_periods  = 3
+  datapoints_to_alarm = 2
+  threshold           = 2
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = var.alarm_action_arns
+  ok_actions          = var.alarm_action_arns
+
+  dimensions = {
+    Service = each.key
+    Signal  = "degraded"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "live_preview_drops" {
+  for_each = local.live_preview_log_groups
+
+  alarm_name          = "${local.common_name}-${each.key}-live-preview-drops"
+  alarm_description   = "${each.key} has a sustained rate of abandoned Live preview messages; durable commits are not affected."
+  namespace           = "${local.common_name}/LivePreview"
+  metric_name         = "MessageOutcomes"
+  statistic           = "Sum"
+  period              = 300
+  evaluation_periods  = 3
+  datapoints_to_alarm = 2
+  threshold           = 5
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = var.alarm_action_arns
+  ok_actions          = var.alarm_action_arns
+
+  dimensions = {
+    Service = each.key
+    Outcome = "dropped"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "live_preview_overflow" {
+  for_each = local.live_preview_log_groups
+
+  alarm_name          = "${local.common_name}-${each.key}-live-preview-overflow"
+  alarm_description   = "${each.key} has sustained Live preview queue overflow; investigate Redis latency or slow clients."
+  namespace           = "${local.common_name}/LivePreview"
+  metric_name         = "Signals"
+  statistic           = "Sum"
+  period              = 300
+  evaluation_periods  = 3
+  datapoints_to_alarm = 2
+  threshold           = 3
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = var.alarm_action_arns
+  ok_actions          = var.alarm_action_arns
+
+  dimensions = {
+    Service = each.key
+    Signal  = "queue_overflow"
+  }
+}
+
 resource "aws_cloudwatch_metric_alarm" "chat_api_unhealthy" {
   alarm_name          = "${local.chat_api_name}-unhealthy-hosts"
   alarm_description   = "chat-api has unhealthy targets behind the internal agent ALB."

--- a/infra/terraform/cloudwatch.tf
+++ b/infra/terraform/cloudwatch.tf
@@ -80,9 +80,9 @@ resource "aws_cloudwatch_metric_alarm" "live_preview_degraded" {
 
 resource "aws_cloudwatch_metric_alarm" "live_preview_widespread_degraded" {
   alarm_name          = "${local.common_name}-live-preview-widespread-degraded"
-  alarm_description   = "Multiple agent services entered Live-only degradation in one period; durable Postgres delivery and service health remain authoritative."
-  evaluation_periods  = 1
-  datapoints_to_alarm = 1
+  alarm_description   = "Multiple agent services repeatedly entered Live-only degradation; durable Postgres delivery and service health remain authoritative."
+  evaluation_periods  = 3
+  datapoints_to_alarm = 2
   threshold           = 2
   comparison_operator = "GreaterThanOrEqualToThreshold"
   treat_missing_data  = "notBreaching"

--- a/infra/terraform/cloudwatch.tf
+++ b/infra/terraform/cloudwatch.tf
@@ -78,6 +78,59 @@ resource "aws_cloudwatch_metric_alarm" "live_preview_degraded" {
   }
 }
 
+resource "aws_cloudwatch_metric_alarm" "live_preview_widespread_degraded" {
+  alarm_name          = "${local.common_name}-live-preview-widespread-degraded"
+  alarm_description   = "Multiple agent services entered Live-only degradation in one period; durable Postgres delivery and service health remain authoritative."
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  threshold           = 2
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = var.alarm_action_arns
+  ok_actions          = var.alarm_action_arns
+
+  metric_query {
+    id          = "widespread"
+    expression  = "IF(FILL(chat, 0) > 0, 1, 0) + IF(FILL(worker, 0) > 0, 1, 0)"
+    label       = "Services degraded"
+    return_data = true
+  }
+
+  metric_query {
+    id          = "chat"
+    return_data = false
+
+    metric {
+      namespace   = "${local.common_name}/LivePreview"
+      metric_name = "Signals"
+      period      = 300
+      stat        = "Sum"
+
+      dimensions = {
+        Service = "chat-api"
+        Signal  = "degraded"
+      }
+    }
+  }
+
+  metric_query {
+    id          = "worker"
+    return_data = false
+
+    metric {
+      namespace   = "${local.common_name}/LivePreview"
+      metric_name = "Signals"
+      period      = 300
+      stat        = "Sum"
+
+      dimensions = {
+        Service = "agent-worker"
+        Signal  = "degraded"
+      }
+    }
+  }
+}
+
 resource "aws_cloudwatch_metric_alarm" "live_preview_drops" {
   for_each = local.live_preview_log_groups
 

--- a/infra/terraform/cloudwatch.tf
+++ b/infra/terraform/cloudwatch.tf
@@ -66,7 +66,7 @@ resource "aws_cloudwatch_metric_alarm" "live_preview_degraded" {
   period              = 300
   evaluation_periods  = 3
   datapoints_to_alarm = 2
-  threshold           = 2
+  threshold           = 1
   comparison_operator = "GreaterThanOrEqualToThreshold"
   treat_missing_data  = "notBreaching"
   alarm_actions       = var.alarm_action_arns

--- a/infra/terraform/examples/prod.tfvars.example
+++ b/infra/terraform/examples/prod.tfvars.example
@@ -38,6 +38,9 @@ worker_max_concurrent_runs = 2
 live_redis_node_type      = "cache.t4g.micro"
 live_redis_engine_version = "7.1"
 
+# SNS topics must already have confirmed incident subscriptions.
+# alarm_action_arns = ["arn:aws:sns:us-east-1:123456789012:mymemo-prod-alarms"]
+
 # Agent-owned writable Postgres. This Terraform root always creates a dedicated
 # RDS instance. The password is generated and stored by RDS in AWS Secrets
 # Manager; ECS receives AGENT_DATABASE_URL without a password plus a DB_PASSWORD

--- a/infra/terraform/locals.tf
+++ b/infra/terraform/locals.tf
@@ -58,6 +58,10 @@ locals {
     }
   ]
 
+  live_redis_url_secret = var.live_preview_enabled ? [
+    { name = "REDIS_URL", valueFrom = local.live_redis_url_secret_arn }
+  ] : []
+
   chat_api_environment = concat([
     { name = "PORT", value = tostring(var.chat_api_port) },
     { name = "LOG_LEVEL", value = var.log_level },
@@ -68,8 +72,7 @@ locals {
   chat_api_secrets = concat([
     { name = "STATSIG_SERVER_SECRET", valueFrom = local.statsig_server_secret_arn },
     { name = "E2B_API_KEY", valueFrom = local.e2b_api_key_secret_arn },
-    { name = "REDIS_URL", valueFrom = local.live_redis_url_secret_arn },
-  ], local.agent_db_password_secret)
+  ], local.live_redis_url_secret, local.agent_db_password_secret)
 
   agent_worker_environment = concat([
     { name = "PORT", value = tostring(var.agent_worker_port) },
@@ -87,6 +90,5 @@ locals {
     { name = "KB_DATABASE_URL", valueFrom = local.kb_database_url_secret_arn },
     { name = "OPENROUTER_API_KEY", valueFrom = local.openrouter_api_key_secret_arn },
     { name = "E2B_API_KEY", valueFrom = local.e2b_api_key_secret_arn },
-    { name = "REDIS_URL", valueFrom = local.live_redis_url_secret_arn },
-  ], local.agent_db_password_secret)
+  ], local.live_redis_url_secret, local.agent_db_password_secret)
 }

--- a/infra/terraform/prod.tfvars
+++ b/infra/terraform/prod.tfvars
@@ -35,6 +35,9 @@ worker_max_concurrent_runs = 2
 live_redis_node_type      = "cache.t4g.micro"
 live_redis_engine_version = "7.1"
 
+# Established account alarm channel used by the shared staging infrastructure.
+alarm_action_arns = ["arn:aws:sns:us-west-2:637423444544:mymemo-staging-alarms"]
+
 agent_database_name               = "mymemo_agent"
 agent_database_username           = "mymemo_agent"
 agent_db_instance_class           = "db.t4g.micro"

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -126,6 +126,18 @@ variable "live_redis_engine_version" {
   default     = "7.1"
 }
 
+variable "live_preview_enabled" {
+  description = "Inject REDIS_URL into trusted agent services. Set false to disable only the optional Live preview lane while leaving Redis provisioned."
+  type        = bool
+  default     = true
+}
+
+variable "alarm_action_arns" {
+  description = "Optional SNS topic ARNs notified by Live preview CloudWatch alarms."
+  type        = list(string)
+  default     = []
+}
+
 variable "assign_public_ip" {
   description = "Inherited existing-network constraint: current mymemo-service ECS subnets are public/default subnets with no NAT/VPC endpoint egress path, so agent ECS tasks need public IPs."
   type        = bool

--- a/packages/live-text/src/index.ts
+++ b/packages/live-text/src/index.ts
@@ -1,6 +1,8 @@
 import { createClient } from "redis";
 import { z } from "zod";
 
+export * from "./telemetry";
+
 export const LIVE_TEXT_MAX_CHUNK_LENGTH = 16_384;
 export const LIVE_TEXT_MAX_WIRE_BYTES = 100_000;
 const LIVE_TEXT_MAX_ID_LENGTH = 128;

--- a/packages/live-text/src/telemetry.test.ts
+++ b/packages/live-text/src/telemetry.test.ts
@@ -13,6 +13,7 @@ it("emits payload-free bounded signals and deduplicates state transitions", () =
 	telemetry.degraded("redis_connection");
 	telemetry.degraded("redis_connection");
 	telemetry.record("queue_overflow", "worker_queue", "dropped");
+	telemetry.recordRecovery("worker_queue");
 	telemetry.recovered("redis_connection");
 	telemetry.recovered("redis_connection");
 
@@ -37,6 +38,13 @@ it("emits payload-free bounded signals and deduplicates state transitions", () =
 			signal: "queue_overflow",
 			reason: "worker_queue",
 			outcome: "dropped",
+			count: 1,
+		},
+		{
+			message: "Live preview signal",
+			service: "agent-worker",
+			signal: "recovered",
+			reason: "worker_queue",
 			count: 1,
 		},
 		{

--- a/packages/live-text/src/telemetry.test.ts
+++ b/packages/live-text/src/telemetry.test.ts
@@ -68,3 +68,28 @@ it("cannot let a failing logger affect Live delivery", () => {
 		telemetry.recovered("subscription");
 	}).not.toThrow();
 });
+
+it("heartbeats an active degradation until its recovery transition", async () => {
+	const events: Record<string, unknown>[] = [];
+	const telemetry = createLiveTextTelemetry(
+		"chat-api",
+		{
+			info: (event) => events.push(event),
+			warn: (event) => events.push(event),
+		},
+		{ degradedHeartbeatMs: 5 },
+	);
+
+	telemetry.degraded("redis_connection");
+	await Bun.sleep(12);
+	telemetry.recovered("redis_connection");
+	const countAfterRecovery = events.length;
+	await Bun.sleep(8);
+	telemetry.close();
+
+	expect(
+		events.filter(({ signal }) => signal === "degraded").length,
+	).toBeGreaterThanOrEqual(2);
+	expect(events.filter(({ signal }) => signal === "recovered")).toHaveLength(1);
+	expect(events).toHaveLength(countAfterRecovery);
+});

--- a/packages/live-text/src/telemetry.test.ts
+++ b/packages/live-text/src/telemetry.test.ts
@@ -1,0 +1,70 @@
+import { expect, it } from "bun:test";
+import { createLiveTextTelemetry } from "./telemetry";
+
+it("emits payload-free bounded signals and deduplicates state transitions", () => {
+	const events: Record<string, unknown>[] = [];
+	const telemetry = createLiveTextTelemetry("agent-worker", {
+		info: (event) => events.push(event),
+		warn: (event) => events.push(event),
+	});
+
+	telemetry.disabled("configuration");
+	telemetry.disabled("configuration");
+	telemetry.degraded("redis_connection");
+	telemetry.degraded("redis_connection");
+	telemetry.record("queue_overflow", "worker_queue", "dropped");
+	telemetry.recovered("redis_connection");
+	telemetry.recovered("redis_connection");
+
+	expect(events).toEqual([
+		{
+			message: "Live preview signal",
+			service: "agent-worker",
+			signal: "disabled",
+			reason: "configuration",
+			count: 1,
+		},
+		{
+			message: "Live preview signal",
+			service: "agent-worker",
+			signal: "degraded",
+			reason: "redis_connection",
+			count: 1,
+		},
+		{
+			message: "Live preview signal",
+			service: "agent-worker",
+			signal: "queue_overflow",
+			reason: "worker_queue",
+			outcome: "dropped",
+			count: 1,
+		},
+		{
+			message: "Live preview signal",
+			service: "agent-worker",
+			signal: "recovered",
+			reason: "redis_connection",
+			count: 1,
+		},
+	]);
+	expect(JSON.stringify(events)).not.toContain("text");
+	expect(JSON.stringify(events)).not.toContain("runId");
+	expect(JSON.stringify(events)).not.toContain("messageId");
+});
+
+it("cannot let a failing logger affect Live delivery", () => {
+	const telemetry = createLiveTextTelemetry("chat-api", {
+		info() {
+			throw new Error("logger unavailable");
+		},
+		warn() {
+			throw new Error("logger unavailable");
+		},
+	});
+
+	expect(() => {
+		telemetry.degraded("subscription");
+		telemetry.record("gap_detected", "delta_gap", "dropped");
+		telemetry.recovered("subscription");
+	}).not.toThrow();
+});

--- a/packages/live-text/src/telemetry.ts
+++ b/packages/live-text/src/telemetry.ts
@@ -20,7 +20,6 @@ export type LiveTextReason =
 	| "connection_buffer"
 	| "delta_gap"
 	| "duplicate_delta"
-	| "durable_backlog"
 	| "late_delta"
 	| "message_projection"
 	| "message_publication"
@@ -54,6 +53,7 @@ interface LiveTextTelemetryLogger {
 }
 
 export interface LiveTextTelemetry {
+	close(): void;
 	disabled(reason: LiveTextReason): void;
 	degraded(reason: LiveTextReason): void;
 	recovered(reason: LiveTextReason): void;
@@ -72,9 +72,16 @@ export interface LiveTextTelemetry {
 export function createLiveTextTelemetry(
 	service: LiveTextService,
 	logger: LiveTextTelemetryLogger,
+	options: { degradedHeartbeatMs?: number } = {},
 ): LiveTextTelemetry {
+	const degradedHeartbeatMs = options.degradedHeartbeatMs ?? 300_000;
+	if (!Number.isSafeInteger(degradedHeartbeatMs) || degradedHeartbeatMs < 1) {
+		throw new Error("degradedHeartbeatMs must be a positive integer");
+	}
 	const disabledReasons = new Set<LiveTextReason>();
 	const degradedReasons = new Set<LiveTextReason>();
+	let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
+	let closed = false;
 	const emit = (
 		signal: LiveTextSignal,
 		reason: LiveTextReason,
@@ -103,23 +110,45 @@ export function createLiveTextTelemetry(
 			// Observability is optional and must not change boot, health, or delivery.
 		}
 	};
+	const stopHeartbeat = () => {
+		if (heartbeatTimer === undefined) return;
+		clearInterval(heartbeatTimer);
+		heartbeatTimer = undefined;
+	};
+	const startHeartbeat = () => {
+		if (heartbeatTimer !== undefined) return;
+		heartbeatTimer = setInterval(() => {
+			for (const reason of degradedReasons) emit("degraded", reason);
+		}, degradedHeartbeatMs);
+		heartbeatTimer.unref?.();
+	};
 
 	return {
+		close() {
+			closed = true;
+			stopHeartbeat();
+		},
 		disabled(reason) {
+			if (closed) return;
 			if (disabledReasons.has(reason)) return;
 			disabledReasons.add(reason);
 			emit("disabled", reason);
 		},
 		degraded(reason) {
+			if (closed) return;
 			if (degradedReasons.has(reason)) return;
 			degradedReasons.add(reason);
 			emit("degraded", reason);
+			startHeartbeat();
 		},
 		recovered(reason) {
+			if (closed) return;
 			if (!degradedReasons.delete(reason)) return;
 			emit("recovered", reason);
+			if (degradedReasons.size === 0) stopHeartbeat();
 		},
 		record(signal, reason, outcome) {
+			if (closed) return;
 			emit(signal, reason, outcome);
 		},
 	};

--- a/packages/live-text/src/telemetry.ts
+++ b/packages/live-text/src/telemetry.ts
@@ -57,6 +57,7 @@ export interface LiveTextTelemetry {
 	disabled(reason: LiveTextReason): void;
 	degraded(reason: LiveTextReason): void;
 	recovered(reason: LiveTextReason): void;
+	recordRecovery(reason: LiveTextReason): void;
 	record(
 		signal: Exclude<LiveTextSignal, "disabled" | "degraded" | "recovered">,
 		reason: LiveTextReason,
@@ -146,6 +147,10 @@ export function createLiveTextTelemetry(
 			if (!degradedReasons.delete(reason)) return;
 			emit("recovered", reason);
 			if (degradedReasons.size === 0) stopHeartbeat();
+		},
+		recordRecovery(reason) {
+			if (closed) return;
+			emit("recovered", reason);
 		},
 		record(signal, reason, outcome) {
 			if (closed) return;

--- a/packages/live-text/src/telemetry.ts
+++ b/packages/live-text/src/telemetry.ts
@@ -1,0 +1,126 @@
+export type LiveTextService = "agent-worker" | "chat-api";
+
+export type LiveTextSignal =
+	| "attempted"
+	| "degraded"
+	| "delivered"
+	| "disabled"
+	| "dropped"
+	| "gap_detected"
+	| "impossible_ordering"
+	| "malformed"
+	| "mismatch"
+	| "queue_overflow"
+	| "recovered"
+	| "slow_client";
+
+export type LiveTextReason =
+	| "adapter_message"
+	| "configuration"
+	| "connection_buffer"
+	| "delta_gap"
+	| "duplicate_delta"
+	| "durable_backlog"
+	| "late_delta"
+	| "message_projection"
+	| "message_publication"
+	| "partial_complete"
+	| "provider_envelope"
+	| "publisher"
+	| "reconciliation_state"
+	| "redis_connection"
+	| "run_aborted"
+	| "run_ended"
+	| "subscription"
+	| "subscription_timeout"
+	| "terminal_preview"
+	| "transport_channel"
+	| "worker_queue";
+
+export type LiveTextOutcome = "attempted" | "delivered" | "dropped";
+
+export interface LiveTextTelemetryEvent extends Record<string, unknown> {
+	message: "Live preview signal";
+	service: LiveTextService;
+	signal: LiveTextSignal;
+	reason: LiveTextReason;
+	outcome?: LiveTextOutcome;
+	count: 1;
+}
+
+interface LiveTextTelemetryLogger {
+	info(event: LiveTextTelemetryEvent): void;
+	warn(event: LiveTextTelemetryEvent): void;
+}
+
+export interface LiveTextTelemetry {
+	disabled(reason: LiveTextReason): void;
+	degraded(reason: LiveTextReason): void;
+	recovered(reason: LiveTextReason): void;
+	record(
+		signal: Exclude<LiveTextSignal, "disabled" | "degraded" | "recovered">,
+		reason: LiveTextReason,
+		outcome?: LiveTextOutcome,
+	): void;
+}
+
+/**
+ * Builds the complete, bounded structured event before it reaches the logger.
+ * Callers cannot attach text, credentials, or per-request identifiers, and a
+ * telemetry failure can never affect the optional Live lane.
+ */
+export function createLiveTextTelemetry(
+	service: LiveTextService,
+	logger: LiveTextTelemetryLogger,
+): LiveTextTelemetry {
+	const disabledReasons = new Set<LiveTextReason>();
+	const degradedReasons = new Set<LiveTextReason>();
+	const emit = (
+		signal: LiveTextSignal,
+		reason: LiveTextReason,
+		outcome?: LiveTextOutcome,
+	) => {
+		const event: LiveTextTelemetryEvent = {
+			message: "Live preview signal",
+			service,
+			signal,
+			reason,
+			...(outcome ? { outcome } : {}),
+			count: 1,
+		};
+		try {
+			if (
+				signal === "disabled" ||
+				signal === "recovered" ||
+				signal === "attempted" ||
+				signal === "delivered"
+			) {
+				logger.info(event);
+			} else {
+				logger.warn(event);
+			}
+		} catch {
+			// Observability is optional and must not change boot, health, or delivery.
+		}
+	};
+
+	return {
+		disabled(reason) {
+			if (disabledReasons.has(reason)) return;
+			disabledReasons.add(reason);
+			emit("disabled", reason);
+		},
+		degraded(reason) {
+			if (degradedReasons.has(reason)) return;
+			degradedReasons.add(reason);
+			emit("degraded", reason);
+		},
+		recovered(reason) {
+			if (!degradedReasons.delete(reason)) return;
+			emit("recovered", reason);
+		},
+		record(signal, reason, outcome) {
+			emit(signal, reason, outcome);
+		},
+	};
+}

--- a/scripts/deploy-config.test.ts
+++ b/scripts/deploy-config.test.ts
@@ -112,6 +112,7 @@ describe("agent deployment config", () => {
 
 		for (const resource of [
 			"live_preview_degraded",
+			"live_preview_widespread_degraded",
 			"live_preview_drops",
 			"live_preview_overflow",
 		]) {
@@ -120,6 +121,12 @@ describe("agent deployment config", () => {
 			);
 		}
 		expect(cloudwatch.match(/datapoints_to_alarm\s*=\s*2/g)).toHaveLength(3);
+		expect(cloudwatch).toMatch(
+			/resource "aws_cloudwatch_metric_alarm" "live_preview_widespread_degraded"[\s\S]*?evaluation_periods\s*=\s*1[\s\S]*?threshold\s*=\s*2/,
+		);
+		expect(cloudwatch).toContain(
+			'expression  = "IF(FILL(chat, 0) > 0, 1, 0) + IF(FILL(worker, 0) > 0, 1, 0)"',
+		);
 		expect(
 			cloudwatch.match(/evaluation_periods\s*=\s*3/g)?.length,
 		).toBeGreaterThanOrEqual(3);
@@ -192,6 +199,9 @@ describe("agent deployment config", () => {
 		expect(prodTfvars).not.toContain("aws_region");
 		expect(prodTfvars).not.toContain("gateway_public_url");
 		expect(prodTfvars).toContain("mymemo-agent-prod-KB_DATABASE_URL");
+		expect(prodTfvars).toContain(
+			'alarm_action_arns = ["arn:aws:sns:us-west-2:637423444544:mymemo-staging-alarms"]',
+		);
 		expect(prodTfvars).not.toContain("CREATE_AGENT_DATABASE");
 		expect(prodTfvars).not.toContain("AGENT_DATABASE_URL_SECRET_ARN");
 		expect(prodTfvars).not.toContain("DB_PASSWORD_SECRET_ARN");

--- a/scripts/deploy-config.test.ts
+++ b/scripts/deploy-config.test.ts
@@ -82,7 +82,15 @@ describe("agent deployment config", () => {
 		expect(redisConfig).toContain(
 			'"rediss://default:${urlencode(random_password.live_redis.result)}@',
 		);
-		expect(locals.match(/name\s*=\s*"REDIS_URL"/g)).toHaveLength(2);
+		expect(locals.match(/name\s*=\s*"REDIS_URL"/g)).toHaveLength(1);
+		expect(locals).toMatch(
+			/live_redis_url_secret\s*=\s*var\.live_preview_enabled\s*\?/,
+		);
+		expect(
+			locals.match(
+				/\],\s*local\.live_redis_url_secret,\s*local\.agent_db_password_secret\)/g,
+			),
+		).toHaveLength(2);
 		expect(ecsConfig.match(/aws_security_group\.live_redis_clients\.id/g)).toHaveLength(2);
 		expect(migrationConfig).toContain("secrets = local.agent_db_password_secret");
 	});
@@ -95,6 +103,35 @@ describe("agent deployment config", () => {
 		);
 		expect(readme).toContain(
 			"The durable Postgres path remains sufficient for successful Runs",
+		);
+	});
+
+	it("alarms on sustained payload-free Live signals without health coupling", () => {
+		const cloudwatch = readFileSync(join(terraformDir, "cloudwatch.tf"), "utf8");
+		const ecs = readFileSync(join(terraformDir, "ecs.tf"), "utf8");
+
+		for (const resource of [
+			"live_preview_degraded",
+			"live_preview_drops",
+			"live_preview_overflow",
+		]) {
+			expect(cloudwatch).toContain(
+				`resource "aws_cloudwatch_metric_alarm" "${resource}"`,
+			);
+		}
+		expect(cloudwatch.match(/datapoints_to_alarm\s*=\s*2/g)).toHaveLength(3);
+		expect(
+			cloudwatch.match(/evaluation_periods\s*=\s*3/g)?.length,
+		).toBeGreaterThanOrEqual(3);
+		expect(cloudwatch).toContain('treat_missing_data  = "notBreaching"');
+		expect(cloudwatch).toContain('Service = "$.service"');
+		expect(cloudwatch).toContain('Signal  = "$.signal"');
+		expect(cloudwatch).toContain('Outcome = "$.outcome"');
+		expect(cloudwatch).not.toMatch(
+			/ConversationId|RunId|MessageId|text|payload|REDIS_URL/,
+		);
+		expect(ecs).not.toMatch(
+			/live_preview_(degraded|drops|overflow)|LivePreview/,
 		);
 	});
 

--- a/scripts/deploy-config.test.ts
+++ b/scripts/deploy-config.test.ts
@@ -120,9 +120,9 @@ describe("agent deployment config", () => {
 				`resource "aws_cloudwatch_metric_alarm" "${resource}"`,
 			);
 		}
-		expect(cloudwatch.match(/datapoints_to_alarm\s*=\s*2/g)).toHaveLength(3);
+		expect(cloudwatch.match(/datapoints_to_alarm\s*=\s*2/g)).toHaveLength(4);
 		expect(cloudwatch).toMatch(
-			/resource "aws_cloudwatch_metric_alarm" "live_preview_widespread_degraded"[\s\S]*?evaluation_periods\s*=\s*1[\s\S]*?threshold\s*=\s*2/,
+			/resource "aws_cloudwatch_metric_alarm" "live_preview_widespread_degraded"[\s\S]*?evaluation_periods\s*=\s*3[\s\S]*?datapoints_to_alarm\s*=\s*2[\s\S]*?threshold\s*=\s*2/,
 		);
 		expect(cloudwatch).toContain(
 			'expression  = "IF(FILL(chat, 0) > 0, 1, 0) + IF(FILL(worker, 0) > 0, 1, 0)"',


### PR DESCRIPTION
## Summary

- Add payload-free, cardinality-safe Live preview telemetry across agent-worker and chat-api.
- Track disabled, degraded, recovered, attempted, delivered, dropped, loss-tolerance, and invariant-violation paths without recording content or per-request identifiers.
- Add CloudWatch metrics and 2-of-3 alarms for prolonged or cross-service degradation and sustained drop/overflow rates, routed to the production SNS alarm channel.
- Add a Terraform Redis-lane kill switch and an operator runbook for diagnosis, durable-delivery verification, disable/restore, and Postgres-path escalation.

## Impact

Live preview remains optional: Redis and its alarms do not affect service readiness, Run terminalization, or authoritative Postgres `text_commit` delivery.

## Validation

- Full repository suite passed across all five workspaces, including real disposable Redis Pub/Sub and live E2B integration tests.
- TypeScript checks passed for the shared Live package, chat-api, and agent-worker.
- Biome, `terraform fmt -check`, and `terraform validate` passed.
- Reviewed production Terraform plan: **11 to add, 0 to change, 0 to destroy**; dimensions are limited to bounded `Service`, `Signal`, and `Outcome` values.
- Standards and specification reviews completed with no findings.
- GitHub CI `test`, `integration`, and `worker-image` checks pass.

No production infrastructure was applied as part of this PR.

Closes #249
