### PR TITLE
Add Conversation lifecycle persistence

### DIFF
--- a/apps/agent-worker/src/cleanup/cleanup.test.ts
+++ b/apps/agent-worker/src/cleanup/cleanup.test.ts
@@ -136,6 +136,7 @@ describe("Downloadable artifact object cleanup", () => {
 	});
 
 	it("deletes a pending object owned by a terminal Run", async () => {
+		await insertConversation("user-1", "conv-gone");
 		await tdb.db.insert(runs).values({
 			runId: "run-terminal",
 			userId: "user-1",
@@ -158,6 +159,7 @@ describe("Downloadable artifact object cleanup", () => {
 	});
 
 	it("deletes a pending object after its owning Run becomes stale", async () => {
+		await insertConversation("user-1", "conv-gone");
 		await tdb.db.insert(runs).values({
 			runId: "run-stale",
 			userId: "user-1",

--- a/apps/agent-worker/src/run-loop.test.ts
+++ b/apps/agent-worker/src/run-loop.test.ts
@@ -10,7 +10,12 @@ import {
 	createConversationRuntimeTx,
 	loadConversationRuntimeTx,
 } from "@mymemo/agent-db/runtime-store";
-import { conversationRuntime, runEvents, runs } from "@mymemo/agent-db/schema";
+import {
+	conversationRuntime,
+	conversations,
+	runEvents,
+	runs,
+} from "@mymemo/agent-db/schema";
 import { createTestDatabase, type TestDb } from "@mymemo/agent-db/testing";
 import { eq, sql } from "drizzle-orm";
 import type { WorkerLogger } from "./logger";
@@ -34,6 +39,7 @@ afterAll(async () => {
 afterEach(async () => {
 	await tdb.db.delete(runs); // cascades run_events
 	await tdb.db.delete(conversationRuntime);
+	await tdb.db.delete(conversations);
 });
 
 /** A promise whose resolution the test controls, to gate a processor. */
@@ -65,6 +71,10 @@ function buildLoop(worker: Worker, processor: RunProcessor) {
 }
 
 async function queueRun(runId: string, conversationId: string) {
+	await tdb.db
+		.insert(conversations)
+		.values({ userId: "user-1", conversationId, scope: "general" })
+		.onConflictDoNothing();
 	await createQueuedRunTx(tdb.db, { runId, userId: "user-1", conversationId });
 }
 

--- a/apps/agent-worker/src/sdk/run-processor.test.ts
+++ b/apps/agent-worker/src/sdk/run-processor.test.ts
@@ -2,7 +2,12 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
 import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 import { createQueuedRunTx } from "@mymemo/agent-db/run-store";
 import { createConversationRuntimeTx } from "@mymemo/agent-db/runtime-store";
-import { conversationRuntime, runEvents, runs } from "@mymemo/agent-db/schema";
+import {
+	conversationRuntime,
+	conversations,
+	runEvents,
+	runs,
+} from "@mymemo/agent-db/schema";
 import { createTestDatabase, type TestDb } from "@mymemo/agent-db/testing";
 import {
 	InMemoryLiveTextTransport,
@@ -28,6 +33,11 @@ let tdb: TestDb;
 // starts from empty tables via delete, keeping isolation without the cost.
 beforeAll(async () => {
 	tdb = await createTestDatabase();
+	await tdb.db.insert(conversations).values({
+		userId: "user-1",
+		conversationId: "conv-1",
+		scope: "general",
+	});
 });
 
 afterAll(async () => {

--- a/apps/agent-worker/src/sdk/start-run-query.test.ts
+++ b/apps/agent-worker/src/sdk/start-run-query.test.ts
@@ -16,6 +16,7 @@ import {
 } from "@mymemo/agent-db/run-store";
 import {
 	conversationRuntime,
+	conversations,
 	orphanSandboxes,
 	runEvents,
 	runs,
@@ -65,6 +66,7 @@ beforeEach(async () => {
 	await tdb.db.delete(runs); // cascades run_events
 	await tdb.db.delete(conversationRuntime);
 	await tdb.db.delete(orphanSandboxes);
+	await tdb.db.delete(conversations);
 });
 
 /** Queue a run with its run_started event (as chat-api admission writes it)
@@ -77,6 +79,14 @@ async function createClaimedRun(input: {
 	collectionId?: string | null;
 	summaryId?: string | null;
 }): Promise<RunRecord> {
+	await tdb.db
+		.insert(conversations)
+		.values({
+			userId: USER_ID,
+			conversationId: input.conversationId,
+			scope: "general",
+		})
+		.onConflictDoNothing();
 	await createQueuedRunTx(tdb.db, {
 		runId: input.runId,
 		userId: USER_ID,

--- a/apps/chat-api/src/db/run-schema.test.ts
+++ b/apps/chat-api/src/db/run-schema.test.ts
@@ -8,7 +8,7 @@ import {
 } from "bun:test";
 import { eq, sql } from "drizzle-orm";
 import { createTestDatabase, type TestDb } from "@/db/testing";
-import { documentAccessEvents, runEvents, runs } from "./schema";
+import { conversations, documentAccessEvents, runEvents, runs } from "./schema";
 
 let tdb: TestDb;
 
@@ -25,6 +25,11 @@ afterAll(async () => {
 
 beforeEach(async () => {
 	await tdb.db.delete(runs); // cascades run_events
+	await tdb.db.delete(conversations);
+	await tdb.db.insert(conversations).values([
+		{ userId: "user-1", conversationId: "conv-1", scope: "general" },
+		{ userId: "user-1", conversationId: "conv-2", scope: "general" },
+	]);
 	await tdb.db.delete(documentAccessEvents);
 });
 

--- a/apps/chat-api/src/features/conversation-store/conversation-store.ts
+++ b/apps/chat-api/src/features/conversation-store/conversation-store.ts
@@ -24,9 +24,10 @@ export interface ConversationRef {
 	conversationId: string;
 }
 
-/** A persisted conversation. `collectionId`/`summaryId` are non-null only for
- * the matching scope. */
-export interface ConversationRecord {
+/** Input used to create a Conversation before database-owned lifecycle metadata
+ * has been established. `collectionId`/`summaryId` are non-null only for the
+ * matching frozen Scope. */
+export interface ConversationCreateInput {
 	userId: string;
 	conversationId: string;
 	scope: ConversationScope;
@@ -34,13 +35,42 @@ export interface ConversationRecord {
 	summaryId: string | null;
 }
 
+/** A persisted Conversation with its full lifecycle metadata. */
+export interface ConversationRecord extends ConversationCreateInput {
+	title: string | null;
+	createdAt: Date;
+	lastActivityAt: Date;
+	archivedAt: Date | null;
+}
+
+/** Mutable Conversation fields. Rename does not count as Conversation
+ * activity; Archive is represented by a server-owned timestamp. */
+export interface ConversationUpdate {
+	title?: string;
+	archived?: boolean;
+}
+
+export type ConversationUpdateResult =
+	| { outcome: "updated"; conversation: ConversationRecord }
+	| { outcome: "not_found" | "active_run" };
+
+export type ConversationDeleteResult =
+	| { outcome: "deleted" }
+	| { outcome: "not_found" | "active_run" };
+
 /**
  * Persistence seam for the conversation registry, keyed by `{userId,
- * conversationId}`. Small on purpose: a conversation is created once and read
- * each turn. `create` is a plain insert — a second create for the same key fails
- * loudly rather than silently re-scoping an existing conversation.
+ * conversationId}`. Scope is immutable after creation; lifecycle metadata is
+ * changed only through the guarded update and admission paths. `create` is a
+ * plain insert — a second create for the same key fails loudly rather than
+ * silently re-scoping an existing conversation.
  */
 export interface ConversationStore {
 	get(ref: ConversationRef): Promise<ConversationRecord | null>;
-	create(record: ConversationRecord): Promise<void>;
+	create(record: ConversationCreateInput): Promise<ConversationRecord>;
+	update(
+		ref: ConversationRef,
+		changes: ConversationUpdate,
+	): Promise<ConversationUpdateResult>;
+	deletePermanently(ref: ConversationRef): Promise<ConversationDeleteResult>;
 }

--- a/apps/chat-api/src/features/conversation-store/index.ts
+++ b/apps/chat-api/src/features/conversation-store/index.ts
@@ -1,7 +1,11 @@
 export type {
+	ConversationCreateInput,
+	ConversationDeleteResult,
 	ConversationRecord,
 	ConversationRef,
 	ConversationScope,
 	ConversationStore,
+	ConversationUpdate,
+	ConversationUpdateResult,
 } from "./conversation-store";
 export { PostgresConversationStore } from "./postgres-conversation-store";

--- a/apps/chat-api/src/features/conversation-store/postgres-conversation-store.test.ts
+++ b/apps/chat-api/src/features/conversation-store/postgres-conversation-store.test.ts
@@ -1,10 +1,18 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
-import { conversations } from "@/db/schema";
+import {
+	agentSessions,
+	artifactObjects,
+	conversationArtifacts,
+	conversationRuntime,
+	conversations,
+	runEvents,
+	runs,
+} from "@/db/schema";
 import { createTestDatabase, type TestDb } from "@/db/testing";
-import type { ConversationRecord } from "./conversation-store";
+import type { ConversationCreateInput } from "./conversation-store";
 import { PostgresConversationStore } from "./postgres-conversation-store";
 
-const collectionConversation: ConversationRecord = {
+const collectionConversation: ConversationCreateInput = {
 	userId: "user-1",
 	conversationId: "conv-1",
 	scope: "collection",
@@ -27,6 +35,9 @@ describe("PostgresConversationStore", () => {
 	afterAll(() => tdb.close());
 
 	afterEach(async () => {
+		await tdb.db.delete(agentSessions);
+		await tdb.db.delete(artifactObjects);
+		await tdb.db.delete(conversationRuntime);
 		await tdb.db.delete(conversations);
 	});
 
@@ -36,11 +47,20 @@ describe("PostgresConversationStore", () => {
 		).toBeNull();
 	});
 
-	it("create then get round-trips the frozen scope", async () => {
+	it("create then get returns frozen scope and lifecycle defaults", async () => {
 		await store.create(collectionConversation);
-		expect(
-			await store.get({ userId: "user-1", conversationId: "conv-1" }),
-		).toEqual(collectionConversation);
+		const persisted = await store.get({
+			userId: "user-1",
+			conversationId: "conv-1",
+		});
+
+		expect(persisted).toMatchObject({
+			...collectionConversation,
+			title: null,
+			archivedAt: null,
+		});
+		expect(persisted?.createdAt).toBeInstanceOf(Date);
+		expect(persisted?.lastActivityAt).toEqual(persisted?.createdAt);
 	});
 
 	it("round-trips general and document scopes with null id columns", async () => {
@@ -88,5 +108,132 @@ describe("PostgresConversationStore", () => {
 		expect(
 			await store.get({ userId: "other", conversationId: "conv-1" }),
 		).toBeNull();
+	});
+
+	it("renames and Archives without changing Conversation activity", async () => {
+		await store.create(collectionConversation);
+		const before = await store.get({
+			userId: "user-1",
+			conversationId: "conv-1",
+		});
+		if (!before) throw new Error("conversation was not created");
+
+		const archived = await store.update(
+			{ userId: "user-1", conversationId: "conv-1" },
+			{ title: "Quarterly plan", archived: true },
+		);
+		expect(archived).toMatchObject({
+			outcome: "updated",
+			conversation: {
+				title: "Quarterly plan",
+			},
+		});
+		if (archived.outcome !== "updated") throw new Error("update failed");
+		expect(archived.conversation.archivedAt).toBeInstanceOf(Date);
+		expect(archived.conversation.lastActivityAt).toEqual(before.lastActivityAt);
+
+		const unarchived = await store.update(
+			{ userId: "user-1", conversationId: "conv-1" },
+			{ archived: false },
+		);
+		expect(unarchived).toMatchObject({
+			outcome: "updated",
+			conversation: {
+				title: "Quarterly plan",
+				archivedAt: null,
+				lastActivityAt: before.lastActivityAt,
+			},
+		});
+	});
+
+	it("allows rename but rejects Archive and Permanent deletion while a Run is active", async () => {
+		await store.create(collectionConversation);
+		await tdb.db.insert(runs).values({
+			runId: "run-active",
+			userId: "user-1",
+			conversationId: "conv-1",
+			status: "queued",
+		});
+
+		await expect(
+			store.update(
+				{ userId: "user-1", conversationId: "conv-1" },
+				{ title: "Renamed while active" },
+			),
+		).resolves.toMatchObject({ outcome: "updated" });
+		await expect(
+			store.update(
+				{ userId: "user-1", conversationId: "conv-1" },
+				{ archived: true },
+			),
+		).resolves.toEqual({ outcome: "active_run" });
+		await expect(
+			store.deletePermanently({
+				userId: "user-1",
+				conversationId: "conv-1",
+			}),
+		).resolves.toEqual({ outcome: "active_run" });
+	});
+
+	it("Permanent deletion cascades Run history and leaves external cleanup state recoverable", async () => {
+		await store.create(collectionConversation);
+		await tdb.db.insert(conversationRuntime).values({
+			userId: "user-1",
+			conversationId: "conv-1",
+			sandboxId: "sandbox-1",
+		});
+		await tdb.db.insert(agentSessions).values({
+			conversationId: "conv-1",
+			projectKey: "project-1",
+			sessionId: "session-1",
+			entry: { type: "user" },
+		});
+		await tdb.db.insert(runs).values({
+			runId: "run-terminal",
+			userId: "user-1",
+			conversationId: "conv-1",
+			status: "done",
+			terminalAt: new Date(),
+			nextEventSeq: 5,
+		});
+		await tdb.db.insert(runEvents).values([
+			{ runId: "run-terminal", seq: 1, type: "run_started", payload: {} },
+			{ runId: "run-terminal", seq: 2, type: "tool_use", payload: {} },
+			{ runId: "run-terminal", seq: 3, type: "tool_result", payload: {} },
+			{ runId: "run-terminal", seq: 4, type: "run_done", payload: {} },
+		]);
+		await tdb.db.insert(conversationArtifacts).values({
+			artifactId: "artifact-1",
+			userId: "user-1",
+			conversationId: "conv-1",
+			path: "report.pdf",
+			objectKey: "objects/report.pdf",
+			sizeBytes: 42,
+			contentType: "application/pdf",
+		});
+		await tdb.db.insert(artifactObjects).values({
+			objectKey: "objects/report.pdf",
+			userId: "user-1",
+			conversationId: "conv-1",
+			runId: "run-terminal",
+			path: "report.pdf",
+			status: "current",
+		});
+
+		await expect(
+			store.deletePermanently({
+				userId: "user-1",
+				conversationId: "conv-1",
+			}),
+		).resolves.toEqual({ outcome: "deleted" });
+		await expect(
+			store.get({ userId: "user-1", conversationId: "conv-1" }),
+		).resolves.toBeNull();
+		expect(await tdb.db.select().from(runs)).toHaveLength(0);
+		expect(await tdb.db.select().from(runEvents)).toHaveLength(0);
+		expect(await tdb.db.select().from(conversationArtifacts)).toHaveLength(0);
+		expect(await tdb.db.select().from(conversationRuntime)).toHaveLength(1);
+		expect(await tdb.db.select().from(agentSessions)).toHaveLength(1);
+		expect(await tdb.db.select().from(artifactObjects)).toHaveLength(1);
 	});
 });

--- a/apps/chat-api/src/features/conversation-store/postgres-conversation-store.ts
+++ b/apps/chat-api/src/features/conversation-store/postgres-conversation-store.ts
@@ -1,12 +1,25 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import type { Database } from "@/db/client";
-import { conversations } from "@/db/schema";
+import { conversations, runs } from "@/db/schema";
 import type {
+	ConversationCreateInput,
+	ConversationDeleteResult,
 	ConversationRecord,
 	ConversationRef,
 	ConversationScope,
 	ConversationStore,
+	ConversationUpdate,
+	ConversationUpdateResult,
 } from "./conversation-store";
+
+const ACTIVE_RUN_STATUSES = ["queued", "running", "cancel_requested"] as const;
+
+type ConversationRow = typeof conversations.$inferSelect;
+type DbTransaction = Parameters<Parameters<Database["transaction"]>[0]>[0];
+
+function toConversationRecord(row: ConversationRow): ConversationRecord {
+	return { ...row, scope: row.scope as ConversationScope };
+}
 
 /**
  * Drizzle adapter for {@link ConversationStore}, over the `conversations` table.
@@ -18,13 +31,7 @@ export class PostgresConversationStore implements ConversationStore {
 
 	async get(ref: ConversationRef): Promise<ConversationRecord | null> {
 		const rows = await this.db
-			.select({
-				userId: conversations.userId,
-				conversationId: conversations.conversationId,
-				scope: conversations.scope,
-				collectionId: conversations.collectionId,
-				summaryId: conversations.summaryId,
-			})
+			.select()
 			.from(conversations)
 			.where(
 				and(
@@ -35,20 +42,125 @@ export class PostgresConversationStore implements ConversationStore {
 			.limit(1);
 		const row = rows[0];
 		if (!row) return null;
-		// `scope` is stored as text; it is only ever written through `create` from
-		// the typed union, so narrowing here is safe.
-		return { ...row, scope: row.scope as ConversationScope };
+		return toConversationRecord(row);
 	}
 
-	async create(record: ConversationRecord): Promise<void> {
+	async create(record: ConversationCreateInput): Promise<ConversationRecord> {
 		// Plain insert: the composite PK makes a second create for the same
 		// conversation throw rather than silently re-scope it.
-		await this.db.insert(conversations).values({
-			userId: record.userId,
-			conversationId: record.conversationId,
-			scope: record.scope,
-			collectionId: record.collectionId,
-			summaryId: record.summaryId,
+		const [created] = await this.db
+			.insert(conversations)
+			.values({
+				userId: record.userId,
+				conversationId: record.conversationId,
+				scope: record.scope,
+				collectionId: record.collectionId,
+				summaryId: record.summaryId,
+			})
+			.returning();
+		if (!created) {
+			throw new Error(
+				`insert of conversation ${record.conversationId} returned no row`,
+			);
+		}
+		return toConversationRecord(created);
+	}
+
+	async update(
+		ref: ConversationRef,
+		changes: ConversationUpdate,
+	): Promise<ConversationUpdateResult> {
+		return await this.db.transaction(async (tx) => {
+			const [conversation] = await tx
+				.select()
+				.from(conversations)
+				.where(
+					and(
+						eq(conversations.userId, ref.userId),
+						eq(conversations.conversationId, ref.conversationId),
+					),
+				)
+				.for("update");
+			if (!conversation) return { outcome: "not_found" };
+
+			if (changes.archived !== undefined && (await hasActiveRun(tx, ref))) {
+				return { outcome: "active_run" };
+			}
+
+			const [updated] = await tx
+				.update(conversations)
+				.set({
+					title: changes.title,
+					archivedAt:
+						changes.archived === undefined
+							? undefined
+							: changes.archived
+								? sql`coalesce(${conversations.archivedAt}, now())`
+								: null,
+				})
+				.where(
+					and(
+						eq(conversations.userId, ref.userId),
+						eq(conversations.conversationId, ref.conversationId),
+					),
+				)
+				.returning();
+			if (!updated) {
+				throw new Error(
+					`locked conversation ${ref.conversationId} vanished during update`,
+				);
+			}
+			return {
+				outcome: "updated",
+				conversation: toConversationRecord(updated),
+			};
 		});
 	}
+
+	async deletePermanently(
+		ref: ConversationRef,
+	): Promise<ConversationDeleteResult> {
+		return await this.db.transaction(async (tx) => {
+			const [conversation] = await tx
+				.select({ conversationId: conversations.conversationId })
+				.from(conversations)
+				.where(
+					and(
+						eq(conversations.userId, ref.userId),
+						eq(conversations.conversationId, ref.conversationId),
+					),
+				)
+				.for("update");
+			if (!conversation) return { outcome: "not_found" };
+			if (await hasActiveRun(tx, ref)) return { outcome: "active_run" };
+
+			await tx
+				.delete(conversations)
+				.where(
+					and(
+						eq(conversations.userId, ref.userId),
+						eq(conversations.conversationId, ref.conversationId),
+					),
+				);
+			return { outcome: "deleted" };
+		});
+	}
+}
+
+async function hasActiveRun(
+	db: DbTransaction,
+	ref: ConversationRef,
+): Promise<boolean> {
+	const rows = await db
+		.select({ runId: runs.runId })
+		.from(runs)
+		.where(
+			and(
+				eq(runs.userId, ref.userId),
+				eq(runs.conversationId, ref.conversationId),
+				inArray(runs.status, ACTIVE_RUN_STATUSES),
+			),
+		)
+		.limit(1);
+	return rows.length > 0;
 }

--- a/apps/chat-api/src/features/conversations/conversations.controller.test.ts
+++ b/apps/chat-api/src/features/conversations/conversations.controller.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import type { AppDeps } from "@/deps";
 import type {
+	ConversationCreateInput,
 	ConversationRecord,
 	ConversationStore,
 } from "@/features/conversation-store";
@@ -13,13 +14,27 @@ import {
 
 /** In-memory store capturing every created record. */
 function fakeStore() {
-	const created: ConversationRecord[] = [];
+	const created: ConversationCreateInput[] = [];
 	const store: ConversationStore = {
 		async get() {
 			return null;
 		},
 		async create(record) {
 			created.push(record);
+			const now = new Date();
+			return {
+				...record,
+				title: null,
+				createdAt: now,
+				lastActivityAt: now,
+				archivedAt: null,
+			};
+		},
+		async update() {
+			return { outcome: "not_found" };
+		},
+		async deletePermanently() {
+			return { outcome: "not_found" };
 		},
 	};
 	return { store, created };
@@ -31,6 +46,10 @@ const conversation: ConversationRecord = {
 	scope: "general",
 	collectionId: null,
 	summaryId: null,
+	title: null,
+	createdAt: new Date("2026-01-01T00:00:00.000Z"),
+	lastActivityAt: new Date("2026-01-01T00:00:00.000Z"),
+	archivedAt: null,
 };
 
 describe("createConversation", () => {
@@ -131,6 +150,10 @@ describe("queueConversationTurn", () => {
 			scope: "document",
 			collectionId: null,
 			summaryId: "sum-7",
+			title: null,
+			createdAt: new Date("2026-01-01T00:00:00.000Z"),
+			lastActivityAt: new Date("2026-01-01T00:00:00.000Z"),
+			archivedAt: null,
 		};
 
 		await queueConversationTurn(deps, {

--- a/apps/chat-api/src/features/conversations/conversations.route.test.ts
+++ b/apps/chat-api/src/features/conversations/conversations.route.test.ts
@@ -10,6 +10,7 @@ import { runEvents, runs } from "@/db/schema";
 import { createTestDatabase } from "@/db/testing";
 import type { AppDeps } from "@/deps";
 import type {
+	ConversationCreateInput,
 	ConversationRecord,
 	ConversationStore,
 } from "@/features/conversation-store";
@@ -24,6 +25,8 @@ import type {
 import { DrizzleRunEventReader, RunEventType } from "@/features/run-events";
 import {
 	ActiveRunExistsError,
+	ConversationArchivedError,
+	ConversationNotFoundError,
 	PostgresRunStore,
 	type RunRecord,
 	type RunStore,
@@ -47,8 +50,23 @@ function fakeStore(seed: ConversationRecord[] = []) {
 			return rows.get(`${userId}/${conversationId}`) ?? null;
 		},
 		async create(record) {
-			rows.set(`${record.userId}/${record.conversationId}`, record);
-			created.push(record);
+			const now = new Date();
+			const persisted: ConversationRecord = {
+				...record,
+				title: null,
+				createdAt: now,
+				lastActivityAt: now,
+				archivedAt: null,
+			};
+			rows.set(`${record.userId}/${record.conversationId}`, persisted);
+			created.push(persisted);
+			return persisted;
+		},
+		async update() {
+			return { outcome: "not_found" };
+		},
+		async deletePermanently() {
+			return { outcome: "not_found" };
 		},
 	};
 	return { store, created };
@@ -94,8 +112,10 @@ function buildApp(
 }
 
 function fakeRunStore() {
-	const queued: Array<{ conversation: ConversationRecord; message: string }> =
-		[];
+	const queued: Array<{
+		conversation: ConversationCreateInput;
+		message: string;
+	}> = [];
 	const eventsByRun = new Map<string, RunEventRow[]>();
 	const runOwners = new Map<
 		string,
@@ -339,6 +359,10 @@ describe("POST /v1/conversations/:id/events", () => {
 		scope: "general",
 		collectionId: null,
 		summaryId: null,
+		title: null,
+		createdAt: new Date("2026-01-01T00:00:00.000Z"),
+		lastActivityAt: new Date("2026-01-01T00:00:00.000Z"),
+		archivedAt: null,
 	};
 	const userMessage = JSON.stringify({ type: "user.message", text: "hi" });
 
@@ -630,6 +654,58 @@ describe("POST /v1/conversations/:id/events", () => {
 		expect(res.headers.get("content-type")).not.toContain("text/event-stream");
 	});
 
+	it("returns 409 when the conversation is archived during admission", async () => {
+		const { store } = fakeStore([existing]);
+		const runStore: RunStore = {
+			async createQueuedRun() {
+				throw new ConversationArchivedError();
+			},
+			async getRun() {
+				return null;
+			},
+			async requestCancellation() {
+				return { outcome: "not_found" };
+			},
+		};
+		const res = await buildApp(store, recordingGate(true).gate, {
+			...fakeRunStore(),
+			runStore,
+		}).request("/v1/conversations/conv-1/events", {
+			method: "POST",
+			headers: identityHeaders,
+			body: userMessage,
+		});
+
+		expect(res.status).toBe(409);
+		expect(await res.json()).toEqual({ error: "Conversation is archived" });
+	});
+
+	it("returns 404 when the conversation is deleted during admission", async () => {
+		const { store } = fakeStore([existing]);
+		const runStore: RunStore = {
+			async createQueuedRun() {
+				throw new ConversationNotFoundError();
+			},
+			async getRun() {
+				return null;
+			},
+			async requestCancellation() {
+				return { outcome: "not_found" };
+			},
+		};
+		const res = await buildApp(store, recordingGate(true).gate, {
+			...fakeRunStore(),
+			runStore,
+		}).request("/v1/conversations/conv-1/events", {
+			method: "POST",
+			headers: identityHeaders,
+			body: userMessage,
+		});
+
+		expect(res.status).toBe(404);
+		expect(await res.json()).toEqual({ error: "Conversation not found" });
+	});
+
 	it("returns 404 when the conversation does not exist", async () => {
 		const { store } = fakeStore();
 		const res = await buildApp(store).request(
@@ -682,6 +758,10 @@ describe("POST /v1/conversations/:id/events — user.interrupt", () => {
 		scope: "general",
 		collectionId: null,
 		summaryId: null,
+		title: null,
+		createdAt: new Date("2026-01-01T00:00:00.000Z"),
+		lastActivityAt: new Date("2026-01-01T00:00:00.000Z"),
+		archivedAt: null,
 	};
 
 	function interrupt(runId: string) {
@@ -854,6 +934,10 @@ describe("GET /v1/conversations/:id/runs/:runId/events", () => {
 		scope: "general",
 		collectionId: null,
 		summaryId: null,
+		title: null,
+		createdAt: new Date("2026-01-01T00:00:00.000Z"),
+		lastActivityAt: new Date("2026-01-01T00:00:00.000Z"),
+		archivedAt: null,
 	};
 
 	it("validates identity headers before reconnecting", async () => {
@@ -1156,6 +1240,10 @@ describe("exposure gate (MYM-46)", () => {
 		scope: "general",
 		collectionId: null,
 		summaryId: null,
+		title: null,
+		createdAt: new Date("2026-01-01T00:00:00.000Z"),
+		lastActivityAt: new Date("2026-01-01T00:00:00.000Z"),
+		archivedAt: null,
 	};
 	const userMessage = JSON.stringify({ type: "user.message", text: "hi" });
 

--- a/apps/chat-api/src/features/conversations/conversations.route.test.ts
+++ b/apps/chat-api/src/features/conversations/conversations.route.test.ts
@@ -10,8 +10,8 @@ import { runEvents, runs } from "@/db/schema";
 import { createTestDatabase } from "@/db/testing";
 import type { AppDeps } from "@/deps";
 import type {
-	ConversationCreateInput,
 	ConversationRecord,
+	ConversationRef,
 	ConversationStore,
 } from "@/features/conversation-store";
 import { PostgresConversationStore } from "@/features/conversation-store";
@@ -113,7 +113,7 @@ function buildApp(
 
 function fakeRunStore() {
 	const queued: Array<{
-		conversation: ConversationCreateInput;
+		conversation: ConversationRef;
 		message: string;
 	}> = [];
 	const eventsByRun = new Map<string, RunEventRow[]>();

--- a/apps/chat-api/src/features/conversations/conversations.route.ts
+++ b/apps/chat-api/src/features/conversations/conversations.route.ts
@@ -10,7 +10,11 @@ import {
 	reportChatLiveTextSetupSignal,
 } from "@/features/run-events/live-text-telemetry";
 import { prepareLiveTextSubscription } from "@/features/run-events/prepare-live-text-subscription";
-import { ActiveRunExistsError } from "@/features/run-store";
+import {
+	ActiveRunExistsError,
+	ConversationArchivedError,
+	ConversationNotFoundError,
+} from "@/features/run-store";
 import { HonoSSESender } from "@/features/streaming/sse-sender";
 import {
 	createConversation,
@@ -182,6 +186,12 @@ app.post(
 					},
 					409,
 				);
+			}
+			if (error instanceof ConversationArchivedError) {
+				return c.json({ error: "Conversation is archived" }, 409);
+			}
+			if (error instanceof ConversationNotFoundError) {
+				return c.json({ error: "Conversation not found" }, 404);
 			}
 			throw error;
 		}

--- a/apps/chat-api/src/features/run-events/project-run.test.ts
+++ b/apps/chat-api/src/features/run-events/project-run.test.ts
@@ -7,7 +7,7 @@ import {
 	it,
 } from "bun:test";
 import { InMemoryLiveTextTransport } from "@mymemo/live-text";
-import { runEvents, runs } from "@/db/schema";
+import { conversations, runEvents, runs } from "@/db/schema";
 import { createTestDatabase, type TestDb } from "@/db/testing";
 import { type ProjectedFrame, projectRun } from "./project-run";
 import type { RunEventReader, RunEventRow } from "./run-event-reader";
@@ -1482,6 +1482,12 @@ describe("projectRun over the real reader", () => {
 	beforeEach(async () => {
 		const { db } = tdb;
 		await db.delete(runs); // cascades run_events
+		await db.delete(conversations);
+		await db.insert(conversations).values({
+			userId: "user-1",
+			conversationId: "conv-1",
+			scope: "general",
+		});
 		await db.insert(runs).values({
 			runId: "run-1",
 			userId: "user-1",

--- a/apps/chat-api/src/features/run-events/redis-live-text.integration.test.ts
+++ b/apps/chat-api/src/features/run-events/redis-live-text.integration.test.ts
@@ -192,9 +192,6 @@ async function runWorkerThroughRedis(options: {
 			conversation: {
 				userId: "user-1",
 				conversationId: "conversation-1",
-				scope: "general",
-				collectionId: null,
-				summaryId: null,
 			},
 			message: "hello",
 		});

--- a/apps/chat-api/src/features/run-events/redis-live-text.integration.test.ts
+++ b/apps/chat-api/src/features/run-events/redis-live-text.integration.test.ts
@@ -2,7 +2,7 @@ import { expect, it } from "bun:test";
 import { createServer } from "node:net";
 import { createRedisLiveTextTransport } from "@mymemo/live-text";
 import { eq } from "drizzle-orm";
-import { runEvents, runs } from "@/db/schema";
+import { conversations, runEvents, runs } from "@/db/schema";
 import { createTestDatabase } from "@/db/testing";
 import { createQueuedRunStartedTx } from "@/features/run-store";
 import type { WorkerLogger } from "../../../../agent-worker/src/logger";
@@ -182,6 +182,11 @@ async function runWorkerThroughRedis(options: {
 	};
 
 	try {
+		await tdb.db.insert(conversations).values({
+			userId: "user-1",
+			conversationId: "conversation-1",
+			scope: "general",
+		});
 		await createQueuedRunStartedTx(tdb.db, {
 			runId: "run-1",
 			conversation: {

--- a/apps/chat-api/src/features/run-events/run-event-reader.test.ts
+++ b/apps/chat-api/src/features/run-events/run-event-reader.test.ts
@@ -7,11 +7,15 @@ import {
 	it,
 } from "bun:test";
 import type { Database } from "@/db/client";
-import { runEvents, runs } from "@/db/schema";
+import { conversations, runEvents, runs } from "@/db/schema";
 import { createTestDatabase, type TestDb } from "@/db/testing";
 import { DrizzleRunEventReader } from "./run-event-reader";
 
 async function seedRun(db: Database, runId: string, conversationId = "conv-1") {
+	await db
+		.insert(conversations)
+		.values({ userId: "user-1", conversationId, scope: "general" })
+		.onConflictDoNothing();
 	await db.insert(runs).values({
 		runId,
 		userId: "user-1",
@@ -47,6 +51,7 @@ describe("DrizzleRunEventReader", () => {
 
 	beforeEach(async () => {
 		await db.delete(runs); // cascades run_events
+		await db.delete(conversations);
 		await seedRun(db, "run-1");
 	});
 

--- a/apps/chat-api/src/features/run-events/tool-events.conformance.test.ts
+++ b/apps/chat-api/src/features/run-events/tool-events.conformance.test.ts
@@ -1,10 +1,18 @@
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+} from "bun:test";
 import {
 	isToolResultPayload,
 	isToolUsePayload,
 	type PublicToolName,
 } from "@mymemo/agent-db/run-events";
-import { runs } from "@/db/schema";
+import { conversations, runs } from "@/db/schema";
 import { createTestDatabase, type TestDb } from "@/db/testing";
 import { PostgresRunStore } from "@/features/run-store";
 import type { WorkerLogger } from "../../../../agent-worker/src/logger";
@@ -37,8 +45,17 @@ afterAll(async () => {
 	await tdb.close();
 });
 
+beforeEach(async () => {
+	await tdb.db.insert(conversations).values({
+		userId: "user-1",
+		conversationId: "conversation-1",
+		scope: "general",
+	});
+});
+
 afterEach(async () => {
 	await tdb.db.delete(runs); // cascades run_events
+	await tdb.db.delete(conversations);
 });
 
 class InstantNotifier implements RunNotifier {

--- a/apps/chat-api/src/features/run-events/tool-events.conformance.test.ts
+++ b/apps/chat-api/src/features/run-events/tool-events.conformance.test.ts
@@ -288,9 +288,6 @@ describe("durable tool-event conformance", () => {
 			conversation: {
 				userId: "user-1",
 				conversationId: "conversation-1",
-				scope: "general",
-				collectionId: null,
-				summaryId: null,
 			},
 			message: "Inspect everything",
 		});

--- a/apps/chat-api/src/features/run-store/index.ts
+++ b/apps/chat-api/src/features/run-store/index.ts
@@ -14,6 +14,8 @@ export {
 	ActiveRunConflictError,
 	ActiveRunExistsError,
 	appendRunEventTx,
+	ConversationArchivedError,
+	ConversationNotFoundError,
 	claimNextRunTx,
 	createQueuedRunStartedTx,
 	createQueuedRunTx,

--- a/apps/chat-api/src/features/run-store/postgres-run-store.test.ts
+++ b/apps/chat-api/src/features/run-store/postgres-run-store.test.ts
@@ -3,20 +3,34 @@ import { loadRunStartedTx } from "@mymemo/agent-db/run-store";
 import { eq } from "drizzle-orm";
 import { conversations, runEvents, runs } from "@/db/schema";
 import { createTestDatabase, type TestDb } from "@/db/testing";
-import type { ConversationRecord } from "@/features/conversation-store";
-import { ActiveRunExistsError, PostgresRunStore } from "./run-store";
+import {
+	type ConversationRecord,
+	PostgresConversationStore,
+} from "@/features/conversation-store";
+import {
+	ActiveRunExistsError,
+	ConversationArchivedError,
+	ConversationNotFoundError,
+	PostgresRunStore,
+} from "./run-store";
 
+const initialActivity = new Date("2026-01-01T00:00:00.000Z");
 const conversation: ConversationRecord = {
 	userId: "user-1",
 	conversationId: "conv-1",
 	scope: "collection",
 	collectionId: "col-1",
 	summaryId: null,
+	title: null,
+	createdAt: initialActivity,
+	lastActivityAt: initialActivity,
+	archivedAt: null,
 };
 
 describe("PostgresRunStore", () => {
 	let tdb: TestDb;
 	let store: PostgresRunStore;
+	let conversationStore: PostgresConversationStore;
 
 	// One PGlite instance for the whole file (spin-up is the slow part); each
 	// test starts from an empty runs table via delete, keeping isolation without
@@ -24,13 +38,25 @@ describe("PostgresRunStore", () => {
 	beforeAll(async () => {
 		tdb = await createTestDatabase();
 		store = new PostgresRunStore(tdb.db);
+		conversationStore = new PostgresConversationStore(tdb.db);
 		await tdb.db.insert(conversations).values(conversation);
 	});
 
 	afterAll(() => tdb.close());
 
 	afterEach(async () => {
-		await tdb.db.delete(runs); // cascades run_events; keeps the conversation seed
+		await tdb.db.delete(runs); // cascades run_events
+		await tdb.db
+			.insert(conversations)
+			.values(conversation)
+			.onConflictDoUpdate({
+				target: [conversations.userId, conversations.conversationId],
+				set: {
+					title: null,
+					lastActivityAt: initialActivity,
+					archivedAt: null,
+				},
+			});
 	});
 
 	it("creates one queued run and records run_started transactionally", async () => {
@@ -108,6 +134,134 @@ describe("PostgresRunStore", () => {
 		await expect(
 			store.createQueuedRun({ conversation, message: "second" }),
 		).rejects.toThrow(ActiveRunExistsError);
+	});
+
+	it("first admitted User message initializes title and advances activity atomically", async () => {
+		await store.createQueuedRun({
+			conversation,
+			message: "Summarize the quarterly plan",
+		});
+
+		await expect(
+			conversationStore.get({
+				userId: "user-1",
+				conversationId: "conv-1",
+			}),
+		).resolves.toMatchObject({
+			title: "Summarize the quarterly plan",
+		});
+		const persisted = await conversationStore.get({
+			userId: "user-1",
+			conversationId: "conv-1",
+		});
+		expect(persisted?.lastActivityAt.getTime()).toBeGreaterThan(
+			initialActivity.getTime(),
+		);
+	});
+
+	it("later admission advances activity without replacing an explicit title", async () => {
+		await conversationStore.update(
+			{ userId: "user-1", conversationId: "conv-1" },
+			{ title: "Quarterly planning" },
+		);
+
+		await store.createQueuedRun({
+			conversation,
+			message: "What changed this week?",
+		});
+
+		await expect(
+			conversationStore.get({
+				userId: "user-1",
+				conversationId: "conv-1",
+			}),
+		).resolves.toMatchObject({
+			title: "Quarterly planning",
+		});
+		const persisted = await conversationStore.get({
+			userId: "user-1",
+			conversationId: "conv-1",
+		});
+		expect(persisted?.lastActivityAt.getTime()).toBeGreaterThan(
+			initialActivity.getTime(),
+		);
+	});
+
+	it("failed admission leaves title and activity unchanged", async () => {
+		await store.createQueuedRun({ conversation, message: "first" });
+		const before = await conversationStore.get({
+			userId: "user-1",
+			conversationId: "conv-1",
+		});
+
+		await expect(
+			store.createQueuedRun({ conversation, message: "must not commit" }),
+		).rejects.toBeInstanceOf(ActiveRunExistsError);
+
+		const after = await conversationStore.get({
+			userId: "user-1",
+			conversationId: "conv-1",
+		});
+		expect(after?.title).toBe(before?.title);
+		expect(after?.lastActivityAt).toEqual(before?.lastActivityAt);
+	});
+
+	it("serializes Archive before admission and rejects the new Run", async () => {
+		await expect(
+			conversationStore.update(
+				{ userId: "user-1", conversationId: "conv-1" },
+				{ archived: true },
+			),
+		).resolves.toMatchObject({ outcome: "updated" });
+
+		await expect(
+			store.createQueuedRun({ conversation, message: "too late" }),
+		).rejects.toBeInstanceOf(ConversationArchivedError);
+		expect(await tdb.db.select().from(runs)).toHaveLength(0);
+	});
+
+	it("serializes admission before Archive and rejects the lifecycle change", async () => {
+		await store.createQueuedRun({ conversation, message: "admitted first" });
+
+		await expect(
+			conversationStore.update(
+				{ userId: "user-1", conversationId: "conv-1" },
+				{ archived: true },
+			),
+		).resolves.toEqual({ outcome: "active_run" });
+	});
+
+	it("serializes permanent deletion racing admission", async () => {
+		const deletion = conversationStore.deletePermanently({
+			userId: "user-1",
+			conversationId: "conv-1",
+		});
+		const admission = store.createQueuedRun({
+			conversation,
+			message: "racing deletion",
+		});
+
+		const [deletionResult, admissionResult] = await Promise.allSettled([
+			deletion,
+			admission,
+		]);
+		expect(deletionResult.status).toBe("fulfilled");
+		if (deletionResult.status !== "fulfilled") return;
+
+		if (deletionResult.value.outcome === "deleted") {
+			expect(admissionResult.status).toBe("rejected");
+			if (admissionResult.status === "rejected") {
+				expect(admissionResult.reason).toBeInstanceOf(
+					ConversationNotFoundError,
+				);
+			}
+			expect(await tdb.db.select().from(runs)).toHaveLength(0);
+			return;
+		}
+
+		expect(deletionResult.value).toEqual({ outcome: "active_run" });
+		expect(admissionResult.status).toBe("fulfilled");
+		expect(await tdb.db.select().from(runs)).toHaveLength(1);
 	});
 
 	it("lists replay events after a sequence number", async () => {

--- a/apps/chat-api/src/features/run-store/run-store.ts
+++ b/apps/chat-api/src/features/run-store/run-store.ts
@@ -9,7 +9,7 @@ import {
 import { and, eq, gt, sql } from "drizzle-orm";
 import type { Database } from "@/db/client";
 import { conversations, runEvents, runs } from "@/db/schema";
-import type { ConversationCreateInput } from "@/features/conversation-store";
+import type { ConversationRef } from "@/features/conversation-store";
 import { RunEventType } from "@/features/run-events";
 
 /**
@@ -68,7 +68,7 @@ export class ConversationNotFoundError extends Error {
 }
 
 export interface CreateQueuedRunInput {
-	conversation: ConversationCreateInput;
+	conversation: ConversationRef;
 	message: string;
 	/** A Live subscription may be prepared for this id before admission. */
 	runId?: string;

--- a/apps/chat-api/src/features/run-store/run-store.ts
+++ b/apps/chat-api/src/features/run-store/run-store.ts
@@ -6,10 +6,10 @@ import {
 	requestRunCancellationTx,
 	toRunRecord,
 } from "@mymemo/agent-db/run-store";
-import { and, eq, gt } from "drizzle-orm";
+import { and, eq, gt, sql } from "drizzle-orm";
 import type { Database } from "@/db/client";
-import { runEvents, runs } from "@/db/schema";
-import type { ConversationRecord } from "@/features/conversation-store";
+import { conversations, runEvents, runs } from "@/db/schema";
+import type { ConversationCreateInput } from "@/features/conversation-store";
 import { RunEventType } from "@/features/run-events";
 
 /**
@@ -57,8 +57,18 @@ export class ActiveRunExistsError extends ActiveRunConflictError {
 	}
 }
 
+/** Admission lost a lifecycle race with Archive. */
+export class ConversationArchivedError extends Error {
+	override name = "ConversationArchivedError" as const;
+}
+
+/** Admission lost a lifecycle race with Permanent deletion. */
+export class ConversationNotFoundError extends Error {
+	override name = "ConversationNotFoundError" as const;
+}
+
 export interface CreateQueuedRunInput {
-	conversation: ConversationRecord;
+	conversation: ConversationCreateInput;
 	message: string;
 	/** A Live subscription may be prepared for this id before admission. */
 	runId?: string;
@@ -106,6 +116,27 @@ export async function createQueuedRunStartedTx(
 	const { conversation, message, runId } = input;
 	try {
 		return await db.transaction(async (tx) => {
+			const [lockedConversation] = await tx
+				.select()
+				.from(conversations)
+				.where(
+					and(
+						eq(conversations.userId, conversation.userId),
+						eq(conversations.conversationId, conversation.conversationId),
+					),
+				)
+				.for("update");
+			if (!lockedConversation) {
+				throw new ConversationNotFoundError(
+					`Conversation ${conversation.conversationId} does not exist`,
+				);
+			}
+			if (lockedConversation.archivedAt !== null) {
+				throw new ConversationArchivedError(
+					`Conversation ${conversation.conversationId} is archived`,
+				);
+			}
+
 			const [row] = await tx
 				.insert(runs)
 				.values({
@@ -122,15 +153,27 @@ export async function createQueuedRunStartedTx(
 				seq: 1,
 				type: RunEventType.Started,
 				payload: {
-					userId: conversation.userId,
-					conversationId: conversation.conversationId,
+					userId: lockedConversation.userId,
+					conversationId: lockedConversation.conversationId,
 					runId,
 					message,
-					scope: conversation.scope,
-					collectionId: conversation.collectionId,
-					summaryId: conversation.summaryId,
+					scope: lockedConversation.scope,
+					collectionId: lockedConversation.collectionId,
+					summaryId: lockedConversation.summaryId,
 				},
 			});
+			await tx
+				.update(conversations)
+				.set({
+					title: sql`coalesce(${conversations.title}, ${message})`,
+					lastActivityAt: sql`now()`,
+				})
+				.where(
+					and(
+						eq(conversations.userId, lockedConversation.userId),
+						eq(conversations.conversationId, lockedConversation.conversationId),
+					),
+				);
 			return toRunRecord(row);
 		});
 	} catch (error) {

--- a/packages/agent-db/drizzle/0008_careless_proteus.sql
+++ b/packages/agent-db/drizzle/0008_careless_proteus.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "conversations" ADD COLUMN "title" text;--> statement-breakpoint
+ALTER TABLE "conversations" ADD COLUMN "last_activity_at" timestamp with time zone DEFAULT now() NOT NULL;--> statement-breakpoint
+ALTER TABLE "conversations" ADD COLUMN "archived_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "runs" ADD CONSTRAINT "runs_conversation_fk" FOREIGN KEY ("user_id","conversation_id") REFERENCES "public"."conversations"("user_id","conversation_id") ON DELETE cascade ON UPDATE no action;

--- a/packages/agent-db/drizzle/0009_backfill_conversation_activity.sql
+++ b/packages/agent-db/drizzle/0009_backfill_conversation_activity.sql
@@ -1,0 +1,10 @@
+UPDATE "conversations" AS "conversation"
+SET "last_activity_at" = COALESCE(
+	(
+		SELECT MAX("run"."created_at")
+		FROM "runs" AS "run"
+		WHERE "run"."user_id" = "conversation"."user_id"
+			AND "run"."conversation_id" = "conversation"."conversation_id"
+	),
+	"conversation"."created_at"
+);

--- a/packages/agent-db/drizzle/meta/0008_snapshot.json
+++ b/packages/agent-db/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,957 @@
+{
+  "id": "59964bce-0417-4356-9858-ba504637447c",
+  "prevId": "117a0c61-f71d-44b2-8ec2-6e1eb3dfd4aa",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_sessions": {
+      "name": "agent_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subpath": {
+          "name": "subpath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry": {
+          "name": "entry",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_sessions_dedup_idx": {
+          "name": "agent_sessions_dedup_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subpath",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_sessions_transcript_idx": {
+          "name": "agent_sessions_transcript_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subpath",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_sessions_conversation_idx": {
+          "name": "agent_sessions_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artifact_objects": {
+      "name": "artifact_objects",
+      "schema": "",
+      "columns": {
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "artifact_objects_run_idx": {
+          "name": "artifact_objects_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifact_objects_status_idx": {
+          "name": "artifact_objects_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "artifact_objects_status_check": {
+          "name": "artifact_objects_status_check",
+          "value": "\"artifact_objects\".\"status\" in ('pending', 'current', 'superseded')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversation_artifacts": {
+      "name": "conversation_artifacts",
+      "schema": "",
+      "columns": {
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_artifacts_owner_conversation_path_idx": {
+          "name": "conversation_artifacts_owner_conversation_path_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_artifacts_conversation_fk": {
+          "name": "conversation_artifacts_conversation_fk",
+          "tableFrom": "conversation_artifacts",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "user_id",
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "user_id",
+            "conversation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "conversation_artifacts_size_bytes_check": {
+          "name": "conversation_artifacts_size_bytes_check",
+          "value": "\"conversation_artifacts\".\"size_bytes\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversation_runtime": {
+      "name": "conversation_runtime",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_tainted": {
+          "name": "sandbox_tainted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "conversation_runtime_user_id_conversation_id_pk": {
+          "name": "conversation_runtime_user_id_conversation_id_pk",
+          "columns": [
+            "user_id",
+            "conversation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_id": {
+          "name": "summary_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "conversations_user_id_conversation_id_pk": {
+          "name": "conversations_user_id_conversation_id_pk",
+          "columns": [
+            "user_id",
+            "conversation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "conversations_scope_check": {
+          "name": "conversations_scope_check",
+          "value": "\"conversations\".\"scope\" in ('general', 'collection', 'document')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.document_access_events": {
+      "name": "document_access_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_ids": {
+          "name": "document_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_count": {
+          "name": "result_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_access_events_run_id_idx": {
+          "name": "document_access_events_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_access_events_created_at_idx": {
+          "name": "document_access_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "document_access_events_operation_check": {
+          "name": "document_access_events_operation_check",
+          "value": "\"document_access_events\".\"operation\" in ('search', 'list', 'load')"
+        },
+        "document_access_events_scope_type_check": {
+          "name": "document_access_events_scope_type_check",
+          "value": "\"document_access_events\".\"scope_type\" in ('general', 'collection', 'document')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.orphan_sandboxes": {
+      "name": "orphan_sandboxes",
+      "schema": "",
+      "columns": {
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_worker_id": {
+          "name": "created_by_worker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_events": {
+      "name": "run_events",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "run_events_run_id_runs_run_id_fk": {
+          "name": "run_events_run_id_runs_run_id_fk",
+          "tableFrom": "run_events",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "run_events_run_id_seq_pk": {
+          "name": "run_events_run_id_seq_pk",
+          "columns": [
+            "run_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runs": {
+      "name": "runs",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locked_by": {
+          "name": "locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_event_seq": {
+          "name": "next_event_seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "runs_one_active_per_conversation": {
+          "name": "runs_one_active_per_conversation",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"runs\".\"status\" in ('queued', 'running', 'cancel_requested')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_queue_claim_idx": {
+          "name": "runs_queue_claim_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runs\".\"status\" = 'queued'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_stale_recovery_idx": {
+          "name": "runs_stale_recovery_idx",
+          "columns": [
+            {
+              "expression": "locked_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runs\".\"status\" in ('running', 'cancel_requested')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_cleanup_idx": {
+          "name": "runs_cleanup_idx",
+          "columns": [
+            {
+              "expression": "terminal_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runs\".\"status\" in ('done', 'error', 'canceled')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runs_conversation_fk": {
+          "name": "runs_conversation_fk",
+          "tableFrom": "runs",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "user_id",
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "user_id",
+            "conversation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runs_status_check": {
+          "name": "runs_status_check",
+          "value": "\"runs\".\"status\" in ('queued', 'running', 'cancel_requested', 'done', 'error', 'canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/agent-db/drizzle/meta/0009_snapshot.json
+++ b/packages/agent-db/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,957 @@
+{
+  "id": "60ba86e6-7a9e-43d5-a245-52562419509c",
+  "prevId": "59964bce-0417-4356-9858-ba504637447c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_sessions": {
+      "name": "agent_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subpath": {
+          "name": "subpath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry": {
+          "name": "entry",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_sessions_dedup_idx": {
+          "name": "agent_sessions_dedup_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subpath",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "agent_sessions_transcript_idx": {
+          "name": "agent_sessions_transcript_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subpath",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "agent_sessions_conversation_idx": {
+          "name": "agent_sessions_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artifact_objects": {
+      "name": "artifact_objects",
+      "schema": "",
+      "columns": {
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "artifact_objects_run_idx": {
+          "name": "artifact_objects_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "artifact_objects_status_idx": {
+          "name": "artifact_objects_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "artifact_objects_status_check": {
+          "name": "artifact_objects_status_check",
+          "value": "\"artifact_objects\".\"status\" in ('pending', 'current', 'superseded')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversation_artifacts": {
+      "name": "conversation_artifacts",
+      "schema": "",
+      "columns": {
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_artifacts_owner_conversation_path_idx": {
+          "name": "conversation_artifacts_owner_conversation_path_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "conversation_artifacts_conversation_fk": {
+          "name": "conversation_artifacts_conversation_fk",
+          "tableFrom": "conversation_artifacts",
+          "columnsFrom": [
+            "user_id",
+            "conversation_id"
+          ],
+          "tableTo": "conversations",
+          "columnsTo": [
+            "user_id",
+            "conversation_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "conversation_artifacts_size_bytes_check": {
+          "name": "conversation_artifacts_size_bytes_check",
+          "value": "\"conversation_artifacts\".\"size_bytes\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversation_runtime": {
+      "name": "conversation_runtime",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_tainted": {
+          "name": "sandbox_tainted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "conversation_runtime_user_id_conversation_id_pk": {
+          "name": "conversation_runtime_user_id_conversation_id_pk",
+          "columns": [
+            "user_id",
+            "conversation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_id": {
+          "name": "summary_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "conversations_user_id_conversation_id_pk": {
+          "name": "conversations_user_id_conversation_id_pk",
+          "columns": [
+            "user_id",
+            "conversation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "conversations_scope_check": {
+          "name": "conversations_scope_check",
+          "value": "\"conversations\".\"scope\" in ('general', 'collection', 'document')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.document_access_events": {
+      "name": "document_access_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_ids": {
+          "name": "document_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_count": {
+          "name": "result_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_access_events_run_id_idx": {
+          "name": "document_access_events_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "document_access_events_created_at_idx": {
+          "name": "document_access_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "document_access_events_operation_check": {
+          "name": "document_access_events_operation_check",
+          "value": "\"document_access_events\".\"operation\" in ('search', 'list', 'load')"
+        },
+        "document_access_events_scope_type_check": {
+          "name": "document_access_events_scope_type_check",
+          "value": "\"document_access_events\".\"scope_type\" in ('general', 'collection', 'document')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.orphan_sandboxes": {
+      "name": "orphan_sandboxes",
+      "schema": "",
+      "columns": {
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_worker_id": {
+          "name": "created_by_worker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_events": {
+      "name": "run_events",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "run_events_run_id_runs_run_id_fk": {
+          "name": "run_events_run_id_runs_run_id_fk",
+          "tableFrom": "run_events",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "tableTo": "runs",
+          "columnsTo": [
+            "run_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "run_events_run_id_seq_pk": {
+          "name": "run_events_run_id_seq_pk",
+          "columns": [
+            "run_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runs": {
+      "name": "runs",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locked_by": {
+          "name": "locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_event_seq": {
+          "name": "next_event_seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "runs_one_active_per_conversation": {
+          "name": "runs_one_active_per_conversation",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"runs\".\"status\" in ('queued', 'running', 'cancel_requested')",
+          "concurrently": false
+        },
+        "runs_queue_claim_idx": {
+          "name": "runs_queue_claim_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"runs\".\"status\" = 'queued'",
+          "concurrently": false
+        },
+        "runs_stale_recovery_idx": {
+          "name": "runs_stale_recovery_idx",
+          "columns": [
+            {
+              "expression": "locked_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"runs\".\"status\" in ('running', 'cancel_requested')",
+          "concurrently": false
+        },
+        "runs_cleanup_idx": {
+          "name": "runs_cleanup_idx",
+          "columns": [
+            {
+              "expression": "terminal_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"runs\".\"status\" in ('done', 'error', 'canceled')",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "runs_conversation_fk": {
+          "name": "runs_conversation_fk",
+          "tableFrom": "runs",
+          "columnsFrom": [
+            "user_id",
+            "conversation_id"
+          ],
+          "tableTo": "conversations",
+          "columnsTo": [
+            "user_id",
+            "conversation_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runs_status_check": {
+          "name": "runs_status_check",
+          "value": "\"runs\".\"status\" in ('queued', 'running', 'cancel_requested', 'done', 'error', 'canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/agent-db/drizzle/meta/_journal.json
+++ b/packages/agent-db/drizzle/meta/_journal.json
@@ -57,6 +57,20 @@
       "when": 1784434534000,
       "tag": "0007_run_queued_doorbell",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1784539569565,
+      "tag": "0008_careless_proteus",
+      "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1784539585807,
+      "tag": "0009_backfill_conversation_activity",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/agent-db/src/conversation-lifecycle-migration.test.ts
+++ b/packages/agent-db/src/conversation-lifecycle-migration.test.ts
@@ -1,0 +1,90 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { PGlite } from "@electric-sql/pglite";
+import { MIGRATIONS_DIR } from "./migrations";
+
+let db: PGlite;
+
+beforeAll(async () => {
+	db = new PGlite();
+	await db.waitReady;
+	await db.exec(`
+		CREATE TABLE conversations (
+			user_id text NOT NULL,
+			conversation_id text NOT NULL,
+			scope text NOT NULL,
+			collection_id text,
+			summary_id text,
+			created_at timestamptz NOT NULL,
+			PRIMARY KEY (user_id, conversation_id)
+		);
+		CREATE TABLE runs (
+			run_id text PRIMARY KEY,
+			user_id text NOT NULL,
+			conversation_id text NOT NULL,
+			created_at timestamptz NOT NULL
+		);
+		INSERT INTO conversations
+			(user_id, conversation_id, scope, created_at)
+		VALUES
+			('user-1', 'with-run', 'general', '2026-01-01T00:00:00Z'),
+			('user-1', 'empty', 'general', '2026-01-03T00:00:00Z');
+		INSERT INTO runs (run_id, user_id, conversation_id, created_at)
+		VALUES ('run-1', 'user-1', 'with-run', '2026-01-02T00:00:00Z');
+	`);
+
+	for (const file of [
+		"0008_careless_proteus.sql",
+		"0009_backfill_conversation_activity.sql",
+	]) {
+		const migration = await readFile(join(MIGRATIONS_DIR, file), "utf8");
+		for (const statement of migration.split("--> statement-breakpoint")) {
+			if (statement.trim()) await db.exec(statement);
+		}
+	}
+});
+
+afterAll(async () => {
+	await db.close();
+});
+
+describe("Conversation lifecycle migration", () => {
+	it("preserves existing records, backfills activity, and cascades future deletion", async () => {
+		const result = await db.query<{
+			conversation_id: string;
+			title: string | null;
+			last_activity_at: Date;
+			archived_at: Date | null;
+		}>(`
+			SELECT conversation_id, title, last_activity_at, archived_at
+			FROM conversations
+			ORDER BY conversation_id
+		`);
+		expect(
+			result.rows.map((row) => ({
+				...row,
+				last_activity_at: row.last_activity_at.toISOString(),
+			})),
+		).toEqual([
+			{
+				conversation_id: "empty",
+				title: null,
+				last_activity_at: "2026-01-03T00:00:00.000Z",
+				archived_at: null,
+			},
+			{
+				conversation_id: "with-run",
+				title: null,
+				last_activity_at: "2026-01-02T00:00:00.000Z",
+				archived_at: null,
+			},
+		]);
+		expect((await db.query("SELECT run_id FROM runs")).rows).toHaveLength(1);
+
+		await db.exec(
+			"DELETE FROM conversations WHERE user_id = 'user-1' AND conversation_id = 'with-run'",
+		);
+		expect((await db.query("SELECT run_id FROM runs")).rows).toHaveLength(0);
+	});
+});

--- a/packages/agent-db/src/queue-metrics.test.ts
+++ b/packages/agent-db/src/queue-metrics.test.ts
@@ -9,7 +9,7 @@ import {
 import { eq, sql } from "drizzle-orm";
 import { readRunQueueMetrics } from "./queue-metrics";
 import { claimNextRunTx, createQueuedRunTx } from "./run-store";
-import { runs } from "./schema";
+import { conversations, runs } from "./schema";
 import { createTestDatabase, type TestDb } from "./testing";
 
 let tdb: TestDb;
@@ -24,9 +24,14 @@ afterAll(async () => {
 
 beforeEach(async () => {
 	await tdb.db.delete(runs);
+	await tdb.db.delete(conversations);
 });
 
 async function queueRun(runId: string, conversationId: string) {
+	await tdb.db
+		.insert(conversations)
+		.values({ userId: "user-1", conversationId, scope: "general" })
+		.onConflictDoNothing();
 	return await createQueuedRunTx(tdb.db, {
 		runId,
 		userId: "user-1",

--- a/packages/agent-db/src/run-store.test.ts
+++ b/packages/agent-db/src/run-store.test.ts
@@ -20,7 +20,7 @@ import {
 	requestRunCancellationTx,
 	transitionRunTerminalTx,
 } from "./run-store";
-import { runEvents, runs } from "./schema";
+import { conversations, runEvents, runs } from "./schema";
 import { createTestDatabase, type TestDb } from "./testing";
 
 let tdb: TestDb;
@@ -38,6 +38,19 @@ afterAll(async () => {
 
 beforeEach(async () => {
 	await tdb.db.delete(runs); // cascades run_events
+	await tdb.db.delete(conversations);
+	await tdb.db.insert(conversations).values([
+		{
+			userId: "user-1",
+			conversationId: "conv-1",
+			scope: "general",
+		},
+		{
+			userId: "user-1",
+			conversationId: "conv-2",
+			scope: "general",
+		},
+	]);
 });
 
 describe("createQueuedRunTx", () => {

--- a/packages/agent-db/src/runtime-store.test.ts
+++ b/packages/agent-db/src/runtime-store.test.ts
@@ -22,7 +22,12 @@ import {
 	recordOrphanSandboxTx,
 	updateRuntimeSandboxTx,
 } from "./runtime-store";
-import { conversationRuntime, orphanSandboxes, runs } from "./schema";
+import {
+	conversationRuntime,
+	conversations,
+	orphanSandboxes,
+	runs,
+} from "./schema";
 import { createTestDatabase, type TestDb } from "./testing";
 
 let tdb: TestDb;
@@ -42,6 +47,12 @@ beforeEach(async () => {
 	await tdb.db.delete(runs); // cascades run_events
 	await tdb.db.delete(conversationRuntime);
 	await tdb.db.delete(orphanSandboxes);
+	await tdb.db.delete(conversations);
+	await tdb.db.insert(conversations).values({
+		userId: "user-1",
+		conversationId: "conv-1",
+		scope: "general",
+	});
 });
 
 async function tableExists(name: string): Promise<boolean> {

--- a/packages/agent-db/src/schema.ts
+++ b/packages/agent-db/src/schema.ts
@@ -110,9 +110,17 @@ export const conversations = pgTable(
 		collectionId: text("collection_id"),
 		/** Non-null only for document scope. */
 		summaryId: text("summary_id"),
+		/** User-visible label, initialized by the first admitted User message. */
+		title: text("title"),
 		createdAt: timestamp("created_at", { withTimezone: true })
 			.notNull()
 			.defaultNow(),
+		/** Creation, or the most recent successfully admitted User message. */
+		lastActivityAt: timestamp("last_activity_at", { withTimezone: true })
+			.notNull()
+			.defaultNow(),
+		/** Non-null while the Conversation is archived. */
+		archivedAt: timestamp("archived_at", { withTimezone: true }),
 	},
 	(t) => [
 		primaryKey({ columns: [t.userId, t.conversationId] }),
@@ -239,6 +247,11 @@ export const runs = pgTable(
 			"runs_status_check",
 			sql`${t.status} in ('queued', 'running', 'cancel_requested', 'done', 'error', 'canceled')`,
 		),
+		foreignKey({
+			columns: [t.userId, t.conversationId],
+			foreignColumns: [conversations.userId, conversations.conversationId],
+			name: "runs_conversation_fk",
+		}).onDelete("cascade"),
 		uniqueIndex("runs_one_active_per_conversation")
 			.on(t.userId, t.conversationId)
 			.where(sql`${t.status} in ('queued', 'running', 'cancel_requested')`),


### PR DESCRIPTION
## Summary

- add nullable/generated Conversation titles, last-activity timestamps, and archive state with migration backfill
- serialize Run admission, archive/unarchive, and permanent deletion through the Conversation row lock
- initialize title and activity atomically on first admission while preserving explicit titles on later turns
- cascade durable Run history on permanent deletion while leaving external cleanup state recoverable
- preserve the legacy events route with explicit archived/deleted admission conflict responses

## Impact

Conversation persistence now supports the lifecycle invariants required by the full agent surface while existing production routes remain usable. Archived Conversations reject new Runs, lifecycle mutations reject active Runs, and permanent deletion cannot race a successful admission.

## Validation

- `E2B_API_KEY= bun test`
- `bunx tsc --noEmit -p tsconfig.json` in chat-api, agent-worker, and agent-db
- focused PGlite migration, lifecycle, cascade, rollback, and concurrency tests

Closes #332