### PR TITLE
Handle Bash kill failures without leaking unhandled rejections

### DIFF
--- a/apps/agent-worker/src/bash-tool/bash-tool.test.ts
+++ b/apps/agent-worker/src/bash-tool/bash-tool.test.ts
@@ -32,6 +32,8 @@ interface SessionScript {
 	result?: RawCommandOutcome;
 	/** Reject `outcome` with this error instead of resolving. */
 	outcomeError?: Error;
+	/** Reject `kill()` after applying its scripted process outcome. */
+	killError?: Error;
 	survivors?: number;
 	reapError?: Error;
 }
@@ -60,6 +62,7 @@ class FakeSession implements SandboxCommandSession {
 		if (this.script.resolve === "on-kill") {
 			this.settle(this.script.result ?? OK_OUTCOME);
 		}
+		if (this.script.killError) throw this.script.killError;
 	}
 
 	async reap(): Promise<{ survivors: number }> {
@@ -264,6 +267,31 @@ describe("runBashTool", () => {
 
 		expect(client.sessions[0]?.killed).toBe(1);
 		expect(parseResult(result).outcome).toBe("canceled");
+	});
+
+	it("contains a rejected cancel request when reap proves cleanup", async () => {
+		const controller = new AbortController();
+		const client = new FakeCommandClient({
+			resolve: "on-kill",
+			result: { ...OK_OUTCOME, exitCode: null },
+			killError: new Error(
+				"13: [internal] protocol error: received unsupported compressed output",
+			),
+		});
+		const { context, taints } = makeContext({
+			client,
+			signal: controller.signal,
+		});
+
+		const running = runBashTool({ command: "sleep 300" }, context);
+		await Promise.resolve();
+		controller.abort();
+		const result = await running;
+
+		expect(client.sessions[0]?.killed).toBe(1);
+		expect(client.sessions[0]?.reaped).toBe(1);
+		expect(parseResult(result).outcome).toBe("canceled");
+		expect(taints).toEqual([]);
 	});
 
 	it("taints the sandbox and refuses a clean result when survivors remain", async () => {

--- a/apps/agent-worker/src/bash-tool/bash-tool.ts
+++ b/apps/agent-worker/src/bash-tool/bash-tool.ts
@@ -225,19 +225,30 @@ export async function runBashTool(
 
 	let canceled = false;
 	let timedOut = false;
+	let killError: unknown;
+	let killCompletion: Promise<void> | undefined;
+	const requestKill = (): void => {
+		if (killCompletion) return;
+		// Abort/timer callbacks cannot await. Attach the rejection handler now so
+		// an E2B transport error cannot escape as an unhandled promise; the
+		// mandatory reap below remains the proof that cleanup succeeded.
+		killCompletion = session.kill().catch((error) => {
+			killError = error;
+		});
+	};
 	const onAbort = (): void => {
 		canceled = true;
-		void session.kill();
+		requestKill();
 	};
 	if (context.signal.aborted) {
 		canceled = true;
-		void session.kill();
+		requestKill();
 	} else {
 		context.signal.addEventListener("abort", onAbort, { once: true });
 	}
 	const timer = setTimeout(() => {
 		timedOut = true;
-		void session.kill();
+		requestKill();
 	}, timeoutMs);
 
 	let raw: RawCommandOutcome | undefined;
@@ -250,6 +261,7 @@ export async function runBashTool(
 		clearTimeout(timer);
 		context.signal.removeEventListener("abort", onAbort);
 	}
+	await killCompletion;
 
 	// Cleanup is mandatory and runs on every path, including a client failure: a
 	// half-started process group must never outlive the tool call.
@@ -264,6 +276,9 @@ export async function runBashTool(
 	} catch (error) {
 		cleanupOk = false;
 		cleanupError = boundedErrorMessage(error);
+	}
+	if (!cleanupOk && killError !== undefined) {
+		cleanupError = `kill failed: ${boundedErrorMessage(killError)}; ${cleanupError}`;
 	}
 
 	const outcome: CommandOutcome = canceled


### PR DESCRIPTION
## Summary
- Route Bash cancel and timeout paths through a single kill request helper that captures transport errors.
- Wait for the kill promise before post-run cleanup so cleanup remains the proof of process termination.
- Surface kill failures in the cleanup error while still treating reap-based cleanup as the deciding signal.
- Add coverage for a cancel path where `kill()` rejects but `reap()` confirms cleanup.

## Testing
- Added a unit test covering rejected `kill()` plus successful `reap()` cleanup.
- Not run (not requested)