### PR TITLE
Ship live-text package in runtime images

### DIFF
--- a/apps/agent-worker/Dockerfile
+++ b/apps/agent-worker/Dockerfile
@@ -30,6 +30,7 @@ COPY apps/agent-worker/package.json apps/agent-worker/tsconfig.json apps/agent-w
 # must be present so the worker's `@mymemo/agent-db` imports resolve through the
 # workspace symlink in node_modules.
 COPY packages/agent-db packages/agent-db
+COPY packages/live-text packages/live-text
 COPY package.json .
 
 # The SDK cwd is a Fargate-side, per-conversation session anchor. Prepare the

--- a/apps/chat-api/Dockerfile
+++ b/apps/chat-api/Dockerfile
@@ -28,6 +28,7 @@ FROM base AS prerelease
 COPY --from=install /temp/dev/node_modules node_modules
 COPY apps/chat-api/ apps/chat-api/
 COPY packages/agent-db/ packages/agent-db/
+COPY packages/live-text/ packages/live-text/
 COPY package.json .
 
 # Final release image
@@ -42,6 +43,7 @@ COPY --from=prerelease /usr/src/app/apps/chat-api/tsconfig.json apps/chat-api/
 # not needed at runtime — and its `src/` so chat-api's `@mymemo/agent-db` imports
 # resolve through the workspace symlink in node_modules.
 COPY --from=prerelease /usr/src/app/packages/agent-db packages/agent-db
+COPY --from=prerelease /usr/src/app/packages/live-text packages/live-text
 COPY --from=prerelease /usr/src/app/package.json .
 
 WORKDIR /usr/src/app/apps/chat-api

--- a/scripts/deploy-config.test.ts
+++ b/scripts/deploy-config.test.ts
@@ -529,6 +529,19 @@ describe("agent deployment config", () => {
 		expect(buildScript).not.toContain("ECR_REPOSITORY_PREFIX");
 	});
 
+	it("ships the Live text workspace package in both runtime images", () => {
+		for (const dockerfile of [
+			join(root, "apps", "chat-api", "Dockerfile"),
+			join(root, "apps", "agent-worker", "Dockerfile"),
+		]) {
+			const releaseStage = readFileSync(dockerfile, "utf8").split(
+				"FROM base AS release",
+			)[1];
+
+			expect(releaseStage).toMatch(/^COPY .*packages\/live-text/m);
+		}
+	});
+
 	it("exec-verifies the SDK CLI in every built worker image before push", () => {
 		const checkPath = join(
 			root,


### PR DESCRIPTION
## Summary

- copy `packages/live-text` into the chat-api prerelease and release stages
- copy `packages/live-text` into the agent-worker release stage
- add regression coverage that requires both final image stages to ship the workspace package

## Root cause

Bun correctly installed `@mymemo/live-text` as the relative workspace link `node_modules/@mymemo/live-text -> ../../packages/live-text`, but both final runtime images omitted the link target. The release migration imported chat-api configuration, attempted to resolve that package, and exited with `ENOENT` before connecting to Postgres.

## Impact

The migration image can resolve its runtime dependencies, and the chat-api and agent-worker images will not fail at boot for the same missing workspace package.

## Verification

- reproduced the original `ENOENT` with the exact failed production image
- added the missing package to that image as an overlay; runtime workspace imports resolved and `db:migrate` advanced to its expected missing-DB configuration check
- regression test failed before the Dockerfile changes and passed afterward
- root deployment/smoke tests: 33 passed
- agent-db and live-text package tests: 90 passed
- agent-worker tests: 261 passed after retrying one transient live-E2B transport error
- chat-api tests: 139 passed
- worker-scaler tests: 17 passed
- `git diff --check` passed