### PR TITLE
feat(artifacts): enforce safety and quotas

### DIFF
--- a/apps/agent-worker/src/artifacts/artifact-content-type.ts
+++ b/apps/agent-worker/src/artifacts/artifact-content-type.ts
@@ -1,0 +1,32 @@
+import { posix } from "node:path";
+
+const CONTENT_TYPES: Readonly<Record<string, string>> = {
+	".csv": "text/csv",
+	".docx":
+		"application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+	".gif": "image/gif",
+	".html": "text/html",
+	".jpeg": "image/jpeg",
+	".jpg": "image/jpeg",
+	".json": "application/json",
+	".md": "text/markdown",
+	".pdf": "application/pdf",
+	".png": "image/png",
+	".pptx":
+		"application/vnd.openxmlformats-officedocument.presentationml.presentation",
+	".svg": "image/svg+xml",
+	".tar": "application/x-tar",
+	".txt": "text/plain",
+	".webp": "image/webp",
+	".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+	".xml": "application/xml",
+	".zip": "application/zip",
+};
+
+/** Content type is selected only from the trusted artifact path extension. */
+export function artifactContentType(path: string): string {
+	return (
+		CONTENT_TYPES[posix.extname(path).toLowerCase()] ??
+		"application/octet-stream"
+	);
+}

--- a/apps/agent-worker/src/artifacts/artifact-manifest.ts
+++ b/apps/agent-worker/src/artifacts/artifact-manifest.ts
@@ -1,0 +1,93 @@
+import { posix } from "node:path";
+
+export const MAX_ARTIFACT_PATH_BYTES = 1_024;
+
+export interface ArtifactManifestEntry {
+	path: string;
+	sizeBytes: number;
+	modifiedAt: string;
+}
+
+export type ArtifactValidationCode =
+	| "invalid_manifest"
+	| "invalid_path"
+	| "invalid_root"
+	| "outside_root"
+	| "special_entry"
+	| "unstable_entry";
+
+/** Safe, bounded validation detail suitable for structured worker logs. */
+export class ArtifactValidationError extends Error {
+	override readonly name = "ArtifactValidationError";
+
+	constructor(readonly code: ArtifactValidationCode) {
+		super(`artifact validation failed: ${code}`);
+	}
+}
+
+export function validateArtifactManifest(
+	manifest: unknown,
+): ArtifactManifestEntry[] {
+	if (!Array.isArray(manifest)) {
+		throw new ArtifactValidationError("invalid_manifest");
+	}
+	const paths = new Set<string>();
+	return manifest.map((entry) => {
+		if (
+			typeof entry !== "object" ||
+			entry === null ||
+			!("path" in entry) ||
+			typeof entry.path !== "string" ||
+			!("sizeBytes" in entry) ||
+			typeof entry.sizeBytes !== "number" ||
+			!Number.isSafeInteger(entry.sizeBytes) ||
+			entry.sizeBytes < 0 ||
+			!("modifiedAt" in entry) ||
+			typeof entry.modifiedAt !== "string" ||
+			!/^\d+$/.test(entry.modifiedAt)
+		) {
+			throw new ArtifactValidationError("invalid_manifest");
+		}
+		validateArtifactPath(entry.path);
+		if (paths.has(entry.path)) {
+			throw new ArtifactValidationError("invalid_manifest");
+		}
+		paths.add(entry.path);
+		return {
+			path: entry.path,
+			sizeBytes: entry.sizeBytes,
+			modifiedAt: entry.modifiedAt,
+		};
+	});
+}
+
+export function validateArtifactPath(path: string): void {
+	if (
+		path.length === 0 ||
+		posix.isAbsolute(path) ||
+		posix.normalize(path) !== path ||
+		path
+			.split("/")
+			.some(
+				(segment) => segment === "" || segment === "." || segment === "..",
+			) ||
+		/\p{Cc}/u.test(path) ||
+		!hasValidUnicode(path) ||
+		new TextEncoder().encode(path).byteLength > MAX_ARTIFACT_PATH_BYTES
+	) {
+		throw new ArtifactValidationError("invalid_path");
+	}
+}
+
+function hasValidUnicode(value: string): boolean {
+	for (let index = 0; index < value.length; index++) {
+		const unit = value.charCodeAt(index);
+		if (unit >= 0xd800 && unit <= 0xdbff) {
+			const next = value.charCodeAt(++index);
+			if (!(next >= 0xdc00 && next <= 0xdfff)) return false;
+		} else if (unit >= 0xdc00 && unit <= 0xdfff) {
+			return false;
+		}
+	}
+	return true;
+}

--- a/apps/agent-worker/src/artifacts/artifact-publication.test.ts
+++ b/apps/agent-worker/src/artifacts/artifact-publication.test.ts
@@ -16,6 +16,7 @@ import { RunLoop } from "../run-loop";
 import type { SupervisedQuery } from "../sdk/agent-stream";
 import { createSdkRunProcessor } from "../sdk/run-processor";
 import { Worker } from "../worker";
+import type { ArtifactManifestEntry } from "./artifact-manifest";
 import {
 	type ArtifactObjectStore,
 	type ArtifactWorkspace,
@@ -25,6 +26,9 @@ import {
 
 const silentLogger: WorkerLogger = { info() {}, warn() {}, error() {} };
 const encoder = new TextEncoder();
+const MIB = 1_024 * 1_024;
+const MAX_ARTIFACT_SIZE_BYTES = 100 * MIB;
+const MAX_CONVERSATION_ARTIFACT_BYTES = 1_024 * MIB;
 
 let tdb: TestDb;
 
@@ -46,13 +50,18 @@ afterEach(async () => {
 class FakeWorkspace implements ArtifactWorkspace {
 	private readonly files = new Map<
 		string,
-		{ body: Uint8Array; modifiedAt: string }
+		{ body: Uint8Array; modifiedAt: string; sizeBytes: number }
 	>();
 	private captures = 0;
 	private failAtCapture: number | null = null;
 
-	write(path: string, body: Uint8Array, modifiedAt: string): void {
-		this.files.set(path, { body, modifiedAt });
+	write(
+		path: string,
+		body: Uint8Array,
+		modifiedAt: string,
+		sizeBytes = body.byteLength,
+	): void {
+		this.files.set(path, { body, modifiedAt, sizeBytes });
 	}
 
 	delete(path: string): void {
@@ -70,16 +79,29 @@ class FakeWorkspace implements ArtifactWorkspace {
 		}
 		return [...this.files].map(([path, file]) => ({
 			path,
-			sizeBytes: file.body.byteLength,
+			sizeBytes: file.sizeBytes,
 			modifiedAt: file.modifiedAt,
 		}));
 	}
 
-	async readFile(path: string): Promise<Uint8Array> {
-		const file = this.files.get(path);
-		if (!file) throw new Error(`missing fake file ${path}`);
-		return file.body;
+	async openFile(
+		entry: ArtifactManifestEntry,
+	): Promise<ReadableStream<Uint8Array>> {
+		const file = this.files.get(entry.path);
+		if (!file) throw new Error(`missing fake file ${entry.path}`);
+		return new ReadableStream({
+			start(controller) {
+				controller.enqueue(file.body);
+				controller.close();
+			},
+		});
 	}
+}
+
+async function readStream(
+	body: ReadableStream<Uint8Array>,
+): Promise<Uint8Array> {
+	return new Uint8Array(await new Response(body).arrayBuffer());
 }
 
 function successfulQuery(onStart: () => void): SupervisedQuery {
@@ -112,6 +134,7 @@ function failedQuery(onStart: () => void, error: Error): SupervisedQuery {
 function buildArtifactHarness(
 	workspace: FakeWorkspace,
 	upload?: ArtifactObjectStore["upload"],
+	logger: WorkerLogger = silentLogger,
 ) {
 	const uploaded = new Map<string, Uint8Array>();
 	const queries = new Map<string, SupervisedQuery>();
@@ -120,7 +143,7 @@ function buildArtifactHarness(
 	const objectStore: ArtifactObjectStore = {
 		async upload(input) {
 			if (upload) await upload(input);
-			else uploaded.set(input.objectKey, input.body);
+			else uploaded.set(input.objectKey, await readStream(input.body));
 		},
 	};
 	const publisher = createArtifactPublisher({
@@ -133,13 +156,13 @@ function buildArtifactHarness(
 		workerId: "worker-1",
 		maxConcurrentRuns: 1,
 		shutdownTimeoutMs: 1_000,
-		logger: silentLogger,
+		logger,
 	});
 	const loop = new RunLoop({
 		db: tdb.db,
 		worker,
 		processor: createSdkRunProcessor({
-			logger: silentLogger,
+			logger,
 			startRunQuery: async (run, signal) => {
 				const query = queries.get(run.runId);
 				if (!query) throw new Error(`no fake query for ${run.runId}`);
@@ -152,7 +175,7 @@ function buildArtifactHarness(
 			},
 		}),
 		heartbeatIntervalMs: 15_000,
-		logger: silentLogger,
+		logger,
 	});
 	return {
 		loop,
@@ -180,6 +203,22 @@ async function insertConversation(): Promise<void> {
 		conversationId: "conv-1",
 		scope: "general",
 	});
+}
+
+async function insertCurrentArtifacts(
+	artifacts: Array<{ path: string; sizeBytes: number }>,
+): Promise<void> {
+	await tdb.db.insert(conversationArtifacts).values(
+		artifacts.map((artifact, index) => ({
+			artifactId: `current-artifact-${index}`,
+			userId: "user-1",
+			conversationId: "conv-1",
+			path: artifact.path,
+			objectKey: `objects/current-${index}`,
+			sizeBytes: artifact.sizeBytes,
+			contentType: "application/octet-stream",
+		})),
+	);
 }
 
 function blockingUpload() {
@@ -212,7 +251,7 @@ describe("Downloadable artifact publication through the Run loop", () => {
 					.from(artifactObjects)
 					.where(eq(artifactObjects.objectKey, input.objectKey));
 				expect(ledger[0]?.status).toBe("pending");
-				uploaded.set(input.objectKey, input.body);
+				uploaded.set(input.objectKey, await readStream(input.body));
 			},
 		};
 		let nextObject = 1;
@@ -276,10 +315,18 @@ describe("Downloadable artifact publication through the Run loop", () => {
 			.from(conversationArtifacts)
 			.orderBy(conversationArtifacts.path);
 		expect(
-			artifacts.map(({ path, sizeBytes }) => ({ path, sizeBytes })),
+			artifacts.map(({ path, sizeBytes, contentType }) => ({
+				path,
+				sizeBytes,
+				contentType,
+			})),
 		).toEqual([
-			{ path: "chart.bin", sizeBytes: 4 },
-			{ path: "report.txt", sizeBytes: 5 },
+			{
+				path: "chart.bin",
+				sizeBytes: 4,
+				contentType: "application/octet-stream",
+			},
+			{ path: "report.txt", sizeBytes: 5, contentType: "text/plain" },
 		]);
 		expect([...uploaded.values()].map((body) => [...body])).toEqual([
 			[0, 255, 1, 254],
@@ -356,6 +403,53 @@ describe("Downloadable artifact publication through the Run loop", () => {
 		).toBe("error");
 	});
 
+	it("detects size or timestamp changes but accepts the preserved-timestamp miss", async () => {
+		await insertConversation();
+		const workspace = new FakeWorkspace();
+		const h = buildArtifactHarness(workspace);
+
+		await h.run(
+			"run-1",
+			successfulQuery(() => {
+				workspace.write("report.txt", encoder.encode("v1"), "1");
+			}),
+		);
+		await h.run(
+			"run-2",
+			successfulQuery(() => {
+				workspace.write("report.txt", encoder.encode("v-two"), "1");
+			}),
+		);
+		const afterSizeChange = (
+			await tdb.db.select().from(conversationArtifacts)
+		)[0]?.objectKey;
+		await h.run(
+			"run-3",
+			successfulQuery(() => {
+				workspace.write("report.txt", encoder.encode("other"), "2");
+			}),
+		);
+		const afterTimestampChange = (
+			await tdb.db.select().from(conversationArtifacts)
+		)[0]?.objectKey;
+		await h.run(
+			"run-4",
+			successfulQuery(() => {
+				workspace.write("report.txt", encoder.encode("again"), "2");
+			}),
+		);
+
+		expect(afterTimestampChange).not.toBe(afterSizeChange);
+		expect(h.uploaded.size).toBe(3);
+		expect(
+			(await tdb.db.select().from(conversationArtifacts))[0]?.objectKey,
+		).toBe(afterTimestampChange);
+		expect(
+			(await tdb.db.select().from(runs)).find((run) => run.runId === "run-4")
+				?.status,
+		).toBe("done");
+	});
+
 	it("keeps prior metadata hidden when an upload fails and does not advance continuity", async () => {
 		await insertConversation();
 		await tdb.db.insert(conversationRuntime).values({
@@ -363,9 +457,22 @@ describe("Downloadable artifact publication through the Run loop", () => {
 			conversationId: "conv-1",
 		});
 		const workspace = new FakeWorkspace();
-		const h = buildArtifactHarness(workspace, async () => {
-			throw new Error("object store unavailable");
-		});
+		const errors: Record<string, unknown>[] = [];
+		const logger: WorkerLogger = {
+			...silentLogger,
+			error(event) {
+				errors.push(event);
+			},
+		};
+		const h = buildArtifactHarness(
+			workspace,
+			async () => {
+				throw new Error(
+					"https://storage.invalid/private?signature=secret objects/key body=secret",
+				);
+			},
+			logger,
+		);
 
 		await h.run(
 			"run-1",
@@ -385,6 +492,14 @@ describe("Downloadable artifact publication through the Run loop", () => {
 		expect(
 			(await tdb.db.select().from(conversationRuntime))[0]?.agentSessionId,
 		).toBeNull();
+		expect(errors).toContainEqual(
+			expect.objectContaining({
+				artifactFailure: { category: "publication", stage: "upload" },
+			}),
+		);
+		expect(JSON.stringify(errors)).not.toContain("storage.invalid");
+		expect(JSON.stringify(errors)).not.toContain("objects/key");
+		expect(JSON.stringify(errors)).not.toContain("body=secret");
 	});
 
 	it("maps a final-manifest failure to the generic error without ledgering objects", async () => {
@@ -406,6 +521,180 @@ describe("Downloadable artifact publication through the Run loop", () => {
 		expect((await tdb.db.select().from(runEvents))[0]?.payload).toEqual({
 			message: "Run failed",
 		});
+	});
+
+	it("rejects an oversized candidate before ledgering or upload", async () => {
+		await insertConversation();
+		const workspace = new FakeWorkspace();
+		const errors: Record<string, unknown>[] = [];
+		const logger: WorkerLogger = {
+			...silentLogger,
+			error(event) {
+				errors.push(event);
+			},
+		};
+		const h = buildArtifactHarness(workspace, undefined, logger);
+
+		await h.run(
+			"run-1",
+			successfulQuery(() => {
+				workspace.write(
+					"oversized.bin",
+					new Uint8Array([1]),
+					"1",
+					MAX_ARTIFACT_SIZE_BYTES + 1,
+				);
+			}),
+		);
+
+		expect(await tdb.db.select().from(artifactObjects)).toEqual([]);
+		expect(await tdb.db.select().from(conversationArtifacts)).toEqual([]);
+		expect(h.uploaded.size).toBe(0);
+		expect((await tdb.db.select().from(runs))[0]?.status).toBe("error");
+		expect(errors).toContainEqual(
+			expect.objectContaining({
+				artifactFailure: {
+					category: "quota",
+					quota: "artifact_size_bytes",
+					actual: MAX_ARTIFACT_SIZE_BYTES + 1,
+					limit: MAX_ARTIFACT_SIZE_BYTES,
+				},
+			}),
+		);
+	});
+
+	it("rejects a 101st current path without changing the prior set", async () => {
+		await insertConversation();
+		await insertCurrentArtifacts(
+			Array.from({ length: 100 }, (_, index) => ({
+				path: `current-${index.toString().padStart(3, "0")}.txt`,
+				sizeBytes: 1,
+			})),
+		);
+		const workspace = new FakeWorkspace();
+		const h = buildArtifactHarness(workspace);
+
+		await h.run(
+			"run-1",
+			successfulQuery(() => {
+				workspace.write("new.txt", encoder.encode("new"), "1");
+			}),
+		);
+
+		const current = await tdb.db.select().from(conversationArtifacts);
+		expect(current).toHaveLength(100);
+		expect(current.some((artifact) => artifact.path === "new.txt")).toBe(false);
+		expect((await tdb.db.select().from(artifactObjects))[0]?.status).toBe(
+			"pending",
+		);
+		expect((await tdb.db.select().from(runs))[0]?.status).toBe("error");
+	});
+
+	it("rejects an aggregate overflow without exposing any file in a multi-file publication", async () => {
+		await insertConversation();
+		await insertCurrentArtifacts([
+			...Array.from({ length: 10 }, (_, index) => ({
+				path: `large-${index}.bin`,
+				sizeBytes: MAX_ARTIFACT_SIZE_BYTES,
+			})),
+			{ path: "remainder.bin", sizeBytes: 24 * MIB },
+		]);
+		const workspace = new FakeWorkspace();
+		const h = buildArtifactHarness(workspace);
+
+		await h.run(
+			"run-1",
+			successfulQuery(() => {
+				workspace.write(
+					"large-0.bin",
+					new Uint8Array([1]),
+					"1",
+					MAX_ARTIFACT_SIZE_BYTES,
+				);
+				workspace.write("new.txt", new Uint8Array([2]), "1");
+			}),
+		);
+
+		const current = await tdb.db
+			.select()
+			.from(conversationArtifacts)
+			.orderBy(conversationArtifacts.path);
+		expect(current).toHaveLength(11);
+		expect(
+			current.find((artifact) => artifact.path === "large-0.bin")?.objectKey,
+		).toBe("objects/current-0");
+		expect(current.some((artifact) => artifact.path === "new.txt")).toBe(false);
+		expect(
+			(await tdb.db.select().from(artifactObjects)).map(({ status }) => status),
+		).toEqual(["pending", "pending"]);
+		expect((await tdb.db.select().from(runs))[0]?.status).toBe("error");
+	});
+
+	it("counts only the replacement at the aggregate quota ceiling", async () => {
+		await insertConversation();
+		await insertCurrentArtifacts([
+			...Array.from({ length: 10 }, (_, index) => ({
+				path: `large-${index}.bin`,
+				sizeBytes: MAX_ARTIFACT_SIZE_BYTES,
+			})),
+			{
+				path: "remainder.bin",
+				sizeBytes:
+					MAX_CONVERSATION_ARTIFACT_BYTES - 10 * MAX_ARTIFACT_SIZE_BYTES,
+			},
+		]);
+		const workspace = new FakeWorkspace();
+		const h = buildArtifactHarness(workspace);
+
+		await h.run(
+			"run-1",
+			successfulQuery(() => {
+				workspace.write(
+					"large-0.bin",
+					new Uint8Array([1]),
+					"1",
+					MAX_ARTIFACT_SIZE_BYTES,
+				);
+			}),
+		);
+
+		expect(
+			(await tdb.db.select().from(conversationArtifacts)).find(
+				(artifact) => artifact.path === "large-0.bin",
+			)?.objectKey,
+		).toBe("objects/key-1");
+		expect((await tdb.db.select().from(runs))[0]?.status).toBe("done");
+	});
+
+	it("validates every changed path before ledgering a multi-file publication", async () => {
+		await insertConversation();
+		const workspace = new FakeWorkspace();
+		const errors: Record<string, unknown>[] = [];
+		const logger: WorkerLogger = {
+			...silentLogger,
+			error(event) {
+				errors.push(event);
+			},
+		};
+		const h = buildArtifactHarness(workspace, undefined, logger);
+
+		await h.run(
+			"run-1",
+			successfulQuery(() => {
+				workspace.write("safe.txt", encoder.encode("safe"), "1");
+				workspace.write("../escape.txt", encoder.encode("unsafe"), "1");
+			}),
+		);
+
+		expect(await tdb.db.select().from(artifactObjects)).toEqual([]);
+		expect(await tdb.db.select().from(conversationArtifacts)).toEqual([]);
+		expect(h.uploaded.size).toBe(0);
+		expect((await tdb.db.select().from(runs))[0]?.status).toBe("error");
+		expect(errors).toContainEqual(
+			expect.objectContaining({
+				artifactFailure: { category: "validation", reason: "invalid_path" },
+			}),
+		);
 	});
 
 	it("rolls back uploaded metadata when the lifecycle ledger cannot be committed", async () => {

--- a/apps/agent-worker/src/artifacts/artifact-publication.ts
+++ b/apps/agent-worker/src/artifacts/artifact-publication.ts
@@ -1,28 +1,50 @@
 import {
+	ArtifactQuotaError,
+	MAX_ARTIFACT_SIZE_BYTES,
 	type PublishedArtifact,
 	recordArtifactObjectsTx,
 } from "@mymemo/agent-db/artifact-store";
 import type { Database } from "@mymemo/agent-db/client";
 import type { RunRecord } from "@mymemo/agent-db/run-store";
 import type { SupervisedQuery } from "../sdk/agent-stream";
+import { artifactContentType } from "./artifact-content-type";
+import {
+	type ArtifactManifestEntry,
+	ArtifactValidationError,
+	validateArtifactManifest,
+} from "./artifact-manifest";
 
-export interface ArtifactManifestEntry {
-	path: string;
-	sizeBytes: number;
-	modifiedAt: string;
+export type ArtifactPublicationStage =
+	| "ledger"
+	| "manifest"
+	| "read"
+	| "upload";
+
+/** Safe publication-stage detail suitable for structured worker logs. */
+export class ArtifactPublicationError extends Error {
+	override readonly name = "ArtifactPublicationError";
+
+	constructor(readonly stage: ArtifactPublicationStage) {
+		super(`artifact publication failed: ${stage}`);
+	}
 }
 
 /** Trusted-worker view of the reserved artifact subtree in one live workspace. */
 export interface ArtifactWorkspace {
 	captureManifest(signal: AbortSignal): Promise<ArtifactManifestEntry[]>;
-	readFile(path: string, signal: AbortSignal): Promise<Uint8Array>;
+	openFile(
+		entry: ArtifactManifestEntry,
+		signal: AbortSignal,
+	): Promise<ReadableStream<Uint8Array>>;
 }
 
 /** Private object-store boundary. Production uses S3; tests retain exact bytes. */
 export interface ArtifactObjectStore {
 	upload(input: {
 		objectKey: string;
-		body: Uint8Array;
+		body: ReadableStream<Uint8Array>;
+		sizeBytes: number;
+		contentType: string;
 		signal: AbortSignal;
 	}): Promise<void>;
 }
@@ -68,7 +90,9 @@ export function createArtifactPublisher(
 	return {
 		async begin({ run, workspace, signal }) {
 			throwIfAborted(signal);
-			const baseline = manifestByPath(await workspace.captureManifest(signal));
+			const baseline = manifestByPath(
+				await captureValidatedManifest(workspace, signal),
+			);
 			throwIfAborted(signal);
 			let published = false;
 			return {
@@ -77,39 +101,77 @@ export function createArtifactPublisher(
 						throw new Error("artifact publication already attempted");
 					published = true;
 					throwIfAborted(signal);
-					const finalManifest = await workspace.captureManifest(signal);
+					const finalManifest = await captureValidatedManifest(
+						workspace,
+						signal,
+					);
 					throwIfAborted(signal);
 					const changed = finalManifest
 						.filter((entry) => manifestChanged(baseline.get(entry.path), entry))
 						.sort((left, right) => left.path.localeCompare(right.path));
 					if (changed.length === 0) return null;
+					for (const entry of changed) {
+						if (entry.sizeBytes > MAX_ARTIFACT_SIZE_BYTES) {
+							throw new ArtifactQuotaError(
+								"artifact_size_bytes",
+								entry.sizeBytes,
+								MAX_ARTIFACT_SIZE_BYTES,
+							);
+						}
+					}
 
-					const artifacts = changed.map((entry) => ({
-						artifactId: createArtifactId(),
-						path: entry.path,
-						objectKey: createObjectKey(),
-						sizeBytes: entry.sizeBytes,
-						contentType: "application/octet-stream",
+					const candidates = changed.map((entry) => ({
+						entry,
+						artifact: {
+							artifactId: createArtifactId(),
+							path: entry.path,
+							objectKey: createObjectKey(),
+							sizeBytes: entry.sizeBytes,
+							contentType: artifactContentType(entry.path),
+						},
 					}));
-					await recordArtifactObjectsTx(deps.db, {
-						objects: artifacts.map((artifact) => ({
-							objectKey: artifact.objectKey,
-							userId: run.userId,
-							conversationId: run.conversationId,
-							runId: run.runId,
-							path: artifact.path,
-						})),
-					});
-
-					for (const artifact of artifacts) {
-						throwIfAborted(signal);
-						const body = await workspace.readFile(artifact.path, signal);
-						throwIfAborted(signal);
-						await deps.objectStore.upload({
-							objectKey: artifact.objectKey,
-							body,
-							signal,
+					const artifacts = candidates.map(({ artifact }) => artifact);
+					try {
+						await recordArtifactObjectsTx(deps.db, {
+							objects: artifacts.map((artifact) => ({
+								objectKey: artifact.objectKey,
+								userId: run.userId,
+								conversationId: run.conversationId,
+								runId: run.runId,
+								path: artifact.path,
+							})),
 						});
+					} catch {
+						throw new ArtifactPublicationError("ledger");
+					}
+
+					for (const { artifact, entry } of candidates) {
+						throwIfAborted(signal);
+						let body: ReadableStream<Uint8Array>;
+						try {
+							body = await workspace.openFile(entry, signal);
+						} catch (error) {
+							throwIfAborted(signal);
+							if (error instanceof ArtifactValidationError) throw error;
+							throw new ArtifactPublicationError("read");
+						}
+						if (signal.aborted) {
+							await body.cancel(signal.reason).catch(() => {});
+							throwIfAborted(signal);
+						}
+						try {
+							await deps.objectStore.upload({
+								objectKey: artifact.objectKey,
+								body,
+								sizeBytes: artifact.sizeBytes,
+								contentType: artifact.contentType,
+								signal,
+							});
+						} catch {
+							await body.cancel(signal.reason).catch(() => {});
+							throwIfAborted(signal);
+							throw new ArtifactPublicationError("upload");
+						}
 					}
 					throwIfAborted(signal);
 					return { artifacts };
@@ -117,6 +179,19 @@ export function createArtifactPublisher(
 			};
 		},
 	};
+}
+
+async function captureValidatedManifest(
+	workspace: ArtifactWorkspace,
+	signal: AbortSignal,
+): Promise<ArtifactManifestEntry[]> {
+	try {
+		return validateArtifactManifest(await workspace.captureManifest(signal));
+	} catch (error) {
+		throwIfAborted(signal);
+		if (error instanceof ArtifactValidationError) throw error;
+		throw new ArtifactPublicationError("manifest");
+	}
 }
 
 /** Publish only after the SDK stream ends cleanly; errors/cancel skip finish. */

--- a/apps/agent-worker/src/artifacts/artifact-workspace.test.ts
+++ b/apps/agent-worker/src/artifacts/artifact-workspace.test.ts
@@ -1,9 +1,116 @@
 import { describe, expect, it } from "bun:test";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
 	ARTIFACT_ROOT,
+	type ArtifactCommandHandle,
 	type ArtifactSandbox,
 	createE2bArtifactWorkspace,
 } from "./artifact-workspace";
+
+interface LocalRunOptions {
+	background?: boolean;
+	envs?: Record<string, string>;
+	onStderr?: (data: string) => void | Promise<void>;
+	onStdout?: (data: string) => void | Promise<void>;
+}
+
+function manifestSandbox(stdout: string): ArtifactSandbox {
+	return {
+		commands: {
+			async run() {
+				return { exitCode: 0, stdout, stderr: "" };
+			},
+		} as unknown as ArtifactSandbox["commands"],
+		files: {
+			async read() {
+				return new ReadableStream();
+			},
+		},
+	};
+}
+
+function localManifestSandbox(root: string): ArtifactSandbox {
+	let pinnedPath: string | null = null;
+	const run = async (command: string, options?: LocalRunOptions) => {
+		const env = {
+			...globalThis.process.env,
+			...options?.envs,
+			MYMEMO_ARTIFACT_ROOT: root,
+		};
+		if (options?.background) {
+			pinnedPath = options.envs?.MYMEMO_ARTIFACT_PATH ?? null;
+			const process = Bun.spawn(["bash", "-lc", command], {
+				env,
+				stdin: "pipe",
+				stderr: "pipe",
+				stdout: "pipe",
+			});
+			const stdout = consumeText(process.stdout, options.onStdout);
+			const stderr = consumeText(process.stderr, options.onStderr);
+			const result = (async () => ({
+				exitCode: await process.exited,
+				stdout: await stdout,
+				stderr: await stderr,
+			}))();
+			return {
+				pid: process.pid,
+				wait: () => result,
+				async kill() {
+					process.kill();
+					await process.exited;
+					return true;
+				},
+			} satisfies ArtifactCommandHandle;
+		}
+		const process = Bun.spawn(["bash", "-lc", command], {
+			env,
+			stderr: "pipe",
+			stdout: "pipe",
+		});
+		const stdout = new Response(process.stdout).text();
+		const stderr = new Response(process.stderr).text();
+		return {
+			exitCode: await process.exited,
+			stdout: await stdout,
+			stderr: await stderr,
+		};
+	};
+	return {
+		commands: {
+			run: run as ArtifactSandbox["commands"]["run"],
+		},
+		files: {
+			async read(path) {
+				if (!/^\/proc\/\d+\/fd\/3$/.test(path) || pinnedPath === null) {
+					throw new Error("unexpected pinned-file path");
+				}
+				return Bun.file(join(root, pinnedPath)).stream();
+			},
+		},
+	};
+}
+
+async function consumeText(
+	stream: ReadableStream<Uint8Array>,
+	onData?: (data: string) => void | Promise<void>,
+): Promise<string> {
+	const reader = stream.getReader();
+	const decoder = new TextDecoder();
+	let output = "";
+	while (true) {
+		const result = await reader.read();
+		if (result.done) break;
+		const text = decoder.decode(result.value, { stream: true });
+		output += text;
+		await onData?.(text);
+	}
+	const tail = decoder.decode();
+	output += tail;
+	if (tail) await onData?.(tail);
+	return output;
+}
 
 describe("E2B Downloadable artifact workspace", () => {
 	it("captures path, byte size, and modification timestamp under the reserved root", async () => {
@@ -27,12 +134,11 @@ describe("E2B Downloadable artifact workspace", () => {
 						stderr: "",
 					};
 				},
-			},
+			} as ArtifactSandbox["commands"],
 			files: {
 				async read() {
-					return new Uint8Array();
+					return new ReadableStream();
 				},
-				async write() {},
 			},
 		};
 		const workspace = createE2bArtifactWorkspace(sandbox);
@@ -50,30 +156,139 @@ describe("E2B Downloadable artifact workspace", () => {
 		expect(calls[0]?.command).toContain("python3");
 	});
 
-	it("reads binary bytes without decoding them", async () => {
-		const reads: string[] = [];
-		const sandbox: ArtifactSandbox = {
-			commands: {
-				async run() {
-					return { exitCode: 0, stdout: "[]", stderr: "" };
-				},
-			},
-			files: {
-				async read(path) {
-					reads.push(path);
-					return new Uint8Array([0, 255, 1]);
-				},
-				async write() {},
-			},
-		};
-		const workspace = createE2bArtifactWorkspace(sandbox);
+	it("rejects paths that are not normalized, valid UTF-8, and within the byte limit", async () => {
+		const invalidPaths = [
+			"",
+			"/absolute.txt",
+			"../escape.txt",
+			"nested/./report.txt",
+			"nested//report.txt",
+			"nested/../report.txt",
+			"control\u0001.txt",
+			"invalid-\ud800.txt",
+			`${"é".repeat(512)}a`,
+		];
 
-		expect([
-			...(await workspace.readFile(
-				"images/chart.bin",
+		for (const path of invalidPaths) {
+			const workspace = createE2bArtifactWorkspace(
+				manifestSandbox(
+					JSON.stringify([
+						{ path, sizeBytes: 1, modifiedAt: "1784112345000000000" },
+					]),
+				),
+			);
+
+			await expect(
+				workspace.captureManifest(new AbortController().signal),
+			).rejects.toThrow();
+		}
+	});
+
+	it("preserves nested case-sensitive paths up to 1,024 UTF-8 bytes", async () => {
+		const maxPath = [
+			...Array.from({ length: 5 }, () => "é".repeat(100)),
+			"a".repeat(19),
+		].join("/");
+		expect(new TextEncoder().encode(maxPath).byteLength).toBe(1_024);
+		const workspace = createE2bArtifactWorkspace(
+			manifestSandbox(
+				JSON.stringify([
+					{ path: maxPath, sizeBytes: 1, modifiedAt: "1" },
+					{ path: "nested/A.txt", sizeBytes: 2, modifiedAt: "2" },
+					{ path: "nested/a.txt", sizeBytes: 3, modifiedAt: "3" },
+				]),
+			),
+		);
+
+		expect(
+			(await workspace.captureManifest(new AbortController().signal)).map(
+				(entry) => entry.path,
+			),
+		).toEqual([maxPath, "nested/A.txt", "nested/a.txt"]);
+	});
+
+	it("fails the complete manifest for symlinks and special files", async () => {
+		const root = await mkdtemp(join(tmpdir(), "mymemo-artifacts-"));
+		const outside = await mkdtemp(join(tmpdir(), "mymemo-outside-"));
+		try {
+			await mkdir(join(root, "nested"));
+			await writeFile(join(root, "safe.txt"), "safe");
+			await writeFile(join(outside, "secret.txt"), "secret");
+			await symlink(
+				join(outside, "secret.txt"),
+				join(root, "nested", "escape.txt"),
+			);
+
+			const workspace = createE2bArtifactWorkspace(localManifestSandbox(root));
+			await expect(
+				workspace.captureManifest(new AbortController().signal),
+			).rejects.toThrow();
+
+			await rm(join(root, "nested", "escape.txt"));
+			const fifoPath = join(root, "named-pipe");
+			const fifo = Bun.spawn(["mkfifo", fifoPath]);
+			expect(await fifo.exited).toBe(0);
+			await expect(
+				workspace.captureManifest(new AbortController().signal),
+			).rejects.toThrow();
+			await rm(fifoPath);
+		} finally {
+			await rm(root, { force: true, recursive: true });
+			await rm(outside, { force: true, recursive: true });
+		}
+	});
+
+	it("rejects a file swapped to an outside-root symlink after the manifest", async () => {
+		const root = await mkdtemp(join(tmpdir(), "mymemo-artifacts-"));
+		const outside = await mkdtemp(join(tmpdir(), "mymemo-outside-"));
+		try {
+			await mkdir(join(root, "nested"));
+			await writeFile(join(root, "nested", "report.txt"), "inside");
+			await writeFile(join(outside, "secret.txt"), "secret");
+			const workspace = createE2bArtifactWorkspace(localManifestSandbox(root));
+			const [entry] = await workspace.captureManifest(
 				new AbortController().signal,
-			)),
-		]).toEqual([0, 255, 1]);
-		expect(reads).toEqual([`${ARTIFACT_ROOT}/images/chart.bin`]);
+			);
+			if (!entry) throw new Error("expected artifact manifest entry");
+
+			await rm(join(root, "nested", "report.txt"));
+			await symlink(
+				join(outside, "secret.txt"),
+				join(root, "nested", "report.txt"),
+			);
+
+			await expect(
+				workspace.openFile(entry, new AbortController().signal),
+			).rejects.toMatchObject({ code: "special_entry" });
+		} finally {
+			await rm(root, { force: true, recursive: true });
+			await rm(outside, { force: true, recursive: true });
+		}
+	});
+
+	it("opens binary files as streams without decoding them", async () => {
+		const root = await mkdtemp(join(tmpdir(), "mymemo-artifacts-"));
+		try {
+			await mkdir(join(root, "images"));
+			await writeFile(
+				join(root, "images", "chart.bin"),
+				new Uint8Array([0, 255, 1]),
+			);
+			const workspace = createE2bArtifactWorkspace(localManifestSandbox(root));
+			const [entry] = await workspace.captureManifest(
+				new AbortController().signal,
+			);
+			if (!entry) throw new Error("expected artifact manifest entry");
+			const stream = await workspace.openFile(
+				entry,
+				new AbortController().signal,
+			);
+
+			expect([
+				...new Uint8Array(await new Response(stream).arrayBuffer()),
+			]).toEqual([0, 255, 1]);
+		} finally {
+			await rm(root, { force: true, recursive: true });
+		}
 	});
 });

--- a/apps/agent-worker/src/artifacts/artifact-workspace.ts
+++ b/apps/agent-worker/src/artifacts/artifact-workspace.ts
@@ -1,37 +1,139 @@
-import type { FileSandbox } from "../e2b/file-client";
-import type {
-	ArtifactManifestEntry,
-	ArtifactWorkspace,
-} from "./artifact-publication";
+import type { CommandSandbox } from "../e2b/command-client";
+import {
+	type ArtifactManifestEntry,
+	type ArtifactValidationCode,
+	ArtifactValidationError,
+	validateArtifactManifest,
+} from "./artifact-manifest";
+import type { ArtifactWorkspace } from "./artifact-publication";
 
 export const ARTIFACT_ROOT = "/home/user/artifacts";
 
 const MANIFEST_PROGRAM = `import json
 import os
 import stat
+import sys
 
 root = os.environ["MYMEMO_ARTIFACT_ROOT"]
 entries = []
-if os.path.isdir(root):
-    for directory, directories, files in os.walk(root, followlinks=False):
-        directories.sort()
-        files.sort()
-        for name in files:
-            full_path = os.path.join(directory, name)
-            info = os.lstat(full_path)
-            if not stat.S_ISREG(info.st_mode):
-                continue
-            entries.append({
-                "path": os.path.relpath(full_path, root).replace(os.sep, "/"),
-                "sizeBytes": info.st_size,
-                "modifiedAt": str(info.st_mtime_ns),
-            })
+
+def fail(code):
+    print(json.dumps({"artifactValidation": code}, separators=(",", ":")), file=sys.stderr)
+    raise SystemExit(2)
+
+if os.path.lexists(root):
+    root_info = os.lstat(root)
+    if not stat.S_ISDIR(root_info.st_mode) or stat.S_ISLNK(root_info.st_mode):
+        fail("invalid_root")
+    resolved_root = os.path.realpath(root)
+    pending = [("", root)]
+    while pending:
+        relative_directory, directory = pending.pop()
+        for entry in sorted(os.scandir(directory), key=lambda item: item.name):
+            relative_path = entry.name if not relative_directory else relative_directory + "/" + entry.name
+            info = entry.stat(follow_symlinks=False)
+            if stat.S_ISLNK(info.st_mode):
+                fail("special_entry")
+            resolved_path = os.path.realpath(entry.path)
+            if os.path.commonpath((resolved_root, resolved_path)) != resolved_root:
+                fail("outside_root")
+            if stat.S_ISDIR(info.st_mode):
+                pending.append((relative_path, entry.path))
+            elif stat.S_ISREG(info.st_mode):
+                entries.append({
+                    "path": relative_path,
+                    "sizeBytes": info.st_size,
+                    "modifiedAt": str(info.st_mtime_ns),
+                })
+            else:
+                fail("special_entry")
+entries.sort(key=lambda entry: entry["path"])
 print(json.dumps(entries, separators=(",", ":")))
 `;
 
 const MANIFEST_COMMAND = 'python3 -c "$MYMEMO_ARTIFACT_MANIFEST_PROGRAM"';
 
-export type ArtifactSandbox = FileSandbox;
+const PINNED_FILE_DESCRIPTOR = 3;
+const PIN_READY_TIMEOUT_MS = 30_000;
+const PIN_PROGRAM = `import json
+import os
+import signal
+import stat
+import sys
+
+root = os.environ["MYMEMO_ARTIFACT_ROOT"]
+relative_path = os.environ["MYMEMO_ARTIFACT_PATH"]
+expected_size = int(os.environ["MYMEMO_ARTIFACT_SIZE"])
+expected_mtime = os.environ["MYMEMO_ARTIFACT_MTIME"]
+parent_fd = None
+file_fd = None
+
+def fail(code):
+    print(json.dumps({"artifactValidation": code}, separators=(",", ":")), file=sys.stderr, flush=True)
+    raise SystemExit(2)
+
+try:
+    root_info = os.lstat(root)
+    if not stat.S_ISDIR(root_info.st_mode) or stat.S_ISLNK(root_info.st_mode):
+        fail("invalid_root")
+    parent_fd = os.open(root, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    if not stat.S_ISDIR(os.fstat(parent_fd).st_mode):
+        fail("invalid_root")
+    components = relative_path.split("/")
+    for component in components[:-1]:
+        next_fd = os.open(component, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW, dir_fd=parent_fd)
+        os.close(parent_fd)
+        parent_fd = next_fd
+    file_fd = os.open(components[-1], os.O_RDONLY | os.O_NONBLOCK | os.O_NOFOLLOW, dir_fd=parent_fd)
+    os.close(parent_fd)
+    parent_fd = None
+    info = os.fstat(file_fd)
+    if not stat.S_ISREG(info.st_mode):
+        fail("special_entry")
+    if info.st_size != expected_size or str(info.st_mtime_ns) != expected_mtime:
+        fail("unstable_entry")
+    if file_fd != ${PINNED_FILE_DESCRIPTOR}:
+        os.dup2(file_fd, ${PINNED_FILE_DESCRIPTOR})
+        os.close(file_fd)
+        file_fd = ${PINNED_FILE_DESCRIPTOR}
+    print("ready", flush=True)
+    signal.pause()
+except OSError:
+    fail("special_entry")
+finally:
+    if parent_fd is not None:
+        os.close(parent_fd)
+    if file_fd is not None:
+        os.close(file_fd)
+`;
+const PIN_COMMAND = 'exec python3 -c "$MYMEMO_ARTIFACT_PIN_PROGRAM"';
+
+export interface ArtifactCommandHandle {
+	readonly pid: number;
+	wait(): Promise<unknown>;
+	kill(): Promise<boolean>;
+}
+
+export interface ArtifactSandbox extends CommandSandbox {
+	commands: CommandSandbox["commands"] & {
+		run(
+			cmd: string,
+			opts: {
+				background: true;
+				envs: Record<string, string>;
+				onStderr: (data: string) => void | Promise<void>;
+				onStdout: (data: string) => void | Promise<void>;
+				timeoutMs: number;
+			},
+		): Promise<ArtifactCommandHandle>;
+	};
+	files: {
+		read(
+			path: string,
+			opts: { format: "stream" },
+		): Promise<ReadableStream<Uint8Array>>;
+	};
+}
 
 /** E2B-backed view of the reserved artifact root. */
 export function createE2bArtifactWorkspace(
@@ -49,44 +151,181 @@ export function createE2bArtifactWorkspace(
 			});
 			throwIfAborted(signal);
 			if (result.exitCode !== 0) {
+				const code = parseValidationCode(result.stderr);
+				if (code) throw new ArtifactValidationError(code);
 				throw new Error("artifact manifest command failed");
 			}
 			return parseManifest(result.stdout);
 		},
-		async readFile(path, signal) {
-			throwIfAborted(signal);
-			const bytes = await sandbox.files.read(`${ARTIFACT_ROOT}/${path}`, {
-				format: "bytes",
-			});
-			throwIfAborted(signal);
-			return bytes;
+		async openFile(entry, signal) {
+			return await openPinnedFile(sandbox, entry, signal);
 		},
 	};
 }
 
-function parseManifest(raw: string): ArtifactManifestEntry[] {
-	const parsed: unknown = JSON.parse(raw);
-	if (!Array.isArray(parsed))
-		throw new Error("artifact manifest is not an array");
-	return parsed.map((entry) => {
-		if (
-			typeof entry !== "object" ||
-			entry === null ||
-			!("path" in entry) ||
-			typeof entry.path !== "string" ||
-			!("sizeBytes" in entry) ||
-			typeof entry.sizeBytes !== "number" ||
-			!("modifiedAt" in entry) ||
-			typeof entry.modifiedAt !== "string"
-		) {
-			throw new Error("artifact manifest contains an invalid entry");
-		}
-		return {
-			path: entry.path,
-			sizeBytes: entry.sizeBytes,
-			modifiedAt: entry.modifiedAt,
+async function openPinnedFile(
+	sandbox: ArtifactSandbox,
+	entry: ArtifactManifestEntry,
+	signal: AbortSignal,
+): Promise<ReadableStream<Uint8Array>> {
+	throwIfAborted(signal);
+	let stdout = "";
+	let stderr = "";
+	let readySettled = false;
+	let settleReady!: (error?: Error) => void;
+	const ready = new Promise<void>((resolve, reject) => {
+		settleReady = (error) => {
+			if (readySettled) return;
+			readySettled = true;
+			if (error) reject(error);
+			else resolve();
 		};
 	});
+	let handle: ArtifactCommandHandle;
+	try {
+		handle = await sandbox.commands.run(PIN_COMMAND, {
+			background: true,
+			envs: {
+				MYMEMO_ARTIFACT_MTIME: entry.modifiedAt,
+				MYMEMO_ARTIFACT_PATH: entry.path,
+				MYMEMO_ARTIFACT_PIN_PROGRAM: PIN_PROGRAM,
+				MYMEMO_ARTIFACT_ROOT: ARTIFACT_ROOT,
+				MYMEMO_ARTIFACT_SIZE: String(entry.sizeBytes),
+			},
+			onStderr(data) {
+				stderr = `${stderr}${data}`.slice(-256);
+			},
+			onStdout(data) {
+				stdout += data;
+				if (stdout === "ready\n") settleReady();
+				else if (stdout.includes("\n") || stdout.length > 32) {
+					settleReady(new Error("artifact file pin failed"));
+				}
+			},
+			timeoutMs: 15 * 60_000,
+		});
+	} catch {
+		throwIfAborted(signal);
+		throw new Error("artifact file pin failed");
+	}
+	void handle.wait().then(
+		() => settleReady(new Error("artifact file pin failed")),
+		() => settleReady(new Error("artifact file pin failed")),
+	);
+	try {
+		await waitUntilReady(ready, signal);
+		const stream = await sandbox.files.read(
+			`/proc/${handle.pid}/fd/${PINNED_FILE_DESCRIPTOR}`,
+			{ format: "stream" },
+		);
+		if (signal.aborted) {
+			await stream.cancel(signal.reason).catch(() => {});
+			throwIfAborted(signal);
+		}
+		return streamWithCleanup(stream, () => handle.kill());
+	} catch {
+		await handle.kill().catch(() => false);
+		throwIfAborted(signal);
+		const code = parseValidationCode(stderr);
+		if (code) throw new ArtifactValidationError(code);
+		throw new Error("artifact file pin failed");
+	}
+}
+
+async function waitUntilReady(
+	ready: Promise<void>,
+	signal: AbortSignal,
+): Promise<void> {
+	await new Promise<void>((resolve, reject) => {
+		const timeout = setTimeout(
+			() => finish(new Error("artifact file pin timed out")),
+			PIN_READY_TIMEOUT_MS,
+		);
+		const onAbort = () =>
+			finish(signal.reason ?? new Error("artifact workspace aborted"));
+		const finish = (error?: unknown) => {
+			clearTimeout(timeout);
+			signal.removeEventListener("abort", onAbort);
+			if (error !== undefined) reject(error);
+			else resolve();
+		};
+		if (signal.aborted) onAbort();
+		else signal.addEventListener("abort", onAbort, { once: true });
+		ready.then(() => finish(), finish);
+	});
+}
+
+function streamWithCleanup(
+	stream: ReadableStream<Uint8Array>,
+	kill: () => Promise<boolean>,
+): ReadableStream<Uint8Array> {
+	const reader = stream.getReader();
+	let cleaned = false;
+	const cleanup = async () => {
+		if (cleaned) return;
+		cleaned = true;
+		await kill().catch(() => false);
+	};
+	return new ReadableStream({
+		async pull(controller) {
+			try {
+				const result = await reader.read();
+				if (result.done) {
+					await cleanup();
+					controller.close();
+				} else {
+					controller.enqueue(result.value);
+				}
+			} catch (error) {
+				await cleanup();
+				controller.error(error);
+			}
+		},
+		async cancel(reason) {
+			await reader.cancel(reason).catch(() => {});
+			await cleanup();
+		},
+	});
+}
+
+function parseManifest(raw: string) {
+	try {
+		return validateArtifactManifest(JSON.parse(raw));
+	} catch (error) {
+		if (error instanceof ArtifactValidationError) throw error;
+		throw new ArtifactValidationError("invalid_manifest");
+	}
+}
+
+const VALIDATION_CODES = new Set<ArtifactValidationCode>([
+	"invalid_manifest",
+	"invalid_path",
+	"invalid_root",
+	"outside_root",
+	"special_entry",
+	"unstable_entry",
+]);
+
+function parseValidationCode(stderr: string): ArtifactValidationCode | null {
+	for (const line of stderr.trim().split(/\r?\n/).reverse()) {
+		try {
+			const parsed: unknown = JSON.parse(line);
+			if (
+				typeof parsed === "object" &&
+				parsed !== null &&
+				"artifactValidation" in parsed &&
+				typeof parsed.artifactValidation === "string" &&
+				VALIDATION_CODES.has(
+					parsed.artifactValidation as ArtifactValidationCode,
+				)
+			) {
+				return parsed.artifactValidation as ArtifactValidationCode;
+			}
+		} catch {
+			// Only an exact trusted validation record is accepted.
+		}
+	}
+	return null;
 }
 
 function throwIfAborted(signal: AbortSignal): void {

--- a/apps/agent-worker/src/artifacts/s3-artifact-object-store.test.ts
+++ b/apps/agent-worker/src/artifacts/s3-artifact-object-store.test.ts
@@ -2,6 +2,17 @@ import { describe, expect, it } from "bun:test";
 import type { PutObjectCommandInput } from "@aws-sdk/client-s3";
 import { createS3ArtifactObjectStore } from "./s3-artifact-object-store";
 
+const MIB = 1_024 * 1_024;
+
+function byteStream(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
+	return new ReadableStream({
+		start(controller) {
+			for (const chunk of chunks) controller.enqueue(chunk);
+			controller.close();
+		},
+	});
+}
+
 describe("S3 Downloadable artifact object store", () => {
 	it("uploads to the private configured bucket and propagates abort", async () => {
 		const calls: Array<{
@@ -17,11 +28,14 @@ describe("S3 Downloadable artifact object store", () => {
 			},
 		);
 		const controller = new AbortController();
-		const body = new Uint8Array([0, 255, 1]);
+		const body = byteStream([new Uint8Array([0, 255, 1])]);
+		const expectedBody = new Uint8Array([0, 255, 1]);
 
 		await store.upload({
 			objectKey: "objects/opaque",
 			body,
+			sizeBytes: 3,
+			contentType: "application/octet-stream",
 			signal: controller.signal,
 		});
 
@@ -30,10 +44,124 @@ describe("S3 Downloadable artifact object store", () => {
 				request: {
 					Bucket: "private-artifacts",
 					Key: "objects/opaque",
-					Body: body,
+					Body: expectedBody,
+					ContentLength: 3,
+					ContentType: "application/octet-stream",
 				},
 				signal: controller.signal,
 			},
 		]);
+	});
+
+	it("uploads large streams as bounded retryable multipart chunks", async () => {
+		const partSizes: number[] = [];
+		const completed: Array<{ PartNumber?: number; ETag?: string }> = [];
+		let initiatedContentType: string | undefined;
+		let aborted = false;
+		const store = createS3ArtifactObjectStore(
+			{ bucket: "private-artifacts", region: "us-west-2" },
+			{
+				async putObject() {
+					throw new Error("large upload must not use PutObject");
+				},
+				async createMultipartUpload(request) {
+					initiatedContentType = request.ContentType;
+					return "upload-1";
+				},
+				async uploadPart(request) {
+					partSizes.push((request.Body as Uint8Array).byteLength);
+					return `etag-${request.PartNumber}`;
+				},
+				async completeMultipartUpload(request) {
+					completed.push(...(request.MultipartUpload?.Parts ?? []));
+				},
+				async abortMultipartUpload() {
+					aborted = true;
+				},
+			},
+		);
+		const sizeBytes = 5 * MIB + 7;
+
+		await store.upload({
+			objectKey: "objects/large",
+			body: byteStream([new Uint8Array(3 * MIB), new Uint8Array(2 * MIB + 7)]),
+			sizeBytes,
+			contentType: "application/pdf",
+			signal: new AbortController().signal,
+		});
+
+		expect(partSizes).toEqual([5 * MIB, 7]);
+		expect(completed).toEqual([
+			{ PartNumber: 1, ETag: "etag-1" },
+			{ PartNumber: 2, ETag: "etag-2" },
+		]);
+		expect(initiatedContentType).toBe("application/pdf");
+		expect(aborted).toBe(false);
+	});
+
+	it("aborts multipart publication when the stream length differs from the manifest", async () => {
+		let completed = false;
+		let aborted = false;
+		const store = createS3ArtifactObjectStore(
+			{ bucket: "private-artifacts", region: "us-west-2" },
+			{
+				async createMultipartUpload() {
+					return "upload-1";
+				},
+				async uploadPart() {
+					return "etag-1";
+				},
+				async completeMultipartUpload() {
+					completed = true;
+				},
+				async abortMultipartUpload() {
+					aborted = true;
+				},
+			},
+		);
+
+		await expect(
+			store.upload({
+				objectKey: "objects/truncated",
+				body: byteStream([new Uint8Array(5 * MIB)]),
+				sizeBytes: 5 * MIB + 1,
+				contentType: "application/octet-stream",
+				signal: new AbortController().signal,
+			}),
+		).rejects.toThrow(/size/);
+		expect(completed).toBe(false);
+		expect(aborted).toBe(true);
+	});
+
+	it("propagates caller abort through multipart upload and aborts the upload id", async () => {
+		const controller = new AbortController();
+		let aborted = false;
+		const store = createS3ArtifactObjectStore(
+			{ bucket: "private-artifacts", region: "us-west-2" },
+			{
+				async createMultipartUpload() {
+					return "upload-1";
+				},
+				async uploadPart(_request, signal) {
+					expect(signal).toBe(controller.signal);
+					controller.abort(new Error("publication canceled"));
+					throw signal.reason;
+				},
+				async abortMultipartUpload() {
+					aborted = true;
+				},
+			},
+		);
+
+		await expect(
+			store.upload({
+				objectKey: "objects/canceled",
+				body: byteStream([new Uint8Array(5 * MIB + 1)]),
+				sizeBytes: 5 * MIB + 1,
+				contentType: "application/octet-stream",
+				signal: controller.signal,
+			}),
+		).rejects.toThrow("publication canceled");
+		expect(aborted).toBe(true);
 	});
 });

--- a/apps/agent-worker/src/artifacts/s3-artifact-object-store.ts
+++ b/apps/agent-worker/src/artifacts/s3-artifact-object-store.ts
@@ -1,7 +1,15 @@
 import {
+	AbortMultipartUploadCommand,
+	type AbortMultipartUploadCommandInput,
+	CompleteMultipartUploadCommand,
+	type CompleteMultipartUploadCommandInput,
+	CreateMultipartUploadCommand,
+	type CreateMultipartUploadCommandInput,
 	PutObjectCommand,
 	type PutObjectCommandInput,
 	S3Client,
+	UploadPartCommand,
+	type UploadPartCommandInput,
 } from "@aws-sdk/client-s3";
 import type { ArtifactObjectStore } from "./artifact-publication";
 
@@ -10,36 +18,255 @@ export interface ArtifactBucketConfig {
 	region: string;
 }
 
+const MULTIPART_PART_SIZE_BYTES = 5 * 1_024 * 1_024;
+
 export type PutArtifactObject = (
 	request: PutObjectCommandInput,
 	signal: AbortSignal,
 ) => Promise<void>;
 
-/** S3 retries are bounded by the client's standard three-attempt strategy. */
+export interface ArtifactObjectStoreDependencies {
+	putObject?: PutArtifactObject;
+	createMultipartUpload?: (
+		request: CreateMultipartUploadCommandInput,
+		signal: AbortSignal,
+	) => Promise<string>;
+	uploadPart?: (
+		request: UploadPartCommandInput,
+		signal: AbortSignal,
+	) => Promise<string>;
+	completeMultipartUpload?: (
+		request: CompleteMultipartUploadCommandInput,
+		signal: AbortSignal,
+	) => Promise<void>;
+	abortMultipartUpload?: (
+		request: AbortMultipartUploadCommandInput,
+	) => Promise<void>;
+}
+
+/** S3 retries each bounded byte payload with its standard three-attempt strategy. */
 export function createS3ArtifactObjectStore(
 	config: ArtifactBucketConfig,
-	dependencies: { putObject?: PutArtifactObject } = {},
+	dependencies: ArtifactObjectStoreDependencies = {},
 ): ArtifactObjectStore {
+	const client = new S3Client({ region: config.region, maxAttempts: 3 });
 	const putObject =
 		dependencies.putObject ??
-		(() => {
-			const client = new S3Client({ region: config.region, maxAttempts: 3 });
-			return async (request: PutObjectCommandInput, signal: AbortSignal) => {
-				await client.send(new PutObjectCommand(request), {
-					abortSignal: signal,
-				});
-			};
-		})();
-	return {
-		async upload({ objectKey, body, signal }) {
-			await putObject(
+		(async (request: PutObjectCommandInput, signal: AbortSignal) => {
+			await client.send(new PutObjectCommand(request), { abortSignal: signal });
+		});
+	const createMultipartUpload =
+		dependencies.createMultipartUpload ??
+		(async (
+			request: CreateMultipartUploadCommandInput,
+			signal: AbortSignal,
+		) => {
+			const result = await client.send(
+				new CreateMultipartUploadCommand(request),
 				{
-					Bucket: config.bucket,
-					Key: objectKey,
-					Body: body,
+					abortSignal: signal,
 				},
+			);
+			if (!result.UploadId) throw new Error("artifact multipart upload failed");
+			return result.UploadId;
+		});
+	const uploadPart =
+		dependencies.uploadPart ??
+		(async (request: UploadPartCommandInput, signal: AbortSignal) => {
+			const result = await client.send(new UploadPartCommand(request), {
+				abortSignal: signal,
+			});
+			if (!result.ETag) throw new Error("artifact multipart upload failed");
+			return result.ETag;
+		});
+	const completeMultipartUpload =
+		dependencies.completeMultipartUpload ??
+		(async (
+			request: CompleteMultipartUploadCommandInput,
+			signal: AbortSignal,
+		) => {
+			await client.send(new CompleteMultipartUploadCommand(request), {
+				abortSignal: signal,
+			});
+		});
+	const abortMultipartUpload =
+		dependencies.abortMultipartUpload ??
+		(async (request: AbortMultipartUploadCommandInput) => {
+			await client.send(new AbortMultipartUploadCommand(request));
+		});
+
+	return {
+		async upload({ objectKey, body, sizeBytes, contentType, signal }) {
+			if (sizeBytes <= MULTIPART_PART_SIZE_BYTES) {
+				const bytes = await collectBody(body, sizeBytes, signal);
+				await putObject(
+					{
+						Bucket: config.bucket,
+						Key: objectKey,
+						Body: bytes,
+						ContentLength: bytes.byteLength,
+						ContentType: contentType,
+					},
+					signal,
+				);
+				return;
+			}
+
+			const baseRequest = { Bucket: config.bucket, Key: objectKey };
+			const uploadId = await createMultipartUpload(
+				{ ...baseRequest, ContentType: contentType },
 				signal,
 			);
+			try {
+				const parts: Array<{ PartNumber: number; ETag: string }> = [];
+				let partNumber = 1;
+				for await (const part of streamParts(body, sizeBytes, signal)) {
+					const etag = await uploadPart(
+						{
+							...baseRequest,
+							UploadId: uploadId,
+							PartNumber: partNumber,
+							Body: part,
+							ContentLength: part.byteLength,
+						},
+						signal,
+					);
+					parts.push({ PartNumber: partNumber, ETag: etag });
+					partNumber++;
+				}
+				await completeMultipartUpload(
+					{
+						...baseRequest,
+						UploadId: uploadId,
+						MultipartUpload: { Parts: parts },
+					},
+					signal,
+				);
+			} catch (error) {
+				await abortMultipartUpload({
+					...baseRequest,
+					UploadId: uploadId,
+				}).catch(() => {});
+				throw error;
+			}
 		},
 	};
+}
+
+async function collectBody(
+	body: ReadableStream<Uint8Array>,
+	expectedSize: number,
+	signal: AbortSignal,
+): Promise<Uint8Array> {
+	const bytes = new Uint8Array(expectedSize);
+	const reader = body.getReader();
+	let offset = 0;
+	let complete = false;
+	try {
+		while (true) {
+			const result = await readWithAbort(reader, signal);
+			if (result.done) break;
+			if (offset + result.value.byteLength > expectedSize) {
+				throw new Error("artifact upload size mismatch");
+			}
+			bytes.set(result.value, offset);
+			offset += result.value.byteLength;
+		}
+		if (offset !== expectedSize) {
+			throw new Error("artifact upload size mismatch");
+		}
+		complete = true;
+		return bytes;
+	} finally {
+		if (!complete) await reader.cancel().catch(() => {});
+		reader.releaseLock();
+	}
+}
+
+async function* streamParts(
+	body: ReadableStream<Uint8Array>,
+	expectedSize: number,
+	signal: AbortSignal,
+): AsyncGenerator<Uint8Array> {
+	const reader = body.getReader();
+	let part = new Uint8Array(MULTIPART_PART_SIZE_BYTES);
+	let partOffset = 0;
+	let total = 0;
+	let complete = false;
+	try {
+		while (true) {
+			const result = await readWithAbort(reader, signal);
+			if (result.done) break;
+			total += result.value.byteLength;
+			if (total > expectedSize) {
+				throw new Error("artifact upload size mismatch");
+			}
+
+			let chunkOffset = 0;
+			while (chunkOffset < result.value.byteLength) {
+				const copied = Math.min(
+					part.byteLength - partOffset,
+					result.value.byteLength - chunkOffset,
+				);
+				part.set(
+					result.value.subarray(chunkOffset, chunkOffset + copied),
+					partOffset,
+				);
+				partOffset += copied;
+				chunkOffset += copied;
+				if (partOffset === part.byteLength) {
+					yield part;
+					part = new Uint8Array(MULTIPART_PART_SIZE_BYTES);
+					partOffset = 0;
+				}
+			}
+		}
+		if (total !== expectedSize) {
+			throw new Error("artifact upload size mismatch");
+		}
+		complete = true;
+		if (partOffset > 0) yield part.slice(0, partOffset);
+	} finally {
+		if (!complete) await reader.cancel().catch(() => {});
+		reader.releaseLock();
+	}
+}
+
+interface ArtifactStreamReader {
+	read(): Promise<
+		{ done: false; value: Uint8Array } | { done: true; value?: Uint8Array }
+	>;
+	cancel(reason?: unknown): Promise<void>;
+}
+
+function readWithAbort(
+	reader: ArtifactStreamReader,
+	signal: AbortSignal,
+): Promise<
+	{ done: false; value: Uint8Array } | { done: true; value?: Uint8Array }
+> {
+	if (signal.aborted) {
+		void reader.cancel(signal.reason).catch(() => {});
+		return Promise.reject(
+			signal.reason ?? new Error("artifact upload aborted"),
+		);
+	}
+	return new Promise((resolve, reject) => {
+		const onAbort = () => {
+			signal.removeEventListener("abort", onAbort);
+			void reader.cancel(signal.reason).catch(() => {});
+			reject(signal.reason ?? new Error("artifact upload aborted"));
+		};
+		signal.addEventListener("abort", onAbort, { once: true });
+		reader.read().then(
+			(result) => {
+				signal.removeEventListener("abort", onAbort);
+				resolve(result);
+			},
+			(error) => {
+				signal.removeEventListener("abort", onAbort);
+				reject(error);
+			},
+		);
+	});
 }

--- a/apps/agent-worker/src/e2b/sandbox-provisioner.ts
+++ b/apps/agent-worker/src/e2b/sandbox-provisioner.ts
@@ -1,6 +1,9 @@
 import { Sandbox } from "e2b";
 import type { ArtifactWorkspace } from "../artifacts/artifact-publication";
-import { createE2bArtifactWorkspace } from "../artifacts/artifact-workspace";
+import {
+	type ArtifactSandbox,
+	createE2bArtifactWorkspace,
+} from "../artifacts/artifact-workspace";
 import type { SandboxCommandClient } from "../bash-tool/bash-tool";
 import { DEFAULT_COMMAND_CONTROL_DIR } from "../bash-tool/bash-wrapper";
 import type { SandboxFileClient } from "../file-tools/file-tools";
@@ -62,8 +65,10 @@ export interface SandboxProvisioner {
 }
 
 /** The slice of an E2B `Sandbox` a provisioned handle holds. */
-export interface ProvisionerSandbox extends CommandSandbox, FileSandbox {
+export interface ProvisionerSandbox extends CommandSandbox {
 	readonly sandboxId: string;
+	commands: CommandSandbox["commands"] & ArtifactSandbox["commands"];
+	files: FileSandbox["files"] & ArtifactSandbox["files"];
 	setTimeout(timeoutMs: number): Promise<void>;
 }
 

--- a/apps/agent-worker/src/run-loop.ts
+++ b/apps/agent-worker/src/run-loop.ts
@@ -1,4 +1,5 @@
 import {
+	ArtifactQuotaError,
 	type PublishedArtifact,
 	publishArtifactsAndTransitionRunDoneTx,
 } from "@mymemo/agent-db/artifact-store";
@@ -20,6 +21,8 @@ import {
 	transitionRunTerminalTx,
 } from "@mymemo/agent-db/run-store";
 import { advanceAgentSessionPointerTx } from "@mymemo/agent-db/runtime-store";
+import { ArtifactValidationError } from "./artifacts/artifact-manifest";
+import { ArtifactPublicationError } from "./artifacts/artifact-publication";
 import type { WorkerLogger } from "./logger";
 import type { Worker } from "./worker";
 
@@ -384,7 +387,7 @@ export class RunLoop {
 				userId: run.userId,
 				conversationId: run.conversationId,
 				runId,
-				error: toMessage(failure.error),
+				...artifactFailureLogFields(failure.error),
 			});
 			await this.terminalize(runId, "error", {
 				message: GENERIC_RUN_ERROR_MESSAGE,
@@ -452,7 +455,15 @@ export class RunLoop {
 				userId: run.userId,
 				conversationId: run.conversationId,
 				runId: run.runId,
-				error: toMessage(error),
+				...(error instanceof ArtifactQuotaError
+					? artifactFailureLogFields(error)
+					: {
+							error: "artifact metadata publication failed",
+							artifactFailure: {
+								category: "publication",
+								stage: "metadata",
+							},
+						}),
 			});
 			await this.terminalize(run.runId, "error", {
 				message: GENERIC_RUN_ERROR_MESSAGE,
@@ -541,4 +552,37 @@ export class RunLoop {
 
 function toMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
+}
+
+function artifactFailureLogFields(error: unknown): Record<string, unknown> {
+	if (error instanceof ArtifactQuotaError) {
+		return {
+			error: error.message,
+			artifactFailure: {
+				category: "quota",
+				quota: error.quota,
+				actual: error.actual,
+				limit: error.limit,
+			},
+		};
+	}
+	if (error instanceof ArtifactValidationError) {
+		return {
+			error: error.message,
+			artifactFailure: {
+				category: "validation",
+				reason: error.code,
+			},
+		};
+	}
+	if (error instanceof ArtifactPublicationError) {
+		return {
+			error: error.message,
+			artifactFailure: {
+				category: "publication",
+				stage: error.stage,
+			},
+		};
+	}
+	return { error: toMessage(error) };
 }

--- a/apps/agent-worker/src/sdk/start-run-query.test.ts
+++ b/apps/agent-worker/src/sdk/start-run-query.test.ts
@@ -796,7 +796,7 @@ describe("createStartRunQuery — renewal and abort linkage", () => {
 					publishSignal = signal;
 					return {
 						async publish() {
-							await new Promise<never>((_resolve, reject) => {
+							return await new Promise<never>((_resolve, reject) => {
 								if (signal.aborted) return reject(new Error("aborted"));
 								signal.addEventListener(
 									"abort",

--- a/infra/terraform/iam.tf
+++ b/infra/terraform/iam.tf
@@ -61,8 +61,9 @@ resource "aws_iam_role" "agent_worker_task" {
 data "aws_iam_policy_document" "agent_worker_artifact_write" {
   statement {
     actions = [
-      "s3:PutObject",
+      "s3:AbortMultipartUpload",
       "s3:DeleteObject",
+      "s3:PutObject",
     ]
     resources = ["${aws_s3_bucket.artifacts.arn}/*"]
   }

--- a/packages/agent-db/src/artifact-store.ts
+++ b/packages/agent-db/src/artifact-store.ts
@@ -7,6 +7,28 @@ import {
 	conversationRuntime,
 } from "./schema";
 
+export const MAX_CURRENT_ARTIFACT_PATHS = 100;
+export const MAX_ARTIFACT_SIZE_BYTES = 100 * 1_024 * 1_024;
+export const MAX_CONVERSATION_ARTIFACT_BYTES = 1_024 * 1_024 * 1_024;
+
+export type ArtifactQuota =
+	| "artifact_size_bytes"
+	| "conversation_path_count"
+	| "conversation_size_bytes";
+
+/** Bounded quota detail safe for structured worker logs. */
+export class ArtifactQuotaError extends Error {
+	override readonly name = "ArtifactQuotaError";
+
+	constructor(
+		readonly quota: ArtifactQuota,
+		readonly actual: number,
+		readonly limit: number,
+	) {
+		super(`artifact quota exceeded: ${quota}`);
+	}
+}
+
 export interface StagedArtifactObject {
 	objectKey: string;
 	userId: string;
@@ -54,7 +76,24 @@ export async function publishArtifactsAndTransitionRunDoneTx(
 	if (input.artifacts.length === 0) {
 		throw new Error("artifact publication requires at least one staged object");
 	}
+	validatePublishedArtifacts(input.artifacts);
 	return await db.transaction(async (tx) => {
+		const currentArtifacts = await tx
+			.select({
+				path: conversationArtifacts.path,
+				objectKey: conversationArtifacts.objectKey,
+				sizeBytes: conversationArtifacts.sizeBytes,
+			})
+			.from(conversationArtifacts)
+			.where(
+				and(
+					eq(conversationArtifacts.userId, input.userId),
+					eq(conversationArtifacts.conversationId, input.conversationId),
+				),
+			)
+			.for("update");
+		validatePostUpsertQuota(currentArtifacts, input.artifacts);
+
 		let agentSessionPointerAdvanced: boolean | null = null;
 		if (input.agentSessionId !== undefined) {
 			try {
@@ -80,16 +119,10 @@ export async function publishArtifactsAndTransitionRunDoneTx(
 			}
 		}
 		const paths = input.artifacts.map((artifact) => artifact.path);
-		const existing = await tx
-			.select({ objectKey: conversationArtifacts.objectKey })
-			.from(conversationArtifacts)
-			.where(
-				and(
-					eq(conversationArtifacts.userId, input.userId),
-					eq(conversationArtifacts.conversationId, input.conversationId),
-					inArray(conversationArtifacts.path, paths),
-				),
-			);
+		const changedPaths = new Set(paths);
+		const existing = currentArtifacts.filter((artifact) =>
+			changedPaths.has(artifact.path),
+		);
 
 		const objectKeys = input.artifacts.map((artifact) => artifact.objectKey);
 		const promoted = await tx
@@ -151,4 +184,52 @@ export async function publishArtifactsAndTransitionRunDoneTx(
 		});
 		return { run, agentSessionPointerAdvanced };
 	});
+}
+
+function validatePublishedArtifacts(artifacts: PublishedArtifact[]): void {
+	const paths = new Set<string>();
+	for (const artifact of artifacts) {
+		if (!Number.isSafeInteger(artifact.sizeBytes) || artifact.sizeBytes < 0) {
+			throw new Error("artifact publication contains an invalid size");
+		}
+		if (artifact.sizeBytes > MAX_ARTIFACT_SIZE_BYTES) {
+			throw new ArtifactQuotaError(
+				"artifact_size_bytes",
+				artifact.sizeBytes,
+				MAX_ARTIFACT_SIZE_BYTES,
+			);
+		}
+		if (paths.has(artifact.path)) {
+			throw new Error("artifact publication contains duplicate paths");
+		}
+		paths.add(artifact.path);
+	}
+}
+
+function validatePostUpsertQuota(
+	current: Array<{ path: string; sizeBytes: number }>,
+	changed: PublishedArtifact[],
+): void {
+	const resultingSizes = new Map(
+		current.map((artifact) => [artifact.path, artifact.sizeBytes]),
+	);
+	for (const artifact of changed) {
+		resultingSizes.set(artifact.path, artifact.sizeBytes);
+	}
+	if (resultingSizes.size > MAX_CURRENT_ARTIFACT_PATHS) {
+		throw new ArtifactQuotaError(
+			"conversation_path_count",
+			resultingSizes.size,
+			MAX_CURRENT_ARTIFACT_PATHS,
+		);
+	}
+	let totalSize = 0;
+	for (const size of resultingSizes.values()) totalSize += size;
+	if (totalSize > MAX_CONVERSATION_ARTIFACT_BYTES) {
+		throw new ArtifactQuotaError(
+			"conversation_size_bytes",
+			totalSize,
+			MAX_CONVERSATION_ARTIFACT_BYTES,
+		);
+	}
 }

--- a/scripts/deploy-config.test.ts
+++ b/scripts/deploy-config.test.ts
@@ -101,11 +101,11 @@ describe("agent deployment config", () => {
 		expect(iamConfig).toContain('actions   = ["s3:GetObject"]');
 		expect(iamConfig).toContain("role   = aws_iam_role.chat_api_task.id");
 		expect(workerArtifactPolicy).toMatch(
-			/actions\s*=\s*\[\s*"s3:PutObject",\s*"s3:DeleteObject",\s*\]/,
+			/actions\s*=\s*\[\s*"s3:AbortMultipartUpload",\s*"s3:DeleteObject",\s*"s3:PutObject",\s*\]/,
 		);
 		expect(iamConfig).toContain("role   = aws_iam_role.agent_worker_task.id");
 		expect(iamConfig).toMatch(
-			/data "aws_iam_policy_document" "agent_worker_artifact_write" \{[\s\S]*?actions\s*=\s*\[\s*"s3:PutObject",\s*"s3:DeleteObject",\s*\][\s\S]*?resources\s*=\s*\["\$\{aws_s3_bucket\.artifacts\.arn\}\/\*"\][\s\S]*?\}/,
+			/data "aws_iam_policy_document" "agent_worker_artifact_write" \{[\s\S]*?actions\s*=\s*\[\s*"s3:AbortMultipartUpload",\s*"s3:DeleteObject",\s*"s3:PutObject",\s*\][\s\S]*?resources\s*=\s*\["\$\{aws_s3_bucket\.artifacts\.arn\}\/\*"\][\s\S]*?\}/,
 		);
 		expect(workerArtifactPolicy).not.toMatch(
 			/s3:(GetObject|ListBucket|DeleteObjectVersion|GetObjectVersion|ListBucketVersions)/,


### PR DESCRIPTION
## Summary

- enforce normalized, case-sensitive POSIX artifact paths and fail closed on traversal, invalid Unicode, symlinks, and special files
- pin and stream validated regular files through no-follow descriptors to prevent post-manifest path swaps
- enforce atomic per-artifact, path-count, and aggregate conversation quotas
- add bounded S3 multipart uploads with abort cleanup, trusted content types, safe structured errors, and incomplete-upload lifecycle cleanup
- cover manifest validation, quota boundaries, replacement accounting, atomic publication, cancellation, and multipart behavior

## Why

Artifact publication needed a complete safety and resource contract before downloadable outputs could be exposed. The previous path-based publication flow did not provide the required quota enforcement or a descriptor-pinned containment guarantee between manifest capture and upload.

## Impact

Artifact publication now fails closed before current metadata changes, preserves the prior downloadable set on failure, and publishes large outputs without buffering several maximum-size files in worker memory. Client failures remain generic while worker logs retain bounded structured diagnostics.

## Validation

- `bun test` — 750 passed, 11 skipped, 0 failed
- agent-worker and agent-db TypeScript checks
- Biome checks and `git diff --check`
- both Terraform roots validated
- GitHub CI `test`, `worker-image`, and `integration` checks passed
- parallel Standards and issue-spec reviews with no findings

Closes #285
