### PR TITLE
feat(artifacts): reclaim unreachable object storage

### DIFF
--- a/apps/agent-worker/src/cleanup/cleanup-loop.test.ts
+++ b/apps/agent-worker/src/cleanup/cleanup-loop.test.ts
@@ -6,7 +6,7 @@ import {
 	expect,
 	it,
 } from "bun:test";
-import { orphanSandboxes } from "@mymemo/agent-db/schema";
+import { artifactObjects, orphanSandboxes } from "@mymemo/agent-db/schema";
 import { createTestDatabase, type TestDb } from "@mymemo/agent-db/testing";
 import type { WorkerLogger } from "../logger";
 import type { AdvisoryLockClient, AdvisoryLockPool } from "./advisory-lock";
@@ -19,6 +19,13 @@ class FakeJanitor implements SandboxJanitor {
 	killed: string[] = [];
 	async killSandbox(id: string): Promise<void> {
 		this.killed.push(id);
+	}
+}
+
+class FakeArtifactJanitor {
+	deleted: string[] = [];
+	async deleteObject(objectKey: string): Promise<void> {
+		this.deleted.push(objectKey);
 	}
 }
 
@@ -44,6 +51,7 @@ class FakePool implements AdvisoryLockPool {
 
 let tdb: TestDb;
 let janitor: FakeJanitor;
+let artifactJanitor: FakeArtifactJanitor;
 
 // One PGlite instance for the whole file (spin-up is the slow part); each test
 // starts from a single fresh orphan row via delete + re-seed.
@@ -56,8 +64,10 @@ afterAll(async () => {
 });
 
 beforeEach(async () => {
+	await tdb.db.delete(artifactObjects);
 	await tdb.db.delete(orphanSandboxes);
 	janitor = new FakeJanitor();
+	artifactJanitor = new FakeArtifactJanitor();
 	await tdb.db.insert(orphanSandboxes).values({
 		sandboxId: "sbx-orphan",
 		userId: "user-1",
@@ -66,13 +76,21 @@ beforeEach(async () => {
 		createdByWorkerId: "worker-old",
 		reason: "test",
 	});
+	await tdb.db.insert(artifactObjects).values({
+		objectKey: "objects/abandoned",
+		userId: "user-1",
+		conversationId: "conv-1",
+		runId: "run-gone",
+		path: "report.txt",
+	});
 });
 
 function buildLoop(pool: AdvisoryLockPool) {
 	return new CleanupLoop({
 		db: tdb.db,
 		pool,
-		janitor,
+		sandboxJanitor: janitor,
+		artifactJanitor,
 		workerId: "worker-1",
 		intervalMs: 60_000,
 		logger: silentLogger,
@@ -87,6 +105,7 @@ describe("CleanupLoop.runOnce", () => {
 
 		expect(summary?.orphanSandboxesKilled).toBe(1);
 		expect(janitor.killed).toEqual(["sbx-orphan"]);
+		expect(artifactJanitor.deleted).toEqual(["objects/abandoned"]);
 	});
 
 	it("skips the pass when another replica holds the lock", async () => {

--- a/apps/agent-worker/src/cleanup/cleanup-loop.ts
+++ b/apps/agent-worker/src/cleanup/cleanup-loop.ts
@@ -6,6 +6,7 @@ import {
 	tryWithAdvisoryLock,
 } from "./advisory-lock";
 import {
+	type ArtifactObjectJanitor,
 	type CleanupSummary,
 	runCleanupPass,
 	type SandboxJanitor,
@@ -15,7 +16,8 @@ export interface CleanupLoopOptions {
 	db: Database;
 	/** Dedicated-connection source for the single-flight advisory lock. */
 	pool: AdvisoryLockPool;
-	janitor: SandboxJanitor;
+	sandboxJanitor: SandboxJanitor;
+	artifactJanitor: ArtifactObjectJanitor;
 	workerId: string;
 	/** How often {@link CleanupLoop.start} attempts a pass. */
 	intervalMs: number;
@@ -23,7 +25,7 @@ export interface CleanupLoopOptions {
 }
 
 /**
- * The worker-embedded cleanup loop (Task 8.1). On a timer it attempts one
+ * The worker-embedded cleanup loop (Task 8.1, extended by ADR-0010). On a timer it attempts one
  * {@link runCleanupPass} under the Postgres advisory lock, so across replicas at
  * most one pass runs at a time. It is intentionally independent of the run loop
  * — its own timer, its own error isolation — so a cleanup failure can never
@@ -53,7 +55,8 @@ export class CleanupLoop {
 				() =>
 					runCleanupPass({
 						db: this.opts.db,
-						janitor: this.opts.janitor,
+						sandboxJanitor: this.opts.sandboxJanitor,
+						artifactJanitor: this.opts.artifactJanitor,
 						workerId: this.opts.workerId,
 						logger: this.opts.logger,
 					}),

--- a/apps/agent-worker/src/cleanup/cleanup.test.ts
+++ b/apps/agent-worker/src/cleanup/cleanup.test.ts
@@ -9,9 +9,12 @@ import {
 } from "bun:test";
 import {
 	agentSessions,
+	artifactObjects,
+	conversationArtifacts,
 	conversationRuntime,
 	conversations,
 	orphanSandboxes,
+	runs,
 } from "@mymemo/agent-db/schema";
 import {
 	appendAgentSessionEntriesTx,
@@ -39,8 +42,21 @@ class FakeJanitor implements SandboxJanitor {
 	}
 }
 
+class FakeArtifactJanitor {
+	deleted: string[] = [];
+	deleteFailKeys = new Set<string>();
+
+	async deleteObject(objectKey: string): Promise<void> {
+		if (this.deleteFailKeys.has(objectKey)) {
+			throw new Error("S3 delete failed");
+		}
+		this.deleted.push(objectKey);
+	}
+}
+
 let tdb: TestDb;
 let janitor: FakeJanitor;
+let artifactJanitor: FakeArtifactJanitor;
 
 // One PGlite instance for the whole file (spin-up is the slow part); each test
 // starts from empty tables via truncate, keeping isolation without the cost.
@@ -54,10 +70,13 @@ afterAll(async () => {
 
 beforeEach(() => {
 	janitor = new FakeJanitor();
+	artifactJanitor = new FakeArtifactJanitor();
 });
 
 afterEach(async () => {
+	await tdb.db.delete(artifactObjects);
 	await tdb.db.delete(orphanSandboxes);
+	await tdb.db.delete(runs);
 	await tdb.db.delete(conversationRuntime);
 	await tdb.db.delete(conversations);
 	await tdb.db.delete(agentSessions);
@@ -66,12 +85,266 @@ afterEach(async () => {
 function pass(overrides?: Partial<CleanupPassOptions>) {
 	return runCleanupPass({
 		db: tdb.db,
-		janitor,
+		sandboxJanitor: janitor,
+		artifactJanitor,
 		workerId: "worker-1",
 		logger: silentLogger,
 		...overrides,
 	});
 }
+
+describe("Downloadable artifact object cleanup", () => {
+	it("deletes an abandoned pending object and removes its ledger row", async () => {
+		await tdb.db.insert(artifactObjects).values({
+			objectKey: "objects/abandoned",
+			userId: "user-1",
+			conversationId: "conv-gone",
+			runId: "run-gone",
+			path: "report.txt",
+		});
+
+		await pass();
+
+		expect(artifactJanitor.deleted).toEqual(["objects/abandoned"]);
+		expect(await tdb.db.select().from(artifactObjects)).toEqual([]);
+	});
+
+	it("never deletes a currently referenced object regardless of lifecycle status", async () => {
+		await insertConversation("user-1", "conv-live");
+		await tdb.db.insert(artifactObjects).values({
+			objectKey: "objects/referenced",
+			userId: "user-1",
+			conversationId: "conv-live",
+			runId: "run-gone",
+			path: "report.txt",
+			status: "pending",
+		});
+		await tdb.db.insert(conversationArtifacts).values({
+			artifactId: "artifact-1",
+			userId: "user-1",
+			conversationId: "conv-live",
+			path: "report.txt",
+			objectKey: "objects/referenced",
+			sizeBytes: 12,
+			contentType: "text/plain",
+		});
+
+		await pass();
+
+		expect(artifactJanitor.deleted).toEqual([]);
+		expect(await tdb.db.select().from(artifactObjects)).toHaveLength(1);
+	});
+
+	it("deletes a pending object owned by a terminal Run", async () => {
+		await tdb.db.insert(runs).values({
+			runId: "run-terminal",
+			userId: "user-1",
+			conversationId: "conv-gone",
+			status: "error",
+			terminalAt: new Date("2026-07-16T00:00:00.000Z"),
+		});
+		await tdb.db.insert(artifactObjects).values({
+			objectKey: "objects/terminal",
+			userId: "user-1",
+			conversationId: "conv-gone",
+			runId: "run-terminal",
+			path: "report.txt",
+		});
+
+		await pass();
+
+		expect(artifactJanitor.deleted).toEqual(["objects/terminal"]);
+		expect(await tdb.db.select().from(artifactObjects)).toEqual([]);
+	});
+
+	it("deletes a pending object after its owning Run becomes stale", async () => {
+		await tdb.db.insert(runs).values({
+			runId: "run-stale",
+			userId: "user-1",
+			conversationId: "conv-gone",
+			status: "running",
+			lockedBy: "worker-gone",
+			lockedUntil: new Date("2026-07-16T00:09:59.000Z"),
+		});
+		await tdb.db.insert(artifactObjects).values({
+			objectKey: "objects/stale",
+			userId: "user-1",
+			conversationId: "conv-gone",
+			runId: "run-stale",
+			path: "report.txt",
+		});
+
+		await pass({ now: new Date("2026-07-16T00:10:00.000Z") });
+
+		expect(artifactJanitor.deleted).toEqual(["objects/stale"]);
+		expect(await tdb.db.select().from(artifactObjects)).toEqual([]);
+	});
+
+	it("keeps a pending object while its owning Run has a live lock", async () => {
+		await insertConversation("user-1", "conv-live");
+		await tdb.db.insert(runs).values({
+			runId: "run-active",
+			userId: "user-1",
+			conversationId: "conv-live",
+			status: "running",
+			lockedBy: "worker-live",
+			lockedUntil: new Date("2026-07-16T00:10:01.000Z"),
+		});
+		await tdb.db.insert(artifactObjects).values({
+			objectKey: "objects/uploading",
+			userId: "user-1",
+			conversationId: "conv-live",
+			runId: "run-active",
+			path: "report.txt",
+		});
+
+		await pass({ now: new Date("2026-07-16T00:10:00.000Z") });
+
+		expect(artifactJanitor.deleted).toEqual([]);
+		expect(await tdb.db.select().from(artifactObjects)).toHaveLength(1);
+	});
+
+	it("deletes a superseded object once its ten-minute grace has elapsed", async () => {
+		await insertConversation("user-1", "conv-live");
+		await tdb.db.insert(artifactObjects).values({
+			objectKey: "objects/superseded",
+			userId: "user-1",
+			conversationId: "conv-live",
+			runId: "run-old",
+			path: "report.txt",
+			status: "superseded",
+			supersededAt: new Date("2026-07-16T00:00:00.000Z"),
+		});
+
+		await pass({ now: new Date("2026-07-16T00:10:00.000Z") });
+
+		expect(artifactJanitor.deleted).toEqual(["objects/superseded"]);
+		expect(await tdb.db.select().from(artifactObjects)).toEqual([]);
+	});
+
+	it("keeps a superseded object until the full grace period elapses", async () => {
+		await insertConversation("user-1", "conv-live");
+		await tdb.db.insert(artifactObjects).values({
+			objectKey: "objects/still-graceful",
+			userId: "user-1",
+			conversationId: "conv-live",
+			runId: "run-old",
+			path: "report.txt",
+			status: "superseded",
+			supersededAt: new Date("2026-07-16T00:00:00.001Z"),
+		});
+
+		await pass({ now: new Date("2026-07-16T00:10:00.000Z") });
+
+		expect(artifactJanitor.deleted).toEqual([]);
+		expect(await tdb.db.select().from(artifactObjects)).toHaveLength(1);
+	});
+
+	it("waives supersession grace after the conversation is deleted", async () => {
+		await insertConversation("user-1", "conv-delete");
+		await tdb.db.insert(artifactObjects).values({
+			objectKey: "objects/recently-superseded",
+			userId: "user-1",
+			conversationId: "conv-delete",
+			runId: "run-old",
+			path: "report.txt",
+			status: "superseded",
+			supersededAt: new Date("2026-07-16T00:09:59.999Z"),
+		});
+		await tdb.db
+			.delete(conversations)
+			.where(eq(conversations.conversationId, "conv-delete"));
+
+		await pass({ now: new Date("2026-07-16T00:10:00.000Z") });
+
+		expect(artifactJanitor.deleted).toEqual(["objects/recently-superseded"]);
+		expect(await tdb.db.select().from(artifactObjects)).toEqual([]);
+	});
+
+	it("deletes a formerly current object after its conversation is deleted", async () => {
+		await insertConversation("user-1", "conv-delete");
+		await tdb.db.insert(artifactObjects).values({
+			objectKey: "objects/deleted-conversation",
+			userId: "user-1",
+			conversationId: "conv-delete",
+			runId: "run-old",
+			path: "report.txt",
+			status: "current",
+			committedAt: new Date("2026-07-16T00:00:00.000Z"),
+		});
+		await tdb.db.insert(conversationArtifacts).values({
+			artifactId: "artifact-delete",
+			userId: "user-1",
+			conversationId: "conv-delete",
+			path: "report.txt",
+			objectKey: "objects/deleted-conversation",
+			sizeBytes: 12,
+			contentType: "text/plain",
+		});
+
+		await tdb.db
+			.delete(conversations)
+			.where(eq(conversations.conversationId, "conv-delete"));
+		expect(await tdb.db.select().from(conversationArtifacts)).toEqual([]);
+
+		await pass();
+
+		expect(artifactJanitor.deleted).toEqual(["objects/deleted-conversation"]);
+		expect(await tdb.db.select().from(artifactObjects)).toEqual([]);
+	});
+
+	it("retains failed deletes and retries them on a later pass", async () => {
+		await tdb.db.insert(artifactObjects).values({
+			objectKey: "objects/flaky",
+			userId: "user-1",
+			conversationId: "conv-gone",
+			runId: "run-gone",
+			path: "report.txt",
+		});
+		artifactJanitor.deleteFailKeys.add("objects/flaky");
+
+		const first = await pass();
+		expect(first.artifactObjectsFailed).toBe(1);
+		expect(await tdb.db.select().from(artifactObjects)).toHaveLength(1);
+
+		artifactJanitor.deleteFailKeys.clear();
+		const second = await pass();
+		expect(second.artifactObjectsDeleted).toBe(1);
+		expect(artifactJanitor.deleted).toEqual(["objects/flaky"]);
+		expect(await tdb.db.select().from(artifactObjects)).toEqual([]);
+	});
+
+	it("isolates a failing object from healthy objects in the same pass", async () => {
+		await tdb.db.insert(artifactObjects).values([
+			{
+				objectKey: "objects/bad",
+				userId: "user-1",
+				conversationId: "conv-gone",
+				runId: "run-gone",
+				path: "bad.txt",
+			},
+			{
+				objectKey: "objects/good",
+				userId: "user-1",
+				conversationId: "conv-gone",
+				runId: "run-gone",
+				path: "good.txt",
+			},
+		]);
+		artifactJanitor.deleteFailKeys.add("objects/bad");
+
+		const summary = await pass();
+
+		expect(artifactJanitor.deleted).toEqual(["objects/good"]);
+		expect(summary.artifactObjectsDeleted).toBe(1);
+		expect(summary.artifactObjectsFailed).toBe(1);
+		expect(
+			(await tdb.db.select().from(artifactObjects)).map(
+				(object) => object.objectKey,
+			),
+		).toEqual(["objects/bad"]);
+	});
+});
 
 async function insertConversation(userId: string, conversationId: string) {
 	await tdb.db

--- a/apps/agent-worker/src/cleanup/cleanup.ts
+++ b/apps/agent-worker/src/cleanup/cleanup.ts
@@ -1,29 +1,29 @@
 import type { Database } from "@mymemo/agent-db/client";
 import {
+	artifactObjects,
+	conversationArtifacts,
 	conversationRuntime,
 	conversations,
 	orphanSandboxes,
+	runs,
 } from "@mymemo/agent-db/schema";
 import { deleteConversationAgentSessionsTx } from "@mymemo/agent-db/session-store";
-import { and, eq, isNotNull, isNull } from "drizzle-orm";
+import { and, eq, inArray, isNotNull, isNull, lte, or } from "drizzle-orm";
 import type { WorkerLogger } from "../logger";
 
 /**
  * Runtime hygiene for external E2B resources Postgres cannot delete
  * transactionally (design doc "Why Cleanup Exists", Task 8.1; retargeted by
- * ADR-0007): orphaned sandboxes, and runtime rows for deleted
- * conversations/users. Exactly these two sweeps — both cost-independent; there
- * is deliberately no idle reaper for paused sandboxes (a paused sandbox *is*
- * the conversation's workspace and persists at no documented cost on the
- * current tier). The database is the source of truth for what is *referenced*;
- * the janitor reconciles E2B against it. The one rule everything here obeys:
- * never kill a sandbox still referenced by `conversation_runtime`.
+ * ADR-0007 and ADR-0010): orphaned sandboxes, runtime rows for deleted
+ * conversations/users, and unreachable Downloadable artifact objects. There
+ * is deliberately no idle reaper for paused sandboxes or age-based expiry for
+ * current artifacts. The database is the source of truth for what is
+ * referenced; janitors reconcile external resources against it.
  *
- * The pass is deliberately unfenced (it runs when no run owns a conversation)
- * but conservative, idempotent, and per-row isolated: every E2B call is
- * idempotent (kill of an already-gone resource resolves), a failing row is
- * left in place to retry on the next pass, and a failing sweep never aborts
- * the other — so cleanup can never block unrelated user runs.
+ * The pass itself is not fenced to a Run, but it is conservative, idempotent,
+ * and per-row isolated: deleting an already-gone provider resource resolves,
+ * a failing row is left in place to retry on the next pass, and a failing
+ * sweep never aborts another — so cleanup cannot block unrelated user Runs.
  */
 
 /**
@@ -37,6 +37,12 @@ export interface SandboxJanitor {
 	killSandbox(sandboxId: string): Promise<void>;
 }
 
+/** The one S3 operation lifecycle cleanup is allowed to perform. */
+export interface ArtifactObjectJanitor {
+	/** Delete one private object by its opaque ledger key. */
+	deleteObject(objectKey: string): Promise<void>;
+}
+
 /** Per-pass tallies, returned for structured logging and asserted by tests. */
 export interface CleanupSummary {
 	orphanSandboxesKilled: number;
@@ -44,14 +50,19 @@ export interface CleanupSummary {
 	orphanSandboxesSkippedReferenced: number;
 	deletedRuntimesRemoved: number;
 	deletedRuntimesRetained: number;
+	artifactObjectsDeleted: number;
+	artifactObjectsFailed: number;
 }
 
 export interface CleanupPassOptions {
 	db: Database;
-	janitor: SandboxJanitor;
+	sandboxJanitor: SandboxJanitor;
+	artifactJanitor: ArtifactObjectJanitor;
 	/** Records who recorded an orphan when a deleted-conversation kill fails. */
 	workerId: string;
 	logger: WorkerLogger;
+	/** Fixed pass time for deterministic eligibility checks in tests. */
+	now?: Date;
 }
 
 function zeroSummary(): CleanupSummary {
@@ -61,11 +72,13 @@ function zeroSummary(): CleanupSummary {
 		orphanSandboxesSkippedReferenced: 0,
 		deletedRuntimesRemoved: 0,
 		deletedRuntimesRetained: 0,
+		artifactObjectsDeleted: 0,
+		artifactObjectsFailed: 0,
 	};
 }
 
 /**
- * One cleanup pass: the two sweeps, each isolated so a whole-sweep failure
+ * One cleanup pass: the three sweeps, each isolated so a whole-sweep failure
  * (e.g. a transient DB error) is logged and the remaining sweep still runs.
  * Returns the merged per-sweep tallies.
  */
@@ -79,8 +92,81 @@ export async function runCleanupPass(
 	await runSweep(options.logger, "deleted-conversations", async () => {
 		Object.assign(summary, await sweepDeletedConversations(options));
 	});
+	await runSweep(options.logger, "artifact-objects", async () => {
+		Object.assign(summary, await sweepArtifactObjects(options));
+	});
 	return summary;
 }
+
+async function sweepArtifactObjects(
+	options: CleanupPassOptions,
+): Promise<Partial<CleanupSummary>> {
+	const now = options.now ?? new Date();
+	const supersededCutoff = new Date(now.getTime() - SUPERSEDED_GRACE_MS);
+	const candidates = await options.db
+		.select({ objectKey: artifactObjects.objectKey })
+		.from(artifactObjects)
+		.leftJoin(
+			conversationArtifacts,
+			eq(conversationArtifacts.objectKey, artifactObjects.objectKey),
+		)
+		.leftJoin(
+			conversations,
+			and(
+				eq(conversations.userId, artifactObjects.userId),
+				eq(conversations.conversationId, artifactObjects.conversationId),
+			),
+		)
+		.leftJoin(runs, eq(runs.runId, artifactObjects.runId))
+		.where(
+			and(
+				or(
+					and(
+						eq(artifactObjects.status, "pending"),
+						or(
+							isNull(runs.runId),
+							inArray(runs.status, ["done", "error", "canceled"]),
+							and(
+								inArray(runs.status, ["running", "cancel_requested"]),
+								or(isNull(runs.lockedUntil), lte(runs.lockedUntil, now)),
+							),
+						),
+					),
+					and(
+						eq(artifactObjects.status, "superseded"),
+						or(
+							isNull(conversations.conversationId),
+							lte(artifactObjects.supersededAt, supersededCutoff),
+						),
+					),
+					eq(artifactObjects.status, "current"),
+				),
+				isNull(conversationArtifacts.objectKey),
+			),
+		);
+
+	let deleted = 0;
+	let failed = 0;
+	for (const object of candidates) {
+		try {
+			await options.artifactJanitor.deleteObject(object.objectKey);
+			await options.db
+				.delete(artifactObjects)
+				.where(eq(artifactObjects.objectKey, object.objectKey));
+			deleted++;
+		} catch (error) {
+			failed++;
+			options.logger.warn({
+				message: "artifact object delete failed; will retry",
+				objectKey: object.objectKey,
+				error: toMessage(error),
+			});
+		}
+	}
+	return { artifactObjectsDeleted: deleted, artifactObjectsFailed: failed };
+}
+
+const SUPERSEDED_GRACE_MS = 10 * 60 * 1_000;
 
 async function runSweep(
 	logger: WorkerLogger,
@@ -108,7 +194,7 @@ async function runSweep(
 async function sweepOrphanSandboxes(
 	options: CleanupPassOptions,
 ): Promise<Partial<CleanupSummary>> {
-	const { db, janitor, logger } = options;
+	const { db, sandboxJanitor, logger } = options;
 	const orphans = await db.select().from(orphanSandboxes);
 	if (orphans.length === 0) return {};
 
@@ -126,7 +212,7 @@ async function sweepOrphanSandboxes(
 			continue;
 		}
 		try {
-			await janitor.killSandbox(orphan.sandboxId);
+			await sandboxJanitor.killSandbox(orphan.sandboxId);
 		} catch (error) {
 			failed++;
 			logger.warn({
@@ -226,9 +312,9 @@ async function handleDeletedSandbox(
 	sandboxId: string,
 	owner: { userId: string; conversationId: string; workerId: string },
 ): Promise<boolean> {
-	const { db, janitor, logger } = options;
+	const { db, sandboxJanitor, logger } = options;
 	try {
-		await janitor.killSandbox(sandboxId);
+		await sandboxJanitor.killSandbox(sandboxId);
 		return true;
 	} catch (killError) {
 		try {

--- a/apps/agent-worker/src/cleanup/s3-artifact-janitor.test.ts
+++ b/apps/agent-worker/src/cleanup/s3-artifact-janitor.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "bun:test";
+import type { DeleteObjectCommandInput } from "@aws-sdk/client-s3";
+import { createS3ArtifactObjectJanitor } from "./s3-artifact-janitor";
+
+describe("S3 Downloadable artifact janitor", () => {
+	it("deletes only the ledger-named object from the private bucket", async () => {
+		const calls: DeleteObjectCommandInput[] = [];
+		const janitor = createS3ArtifactObjectJanitor(
+			{ bucket: "private-artifacts", region: "us-west-2" },
+			{
+				async deleteObject(request) {
+					calls.push(request);
+				},
+			},
+		);
+
+		await janitor.deleteObject("objects/opaque");
+
+		expect(calls).toEqual([
+			{ Bucket: "private-artifacts", Key: "objects/opaque" },
+		]);
+	});
+});

--- a/apps/agent-worker/src/cleanup/s3-artifact-janitor.ts
+++ b/apps/agent-worker/src/cleanup/s3-artifact-janitor.ts
@@ -1,0 +1,32 @@
+import {
+	DeleteObjectCommand,
+	type DeleteObjectCommandInput,
+	S3Client,
+} from "@aws-sdk/client-s3";
+import type { ArtifactBucketConfig } from "../artifacts/s3-artifact-object-store";
+import type { ArtifactObjectJanitor } from "./cleanup";
+
+export type DeleteArtifactObject = (
+	request: DeleteObjectCommandInput,
+) => Promise<void>;
+
+/** S3 delete is idempotent and uses the client's bounded retry strategy. */
+export function createS3ArtifactObjectJanitor(
+	config: ArtifactBucketConfig,
+	dependencies: { deleteObject?: DeleteArtifactObject } = {},
+): ArtifactObjectJanitor {
+	const deleteObject =
+		dependencies.deleteObject ??
+		(() => {
+			const client = new S3Client({ region: config.region, maxAttempts: 3 });
+			return async (request: DeleteObjectCommandInput) => {
+				await client.send(new DeleteObjectCommand(request));
+			};
+		})();
+
+	return {
+		async deleteObject(objectKey) {
+			await deleteObject({ Bucket: config.bucket, Key: objectKey });
+		},
+	};
+}

--- a/apps/agent-worker/src/index.ts
+++ b/apps/agent-worker/src/index.ts
@@ -8,6 +8,7 @@ import { createS3ArtifactObjectStore } from "./artifacts/s3-artifact-object-stor
 import type { AdvisoryLockPool } from "./cleanup/advisory-lock";
 import { CleanupLoop } from "./cleanup/cleanup-loop";
 import { createE2bSandboxJanitor } from "./cleanup/e2b-janitor";
+import { createS3ArtifactObjectJanitor } from "./cleanup/s3-artifact-janitor";
 import { loadWorkerConfigFromEnv } from "./config/env";
 import { createDocumentSearch } from "./documents/client";
 import { createE2bSandboxProvisioner } from "./e2b/sandbox-provisioner";
@@ -53,6 +54,7 @@ const artifactPublisher = createArtifactPublisher({
 	objectStore: createS3ArtifactObjectStore(config.artifact),
 });
 const sandboxJanitor = createE2bSandboxJanitor(config.e2bApiKey);
+const artifactObjectJanitor = createS3ArtifactObjectJanitor(config.artifact);
 const startRunQuery = createStartRunQuery({
 	db,
 	workerId,
@@ -107,15 +109,16 @@ const runLoop = new RunLoop({
 	heartbeatIntervalMs: config.heartbeatIntervalMs,
 	logger,
 });
-// Worker-embedded orphan/deleted-conversation cleanup (Task 8.1, ADR-0007).
+// Worker-embedded external-resource cleanup (Task 8.1, ADR-0007/ADR-0010).
 // Single-flighted across replicas by a Postgres advisory lock taken on a
 // dedicated connection from Drizzle's underlying pg pool (`db.$client`). The
-// pass only calls E2B once real orphans exist, so it is a no-op until the
-// executor path is creating sandboxes.
+// The pass reconciles E2B sandboxes and S3 artifact objects from Postgres
+// ledgers; it never lists either provider.
 const cleanupLoop = new CleanupLoop({
 	db,
 	pool: db.$client as unknown as AdvisoryLockPool,
-	janitor: sandboxJanitor,
+	sandboxJanitor,
+	artifactJanitor: artifactObjectJanitor,
 	workerId,
 	intervalMs: config.cleanup.intervalMs,
 	logger,

--- a/infra/bootstrap-iam/main.tf
+++ b/infra/bootstrap-iam/main.tf
@@ -72,6 +72,7 @@ data "aws_iam_policy_document" "github_actions_deploy" {
       "s3:PutBucketTagging",
       "s3:PutBucketVersioning",
       "s3:PutEncryptionConfiguration",
+      "s3:PutLifecycleConfiguration",
     ]
     resources = ["arn:aws:s3:::${var.artifact_bucket_name}"]
   }

--- a/infra/terraform/artifacts.tf
+++ b/infra/terraform/artifacts.tf
@@ -37,6 +37,21 @@ resource "aws_s3_bucket_versioning" "artifacts" {
   }
 }
 
+resource "aws_s3_bucket_lifecycle_configuration" "artifacts" {
+  bucket = aws_s3_bucket.artifacts.id
+
+  rule {
+    id     = "abort-incomplete-multipart-uploads"
+    status = "Enabled"
+
+    filter {}
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 1
+    }
+  }
+}
+
 data "aws_iam_policy_document" "artifacts_tls_only" {
   statement {
     sid     = "DenyInsecureTransport"

--- a/infra/terraform/iam.tf
+++ b/infra/terraform/iam.tf
@@ -60,7 +60,10 @@ resource "aws_iam_role" "agent_worker_task" {
 
 data "aws_iam_policy_document" "agent_worker_artifact_write" {
   statement {
-    actions   = ["s3:PutObject"]
+    actions = [
+      "s3:PutObject",
+      "s3:DeleteObject",
+    ]
     resources = ["${aws_s3_bucket.artifacts.arn}/*"]
   }
 }

--- a/scripts/deploy-config.test.ts
+++ b/scripts/deploy-config.test.ts
@@ -55,6 +55,14 @@ describe("agent deployment config", () => {
 	it("separates application task roles and grants least-privilege artifact access", () => {
 		const ecsConfig = readFileSync(join(terraformDir, "ecs.tf"), "utf8");
 		const iamConfig = readFileSync(join(terraformDir, "iam.tf"), "utf8");
+		const workerArtifactPolicy = iamConfig.slice(
+			iamConfig.indexOf(
+				'data "aws_iam_policy_document" "agent_worker_artifact_write"',
+			),
+			iamConfig.indexOf(
+				'resource "aws_iam_role_policy" "agent_worker_artifact_write"',
+			),
+		);
 		const terraformConfig = terraformFiles()
 			.map((path) => readFileSync(path, "utf8"))
 			.join("\n");
@@ -92,12 +100,16 @@ describe("agent deployment config", () => {
 		expect(iamConfig).not.toContain('resource "aws_iam_role" "task"');
 		expect(iamConfig).toContain('actions   = ["s3:GetObject"]');
 		expect(iamConfig).toContain("role   = aws_iam_role.chat_api_task.id");
-		expect(iamConfig).toContain('actions   = ["s3:PutObject"]');
+		expect(workerArtifactPolicy).toMatch(
+			/actions\s*=\s*\[\s*"s3:PutObject",\s*"s3:DeleteObject",\s*\]/,
+		);
 		expect(iamConfig).toContain("role   = aws_iam_role.agent_worker_task.id");
 		expect(iamConfig).toMatch(
-			/data "aws_iam_policy_document" "agent_worker_artifact_write" \{[\s\S]*?actions\s*=\s*\["s3:PutObject"\][\s\S]*?resources\s*=\s*\["\$\{aws_s3_bucket\.artifacts\.arn\}\/\*"\][\s\S]*?\}/,
+			/data "aws_iam_policy_document" "agent_worker_artifact_write" \{[\s\S]*?actions\s*=\s*\[\s*"s3:PutObject",\s*"s3:DeleteObject",\s*\][\s\S]*?resources\s*=\s*\["\$\{aws_s3_bucket\.artifacts\.arn\}\/\*"\][\s\S]*?\}/,
 		);
-		expect(iamConfig).not.toMatch(/s3:(DeleteObject|ListBucket)/);
+		expect(workerArtifactPolicy).not.toMatch(
+			/s3:(GetObject|ListBucket|DeleteObjectVersion|GetObjectVersion|ListBucketVersions)/,
+		);
 		expect(iamConfig).not.toMatch(
 			/role\s*=\s*aws_iam_role\.agent_migration_task\.(?:id|name)[\s\S]*?s3:/,
 		);
@@ -138,6 +150,12 @@ describe("agent deployment config", () => {
 		);
 		expect(artifactsConfig).toMatch(
 			/resource "aws_s3_bucket_versioning" "artifacts"[\s\S]*?status\s*=\s*"Disabled"/,
+		);
+		expect(artifactsConfig).toMatch(
+			/resource "aws_s3_bucket_lifecycle_configuration" "artifacts"[\s\S]*?id\s*=\s*"abort-incomplete-multipart-uploads"[\s\S]*?status\s*=\s*"Enabled"[\s\S]*?abort_incomplete_multipart_upload[\s\S]*?days_after_initiation\s*=\s*1/,
+		);
+		expect(artifactsConfig).not.toMatch(
+			/\b(?:expiration|noncurrent_version_expiration|expired_object_delete_marker)\b/,
 		);
 		expect(artifactsConfig).toContain('variable = "aws:SecureTransport"');
 		expect(artifactsConfig).toContain('values   = ["false"]');
@@ -495,6 +513,7 @@ describe("agent deployment config", () => {
 			"s3:GetLifecycleConfiguration",
 			"s3:GetObjectLockConfiguration",
 			"s3:GetReplicationConfiguration",
+			"s3:PutLifecycleConfiguration",
 			"s3:PutBucketOwnershipControls",
 			"s3:PutBucketPolicy",
 			"s3:PutBucketPublicAccessBlock",


### PR DESCRIPTION
## Summary

- extend the worker's single-flighted cleanup pass to delete unreachable Downloadable artifact objects from the Postgres lifecycle ledger
- preserve current references and active uploads, apply the ten-minute supersession grace, and retain failed deletes for retry
- grant the worker only `s3:DeleteObject`, abort incomplete multipart uploads without expiring artifacts, and grant the deploy role lifecycle-management access

## Why

Artifact publication intentionally creates new opaque S3 keys before atomically swapping current metadata. Without ledger-driven cleanup, failed, abandoned, superseded, and deleted-conversation objects would leak storage. Cleanup must remain conservative so it cannot delete a current object, race a live upload, or invalidate an overwrite URL before its grace period.

## Impact

Unreachable artifact objects are reclaimed asynchronously and retry safely after transient S3 failures. Current artifacts continue to live for the conversation lifetime. The bootstrap IAM Terraform change must be applied before the application Terraform introduces the S3 lifecycle rule.

Closes #286

## Validation

- `bun run test` — root contracts/smokes and all five workspaces passed
- focused cleanup/PGlite and S3 adapter tests — 24 passed
- deployment-contract tests — 32 passed
- `terraform -chdir=infra/terraform validate`
- `terraform -chdir=infra/bootstrap-iam validate`
- Biome checks on the touched worker files
