### PR TITLE
fix(agent-db): centralize artifact runtime fence

### DIFF
--- a/apps/agent-worker/src/run-loop.ts
+++ b/apps/agent-worker/src/run-loop.ts
@@ -20,7 +20,10 @@ import {
 	type TerminalRunStatus,
 	transitionRunTerminalTx,
 } from "@mymemo/agent-db/run-store";
-import { advanceAgentSessionPointerTx } from "@mymemo/agent-db/runtime-store";
+import {
+	advanceAgentSessionPointerTx,
+	type RunOwnershipRef,
+} from "@mymemo/agent-db/runtime-store";
 import { ArtifactValidationError } from "./artifacts/artifact-manifest";
 import { ArtifactPublicationError } from "./artifacts/artifact-publication";
 import type { WorkerLogger } from "./logger";
@@ -401,18 +404,27 @@ export class RunLoop {
 		// (ADR-0005). Only when the turn reported a session to resume from — a
 		// `mirror_error` turn carries none, so the pointer holds and the run still
 		// terminalizes `done`.
+		const owner: RunOwnershipRef = {
+			userId: run.userId,
+			conversationId: run.conversationId,
+			runId: run.runId,
+			workerId: this.workerId,
+		};
 		if (turnResult.artifactPublication) {
-			await this.publishArtifactsAndFinish(run, turnResult);
+			await this.publishArtifactsAndFinish(owner, turnResult);
 			return;
 		}
 		if (turnResult.agentSession) {
-			await this.advanceSessionPointer(run, turnResult.agentSession.sessionId);
+			await this.advanceSessionPointer(
+				owner,
+				turnResult.agentSession.sessionId,
+			);
 		}
 		await this.terminalize(runId, "done");
 	}
 
 	private async publishArtifactsAndFinish(
-		run: RunRecord,
+		owner: RunOwnershipRef,
 		turnResult: TurnResult,
 	): Promise<void> {
 		const publication = turnResult.artifactPublication;
@@ -421,10 +433,7 @@ export class RunLoop {
 			const result = await publishArtifactsAndTransitionRunDoneTx(
 				this.opts.db,
 				{
-					runId: run.runId,
-					workerId: this.workerId,
-					userId: run.userId,
-					conversationId: run.conversationId,
+					owner,
 					artifacts: publication.artifacts,
 					agentSessionId: turnResult.agentSession?.sessionId,
 				},
@@ -436,25 +445,25 @@ export class RunLoop {
 				this.opts.logger.warn({
 					message: "could not advance agent session pointer",
 					workerId: this.workerId,
-					runId: run.runId,
+					runId: owner.runId,
 				});
 			}
 		} catch (error) {
 			if (error instanceof RunFenceError) {
-				if (await this.tryTerminalCanceled(run.runId)) return;
+				if (await this.tryTerminalCanceled(owner.runId)) return;
 				this.opts.logger.warn({
 					message: "could not publish artifacts; leaving to stale-run recovery",
 					workerId: this.workerId,
-					runId: run.runId,
+					runId: owner.runId,
 				});
 				return;
 			}
 			this.opts.logger.error({
 				message: "run failed",
 				workerId: this.workerId,
-				userId: run.userId,
-				conversationId: run.conversationId,
-				runId: run.runId,
+				userId: owner.userId,
+				conversationId: owner.conversationId,
+				runId: owner.runId,
 				...(error instanceof ArtifactQuotaError
 					? artifactFailureLogFields(error)
 					: {
@@ -465,7 +474,7 @@ export class RunLoop {
 							},
 						}),
 			});
-			await this.terminalize(run.runId, "error", {
+			await this.terminalize(owner.runId, "error", {
 				message: GENERIC_RUN_ERROR_MESSAGE,
 			});
 		}
@@ -479,22 +488,19 @@ export class RunLoop {
 	 * run still succeeds, so the terminal `done` must not be blocked by it.
 	 */
 	private async advanceSessionPointer(
-		run: RunRecord,
+		owner: RunOwnershipRef,
 		agentSessionId: string,
 	): Promise<void> {
 		try {
 			await advanceAgentSessionPointerTx(this.opts.db, {
-				userId: run.userId,
-				conversationId: run.conversationId,
-				runId: run.runId,
-				workerId: this.workerId,
+				...owner,
 				agentSessionId,
 			});
 		} catch (error) {
 			this.opts.logger.warn({
 				message: "could not advance agent session pointer",
 				workerId: this.workerId,
-				runId: run.runId,
+				runId: owner.runId,
 				error: toMessage(error),
 			});
 		}

--- a/packages/agent-db/src/artifact-store.test.ts
+++ b/packages/agent-db/src/artifact-store.test.ts
@@ -59,10 +59,12 @@ describe("Downloadable artifact publication", () => {
 		expect(await tdb.db.select().from(conversationArtifacts)).toEqual([]);
 
 		await publishArtifactsAndTransitionRunDoneTx(tdb.db, {
-			runId: "run-1",
-			workerId: "worker-1",
-			userId: "user-1",
-			conversationId: "conv-1",
+			owner: {
+				runId: "run-1",
+				workerId: "worker-1",
+				userId: "user-1",
+				conversationId: "conv-1",
+			},
 			artifacts: [
 				{
 					artifactId: "artifact-1",
@@ -122,10 +124,12 @@ describe("Downloadable artifact publication", () => {
 				],
 			});
 			await publishArtifactsAndTransitionRunDoneTx(tdb.db, {
-				runId,
-				workerId: "worker-1",
-				userId: "user-1",
-				conversationId: "conv-1",
+				owner: {
+					runId,
+					workerId: "worker-1",
+					userId: "user-1",
+					conversationId: "conv-1",
+				},
 				artifacts: [
 					{
 						artifactId,
@@ -176,10 +180,12 @@ describe("Downloadable artifact publication", () => {
 
 		await expect(
 			publishArtifactsAndTransitionRunDoneTx(tdb.db, {
-				runId: "run-1",
-				workerId: "worker-1",
-				userId: "user-1",
-				conversationId: "conv-1",
+				owner: {
+					runId: "run-1",
+					workerId: "worker-1",
+					userId: "user-1",
+					conversationId: "conv-1",
+				},
 				agentSessionId: "session-new",
 				artifacts: [
 					{

--- a/packages/agent-db/src/artifact-store.ts
+++ b/packages/agent-db/src/artifact-store.ts
@@ -2,10 +2,10 @@ import { and, eq, inArray, sql } from "drizzle-orm";
 import type { Database } from "./client";
 import { type RunRecord, transitionRunTerminalInTx } from "./run-store";
 import {
-	artifactObjects,
-	conversationArtifacts,
-	conversationRuntime,
-} from "./schema";
+	advanceAgentSessionPointerInTx,
+	type RunOwnershipRef,
+} from "./runtime-store";
+import { artifactObjects, conversationArtifacts } from "./schema";
 
 export const MAX_CURRENT_ARTIFACT_PATHS = 100;
 export const MAX_ARTIFACT_SIZE_BYTES = 100 * 1_024 * 1_024;
@@ -62,10 +62,7 @@ export async function recordArtifactObjectsTx(
 export async function publishArtifactsAndTransitionRunDoneTx(
 	db: Database,
 	input: {
-		runId: string;
-		workerId: string;
-		userId: string;
-		conversationId: string;
+		owner: RunOwnershipRef;
 		artifacts: PublishedArtifact[];
 		agentSessionId?: string;
 	},
@@ -87,31 +84,22 @@ export async function publishArtifactsAndTransitionRunDoneTx(
 			.from(conversationArtifacts)
 			.where(
 				and(
-					eq(conversationArtifacts.userId, input.userId),
-					eq(conversationArtifacts.conversationId, input.conversationId),
+					eq(conversationArtifacts.userId, input.owner.userId),
+					eq(conversationArtifacts.conversationId, input.owner.conversationId),
 				),
 			)
 			.for("update");
 		validatePostUpsertQuota(currentArtifacts, input.artifacts);
 
 		let agentSessionPointerAdvanced: boolean | null = null;
-		if (input.agentSessionId !== undefined) {
+		const agentSessionId = input.agentSessionId;
+		if (agentSessionId !== undefined) {
 			try {
 				await tx.transaction(async (savepoint) => {
-					const [runtime] = await savepoint
-						.update(conversationRuntime)
-						.set({
-							agentSessionId: input.agentSessionId,
-							updatedAt: sql`now()`,
-						})
-						.where(
-							and(
-								eq(conversationRuntime.userId, input.userId),
-								eq(conversationRuntime.conversationId, input.conversationId),
-							),
-						)
-						.returning({ conversationId: conversationRuntime.conversationId });
-					if (!runtime) throw new Error("conversation runtime row is missing");
+					await advanceAgentSessionPointerInTx(savepoint, {
+						...input.owner,
+						agentSessionId,
+					});
 				});
 				agentSessionPointerAdvanced = true;
 			} catch {
@@ -131,9 +119,9 @@ export async function publishArtifactsAndTransitionRunDoneTx(
 			.where(
 				and(
 					inArray(artifactObjects.objectKey, objectKeys),
-					eq(artifactObjects.userId, input.userId),
-					eq(artifactObjects.conversationId, input.conversationId),
-					eq(artifactObjects.runId, input.runId),
+					eq(artifactObjects.userId, input.owner.userId),
+					eq(artifactObjects.conversationId, input.owner.conversationId),
+					eq(artifactObjects.runId, input.owner.runId),
 					eq(artifactObjects.status, "pending"),
 				),
 			)
@@ -149,8 +137,8 @@ export async function publishArtifactsAndTransitionRunDoneTx(
 				.insert(conversationArtifacts)
 				.values({
 					...artifact,
-					userId: input.userId,
-					conversationId: input.conversationId,
+					userId: input.owner.userId,
+					conversationId: input.owner.conversationId,
 				})
 				.onConflictDoUpdate({
 					target: [
@@ -178,8 +166,8 @@ export async function publishArtifactsAndTransitionRunDoneTx(
 		}
 
 		const run = await transitionRunTerminalInTx(tx, {
-			runId: input.runId,
-			workerId: input.workerId,
+			runId: input.owner.runId,
+			workerId: input.owner.workerId,
 			status: "done",
 		});
 		return { run, agentSessionPointerAdvanced };

--- a/packages/agent-db/src/runtime-store.test.ts
+++ b/packages/agent-db/src/runtime-store.test.ts
@@ -14,6 +14,7 @@ import {
 	RunFenceError,
 } from "./run-store";
 import {
+	advanceAgentSessionPointerInTx,
 	advanceAgentSessionPointerTx,
 	createConversationRuntimeTx,
 	loadConversationRuntimeTx,
@@ -245,6 +246,27 @@ describe("updateRuntimeSandboxTx", () => {
 });
 
 describe("advanceAgentSessionPointerTx", () => {
+	it("participates in its caller's transaction", async () => {
+		await claimOwnedRun();
+		await createConversationRuntimeTx(tdb.db, OWNER);
+
+		await expect(
+			tdb.db.transaction(async (tx) => {
+				await advanceAgentSessionPointerInTx(tx, {
+					...OWNER,
+					agentSessionId: "session-rolled-back",
+				});
+				throw new Error("roll back outer transaction");
+			}),
+		).rejects.toThrow("roll back outer transaction");
+		expect(
+			await loadConversationRuntimeTx(tdb.db, {
+				userId: OWNER.userId,
+				conversationId: OWNER.conversationId,
+			}),
+		).toMatchObject({ agentSessionId: null });
+	});
+
 	it("advances the resume pointer while the run is owned", async () => {
 		await claimOwnedRun();
 		await createConversationRuntimeTx(tdb.db, OWNER);

--- a/packages/agent-db/src/runtime-store.ts
+++ b/packages/agent-db/src/runtime-store.ts
@@ -1,7 +1,7 @@
 import { and, eq, inArray, sql } from "drizzle-orm";
 import type { PgUpdateSetSource } from "drizzle-orm/pg-core";
 import type { Database } from "./client";
-import { RunFenceError } from "./run-store";
+import { type DbTx, RunFenceError } from "./run-store";
 import { conversationRuntime, orphanSandboxes, runs } from "./schema";
 
 /**
@@ -159,7 +159,7 @@ export async function updateRuntimeSandboxTx(
  * own), surfaced as {@link RunFenceError}.
  */
 async function fencedRuntimeUpdate(
-	db: Database,
+	db: Pick<Database, "update">,
 	owner: RunOwnershipRef,
 	operation: string,
 	set: PgUpdateSetSource<typeof conversationRuntime>,
@@ -207,6 +207,20 @@ export async function advanceAgentSessionPointerTx(
 	input: RunOwnershipRef & { agentSessionId: string },
 ): Promise<ConversationRuntimeRecord> {
 	return await fencedRuntimeUpdate(db, input, "agent session pointer advance", {
+		agentSessionId: input.agentSessionId,
+	});
+}
+
+/**
+ * Transaction-scoped form of {@link advanceAgentSessionPointerTx}. Artifact
+ * publication uses it so the canonical runtime fence and `run_done` share the
+ * caller's transaction.
+ */
+export async function advanceAgentSessionPointerInTx(
+	tx: DbTx,
+	input: RunOwnershipRef & { agentSessionId: string },
+): Promise<ConversationRuntimeRecord> {
+	return await fencedRuntimeUpdate(tx, input, "agent session pointer advance", {
 		agentSessionId: input.agentSessionId,
 	});
 }


### PR DESCRIPTION
## Summary

- add a transaction-scoped agent-session pointer helper in the canonical runtime store
- route artifact publication through the shared ownership fence
- pass `RunOwnershipRef` through the publication success path instead of reconstructing its fields
- cover participation in the caller's transaction

## Root cause

Artifact publication updated `conversation_runtime.agent_session_id` directly. Although the later terminal transition rolled the change back after ownership loss, the publication store duplicated the runtime fence protocol instead of using the repository's sole runtime-mutation seam.

## Impact

Runtime fencing now has one canonical implementation, and artifact publication uses the same ownership value for session advancement, metadata publication, and terminalization.

## Validation

- `bunx biome check` on all changed files
- `bunx tsc --noEmit` in `packages/agent-db` and `apps/agent-worker`
- 55 focused runtime-store, artifact-store, run-loop, and artifact-publication tests
- repository-wide suite executed: 752 passed and 11 skipped; three unrelated tests exceeded existing hard 5-second timeouts in this environment