### PR TITLE
feat(e2e): add core artifact smoke check

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,16 +134,17 @@ AGENT_DATABASE_URL=postgres://mymemo:mymemo@localhost:5432/mymemo_agent \
 
 ### Live runtime smoke
 
-The credentialed smoke drives the real worker across two runs of one
-conversation. The first run creates an opaque file in E2B and returns only its
-SHA-256; the second must resume the prior agent session, reconnect to the same
-workspace, read the file, and stream contents matching that hash before the
-`done` outcome. Against the local compose stack:
+The credentialed smoke drives the real worker across three runs of one
+Conversation. The first two prove Agent-session resume, Workspace persistence,
+exact Assistant commits, and byte-exact durable replay. The third writes a
+unique Downloadable artifact, lists it after `done`, obtains a fresh signed URL,
+and downloads the exact attachment without identity headers.
+
+With the local compose stack running, execute the full pre-merge suite with one
+command:
 
 ```sh
-AGENT_SMOKE_BASE_URL=http://localhost:3000 \
-  AGENT_SMOKE_EXPECT_GATE_CLOSED=false \
-  bun run scripts/smoke/agent-conversation-smoke.ts
+bun run smoke:local
 ```
 
 For production, run `scripts/deploy/prod_smoke.sh` from inside the VPC with
@@ -151,6 +152,10 @@ For production, run `scripts/deploy/prod_smoke.sh` from inside the VPC with
 allowlisted in Statsig. OpenRouter and E2B credentials stay in the deployed
 worker; the smoke caller receives none of them. To check only the default-closed
 gate, set `AGENT_SMOKE_EXPECT_GATE_CLOSED=true`.
+
+`AGENT_SMOKE_SUITE` defaults to `core`; `full` is the local superset used by
+`smoke:local`. See [the two-target smoke verification guide](./docs/verification/e2e-smoke.md)
+for suite contents, target selection, and deterministic harness tests.
 
 ### Worker image check
 

--- a/docs/verification/e2e-smoke.md
+++ b/docs/verification/e2e-smoke.md
@@ -1,0 +1,75 @@
+# Split-runtime end-to-end smoke verification
+
+The Conversation smoke is one public-contract client with two targets. It uses
+`AGENT_SMOKE_BASE_URL` to address either the local compose harness or the
+deployed internal ALB; it does not read databases, logs, or runtime internals.
+This guide records the verification strategy from
+[#300](https://github.com/X-GPT/mymemo-agent/issues/300) and the core artifact
+check from [#302](https://github.com/X-GPT/mymemo-agent/issues/302).
+
+## Check sets
+
+`AGENT_SMOKE_SUITE` selects the check set and defaults to `core`. Any other
+value fails before the first HTTP request.
+
+- `core` performs three real Runs in one Conversation. Two Runs prove the SSE
+  contract, exactly one committed Assistant message per Run, Agent-session
+  resume, Workspace persistence, and byte-exact durable reconnect replay. The
+  third asks the agent to write unique exact content under
+  `/home/user/artifacts/`; after `done`, the smoke requires exactly that
+  conversation-relative artifact path, checks its listed size against the
+  downloaded object, obtains `{ downloadUrl }`, and fetches the URL without
+  identity headers. The response must be an attachment whose bytes match the
+  request, with exactly one trailing newline tolerated.
+- `full` is the local pre-merge superset. It currently includes all `core`
+  checks; [#303](https://github.com/X-GPT/mymemo-agent/issues/303) and
+  [#304](https://github.com/X-GPT/mymemo-agent/issues/304) extend it with the
+  local-only interrupt and seeded-document checks. Use `full` now so those
+  checks join the pre-merge command without changing operator habits.
+
+`AGENT_SMOKE_PREVIEW_MODE` is independent of the suite. Use `required` to prove
+the Redis Live-preview lane, `forbidden` to prove Postgres-only delivery, or the
+default `optional` when preview transport is not the subject of the run.
+
+## Target strategy
+
+| Target | Suite | Invocation | Credentials and network |
+| --- | --- | --- | --- |
+| Local compose | `full` | `bun run smoke:local` | The running trusted services hold the developer's OpenRouter, E2B, and AWS credentials. The smoke process needs only localhost access. |
+| Deployed internal ALB | `core` | `AGENT_SMOKE_SUITE=core scripts/deploy/prod_smoke.sh` | Run inside the VPC under the allowlisted smoke identity. The caller receives no provider, sandbox, AWS, or database secrets. |
+
+There is no staging target. Local-real is the pre-merge bar; the deployed core
+suite is the post-deploy bar. The smoke identity must be allowlisted in the
+`mymemo_agent_split_runtime_enabled` Statsig gate before a gate-open deployed
+run. Until the in-VPC release one-shot in
+[#305](https://github.com/X-GPT/mymemo-agent/issues/305) lands, the deployed
+command remains manual from a VPC-reachable environment.
+
+## One-command pre-merge run
+
+First satisfy the compose prerequisites and start the stack as described in the
+[local harness guide](../../README.md#local-end-to-end-harness). With the stack
+healthy, run:
+
+```sh
+bun run smoke:local
+```
+
+The command fixes the local base URL, gate-open expectation, seeded fixture
+member, and `full` suite. A pass prints the Conversation id and all Run ids so
+the evidence can be correlated with service logs. A failure exits non-zero with
+the assertion that failed.
+
+## Deterministic verification of the verifier
+
+The suite logic is tested through its CLI against loopback stub Conversation
+servers. The tests cover both required-preview and forbidden-preview artifact
+happy paths, the allowed single trailing newline, identity-free signed-object
+fetching, tampered object bytes, and environment validation:
+
+```sh
+bun test scripts/smoke/agent-conversation-smoke.test.ts
+```
+
+The broader client-contract evidence and release record remain in
+[ADR-0008 hard-cutover verification](./adr-0008-hard-cutover.md).

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -177,9 +177,10 @@ different settings:
 - `AGENT_SMOKE_BASE_URL` in `prod.env` is optional deploy verification config
   for running `scripts/deploy/prod_smoke.sh` from inside the VPC. The
   GitHub-hosted release workflow does not call this internal URL. The checked-in
-  smoke identity must be allowlisted in Statsig: the script drives two real runs,
-  verifies agent-session resume and E2B workspace persistence, and reconnects
-  each Run from its durable cursor. `AGENT_SMOKE_PREVIEW_MODE=required` proves
+  smoke identity must be allowlisted in Statsig: the default `core` suite drives
+  three real Runs, verifies Agent-session resume and Workspace persistence,
+  reconnects each Run from its durable cursor, and checks Downloadable-artifact
+  listing plus signed attachment delivery. `AGENT_SMOKE_PREVIEW_MODE=required` proves
   the Live-enabled contract; after disabling the lane, override it with
   `AGENT_SMOKE_PREVIEW_MODE=forbidden` to prove exact Postgres-only delivery. Set
   `AGENT_SMOKE_EXPECT_GATE_CLOSED=true` only when checking the default-deny path

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
 	"name": "mymemo-agent",
 	"module": "index.ts",
 	"scripts": {
+		"smoke:local": "AGENT_SMOKE_BASE_URL=http://localhost:3000 AGENT_SMOKE_EXPECT_GATE_CLOSED=false AGENT_SMOKE_MEMBER_CODE=demo-member AGENT_SMOKE_SUITE=full bun run scripts/smoke/agent-conversation-smoke.ts",
 		"test": "bun test scripts/deploy-config.test.ts scripts/smoke/client-contract.test.ts scripts/smoke/agent-conversation-smoke.test.ts && bun run scripts/test-workspaces.ts",
 		"terraform:fmt": "terraform -chdir=infra/bootstrap-iam fmt && terraform -chdir=infra/terraform fmt && terraform -chdir=infra/ecr fmt && terraform -chdir=infra/dev fmt",
 		"terraform:validate": "terraform -chdir=infra/bootstrap-iam validate && terraform -chdir=infra/terraform validate && terraform -chdir=infra/ecr validate && terraform -chdir=infra/dev validate"

--- a/scripts/smoke/agent-conversation-smoke.test.ts
+++ b/scripts/smoke/agent-conversation-smoke.test.ts
@@ -15,6 +15,27 @@ interface UserMessage {
 	text: string;
 }
 
+interface StubRequest {
+	pathname: string;
+	memberCode: string | null;
+	partnerCode: string | null;
+}
+
+interface SmokeStubOptions {
+	conversationId: string;
+	workspaceMarker: string;
+	runIdPrefix: string;
+	includePreview?: boolean;
+	artifactContent?: (requestedContent: string) => string;
+}
+
+interface SmokeStub {
+	baseUrl: string;
+	messages: UserMessage[];
+	reconnectCursors: string[];
+	requests: StubRequest[];
+}
+
 function sseTurn(input: {
 	conversationId: string;
 	runId: string;
@@ -86,101 +107,50 @@ function sseTurn(input: {
 }
 
 describe("agent conversation live smoke", () => {
-	it("proves agent-session resume and persisted workspace contents across two runs", async () => {
+	it("runs the core continuity and artifact checks with Live preview", async () => {
 		const conversationId = "00000000-0000-4000-8000-000000000233";
 		const workspaceMarker = "workspace-0123456789abcdef0123456789abcdef";
-		const workspaceHash = createHash("sha256")
-			.update(workspaceMarker)
-			.digest("hex");
-		const messages: UserMessage[] = [];
-		const identityHeaders: Array<[string | null, string | null]> = [];
-		const responsesByRun = new Map<string, string>();
-		const reconnectCursors: string[] = [];
-
-		const server = Bun.serve({
-			port: await availablePort(),
-			async fetch(request) {
-				const url = new URL(request.url);
-				identityHeaders.push([
-					request.headers.get("x-member-code"),
-					request.headers.get("x-partner-code"),
-				]);
-				if (url.pathname === "/v1/conversations") {
-					return Response.json(
-						{ conversationId, scope: "general" },
-						{ status: 201 },
-					);
-				}
-
-				if (url.pathname === `/v1/conversations/${conversationId}/events`) {
-					messages.push((await request.json()) as UserMessage);
-					const turn = messages.length;
-					const runId = `run-${turn}`;
-					const text =
-						turn === 1
-							? `TURN1_SHA256=${workspaceHash}`
-							: `SESSION_MARKER=${extractSessionMarker(messages[0]?.text)}\nWORKSPACE_MARKER=${workspaceMarker}`;
-					responsesByRun.set(runId, text);
-					return sseTurn({
-						conversationId,
-						runId,
-						includePreview: true,
-						text,
-					});
-				}
-				const reconnect = url.pathname.match(
-					new RegExp(
-						`^/v1/conversations/${conversationId}/runs/(run-[0-9]+)/events$`,
-					),
-				);
-				if (request.method === "GET" && reconnect) {
-					reconnectCursors.push(request.headers.get("last-event-id") ?? "");
-					const runId = reconnect[1] as string;
-					const text = responsesByRun.get(runId);
-					if (!text) return new Response("not found", { status: 404 });
-					return sseTurn({
-						conversationId,
-						runId,
-						text,
-						includeLifecycle: false,
-					});
-				}
-
-				return new Response("not found", { status: 404 });
-			},
+		const stub = await startSmokeStub({
+			conversationId,
+			workspaceMarker,
+			runIdPrefix: "run",
+			includePreview: true,
 		});
-		servers.push(server);
 
-		const { exitCode, stdout, stderr } = await runSmoke(
-			`http://127.0.0.1:${server.port}`,
-			{ AGENT_SMOKE_PREVIEW_MODE: "required" },
-		);
+		const { exitCode, stdout, stderr } = await runSmoke(stub.baseUrl, {
+			AGENT_SMOKE_PREVIEW_MODE: "required",
+		});
 
 		expect(stderr).toBe("");
 		expect(exitCode).toBe(0);
 		expect(stdout).toContain("agent live smoke passed");
+		expect(stdout).toContain("suite=core");
 		expect(stdout).toContain(conversationId);
 		expect(stdout).toContain("run-1");
 		expect(stdout).toContain("run-2");
-		expect(messages).toHaveLength(2);
-		expect(messages[0]?.type).toBe("user.message");
-		expect(messages[0]?.text).toContain("Bash");
-		expect(messages[0]?.text).toContain("/home/user/.mymemo-live-smoke");
-		expect(messages[0]?.text).toContain("sha256");
-		expect(messages[1]?.type).toBe("user.message");
-		expect(messages[1]?.text).toContain("previous turn");
-		expect(messages[1]?.text).toContain("Read");
-		expect(messages[1]?.text).not.toContain(
-			extractSessionMarker(messages[0]?.text),
+		expect(stdout).toContain("run-3");
+		expect(stub.messages).toHaveLength(3);
+		expect(stub.messages[0]?.type).toBe("user.message");
+		expect(stub.messages[0]?.text).toContain("Bash");
+		expect(stub.messages[0]?.text).toContain("/home/user/.mymemo-live-smoke");
+		expect(stub.messages[0]?.text).toContain("sha256");
+		expect(stub.messages[1]?.type).toBe("user.message");
+		expect(stub.messages[1]?.text).toContain("previous turn");
+		expect(stub.messages[1]?.text).toContain("Read");
+		expect(stub.messages[1]?.text).not.toContain(
+			extractSessionMarker(stub.messages[0]?.text),
 		);
-		expect(identityHeaders).toEqual([
-			["live-smoke-member", "live-smoke-partner"],
-			["live-smoke-member", "live-smoke-partner"],
-			["live-smoke-member", "live-smoke-partner"],
-			["live-smoke-member", "live-smoke-partner"],
-			["live-smoke-member", "live-smoke-partner"],
-		]);
-		expect(reconnectCursors).toEqual(["1", "1"]);
+		const artifact = extractArtifactRequest(stub.messages[2]?.text);
+		expect(artifact.relativePath).toBe("smoke/core-check.txt");
+		expect(artifact.content).toMatch(/^mymemo-core-artifact-[0-9a-f-]{36}$/);
+		expect(stub.requests.slice(0, -1).map(identityFromRequest)).toEqual(
+			Array.from({ length: 9 }, () => [
+				"live-smoke-member",
+				"live-smoke-partner",
+			]),
+		);
+		expect(identityFromRequest(stub.requests.at(-1))).toEqual([null, null]);
+		expect(stub.reconnectCursors).toEqual(["1", "1", "1"]);
 	});
 
 	it("rejects a non-positive turn timeout before making a request", async () => {
@@ -194,68 +164,58 @@ describe("agent conversation live smoke", () => {
 		);
 	});
 
-	it("proves exact durable delivery and replay with Redis preview disabled", async () => {
+	it("rejects an unknown suite before making a request", async () => {
+		const { exitCode, stderr } = await runSmoke("http://127.0.0.1:1", {
+			AGENT_SMOKE_SUITE: "extended",
+		});
+
+		expect(exitCode).not.toBe(0);
+		expect(stderr).toContain("AGENT_SMOKE_SUITE must be core or full");
+		expect(stderr).not.toContain("Unable to connect");
+	});
+
+	it("runs the full suite's core checks with Redis preview disabled", async () => {
 		const conversationId = "00000000-0000-4000-8000-000000000235";
 		const workspaceMarker = "workspace-fedcba9876543210fedcba9876543210";
-		const workspaceHash = createHash("sha256")
-			.update(workspaceMarker)
-			.digest("hex");
-		const messages: UserMessage[] = [];
-		const responsesByRun = new Map<string, string>();
-		const reconnectCursors: string[] = [];
-
-		const server = Bun.serve({
-			port: await availablePort(),
-			async fetch(request) {
-				const url = new URL(request.url);
-				if (url.pathname === "/v1/conversations") {
-					return Response.json(
-						{ conversationId, scope: "general" },
-						{ status: 201 },
-					);
-				}
-				if (url.pathname === `/v1/conversations/${conversationId}/events`) {
-					messages.push((await request.json()) as UserMessage);
-					const turn = messages.length;
-					const runId = `disabled-run-${turn}`;
-					const text =
-						turn === 1
-							? `TURN1_SHA256=${workspaceHash}`
-							: `SESSION_MARKER=${extractSessionMarker(messages[0]?.text)}\nWORKSPACE_MARKER=${workspaceMarker}`;
-					responsesByRun.set(runId, text);
-					return sseTurn({ conversationId, runId, text });
-				}
-				const reconnect = url.pathname.match(
-					new RegExp(
-						`^/v1/conversations/${conversationId}/runs/(disabled-run-[0-9]+)/events$`,
-					),
-				);
-				if (request.method === "GET" && reconnect) {
-					reconnectCursors.push(request.headers.get("last-event-id") ?? "");
-					const runId = reconnect[1] as string;
-					const text = responsesByRun.get(runId);
-					if (!text) return new Response("not found", { status: 404 });
-					return sseTurn({
-						conversationId,
-						runId,
-						text,
-						includeLifecycle: false,
-					});
-				}
-				return new Response("not found", { status: 404 });
-			},
+		const stub = await startSmokeStub({
+			conversationId,
+			workspaceMarker,
+			runIdPrefix: "disabled-run",
+			artifactContent: (content) => `${content}\n`,
 		});
-		servers.push(server);
 
-		const { exitCode, stdout, stderr } = await runSmoke(
-			`http://127.0.0.1:${server.port}`,
-			{ AGENT_SMOKE_PREVIEW_MODE: "forbidden" },
-		);
+		const { exitCode, stdout, stderr } = await runSmoke(stub.baseUrl, {
+			AGENT_SMOKE_PREVIEW_MODE: "forbidden",
+			AGENT_SMOKE_SUITE: "full",
+		});
 
 		expect(stderr).toBe("");
 		expect(exitCode).toBe(0);
+		expect(stdout).toContain("suite=full");
 		expect(stdout).toContain("preview=forbidden");
-		expect(reconnectCursors).toEqual(["1", "1"]);
+		expect(extractArtifactRequest(stub.messages[2]?.text).relativePath).toBe(
+			"smoke/core-check.txt",
+		);
+		expect(identityFromRequest(stub.requests.at(-1))).toEqual([null, null]);
+		expect(stub.reconnectCursors).toEqual(["1", "1", "1"]);
+	});
+
+	it("rejects a signed artifact whose bytes do not match the request", async () => {
+		const conversationId = "00000000-0000-4000-8000-000000000237";
+		const workspaceMarker = "workspace-11111111111111111111111111111111";
+		const stub = await startSmokeStub({
+			conversationId,
+			workspaceMarker,
+			runIdPrefix: "tampered-run",
+			artifactContent: (content) => "x".repeat(content.length),
+		});
+
+		const { exitCode, stderr } = await runSmoke(stub.baseUrl);
+
+		expect(exitCode).not.toBe(0);
+		expect(stderr).toContain(
+			"downloaded artifact bytes did not match requested content",
+		);
 	});
 
 	it("rejects an assistant stream that never records the done outcome", async () => {
@@ -323,6 +283,135 @@ describe("agent conversation live smoke", () => {
 	});
 });
 
+async function startSmokeStub(input: SmokeStubOptions): Promise<SmokeStub> {
+	const messages: UserMessage[] = [];
+	const reconnectCursors: string[] = [];
+	const requests: StubRequest[] = [];
+	const responsesByRun = new Map<string, string>();
+	const workspaceHash = createHash("sha256")
+		.update(input.workspaceMarker)
+		.digest("hex");
+	const artifactId = `${input.runIdPrefix}-artifact`;
+	const signedPath = `/signed/${artifactId}`;
+	let downloadedContent = "";
+	const port = await availablePort();
+
+	const server = Bun.serve({
+		port,
+		async fetch(request) {
+			const url = new URL(request.url);
+			requests.push({
+				pathname: url.pathname,
+				memberCode: request.headers.get("x-member-code"),
+				partnerCode: request.headers.get("x-partner-code"),
+			});
+			if (url.pathname === "/v1/conversations") {
+				return Response.json(
+					{ conversationId: input.conversationId, scope: "general" },
+					{ status: 201 },
+				);
+			}
+			if (
+				request.method === "POST" &&
+				url.pathname === `/v1/conversations/${input.conversationId}/events`
+			) {
+				messages.push((await request.json()) as UserMessage);
+				const turn = messages.length;
+				const runId = `${input.runIdPrefix}-${turn}`;
+				const text =
+					turn === 1
+						? `TURN1_SHA256=${workspaceHash}`
+						: turn === 2
+							? `SESSION_MARKER=${extractSessionMarker(messages[0]?.text)}\nWORKSPACE_MARKER=${input.workspaceMarker}`
+							: "ARTIFACT_WRITTEN";
+				responsesByRun.set(runId, text);
+				return sseTurn({
+					conversationId: input.conversationId,
+					runId,
+					includePreview: input.includePreview,
+					text,
+				});
+			}
+
+			const reconnectPrefix = `/v1/conversations/${input.conversationId}/runs/`;
+			const reconnectSuffix = "/events";
+			if (
+				request.method === "GET" &&
+				url.pathname.startsWith(reconnectPrefix) &&
+				url.pathname.endsWith(reconnectSuffix)
+			) {
+				reconnectCursors.push(request.headers.get("last-event-id") ?? "");
+				const runId = url.pathname.slice(
+					reconnectPrefix.length,
+					-reconnectSuffix.length,
+				);
+				const text = responsesByRun.get(runId);
+				if (!text) return new Response("not found", { status: 404 });
+				return sseTurn({
+					conversationId: input.conversationId,
+					runId,
+					text,
+					includeLifecycle: false,
+				});
+			}
+
+			if (
+				request.method === "GET" &&
+				url.pathname === `/v1/conversations/${input.conversationId}/artifacts`
+			) {
+				const artifact = extractArtifactRequest(messages[2]?.text);
+				downloadedContent = input.artifactContent
+					? input.artifactContent(artifact.content)
+					: artifact.content;
+				return Response.json({
+					artifacts: [
+						{
+							artifactId,
+							path: artifact.relativePath,
+							sizeBytes: new TextEncoder().encode(downloadedContent).byteLength,
+							contentType: "text/plain",
+							createdAt: "2026-07-17T00:00:00.000Z",
+							updatedAt: "2026-07-17T00:00:00.000Z",
+						},
+					],
+				});
+			}
+			if (
+				request.method === "GET" &&
+				url.pathname ===
+					`/v1/conversations/${input.conversationId}/artifacts/${artifactId}/download-url`
+			) {
+				return Response.json({
+					downloadUrl: `http://127.0.0.1:${port}${signedPath}`,
+				});
+			}
+			if (request.method === "GET" && url.pathname === signedPath) {
+				return new Response(downloadedContent, {
+					headers: {
+						"content-disposition": 'attachment; filename="core-check.txt"',
+						"content-type": "text/plain",
+					},
+				});
+			}
+			return new Response("not found", { status: 404 });
+		},
+	});
+	servers.push(server);
+	return {
+		baseUrl: `http://127.0.0.1:${port}`,
+		messages,
+		reconnectCursors,
+		requests,
+	};
+}
+
+function identityFromRequest(
+	request: StubRequest | undefined,
+): [string | null, string | null] {
+	if (!request) throw new Error("expected stub request");
+	return [request.memberCode, request.partnerCode];
+}
+
 async function runSmoke(
 	baseUrl: string,
 	env: Record<string, string> = {},
@@ -357,6 +446,23 @@ function extractSessionMarker(prompt: string | undefined): string {
 	if (!marker)
 		throw new Error("first-turn prompt did not contain a session marker");
 	return marker;
+}
+
+function extractArtifactRequest(prompt: string | undefined): {
+	relativePath: string;
+	content: string;
+} {
+	const absolutePath = prompt?.match(
+		/^ARTIFACT_PATH=(\/home\/user\/artifacts\/.+)$/m,
+	)?.[1];
+	const content = prompt?.match(/^ARTIFACT_CONTENT=(.+)$/m)?.[1];
+	if (!absolutePath || !content) {
+		throw new Error("artifact-turn prompt did not contain path and content");
+	}
+	return {
+		relativePath: absolutePath.slice("/home/user/artifacts/".length),
+		content,
+	};
 }
 
 async function availablePort(): Promise<number> {

--- a/scripts/smoke/agent-conversation-smoke.ts
+++ b/scripts/smoke/agent-conversation-smoke.ts
@@ -11,6 +11,7 @@ const baseUrl = requiredEnv("AGENT_SMOKE_BASE_URL").replace(/\/+$/, "");
 const memberCode = Bun.env.AGENT_SMOKE_MEMBER_CODE || "agent-smoke-member";
 const partnerCode = Bun.env.AGENT_SMOKE_PARTNER_CODE || "agent-smoke-partner";
 const expectGateClosed = Bun.env.AGENT_SMOKE_EXPECT_GATE_CLOSED !== "false";
+const suite = parseSuite(Bun.env.AGENT_SMOKE_SUITE);
 const previewMode = parsePreviewMode(Bun.env.AGENT_SMOKE_PREVIEW_MODE);
 const rawTurnTimeout = Bun.env.AGENT_SMOKE_TURN_TIMEOUT_MS;
 const turnTimeoutMs =
@@ -39,6 +40,14 @@ interface TurnResult {
 	runId: string;
 	text: string;
 }
+
+interface ArtifactMetadata {
+	artifactId?: unknown;
+	path?: unknown;
+	sizeBytes?: unknown;
+}
+
+const CORE_ARTIFACT_PATH = "smoke/core-check.txt";
 
 function requiredEnv(name: string): string {
 	const value = Bun.env[name];
@@ -153,9 +162,117 @@ if (secondTurn.text !== expectedSecondText) {
 	);
 }
 
-console.log(
-	`agent live smoke passed: preview=${previewMode}; conversation ${conversationId}; runs ${firstTurn.runId}, ${secondTurn.runId}`,
+const artifactContent = `mymemo-core-artifact-${randomUUID()}`;
+const artifactTurn = await sendTurn(
+	conversationId,
+	[
+		"Create exactly one Downloadable artifact for this automated smoke test.",
+		`ARTIFACT_PATH=/home/user/artifacts/${CORE_ARTIFACT_PATH}`,
+		`ARTIFACT_CONTENT=${artifactContent}`,
+		"Use the Write tool to write the ARTIFACT_CONTENT value as the file's exact UTF-8 contents, with no trailing newline.",
+		"Do not create any other file under /home/user/artifacts.",
+		"Reply with exactly ARTIFACT_WRITTEN and nothing else.",
+	].join("\n"),
 );
+await verifyArtifact(conversationId, artifactContent);
+
+console.log(
+	`agent live smoke passed: suite=${suite}; preview=${previewMode}; conversation ${conversationId}; runs ${firstTurn.runId}, ${secondTurn.runId}, ${artifactTurn.runId}`,
+);
+
+async function verifyArtifact(
+	conversationId: string,
+	expectedContent: string,
+): Promise<void> {
+	const listResponse = await fetch(
+		`${baseUrl}/v1/conversations/${conversationId}/artifacts`,
+		{
+			headers: headers(),
+			signal: AbortSignal.timeout(turnTimeoutMs),
+		},
+	);
+	if (listResponse.status !== 200) {
+		throw new Error(
+			`expected artifact list 200, got ${listResponse.status}: ${await listResponse.text()}`,
+		);
+	}
+	const listBody = (await listResponse.json()) as { artifacts?: unknown };
+	if (!Array.isArray(listBody.artifacts) || listBody.artifacts.length !== 1) {
+		throw new Error("artifact list did not contain exactly one artifact");
+	}
+	const artifact = listBody.artifacts[0] as ArtifactMetadata;
+	if (artifact.path !== CORE_ARTIFACT_PATH) {
+		throw new Error(
+			`artifact list path was ${String(artifact.path)}, expected ${CORE_ARTIFACT_PATH}`,
+		);
+	}
+	if (typeof artifact.artifactId !== "string" || !artifact.artifactId) {
+		throw new Error("artifact list did not include a valid artifactId");
+	}
+	if (!Number.isInteger(artifact.sizeBytes) || Number(artifact.sizeBytes) < 0) {
+		throw new Error("artifact list did not include a valid sizeBytes");
+	}
+
+	const urlResponse = await fetch(
+		`${baseUrl}/v1/conversations/${conversationId}/artifacts/${encodeURIComponent(artifact.artifactId)}/download-url`,
+		{
+			headers: headers(),
+			redirect: "manual",
+			signal: AbortSignal.timeout(turnTimeoutMs),
+		},
+	);
+	if (urlResponse.status !== 200) {
+		throw new Error(
+			`expected artifact download URL 200, got ${urlResponse.status}: ${await urlResponse.text()}`,
+		);
+	}
+	const urlBody = (await urlResponse.json()) as { downloadUrl?: unknown };
+	if (typeof urlBody.downloadUrl !== "string" || !urlBody.downloadUrl) {
+		throw new Error(
+			"artifact download response did not include string downloadUrl",
+		);
+	}
+
+	const downloadResponse = await fetch(urlBody.downloadUrl, {
+		signal: AbortSignal.timeout(turnTimeoutMs),
+	});
+	if (!downloadResponse.ok) {
+		throw new Error(
+			`expected signed artifact download 2xx, got ${downloadResponse.status}: ${await downloadResponse.text()}`,
+		);
+	}
+	if (
+		!/^attachment(?:;|$)/i.test(
+			downloadResponse.headers.get("content-disposition")?.trim() ?? "",
+		)
+	) {
+		throw new Error("signed artifact download was not an attachment");
+	}
+	const downloadedBytes = new Uint8Array(await downloadResponse.arrayBuffer());
+	if (artifact.sizeBytes !== downloadedBytes.byteLength) {
+		throw new Error(
+			`artifact list size ${String(artifact.sizeBytes)} did not match downloaded object size ${downloadedBytes.byteLength}`,
+		);
+	}
+	if (!matchesRequestedContent(downloadedBytes, expectedContent)) {
+		throw new Error(
+			"downloaded artifact bytes did not match requested content",
+		);
+	}
+}
+
+function matchesRequestedContent(
+	actual: Uint8Array,
+	expectedContent: string,
+): boolean {
+	const expected = new TextEncoder().encode(expectedContent);
+	const allowedLength =
+		actual.byteLength === expected.byteLength ||
+		(actual.byteLength === expected.byteLength + 1 &&
+			actual.at(-1) === "\n".charCodeAt(0));
+	if (!allowedLength) return false;
+	return expected.every((byte, index) => actual[index] === byte);
+}
 
 async function sendTurn(
 	conversationId: string,
@@ -390,6 +507,14 @@ function parseFrameData(frame: SSEFrame): unknown {
 }
 
 type PreviewMode = "optional" | "required" | "forbidden";
+
+type SmokeSuite = "core" | "full";
+
+function parseSuite(value: string | undefined): SmokeSuite {
+	if (value === undefined || value === "core") return "core";
+	if (value === "full") return "full";
+	throw new Error("AGENT_SMOKE_SUITE must be core or full");
+}
 
 function parsePreviewMode(value: string | undefined): PreviewMode {
 	if (value === undefined || value === "optional") return "optional";


### PR DESCRIPTION
## Summary

- add an `AGENT_SMOKE_SUITE` check-set switch that defaults to `core`, accepts the future local `full` superset, and rejects unknown values before network access
- extend the core smoke with a third real Run that publishes exact content under the Downloadable-artifact root, lists the conversation-relative artifact, obtains `{ downloadUrl }`, and verifies the identity-free attachment bytes
- add deterministic CLI-level stub coverage for both Live-preview modes, one-trailing-newline tolerance, tampered object failure, and suite validation
- document the two-target verification strategy and add the one-command `bun run smoke:local` pre-merge entrypoint

## Why

The existing smoke proved Agent-session resume, Workspace persistence, authoritative Assistant commits, and durable replay, but did not exercise the Downloadable-artifact client contract. A broken publication, metadata, signing, or direct-download path could therefore pass pre-merge and deploy verification unnoticed.

## Impact

The default `core` smoke now performs three Runs per Conversation and verifies the artifact path through the public HTTP contract on either target. The signed object is deliberately fetched without trusted identity headers, proving the URL is self-authorizing. There is no production API shape change.

The `full` selector currently contains the core checks and is the stable local extension point for the interrupt and seeded-document follow-ups in #303 and #304.

## Validation

- `bun test`: 768 passed, 11 environment-gated skipped, 0 failed
- live E2B suites: 4 passed, 0 failed
- real-Postgres split-runtime integration: 1 passed, 0 failed
- `bun run smoke:local`: passed three real Runs through chat-api, agent-worker, OpenRouter, E2B, Postgres, S3 publication, and signed download
- strict TypeScript checks, Biome checks, and `git diff --check`
- independent Standards and Spec review; duplicated stub routing was consolidated into one configurable public-boundary fixture

Closes #302