### PR TITLE
Document mymemo AWS profile for CLI use in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,10 @@ docker build -t chat-api .
 docker-compose up    # Local development
 ```
 
+### AWS CLI
+
+Always use the `mymemo` profile: `aws --profile mymemo ...`
+
 ## Architecture (chat-api)
 
 ### Request Flow


### PR DESCRIPTION
## Summary
- Add an "AWS CLI" note to AGENTS.md (imported by CLAUDE.md) so coding agents always use the `mymemo` AWS profile (`aws --profile mymemo ...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)