### PR TITLE
Fix ADR-0008 vocabulary drift and dedupe live-text plumbing

### DIFF
--- a/apps/agent-worker/src/live-text.test.ts
+++ b/apps/agent-worker/src/live-text.test.ts
@@ -3,7 +3,6 @@ import {
 	createWorkerLiveTextTelemetry,
 	createWorkerLiveTextTransport,
 	reportWorkerLiveTextPreviewSignal,
-	reportWorkerLiveTextRuntimeSignal,
 } from "./live-text";
 
 const logger = {
@@ -45,21 +44,13 @@ it("constructs the lazy production publisher when Redis is configured", async ()
 	await transport?.close();
 });
 
-it("maps every worker Live path to bounded payload-free signals", () => {
+it("maps every worker Live preview path to bounded payload-free signals", () => {
 	const events: Record<string, unknown>[] = [];
 	const telemetry = createWorkerLiveTextTelemetry({
 		info: (event) => events.push(event),
 		warn: (event) => events.push(event),
 	});
 
-	for (const signal of [
-		"degraded",
-		"recovered",
-		"invalid_message",
-		"oversized_message",
-	] as const) {
-		reportWorkerLiveTextRuntimeSignal(telemetry, signal);
-	}
 	for (const signal of [
 		{ type: "attempted" },
 		{ type: "delivered" },
@@ -77,10 +68,6 @@ it("maps every worker Live path to bounded payload-free signals", () => {
 	expect(
 		events.map(({ signal, reason, outcome }) => ({ signal, reason, outcome })),
 	).toEqual([
-		{ signal: "degraded", reason: "redis_connection", outcome: undefined },
-		{ signal: "recovered", reason: "redis_connection", outcome: undefined },
-		{ signal: "malformed", reason: "adapter_message", outcome: "dropped" },
-		{ signal: "malformed", reason: "adapter_message", outcome: "dropped" },
 		{
 			signal: "attempted",
 			reason: "message_publication",

--- a/apps/agent-worker/src/live-text.ts
+++ b/apps/agent-worker/src/live-text.ts
@@ -4,6 +4,7 @@ import {
 	type LiveTextTelemetry,
 	type LiveTextTransport,
 	type RedisLiveTextSignal,
+	reportRedisLiveTextSignal,
 } from "@mymemo/live-text";
 import type { LiveTextPreviewSignal } from "./sdk/live-text-preview";
 
@@ -57,19 +58,6 @@ export function reportWorkerLiveTextPreviewSignal(
 	}
 }
 
-export function reportWorkerLiveTextRuntimeSignal(
-	telemetry: LiveTextTelemetry,
-	signal: RedisLiveTextSignal,
-): void {
-	if (signal === "degraded") {
-		telemetry.degraded("redis_connection");
-	} else if (signal === "recovered") {
-		telemetry.recovered("redis_connection");
-	} else {
-		telemetry.record("malformed", "adapter_message", "dropped");
-	}
-}
-
 /** Select the lazy production publisher only for validated Redis config. */
 export function createWorkerLiveTextTransport(
 	redisUrl: string | undefined,
@@ -82,6 +70,6 @@ export function createWorkerLiveTextTransport(
 	return createRedisLiveTextTransport({
 		url: redisUrl,
 		onSignal: (signal: RedisLiveTextSignal) =>
-			reportWorkerLiveTextRuntimeSignal(telemetry, signal),
+			reportRedisLiveTextSignal(telemetry, signal),
 	});
 }

--- a/apps/chat-api/src/features/run-events/live-text-telemetry.ts
+++ b/apps/chat-api/src/features/run-events/live-text-telemetry.ts
@@ -1,4 +1,8 @@
-import type { LiveTextTelemetry, RedisLiveTextSignal } from "@mymemo/live-text";
+import {
+	type LiveTextTelemetry,
+	type RedisLiveTextSignal,
+	reportRedisLiveTextSignal,
+} from "@mymemo/live-text";
 import type { LiveTextSetupSignal } from "./prepare-live-text-subscription";
 import type { ProjectRunLiveTextSignal } from "./project-run";
 
@@ -8,13 +12,9 @@ export function reportChatLiveTextRuntimeSignal(
 ): void {
 	if (signal === "disabled") {
 		telemetry.disabled("configuration");
-	} else if (signal === "degraded") {
-		telemetry.degraded("redis_connection");
-	} else if (signal === "recovered") {
-		telemetry.recovered("redis_connection");
-	} else {
-		telemetry.record("malformed", "adapter_message", "dropped");
+		return;
 	}
+	reportRedisLiveTextSignal(telemetry, signal);
 }
 
 export function reportChatLiveTextSetupSignal(

--- a/docs/adr/0008-token-streaming-redis-live-lane.md
+++ b/docs/adr/0008-token-streaming-redis-live-lane.md
@@ -1,4 +1,4 @@
-# Token streaming via a Redis live lane
+# Live preview via a Redis live lane
 
 Status: accepted (2026-07-10); implementation in progress
 
@@ -8,10 +8,10 @@ implemented. The worker appends one `assistant_text` event per complete
 Assistant message, and chat-api projects it as the authoritative, replayable
 `text_commit`. Coordinated client rollout remains a release concern.
 
-Smooth token streaming cannot use the durable tier for every fragment: one
+A smooth Live preview cannot use the durable tier for every fragment: one
 `text_delta` per token would mean hundreds of fenced `appendRunEventTx` and
-`NOTIFY` transactions per turn. The accepted design therefore separates
-provisional presentation from authoritative transcript storage.
+`NOTIFY` transactions per turn. The accepted design therefore separates the
+provisional Live preview from authoritative Assistant-message storage.
 
 ## Decision
 
@@ -79,8 +79,8 @@ provisional presentation from authoritative transcript storage.
   failure still admits the run immediately onto the Postgres-only path, and a
   failed admission closes the unused subscription. Reconnects retain the weaker
   best-effort behavior below.
-- Redis text is a **provisional live preview**, not committed transcript. Every
-  open connection must converge in place to the exact complete
+- Redis text is a **provisional live preview**, not a committed Assistant
+  message. Every open connection must converge in place to the exact complete
   `assistant_text` recorded in Postgres, including when it joins mid-message or
   Redis fails mid-message. The durable message therefore cannot simply be
   suppressed during live tailing: the client protocol must support a
@@ -93,9 +93,10 @@ provisional presentation from authoritative transcript storage.
 - Every terminal frame discards any uncommitted preview. For `error` and
   `canceled`, this is the normal fate of an interrupted assistant message. A
   `done` with an uncommitted preview is an invariant violation that chat-api
-  records before discarding it. Partial text is never retained in the live
-  transcript when no corresponding durable event exists; preserving
-  interrupted output would require a separate deliberate durable-event design.
+  records before discarding it. Partial text is never retained in the
+  user-visible history when no corresponding durable Run event exists;
+  preserving interrupted output would require a separate deliberate
+  durable-event design.
 - Pub/sub remains retention-free. chat-api forwards a message's live preview
   only while it observes a contiguous `deltaIndex` sequence beginning at zero.
   If a reconnect joins mid-message, or any delta is missed, it suppresses that
@@ -133,7 +134,7 @@ provisional presentation from authoritative transcript storage.
   services and are never passed into E2B.
 - Pub/sub, not Redis Streams: the durable tier is Postgres, so the live lane
   needs no retention. (`NOTIFY` is unsuitable — 8 KB payload cap, not built for
-  high-frequency token streams.)
+  high-frequency `text_delta` publication.)
 
 ## Client reconciliation
 

--- a/packages/live-text/src/index.test.ts
+++ b/packages/live-text/src/index.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "bun:test";
 import {
+	createLiveTextTelemetry,
 	InMemoryLiveTextTransport,
 	LIVE_TEXT_MAX_CHUNK_LENGTH,
 	LiveTextMessageSchema,
+	reportRedisLiveTextSignal,
 	resolveLiveTextRedisUrl,
 } from "./index";
 
@@ -170,5 +172,38 @@ describe("InMemoryLiveTextTransport", () => {
 			type: "message_ids",
 			messageIds: [],
 		});
+	});
+});
+
+describe("reportRedisLiveTextSignal", () => {
+	it("maps every Redis transport signal to a bounded payload-free event", () => {
+		const events: Record<string, unknown>[] = [];
+		const telemetry = createLiveTextTelemetry("agent-worker", {
+			info: (event) => events.push(event),
+			warn: (event) => events.push(event),
+		});
+
+		for (const signal of [
+			"degraded",
+			"recovered",
+			"invalid_message",
+			"oversized_message",
+		] as const) {
+			reportRedisLiveTextSignal(telemetry, signal);
+		}
+
+		expect(
+			events.map(({ signal, reason, outcome }) => ({
+				signal,
+				reason,
+				outcome,
+			})),
+		).toEqual([
+			{ signal: "degraded", reason: "redis_connection", outcome: undefined },
+			{ signal: "recovered", reason: "redis_connection", outcome: undefined },
+			{ signal: "malformed", reason: "adapter_message", outcome: "dropped" },
+			{ signal: "malformed", reason: "adapter_message", outcome: "dropped" },
+		]);
+		telemetry.close();
 	});
 });

--- a/packages/live-text/src/index.ts
+++ b/packages/live-text/src/index.ts
@@ -1,5 +1,6 @@
 import { createClient } from "redis";
 import { z } from "zod";
+import type { LiveTextTelemetry } from "./telemetry";
 
 export * from "./telemetry";
 
@@ -99,20 +100,17 @@ class BufferedLiveTextSubscription implements LiveTextSubscription {
 					this.#droppedMessageIds.add(message.messageId);
 				}
 			}
-			for (const wake of this.#waiters) wake(true);
-			this.#waiters.clear();
+			this.#wake(true);
 			return;
 		}
 		this.#buffer.push(message);
-		for (const wake of this.#waiters) wake(true);
-		this.#waiters.clear();
+		this.#wake(true);
 	}
 
 	dropInvalidWireMessage(): void {
 		if (this.#closed) return;
 		this.#invalidWireMessageDropped = true;
-		for (const wake of this.#waiters) wake(true);
-		this.#waiters.clear();
+		this.#wake(true);
 	}
 
 	readAvailable(): LiveTextMessage[] {
@@ -170,9 +168,13 @@ class BufferedLiveTextSubscription implements LiveTextSubscription {
 		this.#droppedMessageIds.clear();
 		this.#droppedMessageIdsOverflowed = false;
 		this.#invalidWireMessageDropped = false;
-		for (const wake of this.#waiters) wake(false);
-		this.#waiters.clear();
+		this.#wake(false);
 		await this.onClose();
+	}
+
+	#wake(available: boolean): void {
+		for (const waiter of this.#waiters) waiter(available);
+		this.#waiters.clear();
 	}
 }
 
@@ -239,6 +241,20 @@ export type RedisLiveTextSignal =
 	| "recovered"
 	| "invalid_message"
 	| "oversized_message";
+
+/** Map a Redis transport signal to its bounded payload-free telemetry event. */
+export function reportRedisLiveTextSignal(
+	telemetry: LiveTextTelemetry,
+	signal: RedisLiveTextSignal,
+): void {
+	if (signal === "degraded") {
+		telemetry.degraded("redis_connection");
+	} else if (signal === "recovered") {
+		telemetry.recovered("redis_connection");
+	} else {
+		telemetry.record("malformed", "adapter_message", "dropped");
+	}
+}
 
 export interface RedisLiveTextTransportOptions {
 	/** Authenticated rediss:// production secret, or redis:// in disposable tests. */


### PR DESCRIPTION
Addresses three code-review findings.

## ADR-0008 vocabulary drift (P2)

`docs/adr/0008-token-streaming-redis-live-lane.md` used "token streaming", "transcript storage", and "live transcript" — all terms the CONTEXT.md glossary explicitly avoids (*Live preview* and *Assistant message* both say avoid "token stream"; "transcript" is reserved for the internal *Agent session*). Reworded the title and four passages to glossary vocabulary: Live preview, Assistant-message storage, user-visible history / durable Run event, and `text_delta` publication. The filename keeps its historical slug so the verification record's link and any public issue links stay valid.

## Duplicated waiter wake (P3)

`BufferedLiveTextSubscription` repeated the notify-and-clear waiter pair four times (both `enqueue` branches, `dropInvalidWireMessage`, `close`). Extracted a private `#wake(available)` method; behavior unchanged.

## Duplicated Redis-signal-to-telemetry mapping (P3)

`apps/agent-worker/src/live-text.ts` and `apps/chat-api/src/features/run-events/live-text-telemetry.ts` carried an identical `RedisLiveTextSignal` → telemetry mapping. It now lives once in `@mymemo/live-text` as `reportRedisLiveTextSignal`. chat-api keeps only its extra `"disabled"` branch and delegates the rest; the worker's reporter would have become a pure alias, so it is removed and the transport wires the shared function directly. The mapping test moved into the package suite alongside the code.

## Verification

- `packages/live-text`: 17/17 tests pass (includes the transport-contract suite exercising the `#wake` paths)
- agent-worker `live-text` / `live-text-preview` / `agent-stream` / `run-processor`: 63 tests pass
- chat-api `run-events` + `deps` + conversations route: 99 tests pass
- `tsc --noEmit` clean in all three workspaces; Biome check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)