### PR TITLE
feat(deploy): auto-deploy CI-green main with hybrid app/infra lanes

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -1,6 +1,22 @@
 name: Release deploy
 
+# Trunk-based continuous deploy with hybrid lanes (private-repo friendly: no
+# GitHub environment features are used — the deploy role's OIDC trust is
+# pinned to runs on refs/heads/main instead, see infra/bootstrap-iam):
+# - Every CI-green push to main deploys that exact commit automatically.
+# - The plan job builds and pushes images, then classifies the Terraform plan
+#   (scripts/deploy/classify_terraform_plan.sh). An app-only plan — just the
+#   image-tag task-definition roll — applies unattended. Any other change
+#   fails the automatic run with instructions; a human applies it by
+#   re-running via workflow_dispatch with the typed confirm phrase.
+# - workflow_dispatch (from main only; other refs cannot assume the deploy
+#   role) also covers bootstrap, re-deploys, and incident response.
+
 on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
     inputs:
       environment:
@@ -11,29 +27,39 @@ on:
         required: true
         default: "prod"
       confirm_prod_apply:
-        description: "Type apply-mymemo-agent-prod to apply production Terraform changes."
+        description: "Type apply-mymemo-agent-prod to apply infra-lane (non-app) Terraform changes."
         required: true
 
 concurrency:
-  group: release-deploy-${{ inputs.environment }}
+  group: release-deploy-${{ inputs.environment || 'prod' }}
   cancel-in-progress: false
 
 env:
   TF_INPUT: false
   TF_IN_AUTOMATION: true
+  DEPLOY_ENVIRONMENT: ${{ inputs.environment || 'prod' }}
+  DEPLOY_CONFIG: infra/deploy/${{ inputs.environment || 'prod' }}.env
+  # The commit CI validated (workflow_run) or the dispatched ref's head — the
+  # only commit this workflow builds, plans, and applies.
+  DEPLOY_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
 
 jobs:
-  deploy:
+  plan:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
-    env:
-      DEPLOY_ENVIRONMENT: ${{ inputs.environment }}
-      DEPLOY_CONFIG: infra/deploy/${{ inputs.environment }}.env
     permissions:
       contents: read
       id-token: write
+    outputs:
+      image_tag: ${{ steps.image_tag.outputs.image_tag }}
+      chat_api_image: ${{ steps.images.outputs.chat_api_image }}
+      agent_worker_image: ${{ steps.images.outputs.agent_worker_image }}
+      first_deploy: ${{ steps.agent_deploy_state.outputs.first_deploy }}
+      lane: ${{ steps.classify.outputs.lane }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ env.DEPLOY_SHA }}
 
       - name: Load deploy config
         run: |
@@ -66,8 +92,9 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Compute immutable image tag
+        id: image_tag
         run: |
-          short_sha="${GITHUB_SHA::7}"
+          short_sha="${DEPLOY_SHA::7}"
           image_tag="release-${short_sha}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}"
 
           if [[ ! "${image_tag}" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
@@ -76,11 +103,20 @@ jobs:
           fi
 
           printf 'IMAGE_TAG=%s\n' "${image_tag}" >> "${GITHUB_ENV}"
+          printf 'image_tag=%s\n' "${image_tag}" >> "${GITHUB_OUTPUT}"
 
       - name: Ensure ECR repositories
         run: |
           terraform -chdir=infra/ecr init
           terraform -chdir=infra/ecr apply -auto-approve -var="aws_region=${AWS_REGION}"
+
+      - name: Resolve image references
+        id: images
+        run: |
+          chat_api_repository_url="$(terraform -chdir=infra/ecr output -raw chat_api_ecr_repository_url)"
+          agent_worker_repository_url="$(terraform -chdir=infra/ecr output -raw agent_worker_ecr_repository_url)"
+          printf 'chat_api_image=%s:%s\n' "${chat_api_repository_url}" "${IMAGE_TAG}" >> "${GITHUB_OUTPUT}"
+          printf 'agent_worker_image=%s:%s\n' "${agent_worker_repository_url}" "${IMAGE_TAG}" >> "${GITHUB_OUTPUT}"
 
       - name: Prepare Terraform variables
         run: scripts/deploy/ci_prepare_tfvars.sh
@@ -97,39 +133,126 @@ jobs:
       - name: Build and push agent-worker image
         run: scripts/deploy/build_and_push_agent_image.sh agent-worker
 
+      - name: Terraform plan
+        run: scripts/deploy/terraform_prod_in_place_plan.sh
+
+      - name: Classify plan into a deploy lane
+        id: classify
+        env:
+          FIRST_DEPLOY: ${{ steps.agent_deploy_state.outputs.first_deploy }}
+        run: |
+          if [[ "${FIRST_DEPLOY}" == "true" ]]; then
+            lane="infra"
+          else
+            lane="$(scripts/deploy/classify_terraform_plan.sh)"
+          fi
+          echo "Deploy lane: ${lane}"
+          printf 'lane=%s\n' "${lane}" >> "${GITHUB_OUTPUT}"
+
+  deploy:
+    needs: plan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      IMAGE_TAG: ${{ needs.plan.outputs.image_tag }}
+      # Pin the exact images the plan job pushed so this job never resolves
+      # ECR outputs (ci_prepare_tfvars.sh short-circuits on these).
+      CHAT_API_IMAGE: ${{ needs.plan.outputs.chat_api_image }}
+      AGENT_WORKER_IMAGE: ${{ needs.plan.outputs.agent_worker_image }}
+      FIRST_DEPLOY: ${{ needs.plan.outputs.first_deploy }}
+      # App lane: human intent is the CI-green merge, so the phrase is
+      # supplied automatically. Infra lane: the operator must have typed it
+      # into the workflow_dispatch input (validated by the apply script).
+      CONFIRM_AGENT_PROD_APPLY: ${{ needs.plan.outputs.lane == 'app' && 'apply-mymemo-agent-prod' || inputs.confirm_prod_apply }}
+    steps:
+      # A failed run (rather than a skip) so infra changes waiting for a human
+      # are impossible to miss.
+      - name: Require manual dispatch for infra changes
+        if: needs.plan.outputs.lane == 'infra' && github.event_name != 'workflow_dispatch'
+        run: |
+          echo "This deploy includes non-app Terraform changes (or is the bootstrap deploy) and cannot apply unattended." >&2
+          echo "Review the plan in the plan job's log, then run the 'Release deploy' workflow manually from main with confirm_prod_apply=apply-mymemo-agent-prod." >&2
+          exit 1
+
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ env.DEPLOY_SHA }}
+
+      - name: Load deploy config
+        run: |
+          set -euo pipefail
+          set -a
+          source "${DEPLOY_CONFIG}"
+          set +a
+
+          : "${AWS_REGION:?AWS_REGION is required in ${DEPLOY_CONFIG}}"
+          : "${AWS_ACCOUNT_ID:?AWS_ACCOUNT_ID is required in ${DEPLOY_CONFIG}}"
+          : "${DEPLOY_ENVIRONMENT:?DEPLOY_ENVIRONMENT is required in ${DEPLOY_CONFIG}}"
+
+          {
+            printf 'AWS_REGION=%s\n' "${AWS_REGION}"
+            printf 'AWS_ACCOUNT_ID=%s\n' "${AWS_ACCOUNT_ID}"
+            printf 'DEPLOY_ENVIRONMENT=%s\n' "${DEPLOY_ENVIRONMENT}"
+          } >> "${GITHUB_ENV}"
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.0
+      - uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_wrapper: false
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/mymemo-agent-github-actions-deploy
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Prepare Terraform variables
+        run: scripts/deploy/ci_prepare_tfvars.sh
+
       - name: Terraform bootstrap plan
-        if: steps.agent_deploy_state.outputs.first_deploy == 'true'
+        if: env.FIRST_DEPLOY == 'true'
         env:
           BOOTSTRAP_ZERO_DESIRED_COUNT: true
         run: scripts/deploy/terraform_prod_in_place_plan.sh agent-bootstrap.tfplan
 
       - name: Terraform bootstrap apply
-        if: steps.agent_deploy_state.outputs.first_deploy == 'true'
-        env:
-          CONFIRM_AGENT_PROD_APPLY: ${{ inputs.confirm_prod_apply }}
+        if: env.FIRST_DEPLOY == 'true'
         run: scripts/deploy/terraform_prod_in_place_apply.sh agent-bootstrap.tfplan
 
       - name: Terraform plan
-        if: steps.agent_deploy_state.outputs.first_deploy != 'true'
+        if: env.FIRST_DEPLOY != 'true'
         run: scripts/deploy/terraform_prod_in_place_plan.sh
 
+      # The plan is recomputed in this job (a saved plan file may embed
+      # sensitive values, so it is never passed between jobs as an artifact).
+      # Re-classify so state drift between the jobs cannot smuggle infra
+      # changes through the unattended lane.
+      - name: Confirm plan still qualifies for the unattended lane
+        if: env.FIRST_DEPLOY != 'true' && needs.plan.outputs.lane == 'app'
+        run: |
+          lane="$(scripts/deploy/classify_terraform_plan.sh)"
+          if [[ "${lane}" != "app" ]]; then
+            echo "Plan gained non-app changes after lane selection; re-run the workflow so it requires manual confirmation." >&2
+            exit 1
+          fi
+
       - name: Terraform apply
-        if: steps.agent_deploy_state.outputs.first_deploy != 'true'
-        env:
-          CONFIRM_AGENT_PROD_APPLY: ${{ inputs.confirm_prod_apply }}
+        if: env.FIRST_DEPLOY != 'true'
         run: scripts/deploy/terraform_prod_in_place_apply.sh
 
       - name: Run agent DB migrations
         run: scripts/deploy/run_agent_migration.sh
 
       - name: Terraform plan desired service counts
-        if: steps.agent_deploy_state.outputs.first_deploy == 'true'
+        if: env.FIRST_DEPLOY == 'true'
         run: scripts/deploy/terraform_prod_in_place_plan.sh
 
       - name: Terraform apply desired service counts
-        if: steps.agent_deploy_state.outputs.first_deploy == 'true'
-        env:
-          CONFIRM_AGENT_PROD_APPLY: ${{ inputs.confirm_prod_apply }}
+        if: env.FIRST_DEPLOY == 'true'
         run: scripts/deploy/terraform_prod_in_place_apply.sh
 
       - name: Roll ECS services

--- a/infra/bootstrap-iam/main.tf
+++ b/infra/bootstrap-iam/main.tf
@@ -1,6 +1,6 @@
 locals {
   github_oidc_provider_arn = "arn:aws:iam::${var.aws_account_id}:oidc-provider/token.actions.githubusercontent.com"
-  github_environment_sub   = "repo:${var.github_owner}/${var.github_repository}:environment:${var.github_environment}"
+  github_ref_sub           = "repo:${var.github_owner}/${var.github_repository}:ref:${var.github_deploy_ref}"
 }
 
 data "aws_iam_openid_connect_provider" "github" {
@@ -26,7 +26,7 @@ data "aws_iam_policy_document" "github_actions_assume_role" {
     condition {
       test     = "StringLike"
       variable = "token.actions.githubusercontent.com:sub"
-      values   = [local.github_environment_sub]
+      values   = [local.github_ref_sub]
     }
   }
 }

--- a/infra/bootstrap-iam/outputs.tf
+++ b/infra/bootstrap-iam/outputs.tf
@@ -5,5 +5,5 @@ output "deploy_role_arn" {
 
 output "github_oidc_subject" {
   description = "GitHub OIDC subject allowed to assume the deploy role."
-  value       = local.github_environment_sub
+  value       = local.github_ref_sub
 }

--- a/infra/bootstrap-iam/variables.tf
+++ b/infra/bootstrap-iam/variables.tf
@@ -20,10 +20,12 @@ variable "github_repository" {
   default     = "mymemo-agent"
 }
 
-variable "github_environment" {
-  description = "GitHub Actions environment allowed to assume this deploy role."
+# Ref-pinned (not environment-pinned) so the release workflow needs no GitHub
+# environment features, which are plan-gated on private repositories.
+variable "github_deploy_ref" {
+  description = "Git ref whose GitHub Actions runs are allowed to assume this deploy role."
   type        = string
-  default     = "prod"
+  default     = "refs/heads/main"
 }
 
 variable "deploy_role_name" {

--- a/scripts/deploy-config.test.ts
+++ b/scripts/deploy-config.test.ts
@@ -519,14 +519,18 @@ describe("agent deployment config", () => {
 		expect(releaseDeployWorkflow).toContain(
 			"arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/mymemo-agent-github-actions-deploy",
 		);
-		expect(releaseDeployWorkflow).toContain("DEPLOY_ENVIRONMENT: ${{ inputs.environment }}");
+		expect(releaseDeployWorkflow).toContain("DEPLOY_ENVIRONMENT: ${{ inputs.environment || 'prod' }}");
 		expect(releaseDeployWorkflow).toContain("GITHUB_RUN_ATTEMPT");
 		expect(releaseDeployWorkflow).toContain("type: choice");
 		expect(releaseDeployWorkflow).toContain("- prod");
 		expect(releaseDeployWorkflow).toContain("confirm_prod_apply");
 		expect(releaseDeployWorkflow).not.toContain("gateway_public_url");
 		expect(releaseDeployWorkflow).not.toContain("GATEWAY_PUBLIC_URL");
-		expect(releaseDeployWorkflow).toContain("CONFIRM_AGENT_PROD_APPLY: ${{ inputs.confirm_prod_apply }}");
+		// The phrase is auto-supplied only for the unattended app lane; the infra
+		// lane still requires the operator-typed dispatch input.
+		expect(releaseDeployWorkflow).toContain(
+			"CONFIRM_AGENT_PROD_APPLY: ${{ needs.plan.outputs.lane == 'app' && 'apply-mymemo-agent-prod' || inputs.confirm_prod_apply }}",
+		);
 		expect(releaseDeployWorkflow).not.toContain("CONFIRM_AGENT_PROD_APPLY: apply-mymemo-agent-prod");
 	});
 
@@ -545,7 +549,12 @@ describe("agent deployment config", () => {
 			/aws_account_id\s*=\s*"637423444544"/,
 		);
 		expect(combined).toContain("token.actions.githubusercontent.com:sub");
-		expect(combined).toContain("repo:${var.github_owner}/${var.github_repository}:environment:${var.github_environment}");
+		// Ref-pinned, not environment-pinned: no GitHub environment features are
+		// used (plan-gated on private repos) and only runs on main can assume
+		// the deploy role.
+		expect(combined).toContain("repo:${var.github_owner}/${var.github_repository}:ref:${var.github_deploy_ref}");
+		expect(combined).toContain('default     = "refs/heads/main"');
+		expect(combined).not.toContain(":environment:");
 		expect(combined).toContain("sts:AssumeRoleWithWebIdentity");
 		expect(combined).toContain("mymemo-agent/bootstrap-iam-prod.tfstate");
 		expect(combined).not.toContain("mymemo-github-actions-deploy");
@@ -577,7 +586,7 @@ describe("agent deployment config", () => {
 
 	it("release deploy serializes runs and generates unique immutable image tags", () => {
 		expect(releaseDeployWorkflow).toContain("concurrency:");
-		expect(releaseDeployWorkflow).toContain("group: release-deploy-${{ inputs.environment }}");
+		expect(releaseDeployWorkflow).toContain("group: release-deploy-${{ inputs.environment || 'prod' }}");
 		expect(releaseDeployWorkflow).toContain("cancel-in-progress: false");
 		expect(releaseDeployWorkflow).not.toContain("inputs.image_tag");
 		expect(releaseDeployWorkflow).not.toContain("REQUESTED_IMAGE_TAG");
@@ -585,6 +594,43 @@ describe("agent deployment config", () => {
 		expect(releaseDeployWorkflow).toContain('if [[ ! "${image_tag}" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]');
 		expect(releaseDeployWorkflow).toContain("printf 'IMAGE_TAG=%s\\n'");
 		expect(releaseDeployWorkflow).not.toContain('echo "IMAGE_TAG=${REQUESTED_IMAGE_TAG}" >> "${GITHUB_ENV}"');
+	});
+
+	it("release deploy auto-deploys CI-green main through classified lanes", () => {
+		const classifyScript = readFileSync(
+			join(root, "scripts", "deploy", "classify_terraform_plan.sh"),
+			"utf8",
+		);
+
+		// Auto trigger: only a green CI run on main, deploying the exact commit
+		// CI validated rather than main's tip at run time.
+		expect(releaseDeployWorkflow).toContain("workflow_run:");
+		expect(releaseDeployWorkflow).toContain("workflows: [CI]");
+		expect(releaseDeployWorkflow).toContain("branches: [main]");
+		expect(releaseDeployWorkflow).toContain("github.event.workflow_run.conclusion == 'success'");
+		expect(releaseDeployWorkflow).toContain(
+			"DEPLOY_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}",
+		);
+		expect(releaseDeployWorkflow).toContain("ref: ${{ env.DEPLOY_SHA }}");
+
+		// App-only plans (the image-tag roll) apply unattended; infra plans fail
+		// the automatic run and require a manual dispatch with the confirm phrase.
+		expect(releaseDeployWorkflow).toContain("scripts/deploy/classify_terraform_plan.sh");
+		expect(releaseDeployWorkflow).toContain(
+			"if: needs.plan.outputs.lane == 'infra' && github.event_name != 'workflow_dispatch'",
+		);
+		expect(classifyScript).toContain('. != "aws_ecs_task_definition" and . != "aws_ecs_service"');
+		expect(classifyScript).toContain('["no-op", "read"]');
+
+		// The deploy job re-plans and re-classifies so drift between the jobs
+		// cannot smuggle infra changes through the unattended lane.
+		expect(releaseDeployWorkflow).toContain(
+			"if: env.FIRST_DEPLOY != 'true' && needs.plan.outputs.lane == 'app'",
+		);
+
+		// No GitHub environment features anywhere (plan-gated on private repos);
+		// the OIDC trust is ref-pinned instead.
+		expect(releaseDeployWorkflow).not.toContain("\n    environment:");
 	});
 
 	it("agent RDS tracks the PostgreSQL major version for auto-minor upgrades", () => {

--- a/scripts/deploy/classify_terraform_plan.sh
+++ b/scripts/deploy/classify_terraform_plan.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Classify a saved Terraform plan into a release lane:
+#   app   - every change is the routine image-tag roll (task definitions and
+#           the ECS services that point at them); safe to apply unattended.
+#   infra - anything else changes; the deploy requires a manual
+#           workflow_dispatch with the typed confirm phrase.
+# Prints the lane on stdout; diagnostics go to stderr.
+
+plan_file="${1:-agent-prod.tfplan}"
+
+non_app_types="$(
+  terraform -chdir=infra/terraform show -json "$plan_file" \
+    | jq -r '
+        [.resource_changes[]?
+          | select((.change.actions - ["no-op", "read"]) != [])
+          | .type
+          | select(. != "aws_ecs_task_definition" and . != "aws_ecs_service")]
+        | unique | .[]'
+)"
+
+if [[ -z "$non_app_types" ]]; then
+  echo "app"
+else
+  echo "Plan changes non-app resource types:" >&2
+  sed 's/^/  /' <<<"$non_app_types" >&2
+  echo "infra"
+fi


### PR DESCRIPTION
## Summary

Moves the release flow from fully manual `workflow_dispatch` to trunk-based continuous deploy, with a hybrid gate:

- **Auto trigger**: `release-deploy` now runs on `workflow_run` after the CI workflow concludes green on `main`, and checks out `workflow_run.head_sha` so it builds/plans/applies the exact commit CI validated. `workflow_dispatch` remains for bootstrap, re-deploys, and incident response.
- **Two jobs, two lanes**: a `plan` job builds and pushes both images, runs `terraform plan`, and classifies it via the new `scripts/deploy/classify_terraform_plan.sh`:
  - `app` — every change is `aws_ecs_task_definition` / `aws_ecs_service` (the routine image-tag roll): the `deploy` job applies, migrates, and rolls ECS unattended (the confirm phrase is supplied by the workflow for this lane).
  - `infra` — anything else changed, or first-deploy bootstrap: the automatic run fails with instructions, and a human applies by dispatching the workflow with `confirm_prod_apply=apply-mymemo-agent-prod`.
- **Drift guard**: the deploy job re-plans and re-classifies before applying; an app-lane run refuses to apply if the plan gained non-app changes between the jobs. The plan file is never passed between jobs as an artifact.
- **OIDC trust re-pinned** (`infra/bootstrap-iam`): the deploy role's sub condition moves from `environment:prod` to `ref:refs/heads/main`. No GitHub environment features are used anywhere (they are plan-gated on private repos), and only workflow runs on `main` can assume the deploy role.

## Rollout notes

- `infra/bootstrap-iam` must be re-applied with admin credentials close to merging this: once the trust policy switches to the ref sub, the old environment-pinned workflow can no longer assume the role.
- Branch protection on `main` requiring the `test`, `worker-image`, and `integration` checks is the prerequisite for trusting the unattended lane.
- The `prod` GitHub environment is no longer referenced and can be deleted.
- With a deploy per merge, DB migrations should stay expand/contract: never drop/rename a column in the same PR that stops using it (migrations run before the ECS roll).

## Verification

- Classifier jq logic exercised against synthetic app-only, infra, and empty plan JSON (correct lane in all three).
- `terraform validate` + `fmt -check` pass on `infra/bootstrap-iam` (validate caught and fixed a stale local reference in `outputs.tf`).
- Workflow YAML parse-checked; confirmed no `environment:` references remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)