### PR TITLE
Harden SDK shutdown and reject malformed tool invocations

### DIFF
--- a/apps/agent-worker/src/sdk/agent-stream.test.ts
+++ b/apps/agent-worker/src/sdk/agent-stream.test.ts
@@ -1026,6 +1026,85 @@ describe("consumeAgentStream", () => {
 		expect(appended.map((content) => content.kind)).toEqual(["tool_use"]);
 	});
 
+	it("stops appending tool events when shutdown aborts a stalled append", async () => {
+		const appended: ModelContent[] = [];
+		const controller = new AbortController();
+		let markAppendStarted!: () => void;
+		const appendStarted = new Promise<void>((resolve) => {
+			markAppendStarted = resolve;
+		});
+		let releaseAppend!: () => void;
+		const appendGate = new Promise<void>((resolve) => {
+			releaseAppend = resolve;
+		});
+		const messages = toolEnvelope({
+			toolUses: [
+				{
+					toolUseId: "toolu-1",
+					name: "mcp__mymemo-executor__Bash",
+					input: { command: "first" },
+				},
+				{
+					toolUseId: "toolu-2",
+					name: "mcp__mymemo-executor__Bash",
+					input: { command: "second" },
+				},
+			],
+		});
+		const query = fakeQuery(messages.map((message) => ({ message })));
+
+		const consuming = consumeAgentStream({
+			query,
+			signal: controller.signal,
+			appendModelContent: async (content) => {
+				appended.push(content);
+				if (appended.length === 1) {
+					markAppendStarted();
+					await appendGate;
+				}
+			},
+		});
+
+		await appendStarted;
+		controller.abort();
+		releaseAppend();
+
+		await expect(consuming).rejects.toBeInstanceOf(QueryInterruptedError);
+		expect(query.interrupts).toBe(1);
+		expect(appended.map((content) => content.kind)).toEqual(["tool_use"]);
+	});
+
+	it("logs and omits a tool invocation with malformed required arguments", async () => {
+		const appended: ModelContent[] = [];
+		const { logger, warnings } = spyLogger();
+		const messages = toolEnvelope({
+			toolUses: [
+				{
+					toolUseId: "toolu-1",
+					name: "mcp__mymemo-executor__Bash",
+					input: { command: 42 },
+				},
+			],
+		});
+
+		await consumeAgentStream({
+			runId: "run-1",
+			query: fakeQuery(messages.map((message) => ({ message }))),
+			signal: new AbortController().signal,
+			appendModelContent: captureModelContent(appended),
+			logger,
+		});
+
+		expect(appended).toEqual([]);
+		expect(warnings).toEqual([
+			expect.objectContaining({
+				message: "tool invocation omitted",
+				runId: "run-1",
+				tool: "Bash",
+			}),
+		]);
+	});
+
 	it("leaves the history resultless when the stream ends without a result", async () => {
 		const appended: ModelContent[] = [];
 		const messages = [

--- a/apps/agent-worker/src/sdk/agent-stream.ts
+++ b/apps/agent-worker/src/sdk/agent-stream.ts
@@ -168,10 +168,18 @@ export async function consumeAgentStream(
 	// established only when the invocation's event is appended — so a result for
 	// an omitted or unknown invocation is itself omitted (ADR-0009).
 	const toolNamesByUseId = new Map<string, PublicToolName>();
+	const appendWhileRunning = async (content: ModelContent): Promise<void> => {
+		if (signal.aborted) throw new QueryInterruptedError();
+		await appendModelContent(content);
+		// The append itself is not abortable. Recheck after it settles so shutdown
+		// cannot let the rest of the envelope append while the DB Run is still
+		// fenced as running.
+		if (signal.aborted) throw new QueryInterruptedError();
+	};
 
 	const commitEnvelope = async (commit: EnvelopeCommit): Promise<void> => {
 		if (commit.text !== null) {
-			await appendModelContent({
+			await appendWhileRunning({
 				kind: "assistant_message",
 				payload: commit.text,
 			});
@@ -196,7 +204,7 @@ export async function consumeAgentStream(
 				});
 				continue;
 			}
-			await appendModelContent({
+			await appendWhileRunning({
 				kind: "tool_use",
 				payload: projected.payload,
 			});
@@ -233,7 +241,7 @@ export async function consumeAgentStream(
 				});
 				continue;
 			}
-			await appendModelContent({
+			await appendWhileRunning({
 				kind: "tool_result",
 				payload: projected.payload,
 			});

--- a/apps/agent-worker/src/sdk/tool-event-projection.test.ts
+++ b/apps/agent-worker/src/sdk/tool-event-projection.test.ts
@@ -159,22 +159,14 @@ describe("projectToolUse — Bash", () => {
 		});
 	});
 
-	it("omits missing or wrong-typed argument fields instead of forwarding them", () => {
-		const projected = projectToolUse("Bash", {
-			command: 42,
-			cwd: ["src"],
-			timeoutMs: "soon",
-			env: { SECRET: "leak" },
-		});
-		if (!projected.ok) throw new Error("expected a projected payload");
-		expect(projected.payload.arguments).toEqual({});
+	it("omits invocations with missing or wrong-typed required arguments", () => {
+		for (const input of [{}, { command: 42 }]) {
+			expect(projectToolUse("Bash", input).ok).toBe(false);
+		}
 	});
 
-	it("projects a non-record input as empty arguments", () => {
-		const projected = projectToolUse("Bash", "rm -rf /");
-		if (!projected.ok) throw new Error("expected a projected payload");
-		expect(projected.payload.arguments).toEqual({});
-		expect(projected.payload.truncated).toBe(false);
+	it("omits a non-record input", () => {
+		expect(projectToolUse("Bash", "rm -rf /").ok).toBe(false);
 	});
 
 	it("caps a huge command to a bounded preview and flags truncation", () => {
@@ -226,15 +218,10 @@ describe("projectToolUse — Read", () => {
 		});
 	});
 
-	it("omits missing or wrong-typed argument fields instead of forwarding them", () => {
-		const projected = projectToolUse("Read", {
-			path: 42,
-			offset: "ten",
-			limit: Number.POSITIVE_INFINITY,
-			follow: true,
-		});
-		if (!projected.ok) throw new Error("expected a projected payload");
-		expect(projected.payload.arguments).toEqual({});
+	it("omits invocations with missing or wrong-typed required arguments", () => {
+		for (const input of [{}, { path: 42 }]) {
+			expect(projectToolUse("Read", input).ok).toBe(false);
+		}
 	});
 
 	it("caps a huge path to a bounded preview and flags truncation", () => {
@@ -682,13 +669,14 @@ describe("projectToolUse — Write", () => {
 		});
 	});
 
-	it("omits missing or wrong-typed argument fields instead of forwarding them", () => {
-		const projected = projectToolUse("Write", {
-			path: 42,
-			content: ["not", "text"],
-		});
-		if (!projected.ok) throw new Error("expected a projected payload");
-		expect(projected.payload.arguments).toEqual({});
+	it("omits invocations with missing or wrong-typed required arguments", () => {
+		for (const input of [
+			{},
+			{ path: 42, content: "text" },
+			{ path: "notes.md", content: ["not", "text"] },
+		]) {
+			expect(projectToolUse("Write", input).ok).toBe(false);
+		}
 	});
 
 	it("caps a huge content preview but reports the full byte count", () => {
@@ -773,14 +761,15 @@ describe("projectToolUse — Edit", () => {
 		});
 	});
 
-	it("omits missing or wrong-typed argument fields instead of forwarding them", () => {
-		const projected = projectToolUse("Edit", {
-			path: null,
-			oldText: 1,
-			newText: ["b"],
-		});
-		if (!projected.ok) throw new Error("expected a projected payload");
-		expect(projected.payload.arguments).toEqual({});
+	it("omits invocations with missing or wrong-typed required arguments", () => {
+		for (const input of [
+			{},
+			{ path: null, oldText: "a", newText: "b" },
+			{ path: "app.ts", oldText: 1, newText: "b" },
+			{ path: "app.ts", oldText: "a", newText: ["b"] },
+		]) {
+			expect(projectToolUse("Edit", input).ok).toBe(false);
+		}
 	});
 
 	it("caps huge text previews but reports the full byte counts", () => {
@@ -981,16 +970,10 @@ describe("projectToolUse — Grep", () => {
 		});
 	});
 
-	it("omits missing or wrong-typed argument fields instead of forwarding them", () => {
-		const projected = projectToolUse("Grep", {
-			pattern: /TODO/,
-			path: 1,
-			include: null,
-			caseSensitive: "yes",
-			maxResults: "many",
-		});
-		if (!projected.ok) throw new Error("expected a projected payload");
-		expect(projected.payload.arguments).toEqual({});
+	it("omits invocations with missing or wrong-typed required arguments", () => {
+		for (const input of [{}, { pattern: /TODO/ }]) {
+			expect(projectToolUse("Grep", input).ok).toBe(false);
+		}
 	});
 
 	it("caps a huge pattern to a bounded preview and flags truncation", () => {
@@ -1160,15 +1143,10 @@ describe("projectToolUse — Glob", () => {
 		});
 	});
 
-	it("omits missing or wrong-typed argument fields instead of forwarding them", () => {
-		const projected = projectToolUse("Glob", {
-			pattern: 7,
-			path: false,
-			includeHidden: "yes",
-			maxResults: Number.NaN,
-		});
-		if (!projected.ok) throw new Error("expected a projected payload");
-		expect(projected.payload.arguments).toEqual({});
+	it("omits invocations with missing or wrong-typed required arguments", () => {
+		for (const input of [{}, { pattern: 7 }]) {
+			expect(projectToolUse("Glob", input).ok).toBe(false);
+		}
 	});
 
 	it("caps a huge pattern to a bounded preview and flags truncation", () => {

--- a/apps/agent-worker/src/sdk/tool-event-projection.ts
+++ b/apps/agent-worker/src/sdk/tool-event-projection.ts
@@ -101,9 +101,18 @@ export function projectToolUse(
 	if (tool === "LoadDocuments") {
 		return projectLoadDocumentsUse(input);
 	}
-	const projected = projectToolUseArguments(tool, isRecord(input) ? input : {});
+	if (!isRecord(input)) {
+		return {
+			ok: false,
+			reason: `${tool} arguments did not match the executor shape`,
+		};
+	}
+	const projected = projectToolUseArguments(tool, input);
 	if (projected === null) {
-		return { ok: false, reason: `no argument projection for tool ${tool}` };
+		return {
+			ok: false,
+			reason: `${tool} arguments did not match the executor shape`,
+		};
 	}
 	return fitOrOmit({
 		tool,
@@ -155,8 +164,8 @@ interface ProjectedArguments {
 	clipped: boolean;
 }
 
-/** Dispatch to the per-tool argument projection; `null` for tools without one
- * yet, whose invocations are logged and omitted upstream. */
+/** Dispatch to the per-tool argument projection; `null` when required
+ * arguments do not match the executor schema. */
 function projectToolUseArguments(
 	tool: PublicToolName,
 	fields: Record<string, unknown>,
@@ -181,7 +190,8 @@ function projectToolUseArguments(
 
 function bashToolUseArguments(
 	fields: Record<string, unknown>,
-): ProjectedArguments {
+): ProjectedArguments | null {
+	if (typeof fields.command !== "string") return null;
 	const args: Record<string, unknown> = {};
 	let clipped = putClampedString(
 		args,
@@ -198,7 +208,8 @@ function bashToolUseArguments(
 
 function readToolUseArguments(
 	fields: Record<string, unknown>,
-): ProjectedArguments {
+): ProjectedArguments | null {
+	if (typeof fields.path !== "string") return null;
 	const args: Record<string, unknown> = {};
 	const clipped = putClampedString(
 		args,
@@ -213,7 +224,10 @@ function readToolUseArguments(
 
 function writeToolUseArguments(
 	fields: Record<string, unknown>,
-): ProjectedArguments {
+): ProjectedArguments | null {
+	if (typeof fields.path !== "string" || typeof fields.content !== "string") {
+		return null;
+	}
 	const args: Record<string, unknown> = {};
 	let clipped = putClampedString(
 		args,
@@ -227,7 +241,14 @@ function writeToolUseArguments(
 
 function editToolUseArguments(
 	fields: Record<string, unknown>,
-): ProjectedArguments {
+): ProjectedArguments | null {
+	if (
+		typeof fields.path !== "string" ||
+		typeof fields.oldText !== "string" ||
+		typeof fields.newText !== "string"
+	) {
+		return null;
+	}
 	const args: Record<string, unknown> = {};
 	let clipped = putClampedString(
 		args,
@@ -242,7 +263,8 @@ function editToolUseArguments(
 
 function grepToolUseArguments(
 	fields: Record<string, unknown>,
-): ProjectedArguments {
+): ProjectedArguments | null {
+	if (typeof fields.pattern !== "string") return null;
 	const args: Record<string, unknown> = {};
 	let clipped = putClampedString(
 		args,
@@ -267,7 +289,8 @@ function grepToolUseArguments(
 
 function globToolUseArguments(
 	fields: Record<string, unknown>,
-): ProjectedArguments {
+): ProjectedArguments | null {
+	if (typeof fields.pattern !== "string") return null;
 	const args: Record<string, unknown> = {};
 	let clipped = putClampedString(
 		args,


### PR DESCRIPTION
## Summary
- Stop streaming additional SDK content after shutdown aborts an in-flight append, so a stalled append cannot let later tool events leak through.
- Treat malformed required tool arguments as omissions instead of projecting empty or partial executor calls.
- Update tests to cover shutdown interruption and invalid tool payloads across Bash, Read, Write, Edit, Grep, and Glob.

## Testing
- Added unit coverage for shutdown during a stalled append in `consumeAgentStream`.
- Added projection tests that verify required-argument validation now omits malformed tool invocations.
- Existing stream/projection test suite updated to reflect the stricter behavior.