### PR TITLE
Tool-event vocabulary and discriminated model-content append (prefactor)

### DIFF
--- a/apps/agent-worker/src/run-loop.test.ts
+++ b/apps/agent-worker/src/run-loop.test.ts
@@ -104,9 +104,12 @@ async function readEventTypes(runId: string) {
 
 /** Appends one complete Assistant message then returns. */
 const appendMessageProcessor: RunProcessor = async (ctx) => {
-	await ctx.appendAssistantMessage({
-		messageId: `message-${ctx.run.runId}`,
-		text: `synthetic ${ctx.run.runId}`,
+	await ctx.appendModelContent({
+		kind: "assistant_message",
+		payload: {
+			messageId: `message-${ctx.run.runId}`,
+			text: `synthetic ${ctx.run.runId}`,
+		},
 	});
 };
 
@@ -482,6 +485,65 @@ describe("RunLoop — stale-run recovery", () => {
 
 		expect((await readRun("run-1"))?.status).toBe("error");
 		expect(await readEventTypes("run-1")).toEqual(["run_error"]);
+	});
+});
+
+describe("RunLoop — model-content append", () => {
+	it("maps each model-content kind to its durable event type", async () => {
+		const worker = buildWorker(1);
+		// One turn recording a Tool invocation, its result, then the Assistant
+		// message — the loop, not the processor, owns the kind→type mapping.
+		const loop = buildLoop(worker, async (ctx) => {
+			await ctx.appendModelContent({
+				kind: "tool_use",
+				payload: {
+					tool: "Bash",
+					arguments: { command: "ls" },
+					truncated: false,
+				},
+			});
+			await ctx.appendModelContent({
+				kind: "tool_result",
+				payload: {
+					tool: "Bash",
+					result: { exitCode: 0 },
+					isError: false,
+					truncated: false,
+				},
+			});
+			await ctx.appendModelContent({
+				kind: "assistant_message",
+				payload: { messageId: "message-1", text: "listed" },
+			});
+		});
+		await queueRun("run-1", "conv-1");
+
+		await loop.tick();
+		await worker.drain();
+
+		expect((await readRun("run-1"))?.status).toBe("done");
+		const events = await tdb.db
+			.select()
+			.from(runEvents)
+			.where(eq(runEvents.runId, "run-1"))
+			.orderBy(runEvents.seq);
+		expect(events.map((e) => e.type)).toEqual([
+			"tool_use",
+			"tool_result",
+			"assistant_text",
+			"run_done",
+		]);
+		expect(events[0]?.payload).toEqual({
+			tool: "Bash",
+			arguments: { command: "ls" },
+			truncated: false,
+		});
+		expect(events[1]?.payload).toEqual({
+			tool: "Bash",
+			result: { exitCode: 0 },
+			isError: false,
+			truncated: false,
+		});
 	});
 });
 

--- a/apps/agent-worker/src/run-loop.ts
+++ b/apps/agent-worker/src/run-loop.ts
@@ -2,6 +2,8 @@ import type { Database } from "@mymemo/agent-db/client";
 import {
 	type AssistantTextPayload,
 	RunEventType,
+	type ToolResultPayload,
+	type ToolUsePayload,
 } from "@mymemo/agent-db/run-events";
 import {
 	appendRunEventTx,
@@ -38,15 +40,37 @@ export interface TurnResult {
 const EMPTY_TURN: TurnResult = {};
 
 /**
- * What a claimed run's processing is handed. `appendAssistantMessage` is the
- * bound durable-message append for this owned run (fenced by the run store);
- * `signal` fires when the loop observes cancellation or loses ownership, so
- * long-running processing can stop promptly.
+ * One piece of durable model content a processor can record while its run is
+ * `running`: a complete Assistant message, a Tool invocation, or a Tool result
+ * (ADR-0009). The payload is already the client-safe shape — the loop persists
+ * it verbatim under the event type its kind maps to.
+ */
+export type ModelContent =
+	| { kind: "assistant_message"; payload: AssistantTextPayload }
+	| { kind: "tool_use"; payload: ToolUsePayload }
+	| { kind: "tool_result"; payload: ToolResultPayload };
+
+/** The loop owns the kind→event-type mapping in exactly one place, so a
+ * processor can never write a payload under a mismatched vocabulary type. */
+const MODEL_CONTENT_EVENT_TYPES = {
+	// The shared vocabulary type the projector maps to `text_commit` — never
+	// the frame name itself, or the projector drops it.
+	assistant_message: RunEventType.AssistantText,
+	tool_use: RunEventType.ToolUse,
+	tool_result: RunEventType.ToolResult,
+} as const satisfies Record<ModelContent["kind"], RunEventType>;
+
+/**
+ * What a claimed run's processing is handed. `appendModelContent` is the bound
+ * durable model-content append for this owned run (fenced by the run store to
+ * `running`, all kinds alike); `signal` fires when the loop observes
+ * cancellation or loses ownership, so long-running processing can stop
+ * promptly.
  */
 export interface RunProcessContext {
 	run: RunRecord;
 	signal: AbortSignal;
-	appendAssistantMessage(message: AssistantTextPayload): Promise<void>;
+	appendModelContent(content: ModelContent): Promise<void>;
 }
 
 /**
@@ -301,8 +325,8 @@ export class RunLoop {
 				(await this.opts.processor({
 					run,
 					signal: entry.controller.signal,
-					appendAssistantMessage: (message) =>
-						this.appendAssistantMessage(run.runId, message),
+					appendModelContent: (content) =>
+						this.appendModelContent(run.runId, content),
 				})) ?? EMPTY_TURN;
 		} catch (error) {
 			failure = { error };
@@ -313,17 +337,15 @@ export class RunLoop {
 		await this.finish(run, entry.state, turnResult, failure);
 	}
 
-	private async appendAssistantMessage(
+	private async appendModelContent(
 		runId: string,
-		message: AssistantTextPayload,
+		content: ModelContent,
 	): Promise<void> {
 		await appendRunEventTx(this.opts.db, {
 			runId,
 			workerId: this.workerId,
-			// The shared vocabulary type the projector maps to `text_commit` — never
-			// the frame name itself, or the projector drops it.
-			type: RunEventType.AssistantText,
-			payload: message,
+			type: MODEL_CONTENT_EVENT_TYPES[content.kind],
+			payload: content.payload,
 			appendClass: "model",
 		});
 	}

--- a/apps/agent-worker/src/sdk/agent-stream.test.ts
+++ b/apps/agent-worker/src/sdk/agent-stream.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 import { InMemoryLiveTextTransport } from "@mymemo/live-text";
+import type { ModelContent } from "../run-loop";
 import {
 	AgentResultError,
 	consumeAgentStream,
@@ -81,6 +82,25 @@ function fakeQuery(steps: Step[]): SupervisedQuery & { interrupts: number } {
 	return query;
 }
 
+type AssistantCommit = Extract<
+	ModelContent,
+	{ kind: "assistant_message" }
+>["payload"];
+
+/** These fixtures only ever commit Assistant messages through the
+ * discriminated model-content seam; any other kind is a bug — fail loudly
+ * rather than silently dropping it. */
+function onAssistantCommit(
+	handle: (payload: AssistantCommit) => void,
+): (content: ModelContent) => Promise<void> {
+	return async (content) => {
+		if (content.kind !== "assistant_message") {
+			throw new Error(`unexpected model content kind: ${content.kind}`);
+		}
+		handle(content.payload);
+	};
+}
+
 describe("sessionIdFromResult", () => {
 	it("returns the session id only from a result message", () => {
 		expect(sessionIdFromResult(resultMessage("session-1"))).toBe("session-1");
@@ -145,9 +165,9 @@ describe("consumeAgentStream", () => {
 					await transport.publish(message);
 				},
 			},
-			appendAssistantMessage: async (message) => {
-				order.push(`commit:${message.text}`);
-			},
+			appendModelContent: onAssistantCommit((message) =>
+				order.push(`commit:${message.text}`),
+			),
 		});
 
 		const preview = subscription.readAvailable();
@@ -191,9 +211,9 @@ describe("consumeAgentStream", () => {
 					});
 				},
 			},
-			appendAssistantMessage: async (message) => {
-				appended.push(message);
-			},
+			appendModelContent: onAssistantCommit((message) =>
+				appended.push(message),
+			),
 		});
 
 		expect(outcome).toEqual({
@@ -218,9 +238,9 @@ describe("consumeAgentStream", () => {
 			consumeAgentStream({
 				query,
 				signal: controller.signal,
-				appendAssistantMessage: async (message) => {
-					appended.push(message);
-				},
+				appendModelContent: onAssistantCommit((message) =>
+					appended.push(message),
+				),
 			}),
 		).resolves.toEqual({
 			sessionId: "session-42",
@@ -245,9 +265,9 @@ describe("consumeAgentStream", () => {
 		await consumeAgentStream({
 			query,
 			signal: new AbortController().signal,
-			appendAssistantMessage: async (message) => {
-				appended.push(message);
-			},
+			appendModelContent: onAssistantCommit((message) =>
+				appended.push(message),
+			),
 		});
 
 		expect(appended).toHaveLength(1);
@@ -271,9 +291,9 @@ describe("consumeAgentStream", () => {
 			consumeAgentStream({
 				query,
 				signal: controller.signal,
-				appendAssistantMessage: async (message) => {
-					appended.push(message);
-				},
+				appendModelContent: onAssistantCommit((message) =>
+					appended.push(message),
+				),
 			}),
 		).rejects.toBeInstanceOf(QueryInterruptedError);
 
@@ -293,9 +313,9 @@ describe("consumeAgentStream", () => {
 			consumeAgentStream({
 				query,
 				signal: controller.signal,
-				appendAssistantMessage: async (message) => {
-					appended.push(message);
-				},
+				appendModelContent: onAssistantCommit((message) =>
+					appended.push(message),
+				),
 			}),
 		).rejects.toBeInstanceOf(QueryInterruptedError);
 
@@ -317,9 +337,9 @@ describe("consumeAgentStream", () => {
 			consumeAgentStream({
 				query,
 				signal: controller.signal,
-				appendAssistantMessage: async (message) => {
-					appended.push(message);
-				},
+				appendModelContent: onAssistantCommit((message) =>
+					appended.push(message),
+				),
 			}),
 		).rejects.toThrow("rate limited");
 		expect(appended).toEqual([]);
@@ -341,7 +361,7 @@ describe("consumeAgentStream", () => {
 				query,
 				signal: controller.signal,
 				liveTextPublisher: liveText,
-				appendAssistantMessage: async () => {},
+				appendModelContent: async () => {},
 			}),
 		).rejects.toBeInstanceOf(AssistantEnvelopeProtocolError);
 		await Bun.sleep(60);
@@ -366,7 +386,7 @@ describe("consumeAgentStream", () => {
 				query,
 				signal: new AbortController().signal,
 				liveTextPublisher: liveText,
-				appendAssistantMessage: async () => {},
+				appendModelContent: async () => {},
 			}),
 		).rejects.toBeInstanceOf(AssistantEnvelopeProtocolError);
 		expect(subscription.readAvailable()).toEqual([]);
@@ -389,7 +409,7 @@ describe("consumeAgentStream", () => {
 			consumeAgentStream({
 				query,
 				signal: controller.signal,
-				appendAssistantMessage: async () => {},
+				appendModelContent: async () => {},
 			}),
 		).rejects.toBeInstanceOf(AgentResultError);
 	});
@@ -408,7 +428,7 @@ describe("consumeAgentStream", () => {
 			consumeAgentStream({
 				query,
 				signal: controller.signal,
-				appendAssistantMessage: async () => {},
+				appendModelContent: async () => {},
 			}),
 		).resolves.toEqual({
 			sessionId: "session-7",
@@ -430,9 +450,9 @@ describe("consumeAgentStream", () => {
 			consumeAgentStream({
 				query,
 				signal: controller.signal,
-				appendAssistantMessage: async (message) => {
-					appended.push(message);
-				},
+				appendModelContent: onAssistantCommit((message) =>
+					appended.push(message),
+				),
 			}),
 		).rejects.toBe(boom);
 		expect(appended).toEqual([]);

--- a/apps/agent-worker/src/sdk/agent-stream.ts
+++ b/apps/agent-worker/src/sdk/agent-stream.ts
@@ -1,6 +1,6 @@
 import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
-import type { AssistantTextPayload } from "@mymemo/agent-db/run-events";
 import type { LiveTextPublisher } from "@mymemo/live-text";
+import type { ModelContent } from "../run-loop";
 import { AssistantMessageAssembler } from "./assistant-message-assembler";
 import {
 	LiveTextPreview,
@@ -82,8 +82,9 @@ export interface ConsumeAgentStreamParams {
 	query: SupervisedQuery;
 	/** Fires on cancel, ownership loss, or shutdown; interrupts the query. */
 	signal: AbortSignal;
-	/** Persists one complete Assistant message (fenced to `running` upstream). */
-	appendAssistantMessage: (message: AssistantTextPayload) => Promise<void>;
+	/** Persists one piece of model content — an Assistant message, a Tool
+	 * invocation, or a Tool result (fenced to `running` upstream). */
+	appendModelContent: (content: ModelContent) => Promise<void>;
 	liveTextPublisher?: LiveTextPublisher;
 	liveTextCoalesceWindowMs?: number;
 	/** Payload-free, fixed-vocabulary Live preview transport signal. */
@@ -110,7 +111,7 @@ export interface ConsumeAgentStreamParams {
 export async function consumeAgentStream(
 	params: ConsumeAgentStreamParams,
 ): Promise<AgentStreamOutcome> {
-	const { query, signal, appendAssistantMessage } = params;
+	const { query, signal, appendModelContent } = params;
 	const outcome: AgentStreamOutcome = {
 		sessionId: null,
 		mirrorErrorObserved: false,
@@ -172,7 +173,10 @@ export async function consumeAgentStream(
 			} else if (assembled?.type === "message_stop") {
 				await preview?.flushMessage();
 				if (assembled.commit !== null) {
-					await appendAssistantMessage(assembled.commit);
+					await appendModelContent({
+						kind: "assistant_message",
+						payload: assembled.commit,
+					});
 				}
 			}
 		}

--- a/apps/agent-worker/src/sdk/run-processor.ts
+++ b/apps/agent-worker/src/sdk/run-processor.ts
@@ -57,7 +57,7 @@ export function createSdkRunProcessor(deps: SdkRunProcessorDeps): RunProcessor {
 				runId: ctx.run.runId,
 				query,
 				signal: ctx.signal,
-				appendAssistantMessage: ctx.appendAssistantMessage,
+				appendModelContent: ctx.appendModelContent,
 				liveTextPublisher: deps.liveTextPublisher,
 				onLiveTextSignal: (signal) =>
 					reportWorkerLiveTextPreviewSignal(telemetry, signal),

--- a/e2e/synthetic-worker.ts
+++ b/e2e/synthetic-worker.ts
@@ -22,9 +22,12 @@ const worker = new Worker({
 	logger,
 });
 const processor: RunProcessor = async (ctx) => {
-	await ctx.appendAssistantMessage({
-		messageId: `message-${ctx.run.runId}`,
-		text: `Synthetic response for run ${ctx.run.runId}`,
+	await ctx.appendModelContent({
+		kind: "assistant_message",
+		payload: {
+			messageId: `message-${ctx.run.runId}`,
+			text: `Synthetic response for run ${ctx.run.runId}`,
+		},
 	});
 };
 const runLoop = new RunLoop({

--- a/packages/agent-db/src/run-events.test.ts
+++ b/packages/agent-db/src/run-events.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { isAssistantTextPayload } from "./run-events";
+import {
+	isAssistantTextPayload,
+	isToolResultPayload,
+	isToolUsePayload,
+} from "./run-events";
 
 describe("isAssistantTextPayload", () => {
 	it("accepts only the authoritative complete-message payload", () => {
@@ -15,5 +19,141 @@ describe("isAssistantTextPayload", () => {
 			false,
 		);
 		expect(isAssistantTextPayload(null)).toBe(false);
+	});
+});
+
+describe("isToolUsePayload", () => {
+	it("accepts a client-safe Tool invocation payload", () => {
+		expect(
+			isToolUsePayload({
+				tool: "Bash",
+				arguments: { command: "ls -la", timeoutMs: 120_000 },
+				truncated: false,
+			}),
+		).toBe(true);
+		// A projection may legitimately produce an empty arguments record.
+		expect(
+			isToolUsePayload({ tool: "Glob", arguments: {}, truncated: true }),
+		).toBe(true);
+	});
+
+	it("rejects payloads with a missing field", () => {
+		expect(
+			isToolUsePayload({ arguments: { command: "ls" }, truncated: false }),
+		).toBe(false);
+		expect(isToolUsePayload({ tool: "Bash", truncated: false })).toBe(false);
+		expect(
+			isToolUsePayload({ tool: "Bash", arguments: { command: "ls" } }),
+		).toBe(false);
+		expect(isToolUsePayload(null)).toBe(false);
+		expect(isToolUsePayload(undefined)).toBe(false);
+	});
+
+	it("rejects payloads with a wrong-type field", () => {
+		// Only the eight short public names are client-visible (ADR-0009); a
+		// prefixed executor name or an unknown tool must fail closed.
+		expect(
+			isToolUsePayload({
+				tool: "mcp__executor__Bash",
+				arguments: {},
+				truncated: false,
+			}),
+		).toBe(false);
+		expect(isToolUsePayload({ tool: 7, arguments: {}, truncated: false })).toBe(
+			false,
+		);
+		expect(
+			isToolUsePayload({ tool: "Read", arguments: "path", truncated: false }),
+		).toBe(false);
+		expect(
+			isToolUsePayload({ tool: "Read", arguments: ["path"], truncated: false }),
+		).toBe(false);
+		expect(
+			isToolUsePayload({ tool: "Read", arguments: null, truncated: false }),
+		).toBe(false);
+		expect(
+			isToolUsePayload({ tool: "Read", arguments: {}, truncated: "false" }),
+		).toBe(false);
+	});
+});
+
+describe("isToolResultPayload", () => {
+	it("accepts a client-safe Tool result payload", () => {
+		expect(
+			isToolResultPayload({
+				tool: "Read",
+				result: { preview: "line one", lines: 1 },
+				isError: false,
+				truncated: true,
+			}),
+		).toBe(true);
+		// The fixed error result (ADR-0009): error-marked, generic message.
+		expect(
+			isToolResultPayload({
+				tool: "SearchDocuments",
+				result: { message: "Tool failed" },
+				isError: true,
+				truncated: false,
+			}),
+		).toBe(true);
+	});
+
+	it("rejects payloads with a missing field", () => {
+		expect(
+			isToolResultPayload({ result: {}, isError: false, truncated: false }),
+		).toBe(false);
+		expect(
+			isToolResultPayload({ tool: "Bash", isError: false, truncated: false }),
+		).toBe(false);
+		expect(
+			isToolResultPayload({ tool: "Bash", result: {}, truncated: false }),
+		).toBe(false);
+		expect(
+			isToolResultPayload({ tool: "Bash", result: {}, isError: false }),
+		).toBe(false);
+		expect(isToolResultPayload(null)).toBe(false);
+	});
+
+	it("rejects payloads with a wrong-type field", () => {
+		expect(
+			isToolResultPayload({
+				tool: "NotATool",
+				result: {},
+				isError: false,
+				truncated: false,
+			}),
+		).toBe(false);
+		expect(
+			isToolResultPayload({
+				tool: "Bash",
+				result: "raw stdout",
+				isError: false,
+				truncated: false,
+			}),
+		).toBe(false);
+		expect(
+			isToolResultPayload({
+				tool: "Bash",
+				result: [],
+				isError: false,
+				truncated: false,
+			}),
+		).toBe(false);
+		expect(
+			isToolResultPayload({
+				tool: "Bash",
+				result: {},
+				isError: "true",
+				truncated: false,
+			}),
+		).toBe(false);
+		expect(
+			isToolResultPayload({
+				tool: "Bash",
+				result: {},
+				isError: false,
+				truncated: 1,
+			}),
+		).toBe(false);
 	});
 });

--- a/packages/agent-db/src/run-events.ts
+++ b/packages/agent-db/src/run-events.ts
@@ -2,9 +2,10 @@
  * The `run_events.type` vocabulary — the write-side contract for the durable
  * run-event log, shared by every appender so the type strings are defined in
  * exactly one place: chat-api's run queue writes `run_started`; the agent-worker
- * writes assistant text and, through the run-store terminal helpers, the
- * terminal events. chat-api's projector is the READ side — it maps these types
- * to client SSE frames, and an unmapped type produces no frame (fail-closed).
+ * writes assistant text and tool events and, through the run-store terminal
+ * helpers, the terminal events. chat-api's projector is the READ side — it maps
+ * these types to client SSE frames, and an unmapped type produces no frame
+ * (fail-closed).
  *
  * Appenders MUST use these constants, never the raw strings, so a rename cannot
  * silently desync a writer from the projector (a text event written under the
@@ -16,6 +17,11 @@ export const RunEventType = {
 	/** One complete Assistant message. Payload `{ messageId, text }`. Projected
 	 * to the durable `text_commit` client frame. */
 	AssistantText: "assistant_text",
+	/** One Tool invocation. Payload {@link ToolUsePayload} — already the
+	 * client-safe projection (ADR-0009); the projector forwards, never derives. */
+	ToolUse: "tool_use",
+	/** One Tool result. Payload {@link ToolResultPayload}. */
+	ToolResult: "tool_result",
 	/** Terminal: the run finished successfully. */
 	Done: "run_done",
 	/** Terminal: the run failed. Payload `{ message }`. */
@@ -46,4 +52,89 @@ export function isAssistantTextPayload(
 		typeof value.text === "string" &&
 		value.text.length > 0
 	);
+}
+
+/**
+ * The eight short public tool names a client may see (ADR-0009). Tool events
+ * carry these — never the executor's prefixed tool names — and the guards fail
+ * closed on anything else, so an internal name cannot reach the client stream.
+ */
+export const PUBLIC_TOOL_NAMES = [
+	"Read",
+	"Write",
+	"Edit",
+	"Grep",
+	"Glob",
+	"Bash",
+	"SearchDocuments",
+	"LoadDocuments",
+] as const;
+
+export type PublicToolName = (typeof PUBLIC_TOOL_NAMES)[number];
+
+/**
+ * The durable payload for one Tool invocation (ADR-0009). `arguments` is the
+ * bounded per-tool projection of what the tool was asked to do — recorded
+ * already client-safe, never raw SDK input — and `truncated` marks that some
+ * field was clipped to fit the event cap.
+ */
+export interface ToolUsePayload {
+	[key: string]: unknown;
+	tool: PublicToolName;
+	arguments: Record<string, unknown>;
+	truncated: boolean;
+}
+
+/**
+ * The durable payload for one Tool result (ADR-0009). `result` is the bounded
+ * per-tool projection of what came back; an `isError` result carries the fixed
+ * safe message, never raw error text.
+ */
+export interface ToolResultPayload {
+	[key: string]: unknown;
+	tool: PublicToolName;
+	result: Record<string, unknown>;
+	isError: boolean;
+	truncated: boolean;
+}
+
+export function isToolUsePayload(value: unknown): value is ToolUsePayload {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"tool" in value &&
+		isPublicToolName(value.tool) &&
+		"arguments" in value &&
+		isPlainRecord(value.arguments) &&
+		"truncated" in value &&
+		typeof value.truncated === "boolean"
+	);
+}
+
+export function isToolResultPayload(
+	value: unknown,
+): value is ToolResultPayload {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"tool" in value &&
+		isPublicToolName(value.tool) &&
+		"result" in value &&
+		isPlainRecord(value.result) &&
+		"isError" in value &&
+		typeof value.isError === "boolean" &&
+		"truncated" in value &&
+		typeof value.truncated === "boolean"
+	);
+}
+
+function isPublicToolName(value: unknown): value is PublicToolName {
+	return (
+		typeof value === "string" &&
+		(PUBLIC_TOOL_NAMES as readonly string[]).includes(value)
+	);
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/packages/agent-db/src/run-store.test.ts
+++ b/packages/agent-db/src/run-store.test.ts
@@ -279,6 +279,89 @@ describe("appendRunEventTx", () => {
 		).rejects.toBeInstanceOf(RunFenceError);
 	});
 
+	it("sequences tool events with assistant text under the model class", async () => {
+		await claimRun("run-1", "conv-1", "worker-1");
+
+		const toolUse = await appendRunEventTx(tdb.db, {
+			runId: "run-1",
+			workerId: "worker-1",
+			type: RunEventType.ToolUse,
+			payload: { tool: "Bash", arguments: { command: "ls" }, truncated: false },
+			appendClass: "model",
+		});
+		const toolResult = await appendRunEventTx(tdb.db, {
+			runId: "run-1",
+			workerId: "worker-1",
+			type: RunEventType.ToolResult,
+			payload: {
+				tool: "Bash",
+				result: { exitCode: 0 },
+				isError: false,
+				truncated: false,
+			},
+			appendClass: "model",
+		});
+		const text = await appendRunEventTx(tdb.db, {
+			runId: "run-1",
+			workerId: "worker-1",
+			type: RunEventType.AssistantText,
+			payload: { messageId: "message-1", text: "done" },
+			appendClass: "model",
+		});
+
+		expect([toolUse.seq, toolResult.seq, text.seq]).toEqual([1, 2, 3]);
+		expect((await readEvents("run-1")).map((e) => [e.seq, e.type])).toEqual([
+			[1, RunEventType.ToolUse],
+			[2, RunEventType.ToolResult],
+			[3, RunEventType.AssistantText],
+		]);
+	});
+
+	// Tool events ride the same `model` append class as assistant text, so the
+	// same fence rejects them once the run leaves `running`…
+	it("rejects a tool-event model append after cancellation is requested", async () => {
+		await claimRun("run-1", "conv-1", "worker-1");
+		await tdb.db
+			.update(runs)
+			.set({ status: "cancel_requested" })
+			.where(eq(runs.runId, "run-1"));
+
+		await expect(
+			appendRunEventTx(tdb.db, {
+				runId: "run-1",
+				workerId: "worker-1",
+				type: RunEventType.ToolUse,
+				payload: {
+					tool: "Read",
+					arguments: { path: "notes.md" },
+					truncated: false,
+				},
+				appendClass: "model",
+			}),
+		).rejects.toBeInstanceOf(RunFenceError);
+	});
+
+	// …or the worker no longer owns it.
+	it("rejects a tool-event append from a worker that lost ownership", async () => {
+		await claimRun("run-1", "conv-1", "worker-1");
+		await expireOwnership("run-1");
+
+		await expect(
+			appendRunEventTx(tdb.db, {
+				runId: "run-1",
+				workerId: "worker-1",
+				type: RunEventType.ToolResult,
+				payload: {
+					tool: "Read",
+					result: { preview: "…" },
+					isError: false,
+					truncated: true,
+				},
+				appendClass: "model",
+			}),
+		).rejects.toBeInstanceOf(RunFenceError);
+	});
+
 	it("allows cancellation audit appends while running or cancel_requested", async () => {
 		await claimRun("run-1", "conv-1", "worker-1");
 


### PR DESCRIPTION
Closes #266 (parent spec: #265, ADR-0009).

Prefactor with no client-visible change: recording a Tool invocation or Tool result becomes a one-liner for the worker's stream consumer, so the tracer ticket only has to produce payloads.

## What changed

- **Shared vocabulary** (`packages/agent-db/src/run-events.ts`): write-side `tool_use` and `tool_result` event types beside `assistant_text`, with typed payload shapes matching the ADR-0009 frame contract (`PublicToolName`, arguments/result record, `truncated`, `isError` on results) and runtime guards beside the existing assistant-text guard. Guards fail closed on non-public tool names.
- **Run loop** (`apps/agent-worker/src/run-loop.ts`): `RunProcessContext` replaces the assistant-text-only `appendAssistantMessage` callback with one discriminated `appendModelContent` covering the three kinds (assistant message, tool invocation, tool result). The loop owns the kind→event-type mapping in one place; all kinds append under the existing fenced `model` append class — legal only while the Run is `running`.
- **Stream consumer** (`apps/agent-worker/src/sdk/agent-stream.ts`, `run-processor.ts`): rides the new seam; the assistant commit is now `appendModelContent({ kind: "assistant_message", payload })`.

No database migration (the event type column is unconstrained text over jsonb) and chat-api is untouched — its projector maps no new types, so nothing changes client-side until the projection ticket.

## Acceptance criteria

- [x] Vocabulary defines both event types with payload shapes and runtime guards, covered by guard tests (valid, missing-field, wrong-type)
- [x] One discriminated model-content append; kind→type mapping lives in the loop; processors no longer receive an assistant-text-only callback
- [x] Assistant text rides the new seam unchanged: projector still receives `assistant_text` → `text_commit`; all existing run-loop, stream-consumption, and projector tests green
- [x] Fenced-append tests over the PGlite harness show tool-event appends rejected exactly like assistant text (run left `running`; ownership lost)
- [x] No client-visible behavior change, no migration

## Testing

- TDD at the agreed seams: guard tests and the run-loop kind-mapping test written red first
- New PGlite fence pins in `run-store.test.ts` (rejection after `cancel_requested`, after lock expiry, plus interleaved seq allocation)
- Full workspace suite green (agent-db 49, agent-worker 53, chat-api 139, worker-scaler 17); `tsc --noEmit` clean in all three workspaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)