### PR TITLE
Contain the Bun+pglite WASM boot trap in the test harness

### DIFF
--- a/apps/chat-api/src/features/run-events/project-run.test.ts
+++ b/apps/chat-api/src/features/run-events/project-run.test.ts
@@ -1,8 +1,14 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+} from "bun:test";
 import { InMemoryLiveTextTransport } from "@mymemo/live-text";
-import type { Database } from "@/db/client";
 import { runEvents, runs } from "@/db/schema";
-import { createTestDatabase } from "@/db/testing";
+import { createTestDatabase, type TestDb } from "@/db/testing";
 import { type ProjectedFrame, projectRun } from "./project-run";
 import type { RunEventReader, RunEventRow } from "./run-event-reader";
 import { DrizzleRunEventReader } from "./run-event-reader";
@@ -1335,13 +1341,23 @@ describe("projectRun", () => {
 });
 
 describe("projectRun over the real reader", () => {
-	let db: Database;
-	let close: () => Promise<void>;
+	let tdb: TestDb;
+
+	// One PGlite (WASM) instance for the whole describe — a per-test instance
+	// multiplies WASM memory that is not reclaimed promptly and adds boot
+	// attempts, each a chance to hit the flaky WASM boot trap. Tests are
+	// isolated by resetting the rows instead.
+	beforeAll(async () => {
+		tdb = await createTestDatabase();
+	});
+
+	afterAll(async () => {
+		await tdb.close();
+	});
 
 	beforeEach(async () => {
-		const tdb = await createTestDatabase();
-		db = tdb.db;
-		close = tdb.close;
+		const { db } = tdb;
+		await db.delete(runs); // cascades run_events
 		await db.insert(runs).values({
 			runId: "run-1",
 			userId: "user-1",
@@ -1365,10 +1381,8 @@ describe("projectRun over the real reader", () => {
 		]);
 	});
 
-	afterEach(() => close());
-
 	it("projects durable rows end to end, honoring the reconnect cursor", async () => {
-		const reader = new DrizzleRunEventReader(db);
+		const reader = new DrizzleRunEventReader(tdb.db);
 		const notifier = new InstantNotifier();
 
 		const full = frames(

--- a/packages/agent-db/src/testing.test.ts
+++ b/packages/agent-db/src/testing.test.ts
@@ -1,0 +1,86 @@
+import { afterAll, afterEach, describe, expect, it, spyOn } from "bun:test";
+import type { PGlite } from "@electric-sql/pglite";
+import { createTestDatabase } from "./testing";
+
+// The real WASM trap (pglite#831) cannot be provoked deterministically, so
+// these tests drive the retry through the injected client factory with fakes
+// that reject `waitReady` the way a trapped boot does.
+
+interface FakeClient {
+	client: PGlite;
+	closed: () => boolean;
+}
+
+function fakeClient(bootError?: unknown): FakeClient {
+	let closed = false;
+	const client = {
+		waitReady:
+			bootError === undefined ? Promise.resolve() : Promise.reject(bootError),
+		exec: async () => {},
+		close: async () => {
+			closed = true;
+		},
+	} as unknown as PGlite;
+	return { client, closed: () => closed };
+}
+
+function trap(): WebAssembly.RuntimeError {
+	return new WebAssembly.RuntimeError("access to a null reference");
+}
+
+const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+
+afterEach(() => {
+	warnSpy.mockClear();
+});
+
+// bun test shares one process across files — restore the global spy so later
+// files keep their console.warn.
+afterAll(() => {
+	warnSpy.mockRestore();
+});
+
+describe("createTestDatabase boot retry", () => {
+	it("retries a WASM-trapped boot on a fresh instance and succeeds", async () => {
+		const trapped = fakeClient(trap());
+		const healthy = fakeClient();
+		const attempts: FakeClient[] = [trapped, healthy];
+
+		const tdb = await createTestDatabase(() => {
+			const next = attempts.shift();
+			if (!next) throw new Error("factory exhausted");
+			return next.client;
+		});
+
+		expect(attempts).toHaveLength(0); // both attempts consumed
+		expect(trapped.closed()).toBe(true); // trapped instance was released
+		expect(healthy.closed()).toBe(false);
+		expect(warnSpy).toHaveBeenCalledTimes(1);
+		await tdb.close();
+		expect(healthy.closed()).toBe(true);
+	});
+
+	it("gives up after two trapped attempts", async () => {
+		let boots = 0;
+		await expect(
+			createTestDatabase(() => {
+				boots++;
+				return fakeClient(trap()).client;
+			}),
+		).rejects.toBeInstanceOf(WebAssembly.RuntimeError);
+		expect(boots).toBe(2);
+	});
+
+	it("does not retry ordinary boot failures", async () => {
+		let boots = 0;
+		const deterministic = new Error("migration is broken");
+		await expect(
+			createTestDatabase(() => {
+				boots++;
+				return fakeClient(deterministic).client;
+			}),
+		).rejects.toBe(deterministic);
+		expect(boots).toBe(1);
+		expect(warnSpy).not.toHaveBeenCalled();
+	});
+});

--- a/packages/agent-db/src/testing.ts
+++ b/packages/agent-db/src/testing.ts
@@ -16,7 +16,7 @@ import * as schema from "./schema";
  * Shared by chat-api and agent-worker tests: both replay this package's
  * migrations, so the two apps exercise the identical writable-DB schema.
  *
- * Always `close()` the returned handle (e.g. in `afterEach`): an unclosed pglite
+ * Always `close()` the returned handle (e.g. in `afterAll`): an unclosed pglite
  * instance leaks resources and makes `bun test` exit non-zero even when every
  * assertion passes.
  */
@@ -25,38 +25,84 @@ export interface TestDb {
 	close: () => Promise<void>;
 }
 
-export async function createTestDatabase(): Promise<TestDb> {
-	const client = new PGlite();
+// Bun's JSC intermittently traps with `RuntimeError: access to a null
+// reference` inside pglite's WASM while a fresh instance boots: initdb
+// re-enters the postgres main module through Emscripten's dynamic-linking
+// function table and observes a null funcref. It is rare (order of one boot
+// per thousand on CI runners), Bun-specific, and unfixed upstream
+// (https://github.com/electric-sql/pglite/issues/831), and it has only ever
+// been seen during instance creation — never after `waitReady` resolves. So
+// creation retries on exactly that trap, on a fresh instance each time;
+// deterministic failures (migration SQL errors, missing files) rethrow on the
+// first attempt. Capped at one retry: bun:test enforces its 5s default
+// timeout on `beforeAll` hooks, and two boots (~2.5s on CI runners) leave
+// comfortable headroom where a third would ride that limit.
+const BOOT_ATTEMPTS = 2;
+
+function isWasmBootTrap(err: unknown): boolean {
+	return (
+		err instanceof WebAssembly.RuntimeError ||
+		(err instanceof Error && err.name === "RuntimeError")
+	);
+}
+
+async function releaseClient(client: PGlite): Promise<void> {
+	try {
+		await client.close();
+	} finally {
+		// pglite's close() shuts Postgres down but keeps the Emscripten
+		// module — and its ~1GB WASM linear memory — referenced via
+		// `client.mod`. Test files hold their handle in a module-level
+		// `let tdb` that lives for the whole `bun test` process, so each
+		// closed-but-referenced instance stays pinned (~465MB, GC-immune)
+		// and peak memory climbs one corpse per pglite file until a later
+		// `new PGlite()` cannot allocate and fails to initialize — the flaky
+		// CI OOM. Dropping `client.mod` unpins the WASM memory even while the
+		// handle is referenced; the forced GC then reclaims it deterministically
+		// (measured: pinned arrayBuffers 2.3GB -> 0 with the null, unchanged
+		// without it). Runs in `finally` so it still fires if close() throws
+		// (e.g. a double-close raising "PGlite is closed").
+		(client as unknown as { mod?: unknown }).mod = undefined;
+		if (typeof Bun !== "undefined") Bun.gc(true);
+	}
+}
+
+async function bootWithMigrations(createClient: () => PGlite): Promise<PGlite> {
 	const files = readdirSync(MIGRATIONS_DIR)
 		.filter((f) => f.endsWith(".sql"))
 		.sort();
-	for (const file of files) {
-		const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf8");
-		for (const stmt of sql.split("--> statement-breakpoint")) {
-			if (stmt.trim()) await client.exec(stmt);
+	for (let attempt = 1; ; attempt++) {
+		let client: PGlite | undefined;
+		try {
+			client = createClient();
+			await client.waitReady;
+			for (const file of files) {
+				const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf8");
+				for (const stmt of sql.split("--> statement-breakpoint")) {
+					if (stmt.trim()) await client.exec(stmt);
+				}
+			}
+			return client;
+		} catch (err) {
+			if (client) await releaseClient(client).catch(() => {});
+			if (!isWasmBootTrap(err) || attempt >= BOOT_ATTEMPTS) throw err;
+			// Deliberately loud: keeps the upstream flake's frequency observable
+			// in CI logs instead of silently absorbed.
+			console.warn(
+				`pglite WASM boot trap (attempt ${attempt}/${BOOT_ATTEMPTS}), retrying:`,
+				err,
+			);
 		}
 	}
+}
+
+export async function createTestDatabase(
+	// Seam for the harness's own tests; real callers take the default.
+	createClient: () => PGlite = () => new PGlite(),
+): Promise<TestDb> {
+	const client = await bootWithMigrations(createClient);
 	return {
 		db: drizzle(client, { schema }) as unknown as Database,
-		close: async () => {
-			try {
-				await client.close();
-			} finally {
-				// pglite's close() shuts Postgres down but keeps the Emscripten
-				// module — and its ~1GB WASM linear memory — referenced via
-				// `client.mod`. Test files hold their handle in a module-level
-				// `let tdb` that lives for the whole `bun test` process, so each
-				// closed-but-referenced instance stays pinned (~465MB, GC-immune)
-				// and peak memory climbs one corpse per pglite file until a later
-				// `new PGlite()` cannot allocate and fails to initialize — the flaky
-				// CI OOM. Dropping `client.mod` unpins the WASM memory even while the
-				// handle is referenced; the forced GC then reclaims it deterministically
-				// (measured: pinned arrayBuffers 2.3GB -> 0 with the null, unchanged
-				// without it). Runs in `finally` so it still fires if close() throws
-				// (e.g. a double-close raising "PGlite is closed").
-				(client as unknown as { mod?: unknown }).mod = undefined;
-				if (typeof Bun !== "undefined") Bun.gc(true);
-			}
-		},
+		close: () => releaseClient(client),
 	};
 }


### PR DESCRIPTION
## Problem

CI intermittently fails with `RuntimeError: access to a null reference (evaluating 't(r, a)')` inside pglite's WASM during `createTestDatabase()` — e.g. [this job](https://github.com/X-GPT/mymemo-agent/actions/runs/29174568073/job/86601344895) (`beforeAll` in `apps/chat-api/src/db/run-schema.test.ts`, cascading into `TypeError: … 'tdb.close'` in `afterAll`).

This is **not** a recurrence of the PR #220 pinned-handle OOM: the crash hits the **first** PGlite boot in a fresh `bun test` process (only `deps.test.ts` ran before it), so no accumulation mechanism can apply. Reading the minified pglite dist at the stack's exact offsets shows the trap fires while initdb re-enters the postgres main module (`popen` interception → `callMain` → `resolveGlobalSymbol("main")`) and hits a null funcref in Emscripten's dynamic-linking function table. It is Bun/JSC-specific, boot-time only, ~1 in 40 CI runs (~0.1–0.3% per boot), and known-unfixed upstream: electric-sql/pglite#831 reports the same trap class under `bun test`.

## Changes

- **`packages/agent-db/src/testing.ts`** — `createTestDatabase()` retries instance creation once on exactly that WASM trap (`WebAssembly.RuntimeError` / name `RuntimeError`), on a fresh instance, fully releasing the failed one (close + `mod` unpin + forced GC, ordered before the next boot so memory never stacks). Deterministic failures (migration SQL errors etc.) rethrow on the first attempt. Capped at **two** attempts because bun:test enforces its 5s default timeout on `beforeAll` hooks (verified empirically): two boots ≈ 2.5s leaves headroom where a third would ride the limit. Retries emit a loud `pglite WASM boot trap … retrying` warning so the flake's real frequency stays observable in CI logs instead of being silently absorbed.
- **`packages/agent-db/src/testing.test.ts`** (new) — regression tests driving the retry through an injected client factory: retry-then-succeed (failed instance released), give-up-after-two, and no-retry-on-ordinary-errors.
- **`apps/chat-api/src/features/run-events/project-run.test.ts`** — converts the one remaining per-test PGlite `beforeEach` block (missed by PR #220) to the shared per-file instance pattern; fewer boots means fewer trap opportunities and less WASM memory churn.

## Validation

- Full `bun run test` **10/10 green** (40–55s each), zero retries needed locally.
- ~180 additional fresh-process iterations of the exact failing scenario (`bun test src/deps.test.ts src/db/run-schema.test.ts`) — clean.
- `tsc --noEmit` and Biome clean in both touched workspaces.
- Caveat, stated honestly: the trap has never reproduced on macOS, so local runs demonstrate no regression rather than absence of the trap. The retry mechanism itself is exercised by the new unit tests; the confirmation signal in CI is a `retrying` warning appearing alongside a **passing** run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)