### PR TITLE
Split agent service task roles without changing behavior

### DIFF
--- a/infra/terraform/ecs.tf
+++ b/infra/terraform/ecs.tf
@@ -5,7 +5,7 @@ resource "aws_ecs_task_definition" "chat_api" {
   cpu                      = var.chat_api_cpu
   memory                   = var.chat_api_memory
   execution_role_arn       = aws_iam_role.task_execution.arn
-  task_role_arn            = aws_iam_role.task.arn
+  task_role_arn            = aws_iam_role.chat_api_task.arn
 
   container_definitions = jsonencode([
     {
@@ -47,7 +47,7 @@ resource "aws_ecs_task_definition" "agent_worker" {
   cpu                      = var.agent_worker_cpu
   memory                   = var.agent_worker_memory
   execution_role_arn       = aws_iam_role.task_execution.arn
-  task_role_arn            = aws_iam_role.task.arn
+  task_role_arn            = aws_iam_role.agent_worker_task.arn
 
   container_definitions = jsonencode([
     {
@@ -89,7 +89,7 @@ resource "aws_ecs_task_definition" "agent_migration" {
   cpu                      = 512
   memory                   = 1024
   execution_role_arn       = aws_iam_role.task_execution.arn
-  task_role_arn            = aws_iam_role.task.arn
+  task_role_arn            = aws_iam_role.agent_migration_task.arn
 
   container_definitions = jsonencode([
     {

--- a/infra/terraform/iam.tf
+++ b/infra/terraform/iam.tf
@@ -35,7 +35,17 @@ resource "aws_iam_role_policy" "task_execution_read_secrets" {
   policy = data.aws_iam_policy_document.read_secrets.json
 }
 
-resource "aws_iam_role" "task" {
-  name               = "${local.common_name}-task"
+resource "aws_iam_role" "chat_api_task" {
+  name               = "${local.common_name}-chat-api-task"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_assume_role.json
+}
+
+resource "aws_iam_role" "agent_worker_task" {
+  name               = "${local.common_name}-worker-task"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_assume_role.json
+}
+
+resource "aws_iam_role" "agent_migration_task" {
+  name               = "${local.common_name}-migration-task"
   assume_role_policy = data.aws_iam_policy_document.ecs_task_assume_role.json
 }

--- a/scripts/deploy-config.test.ts
+++ b/scripts/deploy-config.test.ts
@@ -52,6 +52,48 @@ describe("agent deployment config", () => {
 		expect(combined).toContain("shared_ecs_subnet_ids");
 	});
 
+	it("separates application task roles without adding artifact permissions", () => {
+		const ecsConfig = readFileSync(join(terraformDir, "ecs.tf"), "utf8");
+		const iamConfig = readFileSync(join(terraformDir, "iam.tf"), "utf8");
+		const terraformConfig = terraformFiles()
+			.map((path) => readFileSync(path, "utf8"))
+			.join("\n");
+		const taskRoles = [
+			"chat_api_task",
+			"agent_worker_task",
+			"agent_migration_task",
+		];
+
+		expect(ecsConfig).toMatch(
+			/resource "aws_ecs_task_definition" "chat_api" \{[\s\S]*?execution_role_arn\s*=\s*aws_iam_role\.task_execution\.arn[\s\S]*?task_role_arn\s*=\s*aws_iam_role\.chat_api_task\.arn/,
+		);
+		expect(ecsConfig).toMatch(
+			/resource "aws_ecs_task_definition" "agent_worker" \{[\s\S]*?execution_role_arn\s*=\s*aws_iam_role\.task_execution\.arn[\s\S]*?task_role_arn\s*=\s*aws_iam_role\.agent_worker_task\.arn/,
+		);
+		expect(ecsConfig).toMatch(
+			/resource "aws_ecs_task_definition" "agent_migration" \{[\s\S]*?execution_role_arn\s*=\s*aws_iam_role\.task_execution\.arn[\s\S]*?task_role_arn\s*=\s*aws_iam_role\.agent_migration_task\.arn/,
+		);
+		expect(
+			ecsConfig.match(
+				/execution_role_arn\s*=\s*aws_iam_role\.task_execution\.arn/g,
+			),
+		).toHaveLength(3);
+
+		for (const role of taskRoles) {
+			expect(iamConfig).toContain(`resource "aws_iam_role" "${role}"`);
+			expect(
+				terraformConfig.match(
+					new RegExp(`\\baws_iam_role\\.${role}\\.(?:arn|id|name)\\b`, "g"),
+				),
+			).toHaveLength(1);
+		}
+		expect(iamConfig).not.toContain('resource "aws_iam_role" "task"');
+		expect(terraformConfig).not.toMatch(/\bs3:/i);
+		expect(
+			iamConfig.match(/role\s*=\s*aws_iam_role\.task_execution\.(?:name|id)/g),
+		).toHaveLength(2);
+	});
+
 	it("provisions the disposable Redis live lane inside the trusted service network", () => {
 		const redisConfig = readFileSync(join(terraformDir, "redis.tf"), "utf8");
 		const locals = readFileSync(join(terraformDir, "locals.tf"), "utf8");


### PR DESCRIPTION
## Summary

- give `chat-api`, `agent-worker`, and the migration task distinct ECS application task roles
- keep the shared ECS execution role and deployment rollout contract unchanged
- add deployment-contract coverage for role isolation and the absence of S3 permissions

## Why

This prefactor establishes the least-privilege boundary required by the Downloadable artifact work without granting artifact access or changing current runtime behavior.

## Impact

Existing application permissions, image pulls, log delivery, secret injection, networking, health checks, migrations, outputs, and migration-before-service rollout remain unchanged.

## Validation

- `bun run test` — 694 configured tests passed
- Terraform formatting checks passed for `infra/bootstrap-iam`, `infra/terraform`, and `infra/ecr`
- Terraform validation passed for all three roots
- two-axis standards/spec review completed with no remaining hard or spec findings

Closes #282