### PR TITLE
fix(agent-worker): reframe system-prompt artifact guidance around user deliverables

### DIFF
--- a/apps/agent-worker/src/sdk/start-run-query.test.ts
+++ b/apps/agent-worker/src/sdk/start-run-query.test.ts
@@ -402,10 +402,12 @@ describe("createStartRunQuery — query configuration (ADR-0006)", () => {
 		expect(MYMEMO_SYSTEM_PROMPT).toContain("LoadDocuments");
 	});
 
-	it("reserves the artifact root for downloadable outputs", () => {
+	it("reserves the artifact root for user deliverables", () => {
+		// The prompt interpolates ARTIFACT_ROOT; the literal here is deliberate so
+		// moving the artifact root is a conscious client-contract change.
 		expect(MYMEMO_SYSTEM_PROMPT).toContain("/home/user/artifacts/");
+		expect(MYMEMO_SYSTEM_PROMPT).toMatch(/a note/i);
 		expect(MYMEMO_SYSTEM_PROMPT).toMatch(/downloadable/i);
-		expect(MYMEMO_SYSTEM_PROMPT).toMatch(/scratch/i);
 	});
 
 	it("spreads the model-client env over the process env plus the ephemeral config dir", async () => {

--- a/apps/agent-worker/src/sdk/start-run-query.ts
+++ b/apps/agent-worker/src/sdk/start-run-query.ts
@@ -14,6 +14,7 @@ import {
 	type ArtifactPublisher,
 	withArtifactPublication,
 } from "../artifacts/artifact-publication";
+import { ARTIFACT_ROOT } from "../artifacts/artifact-workspace";
 import type { BashToolLimits } from "../bash-tool/bash-tool";
 import type { SandboxJanitor } from "../cleanup/cleanup";
 import type { ScopedDocumentQueryClient } from "../documents/client";
@@ -65,8 +66,9 @@ export const MYMEMO_SYSTEM_PROMPT =
 	"ListDocuments, SearchDocuments, and LoadDocuments reach the user's MyMemo knowledge base, limited to this " +
 	"conversation's scope. Use ListDocuments for inventory and exact count questions, SearchDocuments for relevant " +
 	"passages, and LoadDocuments to write chosen documents into the workspace's docs cache and return their paths " +
-	"so you can read and cite them. Put user-requested downloadable outputs under /home/user/artifacts/ and keep " +
-	"scratch work elsewhere in the workspace.\n\n" +
+	"so you can read and cite them. When the user asks you to create a file for them — a note, a document, a report, " +
+	`any deliverable — write it under ${ARTIFACT_ROOT}/; only files in that tree become visible and downloadable to ` +
+	"the user. Keep temporary and intermediate work elsewhere in the workspace.\n\n" +
 	"Ground claims about the user's documents in what ListDocuments, SearchDocuments, and LoadDocuments return, and keep " +
 	"responses concise.";
 


### PR DESCRIPTION
## What changed

Rewrote the artifact-placement sentence in `MYMEMO_SYSTEM_PROMPT` (`apps/agent-worker/src/sdk/start-run-query.ts`) and updated its pinning test.

Before:

> Put user-requested downloadable outputs under /home/user/artifacts/ and keep scratch work elsewhere in the workspace.

After:

> When the user asks you to create a file for them — a note, a document, a report, any deliverable — write it under /home/user/artifacts/; only files in that tree become visible and downloadable to the user. Keep temporary and intermediate work elsewhere in the workspace.

The path is now interpolated from `ARTIFACT_ROOT` (`artifacts/artifact-workspace.ts`) instead of a duplicated string literal.

## Why

Asking the agent to "write a note" produced a file at the workspace root: a note request doesn't pattern-match "downloadable outputs", and the "scratch work elsewhere" clause made the root the default for anything not explicitly downloadable. Since publication only manifests the reserved `artifacts/` subtree (ADR-0011), such files never became listable or downloadable — the deliverable was effectively invisible to the user.

The rewrite names concrete deliverable nouns, states the consequence (only that tree is user-visible), and inverts the default so non-artifact paths are the exception for temporary work.

## Notes for review

- The prompt stays static by construction (ADR-0006 cacheability): `ARTIFACT_ROOT` is a compile-time constant, same pattern as the existing `SANDBOX_WORKSPACE_ROOT` interpolation.
- The pinning test deliberately keeps the `/home/user/artifacts/` **literal** (while the prompt uses the constant), so a future `ARTIFACT_ROOT` change fails the test and forces a conscious decision about the client-facing contract instead of silent drift.
- ADR-0011 is untouched: its description of the mechanism (the static prompt routes downloadable outputs to the reserved tree) still holds; only the model-facing phrasing changed.
- This is a probabilistic fix. If misplaced deliverables persist, the discussed fallback is a one-line notice in `runWriteFileTool`/`runEditFileTool` results when a write lands outside `artifacts/` — deliberately not included here.
- Verified: full agent-worker suite (435 tests) passes; Biome lint and `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)