### PR TITLE
fix(infra): allow deploy role to inspect instance profiles

### DIFF
--- a/infra/bootstrap-iam/main.tf
+++ b/infra/bootstrap-iam/main.tf
@@ -213,6 +213,7 @@ data "aws_iam_policy_document" "github_actions_deploy" {
       "iam:GetRole",
       "iam:GetRolePolicy",
       "iam:ListAttachedRolePolicies",
+      "iam:ListInstanceProfilesForRole",
       "iam:ListPolicyVersions",
       "iam:ListRolePolicies",
       "iam:PassRole",

--- a/scripts/deploy-config.test.ts
+++ b/scripts/deploy-config.test.ts
@@ -479,6 +479,7 @@ describe("agent deployment config", () => {
 		expect(combined).toContain("sts:AssumeRoleWithWebIdentity");
 		expect(combined).toContain("mymemo-agent/bootstrap-iam-prod.tfstate");
 		expect(combined).not.toContain("mymemo-github-actions-deploy");
+		expect(combined).toContain('"iam:ListInstanceProfilesForRole"');
 		expect(combined).toContain('sid = "ArtifactBucketManagement"');
 		for (const action of [
 			"s3:CreateBucket",


### PR DESCRIPTION
## Summary

- grant the GitHub Actions deploy role `iam:ListInstanceProfilesForRole` within the existing agent IAM resource scope
- add regression coverage for the bootstrap IAM contract

## Root cause

[Release deploy run 29407360125](https://github.com/X-GPT/mymemo-agent/actions/runs/29407360125) failed while Terraform deleted the former shared ECS task role. The AWS provider lists a role's instance profiles before deletion, but the deploy role had `iam:DeleteRole` without `iam:ListInstanceProfilesForRole`.

## Impact

This unblocks the task-role split on the next release after the bootstrap IAM root is applied. It does not broaden the existing resource scope or change application runtime behavior.

## Validation

- `bun test scripts/deploy-config.test.ts` — 32 passed
- `bun run test` — all five workspaces passed
- `terraform -chdir=infra/bootstrap-iam fmt -check`
- `git diff --check`

`terraform validate` was unavailable because downloading the lockfile-pinned AWS provider timed out.