### PR TITLE
test(artifacts): prove delivery contract end to end

### DIFF
--- a/apps/agent-worker/src/e2b/sandbox-provisioner.test.ts
+++ b/apps/agent-worker/src/e2b/sandbox-provisioner.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import type { WorkerLogger } from "../logger";
 import {
+	createE2bSandboxProvisioner,
 	createSandboxProvisioner,
+	type E2bSandboxFactory,
 	type ProvisionerSandbox,
 	SANDBOX_WORKSPACE_ROOT,
 	type SandboxProvisionerDeps,
@@ -96,6 +98,72 @@ const input = {
 };
 
 describe("createSandboxProvisioner", () => {
+	it("passes only E2B config and owner metadata across the production SDK boundary", async () => {
+		const created = makeFakeSandbox("sbx-created");
+		const createCalls: Parameters<E2bSandboxFactory["create"]>[] = [];
+		const factory: E2bSandboxFactory = {
+			async connect() {
+				throw new Error("unexpected connect");
+			},
+			async create(...args) {
+				createCalls.push(args);
+				return created.sandbox;
+			},
+		};
+		const trustedOnlyEnvironment = {
+			AWS_ACCESS_KEY_ID: "artifact-aws-access-key",
+			AWS_SECRET_ACCESS_KEY: "artifact-aws-secret-key",
+			AWS_SESSION_TOKEN: "artifact-aws-session-token",
+			ARTIFACT_BUCKET: "artifact-private-bucket",
+			AWS_REGION: "artifact-private-region",
+			ARTIFACT_PRESIGNED_URL:
+				"https://objects.example/private?X-Amz-Signature=artifact-secret",
+		};
+		const previousEnvironment = Object.fromEntries(
+			Object.keys(trustedOnlyEnvironment).map((key) => [key, process.env[key]]),
+		);
+		Object.assign(process.env, trustedOnlyEnvironment);
+
+		try {
+			const { logger } = makeLogger();
+			const provisioner = createE2bSandboxProvisioner(
+				{
+					apiKey: "e2b-only-key",
+					template: "artifact-test-template",
+					sandboxIdleMs: 300_000,
+					logger,
+				},
+				factory,
+			);
+
+			await provisioner.provisionForRun({ ...input, sandboxId: null });
+
+			expect(createCalls).toEqual([
+				[
+					"artifact-test-template",
+					{
+						apiKey: "e2b-only-key",
+						timeoutMs: 300_000,
+						lifecycle: { onTimeout: "pause" },
+						metadata: {
+							userId: "user-1",
+							conversationId: "conv-1",
+						},
+					},
+				],
+			]);
+			const serializedBoundary = JSON.stringify(createCalls);
+			for (const trustedOnlyValue of Object.values(trustedOnlyEnvironment)) {
+				expect(serializedBoundary).not.toContain(trustedOnlyValue);
+			}
+		} finally {
+			for (const [key, value] of Object.entries(previousEnvironment)) {
+				if (value === undefined) delete process.env[key];
+				else process.env[key] = value;
+			}
+		}
+	});
+
 	it("connects to the conversation's sandbox when the pointer is set and not tainted", async () => {
 		const { deps, connectCalls, createCalls } = makeDeps();
 		const provisioner = createSandboxProvisioner(deps);

--- a/apps/agent-worker/src/e2b/sandbox-provisioner.ts
+++ b/apps/agent-worker/src/e2b/sandbox-provisioner.ts
@@ -153,20 +153,44 @@ export interface E2bSandboxProvisionerConfig {
 	logger: WorkerLogger;
 }
 
+/** The exact trusted-worker calls made to the E2B SDK, injectable so boundary
+ * tests can prove which options and metadata leave the worker process. */
+export interface E2bSandboxFactory {
+	connect(
+		sandboxId: string,
+		options: { apiKey: string; timeoutMs: number },
+	): Promise<ProvisionerSandbox>;
+	create(
+		template: string,
+		options: {
+			apiKey: string;
+			timeoutMs: number;
+			lifecycle: { onTimeout: "pause" };
+			metadata: { userId: string; conversationId: string };
+		},
+	): Promise<ProvisionerSandbox>;
+}
+
+const defaultE2bSandboxFactory: E2bSandboxFactory = {
+	connect: (sandboxId, options) => Sandbox.connect(sandboxId, options),
+	create: (template, options) => Sandbox.create(template, options),
+};
+
 /** {@link createSandboxProvisioner} wired to the real E2B SDK. */
 export function createE2bSandboxProvisioner(
 	config: E2bSandboxProvisionerConfig,
+	factory: E2bSandboxFactory = defaultE2bSandboxFactory,
 ): SandboxProvisioner {
 	return createSandboxProvisioner({
 		sandboxIdleMs: config.sandboxIdleMs,
 		logger: config.logger,
 		connectSandbox: (sandboxId) =>
-			Sandbox.connect(sandboxId, {
+			factory.connect(sandboxId, {
 				apiKey: config.apiKey,
 				timeoutMs: config.sandboxIdleMs,
 			}),
 		createSandbox: (input) =>
-			Sandbox.create(config.template, {
+			factory.create(config.template, {
 				apiKey: config.apiKey,
 				timeoutMs: config.sandboxIdleMs,
 				// Idle timeout pauses the workspace instead of killing it; the next

--- a/apps/agent-worker/src/sandbox-env.test.ts
+++ b/apps/agent-worker/src/sandbox-env.test.ts
@@ -21,7 +21,7 @@ describe("buildSandboxEnv — credential boundary", () => {
 		});
 	});
 
-	it("carries no provider or KB secret even when the worker holds them", () => {
+	it("carries no trusted-runtime secret or artifact access material", () => {
 		// The worker config holds OpenRouter/KB/E2B secrets...
 		const config = loadWorkerConfigFromEnv({
 			AGENT_DATABASE_URL: "postgresql://u:p@localhost:5432/mymemo_agent",
@@ -51,6 +51,10 @@ describe("buildSandboxEnv — credential boundary", () => {
 			"E2B_API_KEY",
 			"ARTIFACT_BUCKET",
 			"AWS_REGION",
+			"AWS_ACCESS_KEY_ID",
+			"AWS_SECRET_ACCESS_KEY",
+			"AWS_SESSION_TOKEN",
+			"ARTIFACT_PRESIGNED_URL",
 		]) {
 			expect(env as Record<string, unknown>).not.toHaveProperty(forbidden);
 		}

--- a/apps/chat-api/src/features/artifacts/artifact-delivery.acceptance.test.ts
+++ b/apps/chat-api/src/features/artifacts/artifact-delivery.acceptance.test.ts
@@ -1,0 +1,529 @@
+import { describe, expect, it } from "bun:test";
+import { createQueuedRunTx } from "@mymemo/agent-db/run-store";
+import { asc, eq } from "drizzle-orm";
+import type { ApiConfig } from "@/config/env";
+import {
+	artifactObjects,
+	conversationArtifacts,
+	conversations,
+	runEvents,
+	runs,
+} from "@/db/schema";
+import { createTestDatabase, type TestDb } from "@/db/testing";
+import type { AppDeps } from "@/deps";
+import { PostgresConversationStore } from "@/features/conversation-store";
+import { projectRunEvent } from "@/features/run-events/project-run-event";
+import type { ArtifactManifestEntry } from "../../../../agent-worker/src/artifacts/artifact-manifest";
+import {
+	type ArtifactObjectStore,
+	type ArtifactWorkspace,
+	createArtifactPublisher,
+	withArtifactPublication,
+} from "../../../../agent-worker/src/artifacts/artifact-publication";
+import { runCleanupPass } from "../../../../agent-worker/src/cleanup/cleanup";
+import type { WorkerLogger } from "../../../../agent-worker/src/logger";
+import { RunLoop } from "../../../../agent-worker/src/run-loop";
+import type { SupervisedQuery } from "../../../../agent-worker/src/sdk/agent-stream";
+import { createSdkRunProcessor } from "../../../../agent-worker/src/sdk/run-processor";
+import { Worker } from "../../../../agent-worker/src/worker";
+import type {
+	ArtifactDownloadSigner,
+	ArtifactDownloadSignInput,
+} from "./artifact-download-signer";
+import { PostgresArtifactMetadataStore } from "./postgres-artifact-metadata-store";
+
+const { createApp } = await import("@/app");
+
+const identityHeaders = {
+	"x-member-code": "member-1",
+	"x-partner-code": "partner-1",
+};
+const silentLogger: WorkerLogger = { info() {}, warn() {}, error() {} };
+const encoder = new TextEncoder();
+
+class AcceptanceWorkspace implements ArtifactWorkspace {
+	private readonly files = new Map<
+		string,
+		{ body: Uint8Array; modifiedAt: string; sizeBytes: number }
+	>();
+
+	write(
+		path: string,
+		body: Uint8Array,
+		modifiedAt: string,
+		sizeBytes = body.byteLength,
+	): void {
+		this.files.set(path, { body, modifiedAt, sizeBytes });
+	}
+
+	delete(path: string): void {
+		this.files.delete(path);
+	}
+
+	async captureManifest(): Promise<ArtifactManifestEntry[]> {
+		return [...this.files].map(([path, file]) => ({
+			path,
+			sizeBytes: file.sizeBytes,
+			modifiedAt: file.modifiedAt,
+		}));
+	}
+
+	async openFile(
+		entry: ArtifactManifestEntry,
+	): Promise<ReadableStream<Uint8Array>> {
+		const file = this.files.get(entry.path);
+		if (!file) throw new Error(`missing acceptance file ${entry.path}`);
+		return new ReadableStream({
+			start(controller) {
+				controller.enqueue(file.body);
+				controller.close();
+			},
+		});
+	}
+}
+
+function successfulQuery(onStart: () => void): SupervisedQuery {
+	return {
+		async interrupt() {},
+		async *[Symbol.asyncIterator]() {
+			onStart();
+			yield {
+				type: "result",
+				subtype: "success",
+				is_error: false,
+				result: "done",
+				session_id: "acceptance-session",
+			} as never;
+		},
+	};
+}
+
+async function readBody(body: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+	return new Uint8Array(await new Response(body).arrayBuffer());
+}
+
+function createDeliveryHarness(
+	tdb: TestDb,
+	workspace: AcceptanceWorkspace,
+	logger: WorkerLogger = silentLogger,
+) {
+	const storedObjects = new Map<string, Uint8Array>();
+	let uploadOverride: ArtifactObjectStore["upload"] | undefined;
+	let deleteOverride: ((objectKey: string) => Promise<void>) | undefined;
+	let nextObject = 1;
+	let nextArtifact = 1;
+	const publisher = createArtifactPublisher({
+		db: tdb.db,
+		objectStore: {
+			async upload(input) {
+				if (uploadOverride) return await uploadOverride(input);
+				storedObjects.set(input.objectKey, await readBody(input.body));
+			},
+		},
+		createObjectKey: () => `objects/acceptance-${nextObject++}`,
+		createArtifactId: () => `artifact-${nextArtifact++}`,
+	});
+	const worker = new Worker({
+		workerId: "acceptance-worker",
+		maxConcurrentRuns: 1,
+		shutdownTimeoutMs: 1_000,
+		logger,
+	});
+	const loop = new RunLoop({
+		db: tdb.db,
+		worker,
+		processor: createSdkRunProcessor({
+			logger,
+			startRunQuery: async (run, signal) => {
+				const query = queries.get(run.runId);
+				if (!query) throw new Error(`missing query for ${run.runId}`);
+				const publication = await publisher.begin({ run, workspace, signal });
+				return withArtifactPublication(query, publication);
+			},
+		}),
+		heartbeatIntervalMs: 15_000,
+		logger,
+	});
+	const queries = new Map<string, SupervisedQuery>();
+
+	return {
+		loop,
+		worker,
+		storedObjects,
+		setUploadOverride(override?: ArtifactObjectStore["upload"]) {
+			uploadOverride = override;
+		},
+		setDeleteOverride(override?: (objectKey: string) => Promise<void>) {
+			deleteOverride = override;
+		},
+		async queue(runId: string, query: SupervisedQuery) {
+			queries.set(runId, query);
+			await createQueuedRunTx(tdb.db, {
+				runId,
+				userId: "member-1",
+				conversationId: "conversation-1",
+			});
+		},
+		async run(runId: string, query: SupervisedQuery) {
+			await this.queue(runId, query);
+			await loop.tick();
+			await worker.drain();
+		},
+		async cleanup(now: Date) {
+			return await runCleanupPass({
+				db: tdb.db,
+				workerId: "acceptance-worker",
+				now,
+				logger,
+				sandboxJanitor: { async killSandbox() {} },
+				artifactJanitor: {
+					async deleteObject(objectKey) {
+						if (deleteOverride) await deleteOverride(objectKey);
+						storedObjects.delete(objectKey);
+					},
+				},
+			});
+		},
+	};
+}
+
+function createHttpHarness(tdb: TestDb) {
+	const signInputs: ArtifactDownloadSignInput[] = [];
+	const conversationStore = new PostgresConversationStore(tdb.db);
+	const artifactDownloadSigner: ArtifactDownloadSigner = {
+		async createDownloadUrl(input) {
+			signInputs.push(input);
+			return `https://objects.example/download-${signInputs.length}`;
+		},
+	};
+	const deps = {
+		conversationStore,
+		artifactMetadataStore: new PostgresArtifactMetadataStore(tdb.db),
+		artifactDownloadSigner,
+		exposureGate: {
+			async isAgentEnabled() {
+				throw new Error("artifact reads must not consult the exposure gate");
+			},
+		},
+	} as unknown as AppDeps;
+	return {
+		conversationStore,
+		signInputs,
+		app: createApp({ logLevel: "silent" } as ApiConfig, deps),
+	};
+}
+
+async function currentArtifacts(tdb: TestDb) {
+	return await tdb.db
+		.select()
+		.from(conversationArtifacts)
+		.orderBy(asc(conversationArtifacts.path));
+}
+
+async function artifactList(app: ReturnType<typeof createApp>) {
+	const response = await app.request(
+		"/v1/conversations/conversation-1/artifacts",
+		{ headers: identityHeaders },
+	);
+	return { response, body: await response.json() };
+}
+
+describe("Downloadable artifact delivery acceptance", () => {
+	it("publishes a queued Run through Postgres, HTTP download, overwrite, cleanup, and deletion", async () => {
+		const tdb = await createTestDatabase();
+		try {
+			const workspace = new AcceptanceWorkspace();
+			const delivery = createDeliveryHarness(tdb, workspace);
+			const http = createHttpHarness(tdb);
+			await http.conversationStore.create({
+				userId: "member-1",
+				conversationId: "conversation-1",
+				scope: "general",
+				collectionId: null,
+				summaryId: null,
+			});
+
+			await delivery.run(
+				"run-1",
+				successfulQuery(() => {
+					workspace.write(
+						"charts/chart.bin",
+						new Uint8Array([0, 255, 1, 254]),
+						"1",
+					);
+					workspace.write("reports/report.txt", encoder.encode("v1"), "1");
+				}),
+			);
+
+			const firstEvents = await tdb.db
+				.select()
+				.from(runEvents)
+				.where(eq(runEvents.runId, "run-1"))
+				.orderBy(asc(runEvents.seq));
+			expect(firstEvents.map(({ type }) => type)).toEqual(["run_done"]);
+			expect(
+				firstEvents.flatMap(({ type, payload }) =>
+					projectRunEvent(type, payload),
+				),
+			).toEqual([{ type: "done" }]);
+
+			const firstCurrent = await currentArtifacts(tdb);
+			const firstList = await artifactList(http.app);
+			expect(firstList.response.status).toBe(200);
+			expect(firstList.body).toEqual({
+				artifacts: firstCurrent.map(
+					({
+						artifactId,
+						path,
+						sizeBytes,
+						contentType,
+						createdAt,
+						updatedAt,
+					}) => ({
+						artifactId,
+						path,
+						sizeBytes,
+						contentType,
+						createdAt: createdAt.toISOString(),
+						updatedAt: updatedAt.toISOString(),
+					}),
+				),
+			});
+			expect(JSON.stringify(firstList.body)).not.toContain("objectKey");
+			expect(firstList.body).not.toHaveProperty("runId");
+
+			const firstChart = firstCurrent.find(
+				(artifact) => artifact.path === "charts/chart.bin",
+			);
+			expect(firstChart).toBeDefined();
+			if (!firstChart) throw new Error("published chart is missing");
+			const firstDownload = await http.app.request(
+				`/v1/conversations/conversation-1/artifacts/${firstChart.artifactId}`,
+				{ headers: identityHeaders },
+			);
+			expect(firstDownload.status).toBe(302);
+			expect(firstDownload.headers.get("location")).toBe(
+				"https://objects.example/download-1",
+			);
+			expect(http.signInputs[0]).toEqual({
+				objectKey: firstChart.objectKey,
+				expiresInSeconds: 300,
+				responseContentDisposition:
+					"attachment; filename=\"chart.bin\"; filename*=UTF-8''chart.bin",
+				responseContentType: "application/octet-stream",
+			});
+			expect(delivery.storedObjects.get(firstChart.objectKey)).toEqual(
+				new Uint8Array([0, 255, 1, 254]),
+			);
+
+			const firstReport = firstCurrent.find(
+				(artifact) => artifact.path === "reports/report.txt",
+			);
+			expect(firstReport).toBeDefined();
+			if (!firstReport) throw new Error("published report is missing");
+			await delivery.run(
+				"run-2",
+				successfulQuery(() => {
+					workspace.write("reports/report.txt", encoder.encode("v2"), "2");
+				}),
+			);
+			const overwritten = (await currentArtifacts(tdb)).find(
+				(artifact) => artifact.path === "reports/report.txt",
+			);
+			expect(overwritten).toMatchObject({
+				artifactId: firstReport.artifactId,
+				path: "reports/report.txt",
+			});
+			expect(overwritten?.objectKey).not.toBe(firstReport.objectKey);
+			expect(overwritten?.createdAt).toEqual(firstReport.createdAt);
+			expect(delivery.storedObjects.has(firstReport.objectKey)).toBe(true);
+
+			const currentDownload = await http.app.request(
+				`/v1/conversations/conversation-1/artifacts/${firstReport.artifactId}`,
+				{ headers: identityHeaders },
+			);
+			expect(currentDownload.status).toBe(302);
+			expect(http.signInputs.at(-1)?.objectKey).toBe(overwritten?.objectKey);
+			const overwrittenList = await artifactList(http.app);
+			expect(JSON.stringify(overwrittenList.body)).not.toContain(
+				firstReport.objectKey,
+			);
+
+			const [superseded] = await tdb.db
+				.select()
+				.from(artifactObjects)
+				.where(eq(artifactObjects.objectKey, firstReport.objectKey));
+			expect(superseded?.status).toBe("superseded");
+			expect(superseded?.supersededAt).not.toBeNull();
+			const graceStarted = superseded?.supersededAt?.getTime() ?? 0;
+			await delivery.cleanup(new Date(graceStarted + 10 * 60_000 - 1));
+			expect(delivery.storedObjects.has(firstReport.objectKey)).toBe(true);
+			await delivery.cleanup(new Date(graceStarted + 10 * 60_000));
+			expect(delivery.storedObjects.has(firstReport.objectKey)).toBe(false);
+
+			await delivery.cleanup(new Date("2100-01-01T00:00:00.000Z"));
+			expect(delivery.storedObjects.has(firstChart.objectKey)).toBe(true);
+			expect(delivery.storedObjects.has(overwritten?.objectKey ?? "")).toBe(
+				true,
+			);
+
+			await tdb.db
+				.delete(conversations)
+				.where(eq(conversations.conversationId, "conversation-1"));
+			const deletedList = await artifactList(http.app);
+			expect(deletedList.response.status).toBe(404);
+			expect(await tdb.db.select().from(conversationArtifacts)).toEqual([]);
+			await delivery.cleanup(new Date("2100-01-01T00:00:00.000Z"));
+			expect(delivery.storedObjects.size).toBe(0);
+			expect(await tdb.db.select().from(artifactObjects)).toEqual([]);
+		} finally {
+			await tdb.close();
+		}
+	});
+
+	it("keeps the prior current Downloadable artifact set intact across validation, quota, upload, cancellation, and cleanup failures", async () => {
+		const tdb = await createTestDatabase();
+		try {
+			const logEvents: Record<string, unknown>[] = [];
+			const logger: WorkerLogger = {
+				info() {},
+				warn(event) {
+					logEvents.push(event);
+				},
+				error(event) {
+					logEvents.push(event);
+				},
+			};
+			const workspace = new AcceptanceWorkspace();
+			const delivery = createDeliveryHarness(tdb, workspace, logger);
+			const http = createHttpHarness(tdb);
+			await http.conversationStore.create({
+				userId: "member-1",
+				conversationId: "conversation-1",
+				scope: "general",
+				collectionId: null,
+				summaryId: null,
+			});
+			await delivery.run(
+				"run-seed",
+				successfulQuery(() => {
+					workspace.write("report.txt", encoder.encode("current"), "1");
+				}),
+			);
+			const priorList = (await artifactList(http.app)).body;
+			const priorCurrent = await currentArtifacts(tdb);
+
+			await delivery.run(
+				"run-validation",
+				successfulQuery(() => {
+					workspace.write("../escape.txt", encoder.encode("unsafe"), "2");
+				}),
+			);
+			workspace.delete("../escape.txt");
+
+			await delivery.run(
+				"run-quota",
+				successfulQuery(() => {
+					workspace.write(
+						"oversized.bin",
+						new Uint8Array([1]),
+						"3",
+						100 * 1_024 * 1_024 + 1,
+					);
+				}),
+			);
+			workspace.delete("oversized.bin");
+
+			delivery.setUploadOverride(async () => {
+				throw new Error(
+					"https://storage.invalid/private?signature=secret bucket=private-artifacts",
+				);
+			});
+			await delivery.run(
+				"run-upload",
+				successfulQuery(() => {
+					workspace.write("upload.txt", encoder.encode("partial"), "4");
+				}),
+			);
+			delivery.setUploadOverride();
+			workspace.delete("upload.txt");
+
+			let uploadStarted!: () => void;
+			const started = new Promise<void>((resolve) => {
+				uploadStarted = resolve;
+			});
+			delivery.setUploadOverride(async ({ signal }) => {
+				uploadStarted();
+				await new Promise<never>((_resolve, reject) => {
+					if (signal.aborted) return reject(new Error("upload aborted"));
+					signal.addEventListener(
+						"abort",
+						() => reject(new Error("upload aborted")),
+						{ once: true },
+					);
+				});
+			});
+			await delivery.queue(
+				"run-cancel",
+				successfulQuery(() => {
+					workspace.write("cancel.txt", encoder.encode("partial"), "5");
+				}),
+			);
+			await delivery.loop.tick();
+			await started;
+			await tdb.db
+				.update(runs)
+				.set({ status: "cancel_requested" })
+				.where(eq(runs.runId, "run-cancel"));
+			await delivery.loop.tick();
+			await delivery.worker.drain();
+			delivery.setUploadOverride();
+			workspace.delete("cancel.txt");
+
+			delivery.setDeleteOverride(async () => {
+				throw new Error("delete temporarily unavailable");
+			});
+			const cleanup = await delivery.cleanup(
+				new Date("2100-01-01T00:00:00.000Z"),
+			);
+			expect(cleanup.artifactObjectsFailed).toBe(2);
+
+			expect((await artifactList(http.app)).body).toEqual(priorList);
+			expect(await currentArtifacts(tdb)).toEqual(priorCurrent);
+			const outcomes = await tdb.db
+				.select({ runId: runs.runId, status: runs.status })
+				.from(runs)
+				.orderBy(asc(runs.createdAt));
+			expect(outcomes).toEqual([
+				{ runId: "run-seed", status: "done" },
+				{ runId: "run-validation", status: "error" },
+				{ runId: "run-quota", status: "error" },
+				{ runId: "run-upload", status: "error" },
+				{ runId: "run-cancel", status: "canceled" },
+			]);
+			const publicOutcomes = await tdb.db
+				.select({ type: runEvents.type, payload: runEvents.payload })
+				.from(runEvents)
+				.orderBy(asc(runEvents.createdAt));
+			expect(publicOutcomes).toEqual([
+				{ type: "run_done", payload: {} },
+				{ type: "run_error", payload: { message: "Run failed" } },
+				{ type: "run_error", payload: { message: "Run failed" } },
+				{ type: "run_error", payload: { message: "Run failed" } },
+				{ type: "run_canceled", payload: {} },
+			]);
+			const serializedPublicState = JSON.stringify({
+				list: priorList,
+				outcomes: publicOutcomes,
+			});
+			expect(serializedPublicState).not.toContain("storage.invalid");
+			expect(serializedPublicState).not.toContain("private-artifacts");
+			expect(serializedPublicState).not.toContain("signature=secret");
+			expect(JSON.stringify(logEvents)).not.toContain("storage.invalid");
+			expect(JSON.stringify(logEvents)).not.toContain("signature=secret");
+			expect(await tdb.db.select().from(artifactObjects)).toHaveLength(3);
+		} finally {
+			await tdb.close();
+		}
+	});
+});

--- a/docs/runbooks/downloadable-artifacts.md
+++ b/docs/runbooks/downloadable-artifacts.md
@@ -1,0 +1,154 @@
+# Downloadable artifact operations
+
+Downloadable artifacts are durable, user-visible files deliberately written
+under `/home/user/artifacts/` in a conversation workspace. The architecture and
+security decisions are recorded in
+[ADR-0010](../adr/0010-publish-downloadable-artifacts-on-success.md). This
+runbook covers deployment, failure handling, retention, and the downstream
+integration contract.
+
+## Trusted-runtime configuration
+
+Both `chat-api` and `agent-worker` require:
+
+- `ARTIFACT_BUCKET`: the private S3 bucket provisioned for the environment;
+- `AWS_REGION`: the region containing that bucket.
+
+The AWS SDK uses each ECS task role through its default credential provider
+chain. Do not configure long-lived AWS credentials. `agent-worker` may upload
+and delete objects, while `chat-api` may read the one current object selected by
+an ownership-checked Postgres record so it can sign a download. Neither role may
+list the bucket. The migration task receives neither artifact configuration nor
+artifact S3 permissions.
+
+Artifact bucket configuration, AWS credentials, and presigned URLs stay inside
+the trusted Fargate runtimes. None are passed to E2B. The sandbox receives only
+the per-Run binding produced by `buildSandboxEnv`.
+
+Terraform owns the bucket and enforces Block Public Access,
+bucket-owner-enforced ownership, TLS-only access, SSE-S3 (`AES256`) encryption,
+disabled versioning, and no CORS policy or customer-managed KMS key. Its only
+lifecycle rule aborts incomplete multipart uploads; it does not expire current
+artifacts.
+
+## Publication and quotas
+
+The worker captures the reserved tree at Run start and publishes only files
+whose size or modification timestamp changed during a successful Run. Files
+outside `/home/user/artifacts/`, including scratch files and `.mymemo/docs/`,
+are not Downloadable artifacts.
+
+Publication is all-or-nothing. Object keys are ledgered before upload, and all
+changed metadata becomes current in the same fenced Postgres transaction that
+appends `run_done`. The existing `done` SSE frame is therefore the refresh
+signal; there is no artifact-specific Run event or SSE frame.
+
+The post-upsert current set is limited to:
+
+- 100 MiB per artifact;
+- 100 current artifact paths per conversation;
+- 1 GiB total current artifact bytes per conversation.
+
+Validation, quota, upload, ownership, cancellation, or persistence failure
+leaves the prior current set unchanged. A failed Run exposes only the generic
+`Run failed` message to the client. Internal structured diagnostics identify a
+bounded failure category or stage without object bodies, presigned URLs, or
+provider error details.
+
+## Download and retention behavior
+
+`GET /v1/conversations/:conversationId/artifacts` reads the authoritative
+current set from Postgres. The response is path-sorted and contains only
+`artifactId`, `path`, `sizeBytes`, `contentType`, `createdAt`, and `updatedAt`.
+
+`GET /v1/conversations/:conversationId/artifacts/:artifactId` reauthorizes the
+conversation owner and returns a fresh `302` to S3. The presigned URL expires
+after five minutes and forces `Content-Disposition: attachment`; generated
+HTML, images, scripts, PDFs, and archives are never rendered inline by this
+contract. V1 does not malware-scan outputs, so clients must label and handle
+them as untrusted generated files.
+
+Overwriting one path preserves its stable `artifactId` and immediately makes
+only the new object current. The superseded object is retained for ten minutes
+before cleanup eligibility so a five-minute URL issued just before the swap can
+finish. This grace is storage lifecycle state, not user-visible version history.
+
+Current artifacts live for the conversation lifetime and have no age-based
+expiry. Conversation deletion immediately removes list/download access and
+makes all of its ledgered objects cleanup candidates. A URL issued before
+deletion cannot be revoked and may remain usable until its five-minute expiry.
+
+## Diagnose publication failures
+
+1. Confirm the Run outcome and artifact lifecycle counts without selecting Run
+   payloads or object keys:
+
+   ```sql
+   SELECT status, count(*)
+   FROM runs
+   WHERE updated_at >= now() - interval '15 minutes'
+   GROUP BY status;
+
+   SELECT status, count(*)
+   FROM artifact_objects
+   GROUP BY status;
+   ```
+
+2. Search worker logs for the bounded `artifactFailure` fields. `validation`
+   indicates an unsafe path or tree entry; `quota` names the exceeded bound;
+   `publication` names `manifest`, `ledger`, `read`, or `upload`.
+3. For upload failures, verify worker task-role access and bucket/region
+   injection. Do not copy credentials or a presigned URL into the sandbox for
+   diagnosis.
+4. Confirm that an errored or canceled Run did not change the list endpoint.
+   Staged objects may remain in the ledger; that is expected until cleanup.
+
+## Diagnose cleanup failures
+
+The worker runs one advisory-lock-protected cleanup pass at
+`WORKER_CLEANUP_INTERVAL_MS` (five minutes by default). It never lists S3 and
+never deletes an object still referenced by current metadata. Pending objects
+from active Runs are skipped. Failed deletion retains the ledger row and is
+retried on a later pass; one failed object does not stop other candidates.
+
+If pending or superseded counts keep growing:
+
+1. confirm at least one worker is healthy and cleanup passes continue;
+2. inspect the cleanup summary and bounded warning counts;
+3. verify the worker task role still has object-scoped `s3:DeleteObject` and no
+   bucket-list permission; and
+4. leave ledger rows intact so the next pass can retry safely.
+
+Do not add an S3 age-expiration rule as a cleanup shortcut. It could delete a
+live conversation's current object behind Postgres.
+
+## Deployment order
+
+Run the agent database migrations before rolling either ECS service. The
+release workflow registers infrastructure/task definitions, runs
+`scripts/deploy/run_agent_migration.sh`, then updates the services through
+`scripts/deploy/roll_ecs_services.sh`. This ordering is required because the
+worker publication and API retrieval paths depend on the artifact metadata and
+lifecycle tables.
+
+After deployment, verify that both services boot with `ARTIFACT_BUCKET` and
+`AWS_REGION`, then exercise one Run that writes a small file and confirm `done`,
+list, and attachment redirect behavior. Never follow or log the presigned URL
+as part of automated diagnostics.
+
+## Downstream integration contract
+
+`mymemo-service` authenticates the web request, forwards the trusted
+`X-Member-*` and `X-Partner-*` identity headers, relays the list response
+unchanged, and relays the download `302` plus `Location` without following the
+redirect. It must not proxy object bytes, persist artifact metadata, sign URLs,
+or receive artifact-bucket permissions.
+
+`mymemo-web` refreshes the list after the existing `done` frame. It starts a
+download through a link or other normal browser navigation so the browser
+follows the redirect directly to S3. It must not fetch the object as a
+JavaScript blob or require bucket CORS, and it should present every item as an
+untrusted generated file.
+
+The downstream service and web changes live in their own repositories; no
+`mymemo-service` or `mymemo-web` implementation belongs in this repository.

--- a/docs/runbooks/downloadable-artifacts.md
+++ b/docs/runbooks/downloadable-artifacts.md
@@ -50,10 +50,10 @@ The post-upsert current set is limited to:
 - 1 GiB total current artifact bytes per conversation.
 
 Validation, quota, upload, ownership, cancellation, or persistence failure
-leaves the prior current set unchanged. A failed Run exposes only the generic
-`Run failed` message to the client. Internal structured diagnostics identify a
-bounded failure category or stage without object bodies, presigned URLs, or
-provider error details.
+leaves the prior current set unchanged. A Run with an `error` Outcome exposes
+only the generic `Run failed` message to the client. Internal structured
+diagnostics identify a bounded failure category or stage without object bodies,
+presigned URLs, or provider error details.
 
 ## Download and retention behavior
 

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -42,7 +42,9 @@ The artifact bucket blocks all public access, enforces bucket-owner ownership,
 uses SSE-S3 encryption, denies non-TLS requests, has versioning disabled, and
 defines no CORS policy. Only the `chat-api` application role can read an
 ownership-checked current object for presigning; it cannot write, delete, or
-list bucket contents.
+list bucket contents. Publication, retention, cleanup, and downstream handoff
+procedures are documented in the
+[Downloadable artifact runbook](../../docs/runbooks/downloadable-artifacts.md).
 
 ## Secrets
 

--- a/scripts/deploy-config.test.ts
+++ b/scripts/deploy-config.test.ts
@@ -31,6 +31,10 @@ const createAgentSecretsScript = readFileSync(
 	join(root, "scripts", "deploy", "create_agent_secrets.sh"),
 	"utf8",
 );
+const artifactOperationsRunbook = readFileSync(
+	join(root, "docs", "runbooks", "downloadable-artifacts.md"),
+	"utf8",
+);
 
 function terraformFiles(dir = terraformDir): string[] {
 	return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
@@ -137,6 +141,9 @@ describe("agent deployment config", () => {
 			workerEnvironmentStart,
 		);
 		const workerEnvironment = locals.slice(workerEnvironmentStart);
+		const terraformConfig = terraformFiles()
+			.map((path) => readFileSync(path, "utf8"))
+			.join("\n");
 
 		expect(artifactsConfig).toContain('resource "aws_s3_bucket" "artifacts"');
 		expect(artifactsConfig).toMatch(
@@ -154,12 +161,20 @@ describe("agent deployment config", () => {
 		expect(artifactsConfig).toMatch(
 			/resource "aws_s3_bucket_lifecycle_configuration" "artifacts"[\s\S]*?id\s*=\s*"abort-incomplete-multipart-uploads"[\s\S]*?status\s*=\s*"Enabled"[\s\S]*?abort_incomplete_multipart_upload[\s\S]*?days_after_initiation\s*=\s*1/,
 		);
-		expect(artifactsConfig).not.toMatch(
+		expect(terraformConfig).not.toMatch(
 			/\b(?:expiration|noncurrent_version_expiration|expired_object_delete_marker)\b/,
 		);
 		expect(artifactsConfig).toContain('variable = "aws:SecureTransport"');
 		expect(artifactsConfig).toContain('values   = ["false"]');
-		expect(artifactsConfig).not.toContain("aws_s3_bucket_cors_configuration");
+		expect(terraformConfig).not.toContain("aws_s3_bucket_cors_configuration");
+		expect(terraformConfig).not.toMatch(/\bcors_rule\s*\{/);
+		expect(terraformConfig).not.toMatch(
+			/aws_kms|kms_master_key_id|SSEKMSKeyId/,
+		);
+		expect(
+			terraformConfig.match(/resource\s+"aws_s3_bucket_versioning"/g),
+		).toHaveLength(1);
+		expect(terraformConfig).not.toMatch(/\bversioning\s*\{/);
 
 		expect(iamConfig).toContain('actions   = ["s3:GetObject"]');
 		expect(iamConfig).toContain(
@@ -223,6 +238,31 @@ describe("agent deployment config", () => {
 		);
 		expect(readme).toContain(
 			"The durable Postgres path remains sufficient for successful Runs",
+		);
+	});
+
+	it("documents the Downloadable artifact operator and downstream contracts", () => {
+		for (const requiredContract of [
+			"ARTIFACT_BUCKET",
+			"AWS_REGION",
+			"/home/user/artifacts/",
+			"100 MiB",
+			"100 current artifact paths",
+			"1 GiB",
+			"five minutes",
+			"ten minutes",
+			"conversation lifetime",
+			"Run failed",
+			"Content-Disposition: attachment",
+			"untrusted generated files",
+			"mymemo-service",
+			"mymemo-web",
+			"normal browser navigation",
+		]) {
+			expect(artifactOperationsRunbook).toContain(requiredContract);
+		}
+		expect(artifactOperationsRunbook).toMatch(
+			/without following the\s+redirect/,
 		);
 	});
 


### PR DESCRIPTION
## Summary

- add a highest-level acceptance test covering queued Run publication through artifact listing, signing, overwrite behavior, retention, deletion, and atomic failure paths
- prove the production E2B SDK credential boundary and repository-wide Terraform artifact constraints
- document operator configuration, quotas, download behavior, cleanup timing, failure handling, and downstream integration contracts

## Why

The artifact implementation had focused coverage across the worker, database, HTTP, and deployment layers, but lacked one executable proof tying those contracts together. This change provides the acceptance evidence required by issue #287.

## Impact

There is no public API change and no downstream service or web implementation. Production behavior is unchanged apart from a narrow injectable E2B SDK factory seam used to observe the trusted-worker boundary.

The acceptance test exercises the real application orchestration and persistence contract with controlled workspace, object-store, and signer fakes. It does not call live E2B or S3; a credentialed provider test remains separate follow-up work.

## Validation

- `bun test --silent`: 754 passed, 11 environment-dependent tests skipped, 0 failed
- focused artifact, E2B boundary, sandbox environment, and deployment tests: 46 passed
- chat-api and agent-worker TypeScript checks
- Biome checks and `git diff --check`
- Terraform formatting checks and validation for all three existing roots
- independent Standards and Spec reviews with no remaining hard findings

Closes #287