### PR TITLE
Harden public tool event vocabulary

### DIFF
--- a/apps/agent-worker/src/sdk/tool-event-projection.test.ts
+++ b/apps/agent-worker/src/sdk/tool-event-projection.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import {
 	isToolResultPayload,
 	isToolUsePayload,
+	type PublicToolName,
 } from "@mymemo/agent-db/run-events";
 import {
 	allowlistedExecutorToolNames,
@@ -55,6 +56,8 @@ describe("publicToolName", () => {
 		// Another server's prefixed tool must never become client-visible.
 		expect(publicToolName("mcp__other-server__Bash")).toBeNull();
 		expect(publicToolName("WebSearch")).toBeNull();
+		// Inherited object properties are not allowlisted tool names.
+		expect(publicToolName("constructor")).toBeNull();
 		expect(publicToolName("")).toBeNull();
 		expect(publicToolName(undefined)).toBeNull();
 		expect(publicToolName(42)).toBeNull();
@@ -76,6 +79,68 @@ describe("publicToolName", () => {
 	});
 });
 
+describe("shared tool payload vocabulary", () => {
+	const toolUseCases = [
+		["Bash", { command: "echo hi" }],
+		["Read", { path: "notes.md" }],
+		["Write", { path: "notes.md", content: "x" }],
+		["Edit", { path: "src/app.ts", oldText: "a", newText: "b" }],
+		["Grep", { pattern: "x" }],
+		["Glob", { pattern: "*" }],
+	] satisfies ReadonlyArray<readonly [PublicToolName, unknown]>;
+
+	for (const [tool, input] of toolUseCases) {
+		it(`${tool} tool-use projection satisfies the shared guard`, () => {
+			const projected = projectToolUse(tool, input);
+			if (!projected.ok) throw new Error("expected a projected payload");
+			expect(isToolUsePayload(projected.payload)).toBe(true);
+		});
+	}
+
+	const toolResultCases = [
+		["Bash", completedBashResult()],
+		["Write", { path: "notes.md", bytesWritten: 42 }],
+		["Edit", { path: "src/app.ts", replacements: 1 }],
+		[
+			"Read",
+			{
+				path: "src/index.ts",
+				content: "line one\nline two",
+				startLine: 1,
+				linesRead: 2,
+				truncated: false,
+			},
+		],
+		[
+			"Grep",
+			{
+				matches: [
+					{
+						path: "src/app.ts",
+						line: 12,
+						column: 3,
+						text: "// TODO: fix",
+					},
+				],
+				truncated: false,
+			},
+		],
+		["Glob", { paths: ["a.ts"], truncated: false }],
+	] satisfies ReadonlyArray<readonly [PublicToolName, Record<string, unknown>]>;
+
+	for (const [tool, result] of toolResultCases) {
+		it(`${tool} tool-result projection satisfies the shared guard`, () => {
+			const projected = projectToolResult(
+				tool,
+				executorResultContent(result),
+				false,
+			);
+			if (!projected.ok) throw new Error("expected a projected payload");
+			expect(isToolResultPayload(projected.payload)).toBe(true);
+		});
+	}
+});
+
 describe("projectToolUse — Bash", () => {
 	it("exposes the command preview, cwd, and timeout", () => {
 		const projected = projectToolUse("Bash", {
@@ -92,12 +157,6 @@ describe("projectToolUse — Bash", () => {
 				truncated: false,
 			},
 		});
-	});
-
-	it("produces payloads that satisfy the shared vocabulary guard", () => {
-		const projected = projectToolUse("Bash", { command: "echo hi" });
-		if (!projected.ok) throw new Error("expected a projected payload");
-		expect(isToolUsePayload(projected.payload)).toBe(true);
 	});
 
 	it("omits missing or wrong-typed argument fields instead of forwarding them", () => {
@@ -165,12 +224,6 @@ describe("projectToolUse — Read", () => {
 				truncated: false,
 			},
 		});
-	});
-
-	it("produces payloads that satisfy the shared vocabulary guard", () => {
-		const projected = projectToolUse("Read", { path: "notes.md" });
-		if (!projected.ok) throw new Error("expected a projected payload");
-		expect(isToolUsePayload(projected.payload)).toBe(true);
 	});
 
 	it("omits missing or wrong-typed argument fields instead of forwarding them", () => {
@@ -295,16 +348,6 @@ describe("projectToolResult — Bash", () => {
 				truncated: false,
 			},
 		});
-	});
-
-	it("produces payloads that satisfy the shared vocabulary guard", () => {
-		const projected = projectToolResult(
-			"Bash",
-			executorResultContent(completedBashResult()),
-			false,
-		);
-		if (!projected.ok) throw new Error("expected a projected payload");
-		expect(isToolResultPayload(projected.payload)).toBe(true);
 	});
 
 	it("projects a nonzero exit as a returned result, not a tool error", () => {
@@ -639,15 +682,6 @@ describe("projectToolUse — Write", () => {
 		});
 	});
 
-	it("produces payloads that satisfy the shared vocabulary guard", () => {
-		const projected = projectToolUse("Write", {
-			path: "notes.md",
-			content: "x",
-		});
-		if (!projected.ok) throw new Error("expected a projected payload");
-		expect(isToolUsePayload(projected.payload)).toBe(true);
-	});
-
 	it("omits missing or wrong-typed argument fields instead of forwarding them", () => {
 		const projected = projectToolUse("Write", {
 			path: 42,
@@ -694,16 +728,6 @@ describe("projectToolResult — Write", () => {
 		});
 	});
 
-	it("produces payloads that satisfy the shared vocabulary guard", () => {
-		const projected = projectToolResult(
-			"Write",
-			executorResultContent({ path: "notes.md", bytesWritten: 42 }),
-			false,
-		);
-		if (!projected.ok) throw new Error("expected a projected payload");
-		expect(isToolResultPayload(projected.payload)).toBe(true);
-	});
-
 	it("omits results whose text is not the known executor shape", () => {
 		expect(
 			projectToolResult("Write", [{ type: "text", text: "ok" }], false).ok,
@@ -747,16 +771,6 @@ describe("projectToolUse — Edit", () => {
 				truncated: false,
 			},
 		});
-	});
-
-	it("produces payloads that satisfy the shared vocabulary guard", () => {
-		const projected = projectToolUse("Edit", {
-			path: "src/app.ts",
-			oldText: "a",
-			newText: "b",
-		});
-		if (!projected.ok) throw new Error("expected a projected payload");
-		expect(isToolUsePayload(projected.payload)).toBe(true);
 	});
 
 	it("omits missing or wrong-typed argument fields instead of forwarding them", () => {
@@ -806,16 +820,6 @@ describe("projectToolResult — Edit", () => {
 				truncated: false,
 			},
 		});
-	});
-
-	it("produces payloads that satisfy the shared vocabulary guard", () => {
-		const projected = projectToolResult(
-			"Edit",
-			executorResultContent({ path: "src/app.ts", replacements: 1 }),
-			false,
-		);
-		if (!projected.ok) throw new Error("expected a projected payload");
-		expect(isToolResultPayload(projected.payload)).toBe(true);
 	});
 
 	it("omits results whose text is not the known executor shape", () => {
@@ -873,16 +877,6 @@ describe("projectToolResult — Read", () => {
 				truncated: false,
 			},
 		});
-	});
-
-	it("produces payloads that satisfy the shared vocabulary guard", () => {
-		const projected = projectToolResult(
-			"Read",
-			executorResultContent(completedReadResult()),
-			false,
-		);
-		if (!projected.ok) throw new Error("expected a projected payload");
-		expect(isToolResultPayload(projected.payload)).toBe(true);
 	});
 
 	it("caps a huge content preview and marks the preview incomplete", () => {
@@ -987,12 +981,6 @@ describe("projectToolUse — Grep", () => {
 		});
 	});
 
-	it("produces payloads that satisfy the shared vocabulary guard", () => {
-		const projected = projectToolUse("Grep", { pattern: "x" });
-		if (!projected.ok) throw new Error("expected a projected payload");
-		expect(isToolUsePayload(projected.payload)).toBe(true);
-	});
-
 	it("omits missing or wrong-typed argument fields instead of forwarding them", () => {
 		const projected = projectToolUse("Grep", {
 			pattern: /TODO/,
@@ -1054,16 +1042,6 @@ describe("projectToolResult — Grep", () => {
 				truncated: false,
 			},
 		});
-	});
-
-	it("produces payloads that satisfy the shared vocabulary guard", () => {
-		const projected = projectToolResult(
-			"Grep",
-			executorResultContent({ matches: [grepMatch()], truncated: false }),
-			false,
-		);
-		if (!projected.ok) throw new Error("expected a projected payload");
-		expect(isToolResultPayload(projected.payload)).toBe(true);
 	});
 
 	it("bounds a long match list and marks the list incomplete", () => {
@@ -1182,12 +1160,6 @@ describe("projectToolUse — Glob", () => {
 		});
 	});
 
-	it("produces payloads that satisfy the shared vocabulary guard", () => {
-		const projected = projectToolUse("Glob", { pattern: "*" });
-		if (!projected.ok) throw new Error("expected a projected payload");
-		expect(isToolUsePayload(projected.payload)).toBe(true);
-	});
-
 	it("omits missing or wrong-typed argument fields instead of forwarding them", () => {
 		const projected = projectToolUse("Glob", {
 			pattern: 7,
@@ -1232,16 +1204,6 @@ describe("projectToolResult — Glob", () => {
 				truncated: false,
 			},
 		});
-	});
-
-	it("produces payloads that satisfy the shared vocabulary guard", () => {
-		const projected = projectToolResult(
-			"Glob",
-			executorResultContent({ paths: ["a.ts"], truncated: false }),
-			false,
-		);
-		if (!projected.ok) throw new Error("expected a projected payload");
-		expect(isToolResultPayload(projected.payload)).toBe(true);
 	});
 
 	it("bounds a long path list and marks the list incomplete", () => {

--- a/apps/agent-worker/src/sdk/tool-event-projection.ts
+++ b/apps/agent-worker/src/sdk/tool-event-projection.ts
@@ -58,29 +58,28 @@ const TOOL_FAILED_RESULT = { message: "Tool failed" } as const;
  * events are omitted. A drift pin ties this map's domain to the executor tools
  * the worker actually builds.
  */
-const PUBLIC_TOOL_NAMES_BY_EXECUTOR_NAME: Readonly<
-	Record<string, PublicToolName>
-> = {
-	[`mcp__${EXECUTOR_SERVER_NAME}__Read`]: "Read",
-	[`mcp__${EXECUTOR_SERVER_NAME}__Write`]: "Write",
-	[`mcp__${EXECUTOR_SERVER_NAME}__Edit`]: "Edit",
-	[`mcp__${EXECUTOR_SERVER_NAME}__Grep`]: "Grep",
-	[`mcp__${EXECUTOR_SERVER_NAME}__Glob`]: "Glob",
-	[`mcp__${EXECUTOR_SERVER_NAME}__Bash`]: "Bash",
-	[`mcp__${EXECUTOR_SERVER_NAME}__SearchDocuments`]: "SearchDocuments",
-	[`mcp__${EXECUTOR_SERVER_NAME}__LoadDocuments`]: "LoadDocuments",
-};
+const PUBLIC_TOOL_NAMES_BY_EXECUTOR_NAME: ReadonlyMap<string, PublicToolName> =
+	new Map<string, PublicToolName>([
+		[`mcp__${EXECUTOR_SERVER_NAME}__Read`, "Read"],
+		[`mcp__${EXECUTOR_SERVER_NAME}__Write`, "Write"],
+		[`mcp__${EXECUTOR_SERVER_NAME}__Edit`, "Edit"],
+		[`mcp__${EXECUTOR_SERVER_NAME}__Grep`, "Grep"],
+		[`mcp__${EXECUTOR_SERVER_NAME}__Glob`, "Glob"],
+		[`mcp__${EXECUTOR_SERVER_NAME}__Bash`, "Bash"],
+		[`mcp__${EXECUTOR_SERVER_NAME}__SearchDocuments`, "SearchDocuments"],
+		[`mcp__${EXECUTOR_SERVER_NAME}__LoadDocuments`, "LoadDocuments"],
+	]);
 
 /** The allowlist's domain, for the drift pin against the built executor tools. */
 export function allowlistedExecutorToolNames(): string[] {
-	return Object.keys(PUBLIC_TOOL_NAMES_BY_EXECUTOR_NAME);
+	return [...PUBLIC_TOOL_NAMES_BY_EXECUTOR_NAME.keys()];
 }
 
 /** Map an SDK tool-use block's name to its public name, or `null` when the
  * name is not an allowlisted executor tool (log and omit upstream). */
 export function publicToolName(toolName: unknown): PublicToolName | null {
 	if (typeof toolName !== "string") return null;
-	return PUBLIC_TOOL_NAMES_BY_EXECUTOR_NAME[toolName] ?? null;
+	return PUBLIC_TOOL_NAMES_BY_EXECUTOR_NAME.get(toolName) ?? null;
 }
 
 /** One projected tool event, or the log-worthy reason it must be omitted. */

--- a/apps/chat-api/src/features/streaming/events.ts
+++ b/apps/chat-api/src/features/streaming/events.ts
@@ -1,3 +1,5 @@
+import type { PublicToolName } from "@mymemo/agent-db/run-events";
+
 export interface MymemoEvent {
 	id?: string;
 	message: EventMessage;
@@ -47,7 +49,7 @@ export interface TextDeltaEvent {
  * no correlation id; the matching result is a separate chronological item. */
 export interface ToolUseEvent {
 	type: "tool_use";
-	tool: string;
+	tool: PublicToolName;
 	arguments: Record<string, unknown>;
 	truncated: boolean;
 }
@@ -56,7 +58,7 @@ export interface ToolUseEvent {
  * message; a run may terminate after an invocation with no result. */
 export interface ToolResultEvent {
 	type: "tool_result";
-	tool: string;
+	tool: PublicToolName;
 	result: Record<string, unknown>;
 	isError: boolean;
 	truncated: boolean;


### PR DESCRIPTION
## Summary

- replace the object-backed executor tool allowlist with a `ReadonlyMap` so inherited property names fail closed
- type chat-api tool event names with the shared `PublicToolName`
- consolidate twelve repeated projection guard checks into table-driven tests

## Why

The allowlist indexed a normal object without checking ownership, so names such as `constructor` resolved through `Object.prototype` instead of returning `null`. The chat streaming boundary also widened valid tool names back to arbitrary strings.

## Impact

Unknown or inherited tool names are now omitted as required by ADR-0009, and invalid public tool names are rejected at compile time at the SSE sender boundary. Runtime behavior for the eight supported tools is unchanged.

## Validation

- `bun run test` — 665 tests passed
- `bunx tsc --noEmit -p tsconfig.json` in `apps/agent-worker`
- `bunx tsc --noEmit -p tsconfig.json` in `apps/chat-api`
- Biome check on all three changed files
