### PR TITLE
fix(agent-worker): validate delta subtypes against content block types

### DIFF
--- a/apps/agent-worker/src/sdk/agent-stream.test.ts
+++ b/apps/agent-worker/src/sdk/agent-stream.test.ts
@@ -434,6 +434,185 @@ describe("consumeAgentStream", () => {
 		expect(subscription.readAvailable()).toEqual([]);
 	});
 
+	// Issue #244: a nominally successful stream with invalid envelope structure
+	// fails closed. Each fixture is an otherwise-complete, well-boundaried
+	// envelope whose only defect is a delta subtype that is structurally
+	// impossible for its block type — so it must reject for the pairing itself,
+	// not for a truncated stream.
+	for (const fixture of [
+		{
+			name: "a thinking delta inside a tool_use block",
+			block: { type: "tool_use", id: "toolu-1", name: "WebSearch", input: {} },
+			delta: { type: "thinking_delta", thinking: "…" },
+		},
+		{
+			name: "an input_json delta inside a thinking block",
+			block: { type: "thinking", thinking: "", signature: "" },
+			delta: { type: "input_json_delta", partial_json: "{}" },
+		},
+		{
+			name: "a signature delta inside a tool_use block",
+			block: { type: "tool_use", id: "toolu-1", name: "WebSearch", input: {} },
+			delta: { type: "signature_delta", signature: "sig" },
+		},
+		{
+			name: "a citations delta inside a text block",
+			block: { type: "text", text: "" },
+			delta: { type: "citations_delta", citation: {} },
+		},
+		{
+			name: "a delta inside a delta-less redacted_thinking block",
+			block: { type: "redacted_thinking", data: "opaque" },
+			delta: { type: "thinking_delta", thinking: "…" },
+		},
+		{
+			name: "a delta inside a delta-less web_search_tool_result block",
+			block: {
+				type: "web_search_tool_result",
+				tool_use_id: "srvtoolu-1",
+				content: [],
+			},
+			delta: { type: "input_json_delta", partial_json: "{}" },
+		},
+	]) {
+		it(`rejects ${fixture.name} as a protocol violation`, async () => {
+			const appended: ModelContent[] = [];
+			const query = fakeQuery(
+				[
+					streamEvent({
+						type: "message_start",
+						message: { id: "provider-1", content: [] },
+					}),
+					streamEvent({
+						type: "content_block_start",
+						index: 0,
+						content_block: fixture.block,
+					}),
+					streamEvent({
+						type: "content_block_delta",
+						index: 0,
+						delta: fixture.delta,
+					}),
+					assistantBlock("provider-1", fixture.block),
+					streamEvent({ type: "content_block_stop", index: 0 }),
+					streamEvent({ type: "message_stop" }),
+				].map((message) => ({ message })),
+			);
+
+			await expect(
+				consumeAgentStream({
+					query,
+					signal: new AbortController().signal,
+					appendModelContent: captureModelContent(appended),
+				}),
+			).rejects.toBeInstanceOf(AssistantEnvelopeProtocolError);
+			expect(appended).toEqual([]);
+		});
+	}
+
+	it("accepts protocol-valid thinking deltas and still commits the envelope's text", async () => {
+		const appended: Array<{ messageId: string; text: string }> = [];
+		const query = fakeQuery(
+			[
+				streamEvent({
+					type: "message_start",
+					message: { id: "provider-1", content: [] },
+				}),
+				streamEvent({
+					type: "content_block_start",
+					index: 0,
+					content_block: { type: "thinking", thinking: "", signature: "" },
+				}),
+				streamEvent({
+					type: "content_block_delta",
+					index: 0,
+					delta: { type: "thinking_delta", thinking: "…" },
+				}),
+				streamEvent({
+					type: "content_block_delta",
+					index: 0,
+					delta: { type: "signature_delta", signature: "sig" },
+				}),
+				assistantBlock("provider-1", {
+					type: "thinking",
+					thinking: "…",
+					signature: "sig",
+				}),
+				streamEvent({ type: "content_block_stop", index: 0 }),
+				streamEvent({
+					type: "content_block_start",
+					index: 1,
+					content_block: { type: "text", text: "" },
+				}),
+				streamEvent({
+					type: "content_block_delta",
+					index: 1,
+					delta: { type: "text_delta", text: "visible" },
+				}),
+				assistantBlock("provider-1", { type: "text", text: "visible" }),
+				streamEvent({ type: "content_block_stop", index: 1 }),
+				streamEvent({ type: "message_stop" }),
+			].map((message) => ({ message })),
+		);
+
+		await consumeAgentStream({
+			query,
+			signal: new AbortController().signal,
+			appendModelContent: onAssistantCommit((message) =>
+				appended.push(message),
+			),
+		});
+
+		expect(appended.map(({ text }) => text)).toEqual(["visible"]);
+	});
+
+	it("tolerates deltas inside an unknown block type as opaque content", async () => {
+		const appended: Array<{ messageId: string; text: string }> = [];
+		const query = fakeQuery(
+			[
+				streamEvent({
+					type: "message_start",
+					message: { id: "provider-1", content: [] },
+				}),
+				streamEvent({
+					type: "content_block_start",
+					index: 0,
+					content_block: { type: "novel_block" },
+				}),
+				streamEvent({
+					type: "content_block_delta",
+					index: 0,
+					delta: { type: "thinking_delta", thinking: "…" },
+				}),
+				assistantBlock("provider-1", { type: "novel_block" }),
+				streamEvent({ type: "content_block_stop", index: 0 }),
+				streamEvent({
+					type: "content_block_start",
+					index: 1,
+					content_block: { type: "text", text: "" },
+				}),
+				streamEvent({
+					type: "content_block_delta",
+					index: 1,
+					delta: { type: "text_delta", text: "still committed" },
+				}),
+				assistantBlock("provider-1", { type: "text", text: "still committed" }),
+				streamEvent({ type: "content_block_stop", index: 1 }),
+				streamEvent({ type: "message_stop" }),
+			].map((message) => ({ message })),
+		);
+
+		await consumeAgentStream({
+			query,
+			signal: new AbortController().signal,
+			appendModelContent: onAssistantCommit((message) =>
+				appended.push(message),
+			),
+		});
+
+		expect(appended.map(({ text }) => text)).toEqual(["still committed"]);
+	});
+
 	it("treats an error-bearing Assistant callback as provider rejection", async () => {
 		const controller = new AbortController();
 		const envelope = textEnvelope({ completeText: "rejected" });

--- a/apps/agent-worker/src/sdk/assistant-message-assembler.ts
+++ b/apps/agent-worker/src/sdk/assistant-message-assembler.ts
@@ -61,6 +61,39 @@ export type AssistantAssembly =
 	| { type: "message_stop"; commit: EnvelopeCommit };
 
 /**
+ * The delta subtypes the pinned SDK protocol allows inside each known content
+ * block type. A delta arriving in a known block outside its set is structurally
+ * impossible, so the envelope is invalid and the Run must fail closed rather
+ * than end `done`. Result-style blocks arrive complete and stream no deltas.
+ * `citations_delta` appears nowhere: this pipeline never requests citations
+ * (documents reach the model as files, ADR-0004), so a citing delta is equally
+ * impossible. Unknown block types are deliberately absent — they remain
+ * tolerated as opaque interleaved content whose delta vocabulary this pinned
+ * protocol cannot know (ADR-0008), except that visible text (`text_delta`)
+ * may only ever arrive in a `text` block.
+ */
+const KNOWN_BLOCK_DELTA_TYPES: ReadonlyMap<string, readonly string[]> = new Map<
+	string,
+	readonly string[]
+>([
+	["text", ["text_delta"]],
+	["tool_use", ["input_json_delta"]],
+	["server_tool_use", ["input_json_delta"]],
+	["mcp_tool_use", ["input_json_delta"]],
+	["thinking", ["thinking_delta", "signature_delta"]],
+	["compaction", ["compaction_delta"]],
+	["redacted_thinking", []],
+	["container_upload", []],
+	["web_search_tool_result", []],
+	["web_fetch_tool_result", []],
+	["code_execution_tool_result", []],
+	["bash_code_execution_tool_result", []],
+	["text_editor_code_execution_tool_result", []],
+	["tool_search_tool_result", []],
+	["mcp_tool_result", []],
+]);
+
+/**
  * Deterministically assembles complete Assistant messages from one ordered SDK
  * stream. Partial provider text is evidence only; completed SDK content blocks
  * are the durable source and `message_stop` is the sole commit boundary.
@@ -197,8 +230,12 @@ export class AssistantMessageAssembler {
 				text: delta.text,
 			};
 		}
-		if (block.type === "text") {
-			this.#violation("non-text delta arrived for a text block");
+		const allowedDeltaTypes = KNOWN_BLOCK_DELTA_TYPES.get(block.type);
+		if (
+			allowedDeltaTypes !== undefined &&
+			!allowedDeltaTypes.includes(delta.type)
+		) {
+			this.#violation("content block delta subtype did not match its block");
 		}
 		return null;
 	}

--- a/apps/agent-worker/src/sdk/run-processor.test.ts
+++ b/apps/agent-worker/src/sdk/run-processor.test.ts
@@ -452,6 +452,67 @@ describe("createSdkRunProcessor — through the run loop", () => {
 				streamEvent({ type: "message_stop" }),
 			],
 		},
+		// Both fixtures are otherwise-complete envelopes that would end the Run
+		// `done` if their structurally impossible delta passed silently — the
+		// nominally-successful malformed shape issue #244 requires to fail closed.
+		{
+			name: "a thinking delta inside a tool_use block",
+			messages: [
+				streamEvent({
+					type: "message_start",
+					message: { id: "provider-1", content: [] },
+				}),
+				streamEvent({
+					type: "content_block_start",
+					index: 0,
+					content_block: {
+						type: "tool_use",
+						id: "toolu-0",
+						name: "WebSearch",
+						input: {},
+					},
+				}),
+				streamEvent({
+					type: "content_block_delta",
+					index: 0,
+					delta: { type: "thinking_delta", thinking: "…" },
+				}),
+				assistantBlock("provider-1", {
+					type: "tool_use",
+					id: "toolu-0",
+					name: "WebSearch",
+					input: {},
+				}),
+				streamEvent({ type: "content_block_stop", index: 0 }),
+				streamEvent({ type: "message_stop" }),
+			],
+		},
+		{
+			name: "an input_json delta inside a thinking block",
+			messages: [
+				streamEvent({
+					type: "message_start",
+					message: { id: "provider-1", content: [] },
+				}),
+				streamEvent({
+					type: "content_block_start",
+					index: 0,
+					content_block: { type: "thinking", thinking: "", signature: "" },
+				}),
+				streamEvent({
+					type: "content_block_delta",
+					index: 0,
+					delta: { type: "input_json_delta", partial_json: "{}" },
+				}),
+				assistantBlock("provider-1", {
+					type: "thinking",
+					thinking: "",
+					signature: "",
+				}),
+				streamEvent({ type: "content_block_stop", index: 0 }),
+				streamEvent({ type: "message_stop" }),
+			],
+		},
 	]) {
 		it(`fails the Run closed for ${fixture.name}`, async () => {
 			const warnings: Record<string, unknown>[] = [];


### PR DESCRIPTION
## What

The envelope assembler validated delta/block compatibility in one direction only: a non-text delta arriving in a **text** block was a protocol violation, but a structurally impossible delta inside a **non-text** block — e.g. a `thinking_delta` in a `tool_use` block, an `input_json_delta` in a `thinking` block, or any delta in a delta-less block like `redacted_thinking` — was silently accepted. A nominally successful stream containing such a pair ended the Run `done`, against #244's acceptance criterion that invalid envelope structure must fail closed, and ADR-0008's rule that protocol violations terminalize the Run as `error`.

`AssistantMessageAssembler` now maps every block type in the pinned SDK vocabulary (claude-agent-sdk 0.2.117) to its closed set of legal delta subtypes and treats a delta outside its block's set as an `AssistantEnvelopeProtocolError`, which already propagates through `consumeAgentStream` → `impossible_ordering` telemetry → terminal `error` with the generic client message.

Two deliberate boundaries, both pinned by tests:

- **Unknown block types stay tolerated** as opaque interleaved content (ADR-0008) — their delta vocabulary is unknowable to the pinned protocol, and the existing "ignores non-text blocks" conformance case (an `input_json_delta` inside a synthetic `other` block) must keep ending `done`. Visible text is the exception: `text_delta` may only ever arrive in a `text` block, as before.
- **`citations_delta` is legal nowhere**: this pipeline never requests citations (documents reach the model as files, ADR-0004), and the assembler already rejected it on text blocks — the table extends that stance uniformly instead of loosening it.

## Tests

- `agent-stream.test.ts`: six parametrized rejection cases — each an otherwise-complete, well-boundaried envelope whose only defect is the impossible pair, so it rejects for the pairing itself rather than for a truncated stream — plus two acceptance controls (a valid thinking envelope still commits its text; deltas inside an unknown block type stay tolerated).
- `run-processor.test.ts`: two fixtures added to the existing "fails the Run closed" loop, proving through the run loop over PGlite that the Run ends `error` with a single generic `run_error` event and the payload-free `impossible_ordering` signal.

Red/green verified: with the assembler change stashed, exactly the seven new impossible-pair tests fail (the RunProcessor ones with status `done` — the reported defect); with it, the full agent-worker suite passes (435 tests), `tsc --noEmit` clean, Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)