### PR TITLE
Upgrade hashicorp/setup-terraform to v4

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.0
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@v4
         with:
           terraform_wrapper: false
 

--- a/scripts/deploy-config.test.ts
+++ b/scripts/deploy-config.test.ts
@@ -336,7 +336,7 @@ describe("agent deployment config", () => {
 		expect(planScript).toContain('-var="agent_worker_desired_count=0"');
 		expect(planScript).toContain('terraform -chdir=infra/terraform plan "${plan_args[@]}" -out="$plan_file"');
 		expect(planScript).toContain("generated.auto.tfvars");
-		expect(releaseDeployWorkflow).toContain("uses: hashicorp/setup-terraform@v3");
+		expect(releaseDeployWorkflow).toContain("uses: hashicorp/setup-terraform@v4");
 		expect(releaseDeployWorkflow).toContain("terraform_wrapper: false");
 		expect(prepareScript).toContain("aws_region");
 		expect(prepareScript).toContain("chat_api_image");


### PR DESCRIPTION
## What changed

Bumps `hashicorp/setup-terraform` from `v3` to `v4` in `.github/workflows/release-deploy.yml` — the only place the action is used.

## Why

v4.0.1 is the latest release. Staying on the current major keeps us on the maintained line and picks up the Node 24 `url.parse()` deprecation-warning fix (v4.0.1).

## Reviewer notes

- v4.0.0's only breaking change is that the action runs on Node.js 24, which GitHub-hosted `ubuntu-latest` runners already provide — no other workflow changes needed.
- Inputs are unchanged in v4 (verified against v4.0.1's `action.yml`); our `terraform_wrapper: false` usage works as before.
- Kept the repo's convention of pinning to major-version tags (`@v4`), matching `checkout@v7` and `configure-aws-credentials@v6`.
- The workflow is `workflow_dispatch`-only (prod deploy), so this won't run in CI on this PR; the first real exercise will be the next release deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)