### PR TITLE
Add EC2 Instance Connect access for agent and KB databases

### DIFF
--- a/infra/bootstrap-iam/main.tf
+++ b/infra/bootstrap-iam/main.tf
@@ -83,13 +83,21 @@ data "aws_iam_policy_document" "github_actions_deploy" {
       "cloudwatch:*",
       "ec2:AuthorizeSecurityGroupEgress",
       "ec2:AuthorizeSecurityGroupIngress",
+      "ec2:CreateInstanceConnectEndpoint",
       "ec2:CreateSecurityGroup",
       "ec2:CreateTags",
+      "ec2:DeleteInstanceConnectEndpoint",
       "ec2:DeleteSecurityGroup",
       "ec2:DeleteTags",
       "ec2:Describe*",
+      "ec2:ModifyInstanceAttribute",
+      "ec2:ModifyInstanceConnectEndpoint",
       "ec2:RevokeSecurityGroupEgress",
       "ec2:RevokeSecurityGroupIngress",
+      "ec2:RunInstances",
+      "ec2:StartInstances",
+      "ec2:StopInstances",
+      "ec2:TerminateInstances",
       "ecs:*",
       "elasticache:*",
       "elasticloadbalancing:*",
@@ -106,6 +114,18 @@ data "aws_iam_policy_document" "github_actions_deploy" {
       "secretsmanager:UpdateSecret",
     ]
     resources = ["*"]
+  }
+
+  statement {
+    sid       = "AgentEc2InstanceConnectServiceLinkedRole"
+    actions   = ["iam:CreateServiceLinkedRole"]
+    resources = ["arn:aws:iam::*:role/aws-service-role/ec2-instance-connect.amazonaws.com/AWSServiceRoleForEC2InstanceConnect"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "iam:AWSServiceName"
+      values   = ["ec2-instance-connect.amazonaws.com"]
+    }
   }
 
   statement {

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -27,6 +27,8 @@ the direct remote-state output is absent and the fallback input is present.
 - ECR repositories for `mymemo-agent-chat-api` and `mymemo-agent-worker` in the
   separate `infra/ecr` Terraform root
 - dedicated RDS Postgres instance for writable agent state
+- EC2 Instance Connect Endpoint and private EC2 bridge for operator access to
+  the agent and KB databases
 - single-node ElastiCache Redis replication group for disposable live previews
 - ECS Fargate task definitions and services for chat-api and agent-worker
 - agent DB migration task definition
@@ -177,6 +179,101 @@ different settings:
 The internal ALB accepts traffic only from the configured
 `mymemo_service_api_security_group_ids`. It is not exposed to the public
 internet, and no Cloudflare DNS record is needed for `chat-api`.
+
+## Operator Database Access
+
+The EC2 Instance Connect Endpoint provides IAM-authorized SSH access to a
+private Amazon Linux bridge with no public IP. The endpoint security group can
+reach only port 22 on that bridge, and the bridge can reach only port 5432 on
+the agent and KB database security groups. PostgreSQL is accessed through SSH
+local forwarding; EICE does not tunnel directly to database ports. Client IP
+preservation is disabled, while CloudTrail still records the caller and SSH
+tunnel request.
+
+The commands below require AWS CLI v2, `jq`, and `psql`. Run them from the
+repository root with the `mymemo` profile. Keep each SSH process running while
+using `psql` from a second terminal.
+
+```sh
+export AWS_PROFILE=mymemo
+export AWS_REGION=us-west-2
+EICE_ID="$(terraform -chdir=infra/terraform output -raw database_access_endpoint_id)"
+BRIDGE_INSTANCE_ID="$(terraform -chdir=infra/terraform output -raw database_access_bridge_instance_id)"
+```
+
+To connect to the agent database, start the tunnel on local port 15432:
+
+```sh
+AGENT_DB_HOST="$(terraform -chdir=infra/terraform output -raw agent_database_endpoint)"
+
+aws ec2-instance-connect ssh \
+  --instance-id "$BRIDGE_INSTANCE_ID" \
+  --os-user ec2-user \
+  --connection-type eice \
+  --eice-options "endpointId=$EICE_ID,maxTunnelDuration=3600" \
+  --local-forwarding "15432:$AGENT_DB_HOST:5432"
+```
+
+Then connect from a second terminal. The RDS-managed password is passed to
+`psql` only for the lifetime of the command:
+
+```sh
+export AWS_PROFILE=mymemo
+export AWS_REGION=us-west-2
+AGENT_DB_SECRET_ARN="$(terraform -chdir=infra/terraform output -raw agent_database_password_secret_arn)"
+AGENT_DB_SECRET="$(aws secretsmanager get-secret-value \
+  --secret-id "$AGENT_DB_SECRET_ARN" \
+  --query SecretString \
+  --output text)"
+
+PGPASSWORD="$(printf '%s' "$AGENT_DB_SECRET" | jq -r .password)" \
+  psql "host=127.0.0.1 port=15432 dbname=mymemo_agent user=mymemo_agent sslmode=require"
+
+unset AGENT_DB_SECRET AGENT_DB_SECRET_ARN
+```
+
+To connect to the KB database, start a separate tunnel on local port 25432:
+
+```sh
+export AWS_PROFILE=mymemo
+export AWS_REGION=us-west-2
+EICE_ID="$(terraform -chdir=infra/terraform output -raw database_access_endpoint_id)"
+BRIDGE_INSTANCE_ID="$(terraform -chdir=infra/terraform output -raw database_access_bridge_instance_id)"
+KB_DB_HOST="$(aws rds describe-db-instances \
+  --db-instance-identifier mymemo-staging-pg \
+  --query 'DBInstances[0].Endpoint.Address' \
+  --output text)"
+
+aws ec2-instance-connect ssh \
+  --instance-id "$BRIDGE_INSTANCE_ID" \
+  --os-user ec2-user \
+  --connection-type eice \
+  --eice-options "endpointId=$EICE_ID,maxTunnelDuration=3600" \
+  --local-forwarding "25432:$KB_DB_HOST:5432"
+```
+
+Then read the existing KB connection URL and rebuild only its authority host
+and port for the local tunnel. This preserves the encoded credentials, database
+name, and query parameters without depending on whether the original URL
+explicitly includes port 5432:
+
+```sh
+export AWS_PROFILE=mymemo
+export AWS_REGION=us-west-2
+KB_DATABASE_URL="$(aws secretsmanager get-secret-value \
+  --secret-id mymemo-agent-prod-KB_DATABASE_URL \
+  --query SecretString \
+  --output text)"
+KB_DATABASE_URL_PREFIX="${KB_DATABASE_URL%%@*}@"
+KB_DATABASE_URL_AFTER_AUTHORITY="${KB_DATABASE_URL#*@}"
+KB_DATABASE_URL_PATH="/${KB_DATABASE_URL_AFTER_AUTHORITY#*/}"
+KB_TUNNEL_DATABASE_URL="${KB_DATABASE_URL_PREFIX}127.0.0.1:25432${KB_DATABASE_URL_PATH}"
+
+PGSSLMODE=require psql "$KB_TUNNEL_DATABASE_URL"
+
+unset KB_DATABASE_URL KB_DATABASE_URL_PREFIX KB_DATABASE_URL_AFTER_AUTHORITY
+unset KB_DATABASE_URL_PATH KB_TUNNEL_DATABASE_URL
+```
 
 The workflow does not require GitHub repository variables for Terraform inputs.
 The only credential handoff is GitHub OIDC assuming the deploy role:

--- a/infra/terraform/database-access.tf
+++ b/infra/terraform/database-access.tf
@@ -1,0 +1,130 @@
+resource "aws_security_group" "database_access" {
+  name        = "${local.common_name}-db-access"
+  description = "EC2 Instance Connect access to the agent and KB databases"
+  vpc_id      = local.shared_vpc_id
+}
+
+resource "aws_security_group" "database_bridge" {
+  name        = "${local.common_name}-db-bridge"
+  description = "Private SSH bridge from EC2 Instance Connect to the agent and KB databases"
+  vpc_id      = local.shared_vpc_id
+}
+
+resource "aws_security_group_rule" "database_access_to_bridge" {
+  type                     = "egress"
+  description              = "EC2 Instance Connect to the private database bridge"
+  security_group_id        = aws_security_group.database_access.id
+  source_security_group_id = aws_security_group.database_bridge.id
+  from_port                = 22
+  to_port                  = 22
+  protocol                 = "tcp"
+}
+
+resource "aws_security_group_rule" "database_bridge_from_access" {
+  type                     = "ingress"
+  description              = "SSH through EC2 Instance Connect"
+  security_group_id        = aws_security_group.database_bridge.id
+  source_security_group_id = aws_security_group.database_access.id
+  from_port                = 22
+  to_port                  = 22
+  protocol                 = "tcp"
+}
+
+resource "aws_security_group_rule" "database_access_to_agent_db" {
+  type                     = "egress"
+  description              = "Private database bridge to dedicated agent Postgres"
+  security_group_id        = aws_security_group.database_bridge.id
+  source_security_group_id = aws_security_group.agent_db.id
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+}
+
+resource "aws_security_group_rule" "database_access_to_kb_db" {
+  type                     = "egress"
+  description              = "Private database bridge to existing KB Postgres"
+  security_group_id        = aws_security_group.database_bridge.id
+  source_security_group_id = var.kb_database_security_group_id
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+}
+
+resource "aws_security_group_rule" "agent_db_from_database_access" {
+  type                     = "ingress"
+  description              = "Operator access through the private database bridge"
+  security_group_id        = aws_security_group.agent_db.id
+  source_security_group_id = aws_security_group.database_bridge.id
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+}
+
+resource "aws_security_group_rule" "kb_db_from_database_access" {
+  type                     = "ingress"
+  description              = "Operator access through the private database bridge"
+  security_group_id        = var.kb_database_security_group_id
+  source_security_group_id = aws_security_group.database_bridge.id
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+}
+
+resource "aws_ec2_instance_connect_endpoint" "database_access" {
+  subnet_id          = sort(local.shared_ecs_subnet_ids)[0]
+  security_group_ids = [aws_security_group.database_access.id]
+  preserve_client_ip = false
+
+  tags = {
+    Name = "${local.common_name}-db-access"
+  }
+}
+
+data "aws_ami" "database_bridge" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-2023.*-kernel-6.1-arm64"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["arm64"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+resource "aws_instance" "database_bridge" {
+  ami                         = data.aws_ami.database_bridge.id
+  instance_type               = "t4g.nano"
+  subnet_id                   = sort(local.shared_ecs_subnet_ids)[0]
+  vpc_security_group_ids      = [aws_security_group.database_bridge.id]
+  associate_public_ip_address = false
+
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+  }
+
+  root_block_device {
+    delete_on_termination = true
+    encrypted             = true
+    volume_size           = 8
+    volume_type           = "gp3"
+  }
+
+  tags = {
+    Name = "${local.common_name}-db-bridge"
+  }
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -33,6 +33,21 @@ output "agent_database_password_secret_arn" {
   value       = aws_db_instance.agent.master_user_secret[0].secret_arn
 }
 
+output "database_access_endpoint_id" {
+  description = "EC2 Instance Connect Endpoint ID for operator access to the agent and KB databases."
+  value       = aws_ec2_instance_connect_endpoint.database_access.id
+}
+
+output "database_access_endpoint_dns_name" {
+  description = "DNS name of the EC2 Instance Connect Endpoint for operator database access."
+  value       = aws_ec2_instance_connect_endpoint.database_access.dns_name
+}
+
+output "database_access_bridge_instance_id" {
+  description = "Private EC2 instance used for SSH local forwarding to the agent and KB databases."
+  value       = aws_instance.database_bridge.id
+}
+
 output "service_security_group_id" {
   description = "Security group attached to the agent ECS services."
   value       = aws_security_group.services.id


### PR DESCRIPTION
## Summary
- Provision an EC2 Instance Connect Endpoint plus private bridge instance for operator access to the agent and KB Postgres databases.
- Wire security groups so the bridge can only forward to port 5432 on the two database targets.
- Extend bootstrap IAM permissions for the new EC2 Instance Connect and instance lifecycle actions.
- Document the SSH local-forwarding workflow and Terraform outputs needed to reach each database.

## Testing
- Not run (not requested)