### PR TITLE
feat(e2e): verify seeded document tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,11 +134,14 @@ AGENT_DATABASE_URL=postgres://mymemo:mymemo@localhost:5432/mymemo_agent \
 
 ### Live runtime smoke
 
-The credentialed smoke drives the real worker across three runs of one
-Conversation. The first two prove Agent-session resume, Workspace persistence,
-exact Assistant commits, and byte-exact durable replay. The third writes a
-unique Downloadable artifact, lists it after `done`, obtains a fresh signed URL,
-and downloads the exact attachment without identity headers.
+The credentialed smoke's `core` suite drives the real worker across three Runs
+of one Conversation. The first two prove Agent-session resume, Workspace
+persistence, exact Assistant commits, and byte-exact durable replay. The third
+writes a unique Downloadable artifact, lists it after `done`, obtains a fresh
+signed URL, and downloads the exact attachment without identity headers. The
+local `full` suite adds one interrupted Run and two seeded searchable-document
+Runs that prove inventory, search, docs-cache load, file read-back, and durable
+Tool history.
 
 With the local compose stack running, execute the full pre-merge suite with one
 command:

--- a/docs/verification/e2e-smoke.md
+++ b/docs/verification/e2e-smoke.md
@@ -29,9 +29,14 @@ value fails before the first HTTP request.
   after the first Tool invocation arrives. It requires the running-Run
   `cancel_requested` response, a `canceled` live outcome with no surviving
   provisional Assistant text, and a reconnect that exactly replays the live
-  committed messages and Tool events before ending `canceled`.
-  [#304](https://github.com/X-GPT/mymemo-agent/issues/304) adds the remaining
-  seeded-document checks to this set.
+  committed messages and Tool events before ending `canceled`. A third
+  Conversation performs two searchable-document Runs against the local KB seed: the first
+  reports the exact inventory count through `ListDocuments`; the second uses
+  `SearchDocuments`, `LoadDocuments`, and `Read` to report the seeded title and
+  first markdown heading. The smoke requires those Tool invocations in durable
+  history and proves their exact replay. Because these assertions are coupled
+  to the local fixture, `full` refuses to start unless
+  `AGENT_SMOKE_MEMBER_CODE=demo-member`.
 
 `AGENT_SMOKE_PREVIEW_MODE` is independent of the suite. Use `required` to prove
 the Redis Live-preview lane, `forbidden` to prove Postgres-only delivery, or the
@@ -73,7 +78,9 @@ servers. The tests cover both required-preview and forbidden-preview artifact
 happy paths, a held-open stream canceled only after its Tool invocation,
 canceled durable replay, provisional-text discard, and rejection of a changed
 replayed Tool payload, the allowed single trailing newline, identity-free
-signed-object fetching, tampered object bytes, and environment validation:
+signed-object fetching, tampered object bytes, both seeded searchable-document
+Runs, rejection of a failed `Read` Tool result, and
+fixture-member/environment validation:
 
 ```sh
 bun test scripts/smoke/agent-conversation-smoke.test.ts

--- a/scripts/smoke/agent-conversation-smoke.test.ts
+++ b/scripts/smoke/agent-conversation-smoke.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import { createHash } from "node:crypto";
 import { createServer } from "node:net";
 import { resolve } from "node:path";
+import type { PublicToolName } from "../../packages/agent-db/src/run-events";
 
 const root = resolve(import.meta.dir, "../..");
 const servers: Bun.Server<unknown>[] = [];
@@ -29,12 +30,14 @@ interface StubRequest {
 interface SmokeStubOptions {
 	conversationId: string;
 	interruptConversationId?: string;
+	searchableDocumentConversationId?: string;
 	workspaceMarker: string;
 	runIdPrefix: string;
 	includePreview?: boolean;
 	interruptIncludePreview?: boolean;
 	replayInterruptToolCommand?: string;
 	artifactContent?: (requestedContent: string) => string;
+	failSearchableDocumentRead?: boolean;
 }
 
 interface SmokeStub {
@@ -62,13 +65,40 @@ function sseResponse(frames: StubSSEFrame[]): Response {
 }
 
 function bashToolUseFrame(command: string): StubSSEFrame {
+	return toolUseFrame("2", "Bash", { command });
+}
+
+function toolUseFrame(
+	id: string,
+	tool: PublicToolName,
+	argumentsValue: Record<string, unknown>,
+): StubSSEFrame {
 	return {
-		id: "2",
+		id,
 		event: "tool_use",
 		data: {
 			type: "tool_use",
-			tool: "Bash",
-			arguments: { command },
+			tool,
+			arguments: argumentsValue,
+			truncated: false,
+		},
+	};
+}
+
+function toolResultFrame(
+	id: string,
+	tool: PublicToolName,
+	result: Record<string, unknown>,
+	isError = false,
+): StubSSEFrame {
+	return {
+		id,
+		event: "tool_result",
+		data: {
+			type: "tool_result",
+			tool,
+			result,
+			isError,
 			truncated: false,
 		},
 	};
@@ -82,6 +112,7 @@ function sseTurn(input: {
 	includePreview?: boolean;
 	includeLifecycle?: boolean;
 	commitTexts?: string[];
+	toolFrames?: StubSSEFrame[];
 }): Response {
 	const frames: StubSSEFrame[] = [];
 	if (input.includeLifecycle !== false) {
@@ -96,6 +127,8 @@ function sseTurn(input: {
 			data: { type: "run_id", runId: input.runId },
 		});
 	}
+	const toolFrames = input.toolFrames ?? [];
+	frames.push(...toolFrames);
 	if (input.includePreview) {
 		frames.push({
 			event: "text_delta",
@@ -110,7 +143,7 @@ function sseTurn(input: {
 	const commitTexts = input.commitTexts ?? [input.text];
 	for (const [index, text] of commitTexts.entries()) {
 		frames.push({
-			id: String(index + 2),
+			id: String(index + 2 + toolFrames.length),
 			event: "text_commit",
 			data: {
 				type: "text_commit",
@@ -124,7 +157,7 @@ function sseTurn(input: {
 	}
 	if (input.includeDone !== false) {
 		frames.push({
-			id: String(commitTexts.length + 2),
+			id: String(commitTexts.length + 2 + toolFrames.length),
 			event: "done",
 			data: { type: "done" },
 		});
@@ -200,19 +233,35 @@ describe("agent conversation live smoke", () => {
 		expect(stderr).not.toContain("Unable to connect");
 	});
 
+	it("rejects a non-fixture member before starting the full suite", async () => {
+		const { exitCode, stderr } = await runSmoke("http://127.0.0.1:1", {
+			AGENT_SMOKE_SUITE: "full",
+		});
+
+		expect(exitCode).not.toBe(0);
+		expect(stderr).toContain(
+			"AGENT_SMOKE_SUITE=full requires AGENT_SMOKE_MEMBER_CODE=demo-member",
+		);
+		expect(stderr).not.toContain("Unable to connect");
+	});
+
 	it("interrupts a held-open full-suite Run after its first Tool invocation and replays canceled history", async () => {
 		const conversationId = "00000000-0000-4000-8000-000000000235";
 		const interruptConversationId = "00000000-0000-4000-8000-000000000236";
+		const searchableDocumentConversationId =
+			"00000000-0000-4000-8000-000000000237";
 		const workspaceMarker = "workspace-fedcba9876543210fedcba9876543210";
 		const stub = await startSmokeStub({
 			conversationId,
 			interruptConversationId,
+			searchableDocumentConversationId,
 			workspaceMarker,
 			runIdPrefix: "disabled-run",
 			artifactContent: (content) => `${content}\n`,
 		});
 
 		const { exitCode, stdout, stderr } = await runSmoke(stub.baseUrl, {
+			AGENT_SMOKE_MEMBER_CODE: "demo-member",
 			AGENT_SMOKE_PREVIEW_MODE: "forbidden",
 			AGENT_SMOKE_SUITE: "full",
 		});
@@ -223,11 +272,18 @@ describe("agent conversation live smoke", () => {
 		expect(stdout).toContain("preview=forbidden");
 		expect(stdout).toContain(interruptConversationId);
 		expect(stdout).toContain("disabled-run-interrupt");
+		expect(stdout).toContain(searchableDocumentConversationId);
+		expect(stdout).toContain("disabled-run-searchable-document-inventory");
+		expect(stdout).toContain("disabled-run-searchable-document-content");
 		expect(extractArtifactRequest(stub.messages[2]?.text).relativePath).toBe(
 			"smoke/core-check.txt",
 		);
 		expect(stub.messages[3]?.text).toContain("Bash");
 		expect(stub.messages[3]?.text).toContain("sleep 120");
+		expect(stub.messages[4]?.text).toContain("ListDocuments");
+		expect(stub.messages[5]?.text).toContain("SearchDocuments");
+		expect(stub.messages[5]?.text).toContain("LoadDocuments");
+		expect(stub.messages[5]?.text).toContain("Read");
 		expect(stub.interrupts).toEqual([
 			{
 				type: "user.interrupt",
@@ -235,13 +291,14 @@ describe("agent conversation live smoke", () => {
 				afterToolUse: true,
 			},
 		]);
-		expect(stub.reconnectCursors).toEqual(["1", "1", "1", "1"]);
+		expect(stub.reconnectCursors).toEqual(["1", "1", "1", "1", "1", "1"]);
 	});
 
 	it("discards provisional Assistant text when the interrupted Run is canceled", async () => {
 		const stub = await startSmokeStub({
 			conversationId: "00000000-0000-4000-8000-000000000238",
 			interruptConversationId: "00000000-0000-4000-8000-000000000239",
+			searchableDocumentConversationId: "00000000-0000-4000-8000-000000000242",
 			workspaceMarker: "workspace-22222222222222222222222222222222",
 			runIdPrefix: "preview-run",
 			includePreview: true,
@@ -249,6 +306,7 @@ describe("agent conversation live smoke", () => {
 		});
 
 		const { exitCode, stderr } = await runSmoke(stub.baseUrl, {
+			AGENT_SMOKE_MEMBER_CODE: "demo-member",
 			AGENT_SMOKE_PREVIEW_MODE: "required",
 			AGENT_SMOKE_SUITE: "full",
 		});
@@ -264,6 +322,27 @@ describe("agent conversation live smoke", () => {
 		]);
 	});
 
+	it("rejects searchable-document content when Read returns an error", async () => {
+		const stub = await startSmokeStub({
+			conversationId: "00000000-0000-4000-8000-000000000243",
+			interruptConversationId: "00000000-0000-4000-8000-000000000244",
+			searchableDocumentConversationId: "00000000-0000-4000-8000-000000000245",
+			workspaceMarker: "workspace-44444444444444444444444444444444",
+			runIdPrefix: "missing-read-run",
+			failSearchableDocumentRead: true,
+		});
+
+		const { exitCode, stderr } = await runSmoke(stub.baseUrl, {
+			AGENT_SMOKE_MEMBER_CODE: "demo-member",
+			AGENT_SMOKE_SUITE: "full",
+		});
+
+		expect(exitCode).not.toBe(0);
+		expect(stderr).toContain(
+			"searchable-document content Run did not record the required Tool invocations and successful results",
+		);
+	});
+
 	it("rejects canceled replay whose Tool payload differs from the live stream", async () => {
 		const stub = await startSmokeStub({
 			conversationId: "00000000-0000-4000-8000-000000000240",
@@ -274,6 +353,7 @@ describe("agent conversation live smoke", () => {
 		});
 
 		const { exitCode, stderr } = await runSmoke(stub.baseUrl, {
+			AGENT_SMOKE_MEMBER_CODE: "demo-member",
 			AGENT_SMOKE_SUITE: "full",
 		});
 
@@ -372,6 +452,10 @@ async function startSmokeStub(input: SmokeStubOptions): Promise<SmokeStub> {
 	const reconnectCursors: string[] = [];
 	const requests: StubRequest[] = [];
 	const responsesByRun = new Map<string, string>();
+	const searchableDocumentResponsesByRun = new Map<
+		string,
+		{ text: string; toolFrames: StubSSEFrame[] }
+	>();
 	const workspaceHash = createHash("sha256")
 		.update(input.workspaceMarker)
 		.digest("hex");
@@ -379,6 +463,7 @@ async function startSmokeStub(input: SmokeStubOptions): Promise<SmokeStub> {
 	const signedPath = `/signed/${artifactId}`;
 	let downloadedContent = "";
 	let conversationCreates = 0;
+	let searchableDocumentTurns = 0;
 	let interruptToolUseSent = false;
 	let interruptController:
 		| ReadableStreamDefaultController<Uint8Array>
@@ -395,10 +480,11 @@ async function startSmokeStub(input: SmokeStubOptions): Promise<SmokeStub> {
 				partnerCode: request.headers.get("x-partner-code"),
 			});
 			if (url.pathname === "/v1/conversations") {
-				const conversationId =
-					conversationCreates++ === 0
-						? input.conversationId
-						: input.interruptConversationId;
+				const conversationId = [
+					input.conversationId,
+					input.interruptConversationId,
+					input.searchableDocumentConversationId,
+				][conversationCreates++];
 				if (!conversationId) {
 					return new Response("unexpected Conversation create", {
 						status: 500,
@@ -428,6 +514,84 @@ async function startSmokeStub(input: SmokeStubOptions): Promise<SmokeStub> {
 					runId,
 					includePreview: input.includePreview,
 					text,
+				});
+			}
+
+			if (
+				input.searchableDocumentConversationId &&
+				request.method === "POST" &&
+				url.pathname ===
+					`/v1/conversations/${input.searchableDocumentConversationId}/events`
+			) {
+				messages.push((await request.json()) as UserMessage);
+				searchableDocumentTurns += 1;
+				const isInventory = searchableDocumentTurns === 1;
+				const runId = `${input.runIdPrefix}-searchable-document-${isInventory ? "inventory" : "content"}`;
+				const text = isInventory
+					? "DOCUMENT_COUNT=2"
+					: "DOCUMENT_TITLE=MyMemo Overview\nFIRST_HEADING=# MyMemo Overview";
+				const toolFrames = isInventory
+					? [
+							toolUseFrame("2", "ListDocuments", {
+								limit: 20,
+								cursorProvided: false,
+							}),
+							toolResultFrame("3", "ListDocuments", {
+								total: 2,
+								returnedCount: 2,
+								hasMore: false,
+								documents: [
+									{ title: "Intro to Machine Learning" },
+									{ title: "MyMemo Overview" },
+								],
+							}),
+						]
+					: [
+							toolUseFrame("2", "SearchDocuments", {
+								query: "personal knowledge base",
+							}),
+							toolResultFrame("3", "SearchDocuments", {
+								passages: [
+									{
+										title: "MyMemo Overview",
+										snippet:
+											"MyMemo is a personal knowledge base that answers questions by searching your documents.",
+									},
+								],
+							}),
+							toolUseFrame("4", "LoadDocuments", { requestedCount: 1 }),
+							toolResultFrame("5", "LoadDocuments", {
+								loadedCount: 1,
+								loaded: [{ title: "MyMemo Overview" }],
+								failedCount: 0,
+							}),
+							toolUseFrame("6", "Read", {
+								path: ".mymemo/docs/doc-mymemo-overview.md",
+								offset: 1,
+								limit: 1,
+							}),
+							toolResultFrame(
+								"7",
+								"Read",
+								input.failSearchableDocumentRead
+									? { message: "Tool failed" }
+									: {
+											path: ".mymemo/docs/doc-mymemo-overview.md",
+											content: "# MyMemo Overview",
+											startLine: 1,
+											linesRead: 1,
+											truncated: true,
+										},
+								input.failSearchableDocumentRead,
+							),
+						];
+				searchableDocumentResponsesByRun.set(runId, { text, toolFrames });
+				return sseTurn({
+					conversationId: input.searchableDocumentConversationId,
+					runId,
+					includePreview: input.includePreview,
+					text,
+					toolFrames,
 				});
 			}
 
@@ -525,6 +689,32 @@ async function startSmokeStub(input: SmokeStubOptions): Promise<SmokeStub> {
 						data: { type: "canceled" },
 					},
 				]);
+			}
+
+			const searchableDocumentReconnectPrefix =
+				input.searchableDocumentConversationId
+					? `/v1/conversations/${input.searchableDocumentConversationId}/runs/`
+					: undefined;
+			if (
+				searchableDocumentReconnectPrefix &&
+				request.method === "GET" &&
+				url.pathname.startsWith(searchableDocumentReconnectPrefix) &&
+				url.pathname.endsWith("/events")
+			) {
+				reconnectCursors.push(request.headers.get("last-event-id") ?? "");
+				const runId = url.pathname.slice(
+					searchableDocumentReconnectPrefix.length,
+					-"/events".length,
+				);
+				const response = searchableDocumentResponsesByRun.get(runId);
+				if (!response) return new Response("not found", { status: 404 });
+				return sseTurn({
+					conversationId: input.searchableDocumentConversationId,
+					runId,
+					text: response.text,
+					toolFrames: response.toolFrames,
+					includeLifecycle: false,
+				});
 			}
 
 			const reconnectPrefix = `/v1/conversations/${input.conversationId}/runs/`;

--- a/scripts/smoke/agent-conversation-smoke.ts
+++ b/scripts/smoke/agent-conversation-smoke.ts
@@ -2,6 +2,7 @@
 
 import { createHash, randomUUID } from "node:crypto";
 import { isDeepStrictEqual } from "node:util";
+import type { PublicToolName } from "../../packages/agent-db/src/run-events";
 import {
 	type ClientContractMessage,
 	type ClientContractTerminal,
@@ -14,6 +15,12 @@ const partnerCode = Bun.env.AGENT_SMOKE_PARTNER_CODE || "agent-smoke-partner";
 const expectGateClosed = Bun.env.AGENT_SMOKE_EXPECT_GATE_CLOSED !== "false";
 const suite = parseSuite(Bun.env.AGENT_SMOKE_SUITE);
 const previewMode = parsePreviewMode(Bun.env.AGENT_SMOKE_PREVIEW_MODE);
+const FIXTURE_MEMBER_CODE = "demo-member";
+if (suite === "full" && memberCode !== FIXTURE_MEMBER_CODE) {
+	throw new Error(
+		"AGENT_SMOKE_SUITE=full requires AGENT_SMOKE_MEMBER_CODE=demo-member (the seeded local fixture member)",
+	);
+}
 const rawTurnTimeout = Bun.env.AGENT_SMOKE_TURN_TIMEOUT_MS;
 const turnTimeoutMs =
 	rawTurnTimeout === undefined ? 180_000 : Number(rawTurnTimeout);
@@ -48,6 +55,7 @@ interface SSEFrame {
 interface TurnResult {
 	runId: string;
 	text: string;
+	toolFrames: DurableToolFrame[];
 }
 
 interface DurableToolFrame {
@@ -72,6 +80,9 @@ interface ArtifactMetadata {
 }
 
 const CORE_ARTIFACT_PATH = "smoke/core-check.txt";
+const FIXTURE_SEARCHABLE_DOCUMENT_COUNT = 2;
+const FIXTURE_SEARCHABLE_DOCUMENT_TITLE = "MyMemo Overview";
+const FIXTURE_SEARCHABLE_DOCUMENT_HEADING = "# MyMemo Overview";
 
 function requiredEnv(name: string): string {
 	const value = Bun.env[name];
@@ -184,7 +195,7 @@ const artifactTurn = await sendTurn(
 );
 await verifyArtifact(conversationId, artifactContent);
 
-let interruptEvidence = "";
+let fullSuiteEvidence = "";
 if (suite === "full") {
 	const interruptConversationId = await requireCreatedConversation(
 		await requestConversationCreate(),
@@ -192,11 +203,19 @@ if (suite === "full") {
 	const interruptedTurn = await verifyRunningRunCancellation(
 		interruptConversationId,
 	);
-	interruptEvidence = `; interrupt conversation ${interruptConversationId}; run ${interruptedTurn.runId}`;
+	fullSuiteEvidence = `; interrupt conversation ${interruptConversationId}; run ${interruptedTurn.runId}`;
+
+	const searchableDocumentConversationId = await requireCreatedConversation(
+		await requestConversationCreate(),
+	);
+	const searchableDocumentTurns = await verifySearchableDocumentTools(
+		searchableDocumentConversationId,
+	);
+	fullSuiteEvidence += `; searchable-document conversation ${searchableDocumentConversationId}; runs ${searchableDocumentTurns.inventoryRunId}, ${searchableDocumentTurns.contentRunId}`;
 }
 
 console.log(
-	`agent live smoke passed: suite=${suite}; preview=${previewMode}; conversation ${conversationId}; runs ${firstTurn.runId}, ${secondTurn.runId}, ${artifactTurn.runId}${interruptEvidence}`,
+	`agent live smoke passed: suite=${suite}; preview=${previewMode}; conversation ${conversationId}; runs ${firstTurn.runId}, ${secondTurn.runId}, ${artifactTurn.runId}${fullSuiteEvidence}`,
 );
 
 function requestConversationCreate(): Promise<Response> {
@@ -303,6 +322,161 @@ async function verifyArtifact(
 	if (!matchesRequestedContent(downloadedBytes, expectedContent)) {
 		throw new Error(
 			"downloaded artifact bytes did not match requested content",
+		);
+	}
+}
+
+async function verifySearchableDocumentTools(conversationId: string): Promise<{
+	inventoryRunId: string;
+	contentRunId: string;
+}> {
+	const inventoryTurn = await sendTurn(
+		conversationId,
+		[
+			"Run the local seeded searchable-document inventory check.",
+			"Use ListDocuments exactly once with limit=20 and no cursor to inventory all searchable documents in this Conversation's scope.",
+			"Do not use any other tool.",
+			"Reply with exactly DOCUMENT_COUNT=<the exact total returned by ListDocuments> and nothing else.",
+		].join("\n"),
+	);
+	const expectedInventoryText = `DOCUMENT_COUNT=${FIXTURE_SEARCHABLE_DOCUMENT_COUNT}`;
+	if (inventoryTurn.text !== expectedInventoryText) {
+		throw new Error(
+			`searchable-document inventory did not report the fixture-exact count: ${inventoryTurn.text}`,
+		);
+	}
+	requireToolHistory(inventoryTurn, "searchable-document inventory", [
+		{
+			tool: "ListDocuments",
+			arguments: { limit: 20, cursorProvided: false },
+			result: {
+				total: FIXTURE_SEARCHABLE_DOCUMENT_COUNT,
+				returnedCount: FIXTURE_SEARCHABLE_DOCUMENT_COUNT,
+				hasMore: false,
+				documents: [
+					{ title: "Intro to Machine Learning" },
+					{ title: FIXTURE_SEARCHABLE_DOCUMENT_TITLE },
+				],
+			},
+		},
+	]);
+
+	const contentTurn = await sendTurn(
+		conversationId,
+		[
+			"Run the local seeded searchable-document search, load, and read check.",
+			"Use SearchDocuments exactly once with this exact query: personal knowledge base",
+			"Use LoadDocuments exactly once to load the matching searchable document into the docs cache.",
+			"Use Read exactly once with the cache path returned by LoadDocuments, offset=1, and limit=1 to read the first markdown heading from that file.",
+			"Do not use any other tool.",
+			"Reply with exactly these two lines, replacing both placeholders:",
+			"DOCUMENT_TITLE=<the matching searchable document title>",
+			"FIRST_HEADING=<the first markdown heading, including its leading #>",
+		].join("\n"),
+	);
+	const expectedContentText = `DOCUMENT_TITLE=${FIXTURE_SEARCHABLE_DOCUMENT_TITLE}\nFIRST_HEADING=${FIXTURE_SEARCHABLE_DOCUMENT_HEADING}`;
+	if (contentTurn.text !== expectedContentText) {
+		throw new Error(
+			`searchable-document content check did not report the fixture-exact title and heading: ${contentTurn.text}`,
+		);
+	}
+	requireToolHistory(contentTurn, "searchable-document content", [
+		{
+			tool: "SearchDocuments",
+			arguments: { query: "personal knowledge base" },
+			result: {
+				passages: [
+					{
+						title: FIXTURE_SEARCHABLE_DOCUMENT_TITLE,
+						snippet:
+							"MyMemo is a personal knowledge base that answers questions by searching your documents.",
+					},
+				],
+			},
+		},
+		{
+			tool: "LoadDocuments",
+			arguments: { requestedCount: 1 },
+			result: {
+				loadedCount: 1,
+				loaded: [{ title: FIXTURE_SEARCHABLE_DOCUMENT_TITLE }],
+				failedCount: 0,
+			},
+		},
+		{
+			tool: "Read",
+			arguments: {
+				path: ".mymemo/docs/doc-mymemo-overview.md",
+				offset: 1,
+				limit: 1,
+			},
+			result: {
+				path: ".mymemo/docs/doc-mymemo-overview.md",
+				content: FIXTURE_SEARCHABLE_DOCUMENT_HEADING,
+				startLine: 1,
+				linesRead: 1,
+				truncated: true,
+			},
+		},
+	]);
+
+	return {
+		inventoryRunId: inventoryTurn.runId,
+		contentRunId: contentTurn.runId,
+	};
+}
+
+interface ExpectedToolExchange {
+	tool: PublicToolName;
+	arguments: Record<string, unknown>;
+	result: Record<string, unknown>;
+}
+
+function requireToolHistory(
+	turn: TurnResult,
+	label: string,
+	expected: ExpectedToolExchange[],
+): void {
+	const expectedFrames = expected.flatMap(
+		({ tool, arguments: expectedArguments, result }) =>
+			[
+				{
+					event: "tool_use",
+					data: {
+						type: "tool_use",
+						tool,
+						arguments: expectedArguments,
+						truncated: false,
+					},
+				},
+				{
+					event: "tool_result",
+					data: {
+						type: "tool_result",
+						tool,
+						result,
+						isError: false,
+						truncated: false,
+					},
+				},
+			] satisfies Array<{ event: DurableToolFrame["event"]; data: unknown }>,
+	);
+	const actualFrames = turn.toolFrames.map(({ event, data }) => ({
+		event,
+		data,
+	}));
+	if (!isDeepStrictEqual(actualFrames, expectedFrames)) {
+		const actualTools = turn.toolFrames.flatMap((frame) =>
+			frame.event === "tool_use" &&
+			typeof frame.data === "object" &&
+			frame.data !== null &&
+			"tool" in frame.data &&
+			typeof frame.data.tool === "string"
+				? [frame.data.tool]
+				: [],
+		);
+		throw new Error(
+			`${label} Run did not record the required Tool invocations and successful results: expected ${expected.map(({ tool }) => tool).join(", ")}; got ${actualTools.join(", ") || "none"}`,
 		);
 	}
 }
@@ -619,7 +793,7 @@ async function sendTurn(
 		messages: snapshot.messages,
 		toolFrames: durableToolFrames(frames),
 	});
-	return { runId, text };
+	return { runId, text, toolFrames: durableToolFrames(frames) };
 }
 
 async function replayTurn(expectation: ReplayExpectation): Promise<void> {


### PR DESCRIPTION
## Summary

- extend the local `full` smoke suite with fixture-exact document inventory and search/load/read turns
- assert the public ADR-0009 Tool history and exact durable replay for `ListDocuments`, `SearchDocuments`, `LoadDocuments`, and `Read`
- fail fast when the full suite is run with a member other than the seeded `demo-member`
- document the local-only scope and expected seeded fixture evidence

## Why

The split-runtime smoke harness already covered conversation continuity, artifacts, and interruption, but it did not prove the worker's scoped document path through real model turns. This adds deterministic coverage of the seeded KB path while keeping production/deployed document promotion as a separate follow-up.

## Impact

`bun run smoke:local` now verifies that a real Compose run can inventory the seeded documents, find and materialize the matching document, read its cached markdown, and replay the exact durable Tool events. The checks are intentionally limited to the local full suite.

## Validation

- `bun test`: 776 passed
- workspace typechecks passed
- Biome checks passed
- `bun run smoke:local`: passed against the real Compose stack with OpenRouter, E2B, seeded Postgres KB, S3 artifact publication, cancellation, and durable replay

Closes #304