### PR TITLE
feat(e2e): verify running run cancellation

### DIFF
--- a/docs/verification/e2e-smoke.md
+++ b/docs/verification/e2e-smoke.md
@@ -5,7 +5,9 @@ The Conversation smoke is one public-contract client with two targets. It uses
 deployed internal ALB; it does not read databases, logs, or runtime internals.
 This guide records the verification strategy from
 [#300](https://github.com/X-GPT/mymemo-agent/issues/300) and the core artifact
-check from [#302](https://github.com/X-GPT/mymemo-agent/issues/302).
+check from [#302](https://github.com/X-GPT/mymemo-agent/issues/302), plus the
+local cancellation check from
+[#303](https://github.com/X-GPT/mymemo-agent/issues/303).
 
 ## Check sets
 
@@ -21,11 +23,15 @@ value fails before the first HTTP request.
   downloaded object, obtains `{ downloadUrl }`, and fetches the URL without
   identity headers. The response must be an attachment whose bytes match the
   request, with exactly one trailing newline tolerated.
-- `full` is the local pre-merge superset. It currently includes all `core`
-  checks; [#303](https://github.com/X-GPT/mymemo-agent/issues/303) and
-  [#304](https://github.com/X-GPT/mymemo-agent/issues/304) extend it with the
-  local-only interrupt and seeded-document checks. Use `full` now so those
-  checks join the pre-merge command without changing operator habits.
+- `full` is the local pre-merge superset. After the `core` checks it creates a
+  second Conversation, asks its Run to start an immediate long-running Bash
+  command, reads the live SSE incrementally, and sends `user.interrupt` only
+  after the first Tool invocation arrives. It requires the running-Run
+  `cancel_requested` response, a `canceled` live outcome with no surviving
+  provisional Assistant text, and a reconnect that exactly replays the live
+  committed messages and Tool events before ending `canceled`.
+  [#304](https://github.com/X-GPT/mymemo-agent/issues/304) adds the remaining
+  seeded-document checks to this set.
 
 `AGENT_SMOKE_PREVIEW_MODE` is independent of the suite. Use `required` to prove
 the Redis Live-preview lane, `forbidden` to prove Postgres-only delivery, or the
@@ -64,8 +70,10 @@ the assertion that failed.
 
 The suite logic is tested through its CLI against loopback stub Conversation
 servers. The tests cover both required-preview and forbidden-preview artifact
-happy paths, the allowed single trailing newline, identity-free signed-object
-fetching, tampered object bytes, and environment validation:
+happy paths, a held-open stream canceled only after its Tool invocation,
+canceled durable replay, provisional-text discard, and rejection of a changed
+replayed Tool payload, the allowed single trailing newline, identity-free
+signed-object fetching, tampered object bytes, and environment validation:
 
 ```sh
 bun test scripts/smoke/agent-conversation-smoke.test.ts

--- a/scripts/smoke/agent-conversation-smoke.test.ts
+++ b/scripts/smoke/agent-conversation-smoke.test.ts
@@ -15,6 +15,11 @@ interface UserMessage {
 	text: string;
 }
 
+interface UserInterrupt {
+	type: "user.interrupt";
+	runId: string;
+}
+
 interface StubRequest {
 	pathname: string;
 	memberCode: string | null;
@@ -23,17 +28,50 @@ interface StubRequest {
 
 interface SmokeStubOptions {
 	conversationId: string;
+	interruptConversationId?: string;
 	workspaceMarker: string;
 	runIdPrefix: string;
 	includePreview?: boolean;
+	interruptIncludePreview?: boolean;
+	replayInterruptToolCommand?: string;
 	artifactContent?: (requestedContent: string) => string;
 }
 
 interface SmokeStub {
 	baseUrl: string;
 	messages: UserMessage[];
+	interrupts: Array<UserInterrupt & { afterToolUse: boolean }>;
 	reconnectCursors: string[];
 	requests: StubRequest[];
+}
+
+interface StubSSEFrame {
+	id?: string;
+	event: string;
+	data: Record<string, unknown>;
+}
+
+function serializeSSEFrame(frame: StubSSEFrame): string {
+	return `${frame.id === undefined ? "" : `id: ${frame.id}\n`}event: ${frame.event}\ndata: ${JSON.stringify(frame.data)}\n\n`;
+}
+
+function sseResponse(frames: StubSSEFrame[]): Response {
+	return new Response(frames.map(serializeSSEFrame).join(""), {
+		headers: { "content-type": "text/event-stream" },
+	});
+}
+
+function bashToolUseFrame(command: string): StubSSEFrame {
+	return {
+		id: "2",
+		event: "tool_use",
+		data: {
+			type: "tool_use",
+			tool: "Bash",
+			arguments: { command },
+			truncated: false,
+		},
+	};
 }
 
 function sseTurn(input: {
@@ -45,11 +83,7 @@ function sseTurn(input: {
 	includeLifecycle?: boolean;
 	commitTexts?: string[];
 }): Response {
-	const frames: Array<{
-		id?: string;
-		event: string;
-		data: Record<string, unknown>;
-	}> = [];
+	const frames: StubSSEFrame[] = [];
 	if (input.includeLifecycle !== false) {
 		frames.push({
 			id: "1",
@@ -95,15 +129,7 @@ function sseTurn(input: {
 			data: { type: "done" },
 		});
 	}
-	return new Response(
-		`${frames
-			.map(
-				(frame) =>
-					`${frame.id === undefined ? "" : `id: ${frame.id}\n`}event: ${frame.event}\ndata: ${JSON.stringify(frame.data)}`,
-			)
-			.join("\n\n")}\n\n`,
-		{ headers: { "content-type": "text/event-stream" } },
-	);
+	return sseResponse(frames);
 }
 
 describe("agent conversation live smoke", () => {
@@ -174,11 +200,13 @@ describe("agent conversation live smoke", () => {
 		expect(stderr).not.toContain("Unable to connect");
 	});
 
-	it("runs the full suite's core checks with Redis preview disabled", async () => {
+	it("interrupts a held-open full-suite Run after its first Tool invocation and replays canceled history", async () => {
 		const conversationId = "00000000-0000-4000-8000-000000000235";
+		const interruptConversationId = "00000000-0000-4000-8000-000000000236";
 		const workspaceMarker = "workspace-fedcba9876543210fedcba9876543210";
 		const stub = await startSmokeStub({
 			conversationId,
+			interruptConversationId,
 			workspaceMarker,
 			runIdPrefix: "disabled-run",
 			artifactContent: (content) => `${content}\n`,
@@ -193,11 +221,66 @@ describe("agent conversation live smoke", () => {
 		expect(exitCode).toBe(0);
 		expect(stdout).toContain("suite=full");
 		expect(stdout).toContain("preview=forbidden");
+		expect(stdout).toContain(interruptConversationId);
+		expect(stdout).toContain("disabled-run-interrupt");
 		expect(extractArtifactRequest(stub.messages[2]?.text).relativePath).toBe(
 			"smoke/core-check.txt",
 		);
-		expect(identityFromRequest(stub.requests.at(-1))).toEqual([null, null]);
-		expect(stub.reconnectCursors).toEqual(["1", "1", "1"]);
+		expect(stub.messages[3]?.text).toContain("Bash");
+		expect(stub.messages[3]?.text).toContain("sleep 120");
+		expect(stub.interrupts).toEqual([
+			{
+				type: "user.interrupt",
+				runId: "disabled-run-interrupt",
+				afterToolUse: true,
+			},
+		]);
+		expect(stub.reconnectCursors).toEqual(["1", "1", "1", "1"]);
+	});
+
+	it("discards provisional Assistant text when the interrupted Run is canceled", async () => {
+		const stub = await startSmokeStub({
+			conversationId: "00000000-0000-4000-8000-000000000238",
+			interruptConversationId: "00000000-0000-4000-8000-000000000239",
+			workspaceMarker: "workspace-22222222222222222222222222222222",
+			runIdPrefix: "preview-run",
+			includePreview: true,
+			interruptIncludePreview: true,
+		});
+
+		const { exitCode, stderr } = await runSmoke(stub.baseUrl, {
+			AGENT_SMOKE_PREVIEW_MODE: "required",
+			AGENT_SMOKE_SUITE: "full",
+		});
+
+		expect(stderr).toBe("");
+		expect(exitCode).toBe(0);
+		expect(stub.interrupts).toEqual([
+			{
+				type: "user.interrupt",
+				runId: "preview-run-interrupt",
+				afterToolUse: true,
+			},
+		]);
+	});
+
+	it("rejects canceled replay whose Tool payload differs from the live stream", async () => {
+		const stub = await startSmokeStub({
+			conversationId: "00000000-0000-4000-8000-000000000240",
+			interruptConversationId: "00000000-0000-4000-8000-000000000241",
+			workspaceMarker: "workspace-33333333333333333333333333333333",
+			runIdPrefix: "tampered-tool-run",
+			replayInterruptToolCommand: "sleep 1",
+		});
+
+		const { exitCode, stderr } = await runSmoke(stub.baseUrl, {
+			AGENT_SMOKE_SUITE: "full",
+		});
+
+		expect(exitCode).not.toBe(0);
+		expect(stderr).toContain(
+			"durable reconnect did not replay the exact Tool events",
+		);
 	});
 
 	it("rejects a signed artifact whose bytes do not match the request", async () => {
@@ -285,6 +368,7 @@ describe("agent conversation live smoke", () => {
 
 async function startSmokeStub(input: SmokeStubOptions): Promise<SmokeStub> {
 	const messages: UserMessage[] = [];
+	const interrupts: Array<UserInterrupt & { afterToolUse: boolean }> = [];
 	const reconnectCursors: string[] = [];
 	const requests: StubRequest[] = [];
 	const responsesByRun = new Map<string, string>();
@@ -294,6 +378,11 @@ async function startSmokeStub(input: SmokeStubOptions): Promise<SmokeStub> {
 	const artifactId = `${input.runIdPrefix}-artifact`;
 	const signedPath = `/signed/${artifactId}`;
 	let downloadedContent = "";
+	let conversationCreates = 0;
+	let interruptToolUseSent = false;
+	let interruptController:
+		| ReadableStreamDefaultController<Uint8Array>
+		| undefined;
 	const port = await availablePort();
 
 	const server = Bun.serve({
@@ -306,8 +395,17 @@ async function startSmokeStub(input: SmokeStubOptions): Promise<SmokeStub> {
 				partnerCode: request.headers.get("x-partner-code"),
 			});
 			if (url.pathname === "/v1/conversations") {
+				const conversationId =
+					conversationCreates++ === 0
+						? input.conversationId
+						: input.interruptConversationId;
+				if (!conversationId) {
+					return new Response("unexpected Conversation create", {
+						status: 500,
+					});
+				}
 				return Response.json(
-					{ conversationId: input.conversationId, scope: "general" },
+					{ conversationId, scope: "general" },
 					{ status: 201 },
 				);
 			}
@@ -331,6 +429,102 @@ async function startSmokeStub(input: SmokeStubOptions): Promise<SmokeStub> {
 					includePreview: input.includePreview,
 					text,
 				});
+			}
+
+			if (
+				input.interruptConversationId &&
+				request.method === "POST" &&
+				url.pathname ===
+					`/v1/conversations/${input.interruptConversationId}/events`
+			) {
+				const event = (await request.json()) as UserMessage | UserInterrupt;
+				const runId = `${input.runIdPrefix}-interrupt`;
+				if (event.type === "user.interrupt") {
+					interrupts.push({ ...event, afterToolUse: interruptToolUseSent });
+					if (event.runId !== runId || !interruptController) {
+						return new Response("Run not found", { status: 404 });
+					}
+					interruptController.enqueue(
+						new TextEncoder().encode(
+							serializeSSEFrame({
+								id: "3",
+								event: "canceled",
+								data: { type: "canceled" },
+							}),
+						),
+					);
+					interruptController.close();
+					interruptController = undefined;
+					return Response.json(
+						{ runId, status: "cancel_requested" },
+						{ status: 202 },
+					);
+				}
+
+				messages.push(event);
+				const frames: StubSSEFrame[] = [
+					{
+						id: "1",
+						event: "conversation_id",
+						data: {
+							type: "conversation_id",
+							conversationId: input.interruptConversationId,
+						},
+					},
+					{
+						id: "1",
+						event: "run_id",
+						data: { type: "run_id", runId },
+					},
+				];
+				if (input.interruptIncludePreview) {
+					frames.push({
+						event: "text_delta",
+						data: {
+							type: "text_delta",
+							messageId: `message-${runId}`,
+							deltaIndex: 0,
+							text: "discard this provisional text",
+						},
+					});
+				}
+				const toolUseFrame = bashToolUseFrame("sleep 120");
+				const encoder = new TextEncoder();
+				const stream = new ReadableStream<Uint8Array>({
+					start(controller) {
+						interruptController = controller;
+						for (const frame of frames) {
+							controller.enqueue(encoder.encode(serializeSSEFrame(frame)));
+						}
+						setTimeout(() => {
+							if (interruptController !== controller) return;
+							controller.enqueue(
+								encoder.encode(serializeSSEFrame(toolUseFrame)),
+							);
+							interruptToolUseSent = true;
+						}, 10);
+					},
+				});
+				return new Response(stream, {
+					headers: { "content-type": "text/event-stream" },
+				});
+			}
+
+			if (
+				input.interruptConversationId &&
+				request.method === "GET" &&
+				url.pathname ===
+					`/v1/conversations/${input.interruptConversationId}/runs/${input.runIdPrefix}-interrupt/events`
+			) {
+				reconnectCursors.push(request.headers.get("last-event-id") ?? "");
+				return sseResponse([
+					bashToolUseFrame(input.replayInterruptToolCommand ?? "sleep 120"),
+					{
+						id: "3",
+						event: "canceled",
+						data: { type: "canceled" },
+					},
+				]);
 			}
 
 			const reconnectPrefix = `/v1/conversations/${input.conversationId}/runs/`;
@@ -400,6 +594,7 @@ async function startSmokeStub(input: SmokeStubOptions): Promise<SmokeStub> {
 	return {
 		baseUrl: `http://127.0.0.1:${port}`,
 		messages,
+		interrupts,
 		reconnectCursors,
 		requests,
 	};

--- a/scripts/smoke/agent-conversation-smoke.ts
+++ b/scripts/smoke/agent-conversation-smoke.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env bun
 
 import { createHash, randomUUID } from "node:crypto";
+import { isDeepStrictEqual } from "node:util";
 import {
 	type ClientContractMessage,
-	type ClientContractToolEvent,
+	type ClientContractTerminal,
 	createClientContractFixture,
 } from "./client-contract";
 
@@ -20,14 +21,22 @@ if (!Number.isInteger(turnTimeoutMs) || turnTimeoutMs <= 0) {
 	throw new Error("AGENT_SMOKE_TURN_TIMEOUT_MS must be a positive integer");
 }
 
-const TURN_EVENT_TYPES: ReadonlySet<string> = new Set([
+const TURN_HISTORY_EVENT_TYPES = [
 	"conversation_id",
 	"run_id",
 	"text_delta",
 	"text_commit",
 	"tool_use",
 	"tool_result",
+] as const;
+
+const TURN_EVENT_TYPES: ReadonlySet<string> = new Set([
+	...TURN_HISTORY_EVENT_TYPES,
 	"done",
+]);
+const INTERRUPTED_TURN_EVENT_TYPES: ReadonlySet<string> = new Set([
+	...TURN_HISTORY_EVENT_TYPES,
+	"canceled",
 ]);
 
 interface SSEFrame {
@@ -39,6 +48,21 @@ interface SSEFrame {
 interface TurnResult {
 	runId: string;
 	text: string;
+}
+
+interface DurableToolFrame {
+	id?: string;
+	event: "tool_use" | "tool_result";
+	data: unknown;
+}
+
+interface ReplayExpectation {
+	conversationId: string;
+	runId: string;
+	afterCursor: string;
+	messages: ClientContractMessage[];
+	toolFrames: DurableToolFrame[];
+	terminal?: ClientContractTerminal;
 }
 
 interface ArtifactMetadata {
@@ -63,12 +87,7 @@ function headers(): HeadersInit {
 	};
 }
 
-const create = await fetch(`${baseUrl}/v1/conversations`, {
-	method: "POST",
-	headers: headers(),
-	body: "{}",
-	signal: AbortSignal.timeout(turnTimeoutMs),
-});
+const create = await requestConversationCreate();
 
 if (expectGateClosed) {
 	if (create.status !== 403) {
@@ -80,18 +99,7 @@ if (expectGateClosed) {
 	process.exit(0);
 }
 
-if (create.status !== 201) {
-	throw new Error(
-		`expected conversation create 201, got ${create.status}: ${await create.text()}`,
-	);
-}
-
-const { conversationId } = (await create.json()) as { conversationId?: string };
-if (!conversationId) {
-	throw new Error(
-		"conversation create response did not include conversationId",
-	);
-}
+const conversationId = await requireCreatedConversation(create);
 
 const sessionMarker = `agent-session-${randomUUID()}`;
 const firstTurn = await sendTurn(
@@ -176,9 +184,47 @@ const artifactTurn = await sendTurn(
 );
 await verifyArtifact(conversationId, artifactContent);
 
+let interruptEvidence = "";
+if (suite === "full") {
+	const interruptConversationId = await requireCreatedConversation(
+		await requestConversationCreate(),
+	);
+	const interruptedTurn = await verifyRunningRunCancellation(
+		interruptConversationId,
+	);
+	interruptEvidence = `; interrupt conversation ${interruptConversationId}; run ${interruptedTurn.runId}`;
+}
+
 console.log(
-	`agent live smoke passed: suite=${suite}; preview=${previewMode}; conversation ${conversationId}; runs ${firstTurn.runId}, ${secondTurn.runId}, ${artifactTurn.runId}`,
+	`agent live smoke passed: suite=${suite}; preview=${previewMode}; conversation ${conversationId}; runs ${firstTurn.runId}, ${secondTurn.runId}, ${artifactTurn.runId}${interruptEvidence}`,
 );
+
+function requestConversationCreate(): Promise<Response> {
+	return fetch(`${baseUrl}/v1/conversations`, {
+		method: "POST",
+		headers: headers(),
+		body: "{}",
+		signal: AbortSignal.timeout(turnTimeoutMs),
+	});
+}
+
+async function requireCreatedConversation(response: Response): Promise<string> {
+	if (response.status !== 201) {
+		throw new Error(
+			`expected conversation create 201, got ${response.status}: ${await response.text()}`,
+		);
+	}
+
+	const { conversationId } = (await response.json()) as {
+		conversationId?: string;
+	};
+	if (!conversationId) {
+		throw new Error(
+			"conversation create response did not include conversationId",
+		);
+	}
+	return conversationId;
+}
 
 async function verifyArtifact(
 	conversationId: string,
@@ -272,6 +318,181 @@ function matchesRequestedContent(
 			actual.at(-1) === "\n".charCodeAt(0));
 	if (!allowedLength) return false;
 	return expected.every((byte, index) => actual[index] === byte);
+}
+
+async function verifyRunningRunCancellation(
+	conversationId: string,
+): Promise<{ runId: string }> {
+	const response = await fetch(
+		`${baseUrl}/v1/conversations/${conversationId}/events`,
+		{
+			method: "POST",
+			headers: headers(),
+			body: JSON.stringify({
+				type: "user.message",
+				text: [
+					"Run the local full-suite cancellation check.",
+					"Immediately use the Bash tool to run exactly this command: sleep 120",
+					"Do not use any other tool.",
+					"Do not reply until the command finishes.",
+				].join("\n"),
+			}),
+			signal: AbortSignal.timeout(turnTimeoutMs),
+		},
+	);
+	if (!response.ok) {
+		throw new Error(
+			`expected interrupt-check event stream 2xx, got ${response.status}: ${await response.text()}`,
+		);
+	}
+	if (!response.headers.get("content-type")?.includes("text/event-stream")) {
+		throw new Error("interrupt-check event response was not an SSE stream");
+	}
+
+	const frames: SSEFrame[] = [];
+	const client = createClientContractFixture();
+	let runId: string | undefined;
+	let runCursor: string | undefined;
+	let interruptSent = false;
+
+	await readSSEIncrementally(response, async (frame) => {
+		if (frame.event === "ping") return;
+		if (!INTERRUPTED_TURN_EVENT_TYPES.has(frame.event)) {
+			throw new Error(
+				`interrupted event stream included unexpected ${frame.event}`,
+			);
+		}
+		frames.push(frame);
+		client.receive({ ...frame, data: parseFrameData(frame) });
+
+		if (frame.event === "run_id") {
+			runId = stringField(frame, "runId");
+			runCursor = frame.id;
+			if (!runCursor) {
+				throw new Error("interrupt-check run_id frame had no durable cursor");
+			}
+		}
+		if (frame.event === "tool_use" && !interruptSent) {
+			if (!runId) {
+				throw new Error(
+					"Tool invocation arrived before the interrupt-check run id",
+				);
+			}
+			const tool = stringField(frame, "tool");
+			if (tool !== "Bash") {
+				throw new Error(
+					`interrupt-check first Tool invocation was ${tool}, expected Bash`,
+				);
+			}
+			interruptSent = true;
+			await requestRunningRunCancellation(conversationId, runId);
+		}
+	});
+
+	if (!interruptSent || !runId || !runCursor) {
+		throw new Error(
+			"interrupted event stream ended before the first Tool invocation",
+		);
+	}
+	const events = frames.map((frame) => frame.event);
+	const conversationIndex = events.indexOf("conversation_id");
+	const runIndex = events.indexOf("run_id");
+	const toolUseIndex = events.indexOf("tool_use");
+	if (
+		conversationIndex < 0 ||
+		runIndex < 0 ||
+		toolUseIndex < 0 ||
+		conversationIndex >= runIndex ||
+		runIndex >= toolUseIndex
+	) {
+		throw new Error(
+			`interrupted event stream did not identify the Conversation and Run before the Tool invocation: ${events.join(", ")}`,
+		);
+	}
+	const echoedConversationId = stringField(
+		frames.find((frame) => frame.event === "conversation_id"),
+		"conversationId",
+	);
+	if (echoedConversationId !== conversationId) {
+		throw new Error(
+			`interrupted event stream echoed conversation ${echoedConversationId}, expected ${conversationId}`,
+		);
+	}
+	if (
+		events.at(-1) !== "canceled" ||
+		events.filter((event) => event === "canceled").length !== 1
+	) {
+		throw new Error(
+			`interrupted event stream did not end in one canceled outcome: ${events.join(", ")}`,
+		);
+	}
+
+	const snapshot = client.snapshot();
+	if (snapshot.terminal !== "canceled") {
+		throw new Error("client fixture did not observe the canceled outcome");
+	}
+	if (snapshot.messages.some((message) => message.provisional)) {
+		throw new Error(
+			"client fixture retained provisional Assistant text after cancellation",
+		);
+	}
+	if (
+		!snapshot.toolEvents.some(
+			(event) => event.kind === "tool_use" && event.tool === "Bash",
+		)
+	) {
+		throw new Error("client fixture did not retain the Bash Tool invocation");
+	}
+
+	await replayTurn({
+		conversationId,
+		runId,
+		afterCursor: runCursor,
+		messages: snapshot.messages,
+		toolFrames: durableToolFrames(frames),
+		terminal: "canceled",
+	});
+	return { runId };
+}
+
+async function requestRunningRunCancellation(
+	conversationId: string,
+	runId: string,
+): Promise<void> {
+	const response = await fetch(
+		`${baseUrl}/v1/conversations/${conversationId}/events`,
+		{
+			method: "POST",
+			headers: headers(),
+			body: JSON.stringify({ type: "user.interrupt", runId }),
+			signal: AbortSignal.timeout(turnTimeoutMs),
+		},
+	);
+	const rawBody = await response.text();
+	if (response.status !== 202) {
+		throw new Error(
+			`expected running Run interrupt 202, got ${response.status}: ${rawBody}`,
+		);
+	}
+
+	let body: unknown;
+	try {
+		body = JSON.parse(rawBody);
+	} catch {
+		throw new Error("running Run interrupt response was not JSON");
+	}
+	if (
+		typeof body !== "object" ||
+		body === null ||
+		Array.isArray(body) ||
+		Object.keys(body).sort().join(",") !== "runId,status" ||
+		(body as Record<string, unknown>).runId !== runId ||
+		(body as Record<string, unknown>).status !== "cancel_requested"
+	) {
+		throw new Error(
+			"running Run interrupt response was not the accepted cancel_requested shape",
+		);
+	}
 }
 
 async function sendTurn(
@@ -391,27 +612,25 @@ async function sendTurn(
 		throw new Error("run_id frame did not carry a durable cursor");
 	const text = snapshot.messages.map((message) => message.text).join("");
 	if (!text.trim()) throw new Error("event stream contained no assistant text");
-	await replayTurn(
+	await replayTurn({
 		conversationId,
 		runId,
-		runCursor,
-		snapshot.messages,
-		snapshot.toolEvents,
-	);
+		afterCursor: runCursor,
+		messages: snapshot.messages,
+		toolFrames: durableToolFrames(frames),
+	});
 	return { runId, text };
 }
 
-async function replayTurn(
-	conversationId: string,
-	runId: string,
-	afterCursor: string,
-	expectedMessages: ClientContractMessage[],
-	expectedToolEvents: ClientContractToolEvent[],
-): Promise<void> {
+async function replayTurn(expectation: ReplayExpectation): Promise<void> {
+	const expectedTerminal = expectation.terminal ?? "done";
 	const response = await fetch(
-		`${baseUrl}/v1/conversations/${conversationId}/runs/${runId}/events`,
+		`${baseUrl}/v1/conversations/${expectation.conversationId}/runs/${expectation.runId}/events`,
 		{
-			headers: { ...headers(), "Last-Event-ID": afterCursor },
+			headers: {
+				...headers(),
+				"Last-Event-ID": expectation.afterCursor,
+			},
 			signal: AbortSignal.timeout(turnTimeoutMs),
 		},
 	);
@@ -436,9 +655,20 @@ async function replayTurn(
 			`durable reconnect attempted to replay non-durable frames: ${replayedEvents.join(", ")}`,
 		);
 	}
-	if (replayedEvents.at(-1) !== "done") {
+	if (replayedEvents.at(-1) !== expectedTerminal) {
 		throw new Error(
-			`durable reconnect did not end in done: ${replayedEvents.join(", ")}`,
+			`durable reconnect did not end in ${expectedTerminal}: ${replayedEvents.join(", ")}`,
+		);
+	}
+	const replayedTerminals = replayedEvents.filter((event) =>
+		["done", "canceled", "error"].includes(event),
+	);
+	if (
+		replayedTerminals.length !== 1 ||
+		replayedTerminals[0] !== expectedTerminal
+	) {
+		throw new Error(
+			`durable reconnect did not contain exactly one ${expectedTerminal} outcome: ${replayedEvents.join(", ")}`,
 		);
 	}
 
@@ -447,21 +677,65 @@ async function replayTurn(
 		client.receive({ ...frame, data: parseFrameData(frame) });
 	}
 	const snapshot = client.snapshot();
-	if (snapshot.terminal !== "done") {
-		throw new Error("reconnected client fixture did not observe done");
+	if (snapshot.terminal !== expectedTerminal) {
+		throw new Error(
+			`reconnected client fixture did not observe ${expectedTerminal}`,
+		);
 	}
-	if (JSON.stringify(snapshot.messages) !== JSON.stringify(expectedMessages)) {
+	if (!isDeepStrictEqual(snapshot.messages, expectation.messages)) {
 		throw new Error(
 			"durable reconnect did not replay the exact committed messages",
 		);
 	}
 	// Tool events are durable run events too: a reconnect replays exactly the
 	// invocations and results the live stream showed, in order (ADR-0009).
-	if (
-		JSON.stringify(snapshot.toolEvents) !== JSON.stringify(expectedToolEvents)
-	) {
-		throw new Error("durable reconnect did not replay the exact tool events");
+	if (!isDeepStrictEqual(durableToolFrames(frames), expectation.toolFrames)) {
+		throw new Error("durable reconnect did not replay the exact Tool events");
 	}
+}
+
+function durableToolFrames(frames: SSEFrame[]): DurableToolFrame[] {
+	return frames.flatMap((frame) => {
+		if (frame.event !== "tool_use" && frame.event !== "tool_result") return [];
+		return [
+			{
+				id: frame.id,
+				event: frame.event,
+				data: parseFrameData(frame),
+			},
+		];
+	});
+}
+
+async function readSSEIncrementally(
+	response: Response,
+	onFrame: (frame: SSEFrame) => Promise<void>,
+): Promise<void> {
+	if (!response.body) throw new Error("event response had no body");
+	const reader = response.body.getReader();
+	const decoder = new TextDecoder();
+	let buffer = "";
+
+	const dispatch = async (block: string): Promise<void> => {
+		for (const frame of parseSSE(block)) await onFrame(frame);
+	};
+
+	while (true) {
+		const { done, value } = await reader.read();
+		if (value) buffer += decoder.decode(value, { stream: true });
+
+		let boundary = /\r?\n\r?\n/.exec(buffer);
+		while (boundary?.index !== undefined) {
+			const block = buffer.slice(0, boundary.index);
+			buffer = buffer.slice(boundary.index + boundary[0].length);
+			await dispatch(block);
+			boundary = /\r?\n\r?\n/.exec(buffer);
+		}
+		if (done) break;
+	}
+
+	buffer += decoder.decode();
+	if (buffer.trim()) await dispatch(buffer);
 }
 
 function parseSSE(raw: string): SSEFrame[] {


### PR DESCRIPTION
## Summary

- extend the local-only `full` smoke with a second Conversation whose Run starts an immediate long-running Bash command, reads SSE incrementally, and sends `user.interrupt` only after the first durable Tool invocation arrives
- require the running-Run `202 { runId, status: "cancel_requested" }` response, a single `canceled` live outcome with no surviving provisional Assistant text, and reconnect replay matching the live committed messages and complete Tool-event payloads
- add deterministic CLI-level coverage with a held-open synthetic stream, provisional-text discard, canceled replay, and rejection of a tampered replayed Tool payload; update the two-target verification guide

## Why

Cancellation was covered by lower-level deterministic tests but had never been proven through the public Conversation contract against a really-running split-runtime Run. A regression in incremental SSE handling, interrupt timing, worker cancellation, terminal projection, or canceled replay could therefore pass the existing core smoke.

## Impact

The deployed/default `core` suite is unchanged. The local `full` suite now performs four real Runs across two Conversations: the existing continuity and Downloadable-artifact checks plus one running-Run cancellation check. Interrupt remains local-only and is not induced in the deployed smoke.

## Validation

- `bun run test`: 774 passed, 0 failed across root and all five workspaces
- smoke-file strict TypeScript check, Biome check, and `git diff --check`
- `bun run smoke:local`: passed four real Runs through chat-api, agent-worker, OpenRouter, E2B, Postgres, S3 publication/download, running cancellation, and canceled reconnect replay
- independent Standards and Spec review; shared event/fixture duplication was removed and reconnect comparison was strengthened to include complete Tool payloads

Closes #303
