### PR TITLE
feat(live-text): add bounded per-run stream store

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -91,6 +91,8 @@
       "name": "@mymemo/live-text",
       "version": "0.1.0",
       "dependencies": {
+        "@ag-ui/core": "^0.0.57",
+        "assistant-stream": "^0.3.26",
         "redis": "^5.12.1",
         "zod": "^4.1.12",
       },
@@ -101,6 +103,8 @@
     },
   },
   "packages": {
+    "@ag-ui/core": ["@ag-ui/core@0.0.57", "", { "dependencies": { "zod": "^3.22.4" } }, "sha512-gho1OWjNE6E3Rl7ZEZ1wr2CEpUHjLFU0FqzCZZk439TicLu+BfLCMkMokB07bMGlRmbJ60hM6LW60iOVauCx+Q=="],
+
     "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.117", "", { "dependencies": { "@anthropic-ai/sdk": "^0.81.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.117", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.117", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.117", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.117", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.117", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.117", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.117", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.117" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-pVBss1Vu0w87nKCBhWtjMggSgCh6GVUtdRmuE58ZvXv0E2q0JcnUCQHehmn92BAW0+VCwPY8q/k7uKWkgwz/gA=="],
 
     "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.117", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ZeC/Lz8XMKQ5w+GmjTziPR8bSSarBtNCJMkMAYRT9ekNmyXSWXEwGLENe5TDDmtpzNNzAB1mQNuIYoqTsqgV3w=="],
@@ -353,6 +357,8 @@
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
+    "assistant-stream": ["assistant-stream@0.3.26", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "nanoid": "^6.0.0", "secure-json-parse": "^4.1.0" }, "peerDependencies": { "ioredis": "^5.10.1", "redis": "^5.12.1" }, "optionalPeers": ["ioredis", "redis"] }, "sha512-qjYrK9c5Mpuz3U6oG6YDpBbiICANhNTN86MLNcI47iRYXalqvCZL2Tzmh9pQcGWDX3PltSJtGIFAIHdRDXIg+A=="],
+
     "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
@@ -521,7 +527,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@5.1.7", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ=="],
+    "nanoid": ["nanoid@6.0.0", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-mkUH+rPkwU2qPadJ0oJZOjeZ5Mxn8Q1UhevwkTRWNuUZzyia3h4rhzK39hxaHTk0o2OxB8W2SQ6A8k23ZDi1pQ=="],
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
@@ -615,6 +621,8 @@
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
+    "secure-json-parse": ["secure-json-parse@4.1.0", "", {}, "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA=="],
+
     "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
 
     "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
@@ -697,6 +705,8 @@
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
+    "@ag-ui/core/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
     "@aws-sdk/client-ecs/@aws-sdk/core": ["@aws-sdk/core@3.974.27", "", { "dependencies": { "@aws-sdk/types": "^3.973.15", "@aws-sdk/xml-builder": "^3.972.33", "@aws/lambda-invoke-store": "^0.3.0", "@smithy/core": "^3.29.0", "@smithy/signature-v4": "^5.6.1", "@smithy/types": "^4.15.1", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-WRWEgIq6vx+NU6ot3VrRu4Jovj9MIObitSi6of/GV5THDDPccBhivCRNkWJutMM+m3GvdeI3l/UbGNcoOobxOA=="],
 
     "@aws-sdk/client-ecs/@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.62", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.53", "@aws-sdk/credential-provider-http": "^3.972.55", "@aws-sdk/credential-provider-ini": "^3.972.60", "@aws-sdk/credential-provider-process": "^3.972.53", "@aws-sdk/credential-provider-sso": "^3.972.59", "@aws-sdk/credential-provider-web-identity": "^3.972.59", "@aws-sdk/types": "^3.973.15", "@smithy/core": "^3.29.0", "@smithy/credential-provider-imds": "^4.4.5", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-S6Slq3Tx7bvFk5yc34XNADyZYTX2HUXvaFAnowGRQnhjBO8J/mP62Fn7lxvJwjaDyYm/7gh9h6HEHaltRyMFXw=="],
@@ -716,6 +726,8 @@
     "@mymemo/agent-db/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
     "@mymemo/live-text/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+
+    "@scalar/types/nanoid": ["nanoid@5.1.7", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ=="],
 
     "agent-worker/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 

--- a/packages/live-text/package.json
+++ b/packages/live-text/package.json
@@ -10,6 +10,8 @@
 		"check": "biome check --write"
 	},
 	"dependencies": {
+		"@ag-ui/core": "^0.0.57",
+		"assistant-stream": "^0.3.26",
 		"redis": "^5.12.1",
 		"zod": "^4.1.12"
 	},

--- a/packages/live-text/src/index.ts
+++ b/packages/live-text/src/index.ts
@@ -2,6 +2,7 @@ import { createClient } from "redis";
 import { z } from "zod";
 import type { LiveTextTelemetry } from "./telemetry";
 
+export * from "./redis-live-stream-store";
 export * from "./telemetry";
 
 export const LIVE_TEXT_MAX_CHUNK_LENGTH = 16_384;

--- a/packages/live-text/src/redis-live-stream-store.contract.test.ts
+++ b/packages/live-text/src/redis-live-stream-store.contract.test.ts
@@ -1,0 +1,525 @@
+import { expect, it } from "bun:test";
+import { createServer } from "node:net";
+import {
+	EventSchemas,
+	EventType,
+	type TextMessageContentEvent,
+} from "@ag-ui/core";
+import type { ResumableStreamEntry } from "assistant-stream/resumable";
+import { createClient } from "redis";
+import {
+	createRedisLiveStreamStore,
+	encodeAgUiLiveStreamEvent,
+	LIVE_STREAM_MAX_BYTES,
+	LIVE_STREAM_MAX_EVENT_BYTES,
+	LIVE_STREAM_MAX_EVENTS,
+	LIVE_STREAM_RETENTION_MS,
+	LIVE_STREAM_TEXT_EVENT_TARGET_BYTES,
+	type LiveStreamStore,
+} from "./index";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+async function waitUntil(
+	condition: () => boolean | Promise<boolean>,
+	timeoutMs = 3_000,
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (!(await condition())) {
+		if (Date.now() >= deadline) throw new Error("condition timed out");
+		await Bun.sleep(20);
+	}
+}
+
+async function freePort(): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const server = createServer();
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			const address = server.address();
+			if (!address || typeof address === "string") {
+				server.close();
+				reject(new Error("failed to allocate Redis test port"));
+				return;
+			}
+			server.close((error) => (error ? reject(error) : resolve(address.port)));
+		});
+	});
+}
+
+type RedisProcess = ReturnType<typeof Bun.spawn>;
+
+async function startRedis(
+	port: number,
+	password?: string,
+): Promise<RedisProcess> {
+	const serverArguments = [
+		"redis-server",
+		"--bind",
+		"127.0.0.1",
+		"--port",
+		String(port),
+		"--save",
+		"",
+		"--appendonly",
+		"no",
+	];
+	if (password) serverArguments.push("--requirepass", password);
+	const process = Bun.spawn(serverArguments, {
+		stdout: "ignore",
+		stderr: "ignore",
+	});
+	await waitUntil(async () => {
+		const pingArguments = ["redis-cli", "-h", "127.0.0.1", "-p", String(port)];
+		if (password) pingArguments.push("-a", password);
+		pingArguments.push("ping");
+		const ping = Bun.spawn(pingArguments, { stdout: "pipe", stderr: "ignore" });
+		return (await ping.exited) === 0;
+	});
+	return process;
+}
+
+async function stopRedis(process: RedisProcess): Promise<void> {
+	process.kill("SIGTERM");
+	await process.exited;
+}
+
+async function collect(
+	store: LiveStreamStore,
+	streamId: string,
+	cursor = "",
+): Promise<ResumableStreamEntry[]> {
+	const entries: ResumableStreamEntry[] = [];
+	for await (const entry of store.read(
+		streamId,
+		cursor,
+		new AbortController().signal,
+	)) {
+		entries.push(entry);
+	}
+	return entries;
+}
+
+it("elects exactly one producer when workers race for a Run", async () => {
+	const port = await freePort();
+	const redis = await startRedis(port);
+	const stores = Array.from({ length: 8 }, () =>
+		createRedisLiveStreamStore({
+			url: `redis://127.0.0.1:${port}`,
+			deployment: "test",
+		}),
+	);
+	const event = encoder.encode(
+		JSON.stringify({
+			type: EventType.TEXT_MESSAGE_CONTENT,
+			messageId: "message-1",
+			delta: "producer only",
+		}),
+	);
+	try {
+		const roles = await Promise.all(
+			stores.map((store) => store.acquire("run-1")),
+		);
+		expect(roles.filter((role) => role === "producer")).toHaveLength(1);
+		expect(roles.filter((role) => role === "consumer")).toHaveLength(7);
+		const consumerIndex = roles.indexOf("consumer");
+		const consumer = stores[consumerIndex];
+		if (!consumer) throw new Error("expected a consumer store");
+		await expect(consumer.append("run-1", event)).rejects.toMatchObject({
+			code: "not_producer",
+		});
+	} finally {
+		await Promise.all(stores.map((store) => store.close()));
+		await stopRedis(redis);
+	}
+}, 10_000);
+
+it("replays complete AG-UI events from zero and strictly after a Redis cursor", async () => {
+	const port = await freePort();
+	const redis = await startRedis(port);
+	const store = createRedisLiveStreamStore({
+		url: `redis://127.0.0.1:${port}`,
+		deployment: "test",
+	});
+	const events: TextMessageContentEvent[] = [
+		{
+			type: EventType.TEXT_MESSAGE_CONTENT,
+			messageId: "message-1",
+			delta: "hello ",
+		},
+		{
+			type: EventType.TEXT_MESSAGE_CONTENT,
+			messageId: "message-1",
+			delta: "world",
+		},
+	];
+	try {
+		expect(await store.acquire("run-1")).toBe("producer");
+		for (const event of events) {
+			await store.append("run-1", encoder.encode(JSON.stringify(event)));
+		}
+		await store.finalize("run-1", "done");
+		await store.finalize("run-1", "done");
+
+		const replay = await collect(store, "run-1");
+		expect(
+			replay.map(({ chunk }) => JSON.parse(decoder.decode(chunk))),
+		).toEqual(events);
+		expect(replay.map(({ cursor }) => cursor)).toEqual([
+			expect.stringMatching(/^\d+-\d+$/),
+			expect.stringMatching(/^\d+-\d+$/),
+		]);
+		const [first, second] = replay;
+		if (!first || !second) throw new Error("expected two replay entries");
+		expect(await collect(store, "run-1", first.cursor)).toEqual([second]);
+		expect(await store.status("run-1")).toBe("done");
+	} finally {
+		await store.close();
+		await stopRedis(redis);
+	}
+}, 10_000);
+
+it("does not lose the terminal event when append and finalization race a reader", async () => {
+	const port = await freePort();
+	const redis = await startRedis(port);
+	const store = createRedisLiveStreamStore({
+		url: `redis://127.0.0.1:${port}`,
+		deployment: "test",
+	});
+	const terminalEvent = {
+		type: EventType.RUN_FINISHED,
+		threadId: "conversation-1",
+		runId: "run-1",
+	};
+	try {
+		await store.acquire("run-1");
+		const replayPromise = collect(store, "run-1");
+		await Bun.sleep(20);
+		await store.append("run-1", encoder.encode(JSON.stringify(terminalEvent)));
+		await store.finalize("run-1", "done");
+
+		const replay = await replayPromise;
+		expect(replay).toHaveLength(1);
+		expect(JSON.parse(decoder.decode(replay[0]?.chunk))).toEqual(terminalEvent);
+	} finally {
+		await store.close();
+		await stopRedis(redis);
+	}
+}, 10_000);
+
+it("terminates an active reader when its Stream is deleted", async () => {
+	const port = await freePort();
+	const redis = await startRedis(port);
+	const store = createRedisLiveStreamStore({
+		url: `redis://127.0.0.1:${port}`,
+		deployment: "test",
+	});
+	try {
+		await store.acquire("run-1");
+		const replayPromise = collect(store, "run-1");
+		await Bun.sleep(20);
+		await store.delete("run-1");
+		expect(await replayPromise).toEqual([]);
+	} finally {
+		await store.close();
+		await stopRedis(redis);
+	}
+}, 10_000);
+
+it("deduplicates a sequential append retry without weakening finalization", async () => {
+	const port = await freePort();
+	const redis = await startRedis(port);
+	const store = createRedisLiveStreamStore({
+		url: `redis://127.0.0.1:${port}`,
+		deployment: "test",
+	});
+	const firstEvent = encoder.encode(
+		JSON.stringify({
+			type: EventType.TEXT_MESSAGE_CONTENT,
+			messageId: "message-1",
+			delta: "first",
+		}),
+	);
+	const secondEvent = encoder.encode(
+		JSON.stringify({
+			type: EventType.TEXT_MESSAGE_CONTENT,
+			messageId: "message-1",
+			delta: "second",
+		}),
+	);
+	try {
+		await store.acquire("run-1");
+		const first = await store.appendWithRetryId(
+			"run-1",
+			"append-1",
+			firstEvent,
+		);
+		expect(
+			await store.appendWithRetryId("run-1", "append-1", firstEvent),
+		).toEqual({ cursor: first.cursor, appended: false });
+		await expect(
+			store.appendWithRetryId("run-1", "append-1", secondEvent),
+		).rejects.toMatchObject({ code: "append_retry_conflict" });
+		await store.appendWithRetryId("run-1", "append-2", secondEvent);
+
+		await store.finalize("run-1", "done");
+		await store.finalize("run-1", "done");
+		await expect(
+			store.finalize("run-1", "error", "different"),
+		).rejects.toMatchObject({ code: "finalize_conflict" });
+		expect(await collect(store, "run-1")).toHaveLength(2);
+	} finally {
+		await store.close();
+		await stopRedis(redis);
+	}
+}, 10_000);
+
+it("rejects event, byte, and entry cap crossings without trimming", async () => {
+	expect(LIVE_STREAM_MAX_EVENT_BYTES).toBe(32 * 1_024);
+	expect(LIVE_STREAM_MAX_BYTES).toBe(8 * 1_024 * 1_024);
+	expect(LIVE_STREAM_MAX_EVENTS).toBe(10_000);
+	const port = await freePort();
+	const redis = await startRedis(port);
+	const url = `redis://127.0.0.1:${port}`;
+	const event = encoder.encode(
+		JSON.stringify({
+			type: EventType.TEXT_MESSAGE_CONTENT,
+			messageId: "message-1",
+			delta: "bounded",
+		}),
+	);
+	const oversized = encoder.encode(
+		JSON.stringify({
+			type: EventType.TEXT_MESSAGE_CONTENT,
+			messageId: "message-1",
+			delta: "x".repeat(200),
+		}),
+	);
+	const stores: LiveStreamStore[] = [];
+	try {
+		const hardBound = createRedisLiveStreamStore({
+			url,
+			deployment: "hard-bound",
+		});
+		stores.push(hardBound);
+		await hardBound.acquire("run-1");
+		const overHardBound = encoder.encode(
+			JSON.stringify({
+				type: EventType.CUSTOM,
+				name: "large",
+				value: "x".repeat(LIVE_STREAM_MAX_EVENT_BYTES),
+			}),
+		);
+		await expect(
+			hardBound.append("run-1", overHardBound),
+		).rejects.toMatchObject({ code: "event_too_large" });
+
+		const eventBound = createRedisLiveStreamStore({
+			url,
+			deployment: "event-bound",
+			testLimits: { maxEventBytes: event.byteLength },
+		});
+		stores.push(eventBound);
+		await eventBound.acquire("run-1");
+		await expect(eventBound.append("run-1", oversized)).rejects.toMatchObject({
+			code: "event_too_large",
+		});
+		await eventBound.append("run-1", event);
+		await eventBound.finalize("run-1", "done");
+		expect(await collect(eventBound, "run-1")).toHaveLength(1);
+
+		const byteBound = createRedisLiveStreamStore({
+			url,
+			deployment: "byte-bound",
+			testLimits: { maxStreamBytes: event.byteLength * 2 },
+		});
+		stores.push(byteBound);
+		await byteBound.acquire("run-1");
+		await byteBound.append("run-1", event);
+		await byteBound.append("run-1", event);
+		await expect(byteBound.append("run-1", event)).rejects.toMatchObject({
+			code: "stream_bytes_exceeded",
+		});
+		await byteBound.finalize("run-1", "done");
+		expect(await collect(byteBound, "run-1")).toHaveLength(2);
+
+		const eventCountBound = createRedisLiveStreamStore({
+			url,
+			deployment: "count-bound",
+			testLimits: { maxEvents: 2 },
+		});
+		stores.push(eventCountBound);
+		await eventCountBound.acquire("run-1");
+		await eventCountBound.append("run-1", event);
+		await eventCountBound.append("run-1", event);
+		await expect(eventCountBound.append("run-1", event)).rejects.toMatchObject({
+			code: "stream_events_exceeded",
+		});
+		await eventCountBound.finalize("run-1", "done");
+		expect(await collect(eventCountBound, "run-1")).toHaveLength(2);
+	} finally {
+		await Promise.all(stores.map((store) => store.close()));
+		await stopRedis(redis);
+	}
+}, 10_000);
+
+it("splits large Unicode text deltas into complete standard AG-UI events", () => {
+	const delta = "😀漢字é".repeat(5_000);
+	const encoded = encodeAgUiLiveStreamEvent({
+		type: EventType.TEXT_MESSAGE_CONTENT,
+		messageId: "message-1",
+		delta,
+	});
+
+	expect(encoded.length).toBeGreaterThan(1);
+	const events = encoded.map((bytes) => {
+		expect(bytes.byteLength).toBeLessThanOrEqual(
+			LIVE_STREAM_TEXT_EVENT_TARGET_BYTES,
+		);
+		return EventSchemas.parse(JSON.parse(decoder.decode(bytes)));
+	});
+	const textEvents = events.map((event) => {
+		expect(event.type).toBe(EventType.TEXT_MESSAGE_CONTENT);
+		if (event.type !== EventType.TEXT_MESSAGE_CONTENT) {
+			throw new Error("expected text content event");
+		}
+		const first = event.delta.charCodeAt(0);
+		const last = event.delta.charCodeAt(event.delta.length - 1);
+		expect(first < 0xdc00 || first > 0xdfff).toBe(true);
+		expect(last < 0xd800 || last > 0xdbff).toBe(true);
+		return event;
+	});
+	expect(textEvents.map((event) => event.delta).join("")).toBe(delta);
+});
+
+it("rejects bytes that are not exactly one standard AG-UI event", async () => {
+	const port = await freePort();
+	const redis = await startRedis(port);
+	const store = createRedisLiveStreamStore({
+		url: `redis://127.0.0.1:${port}`,
+		deployment: "test",
+	});
+	try {
+		await store.acquire("run-1");
+		await expect(
+			store.append("run-1", encoder.encode('{"type":"UNKNOWN"}')),
+		).rejects.toMatchObject({ code: "invalid_event" });
+		await expect(
+			store.append(
+				"run-1",
+				encoder.encode(
+					'{"type":"TEXT_MESSAGE_CONTENT","messageId":"m","delta":"ok"}\n{}',
+				),
+			),
+		).rejects.toMatchObject({ code: "invalid_event" });
+		await store.finalize("run-1", "done");
+		expect(await collect(store, "run-1")).toEqual([]);
+	} finally {
+		await store.close();
+		await stopRedis(redis);
+	}
+}, 10_000);
+
+it("refreshes an active Stream and expires both keys after terminal grace", async () => {
+	expect(LIVE_STREAM_RETENTION_MS).toBe(30 * 60 * 1_000);
+	const port = await freePort();
+	const redis = await startRedis(port);
+	const rawRedis = createClient({ url: `redis://127.0.0.1:${port}` });
+	const store = createRedisLiveStreamStore({
+		url: `redis://127.0.0.1:${port}`,
+		deployment: "test",
+		testLimits: { retentionMs: 500 },
+	});
+	const event = encoder.encode(
+		JSON.stringify({
+			type: EventType.TEXT_MESSAGE_CONTENT,
+			messageId: "message-1",
+			delta: "kept alive",
+		}),
+	);
+	try {
+		await rawRedis.connect();
+		await expect(store.acquire("short-run", { ttlMs: 250 })).rejects.toThrow(
+			"ttlMs is fixed by the Live Stream retention policy",
+		);
+		await store.acquire("run-1");
+		await store.append("run-1", event);
+		await Bun.sleep(300);
+		expect(await store.refresh("run-1")).toBe(true);
+		await Bun.sleep(300);
+		await store.append("run-1", event);
+		await store.finalize("run-1", "done");
+		expect(await collect(store, "run-1")).toHaveLength(2);
+
+		await Bun.sleep(300);
+		expect(await store.status("run-1")).toBe("done");
+		await Bun.sleep(250);
+		expect(await store.status("run-1")).toBe("missing");
+		await expect(collect(store, "run-1")).rejects.toMatchObject({
+			code: "missing",
+		});
+		expect(await rawRedis.exists("test:mymemo:agui:{run-1}:meta")).toBe(0);
+		expect(await rawRedis.exists("test:mymemo:agui:{run-1}:stream")).toBe(0);
+	} finally {
+		if (rawRedis.isOpen) rawRedis.destroy();
+		await store.close();
+		await stopRedis(redis);
+	}
+}, 10_000);
+
+it("fails closed on unavailable Redis without exposing credentials or content", async () => {
+	const port = await freePort();
+	const credential = "store-secret";
+	const content = "private assistant output";
+	const redis = await startRedis(port, credential);
+	let redisRunning = true;
+	const store = createRedisLiveStreamStore({
+		url: `redis://default:${credential}@127.0.0.1:${port}`,
+		deployment: "test",
+	});
+	const event = encoder.encode(
+		JSON.stringify({
+			type: EventType.TEXT_MESSAGE_CONTENT,
+			messageId: "message-1",
+			delta: content,
+		}),
+	);
+	const consoleMessages: unknown[][] = [];
+	const captureConsole = (...arguments_: unknown[]) => {
+		consoleMessages.push(arguments_);
+	};
+	const originalConsole = {
+		log: console.log,
+		warn: console.warn,
+		error: console.error,
+	};
+	try {
+		await store.acquire("run-1");
+		console.log = captureConsole;
+		console.warn = captureConsole;
+		console.error = captureConsole;
+		await stopRedis(redis);
+		redisRunning = false;
+
+		let unavailable: unknown;
+		try {
+			await store.appendWithRetryId("run-1", "append-1", event);
+		} catch (error) {
+			unavailable = error;
+		}
+		expect(unavailable).toBeInstanceOf(Error);
+		const message = String(unavailable);
+		expect(message).not.toContain(credential);
+		expect(message).not.toContain(content);
+		const logged = JSON.stringify(consoleMessages);
+		expect(logged).not.toContain(credential);
+		expect(logged).not.toContain(content);
+	} finally {
+		console.log = originalConsole.log;
+		console.warn = originalConsole.warn;
+		console.error = originalConsole.error;
+		await store.close();
+		if (redisRunning) await stopRedis(redis);
+	}
+}, 10_000);

--- a/packages/live-text/src/redis-live-stream-store.ts
+++ b/packages/live-text/src/redis-live-stream-store.ts
@@ -1,0 +1,748 @@
+import { randomUUID } from "node:crypto";
+import {
+	type AGUIEvent,
+	EventSchemas,
+	EventType,
+	type TextMessageContentEvent,
+} from "@ag-ui/core";
+import type {
+	ResumableStreamAcquireOptions,
+	ResumableStreamEntry,
+	ResumableStreamRole,
+	ResumableStreamStatus,
+	ResumableStreamStore,
+} from "assistant-stream/resumable";
+import { createClient } from "redis";
+
+export const LIVE_STREAM_RETENTION_MS = 30 * 60 * 1_000;
+export const LIVE_STREAM_MAX_EVENT_BYTES = 32 * 1_024;
+export const LIVE_STREAM_MAX_BYTES = 8 * 1_024 * 1_024;
+export const LIVE_STREAM_MAX_EVENTS = 10_000;
+export const LIVE_STREAM_TEXT_EVENT_TARGET_BYTES = 16 * 1_024;
+
+const MAX_RUN_ID_LENGTH = 128;
+const RUN_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+const MAX_DEPLOYMENT_LENGTH = 64;
+const DEPLOYMENT_PATTERN = /^[A-Za-z0-9_-]+$/;
+const DEFAULT_REDIS_OPERATION_TIMEOUT_MS = 250;
+const DEFAULT_REDIS_POLL_INTERVAL_MS = 100;
+const REDIS_BLOB_STRING = 36;
+const REDIS_STREAM_ID_PATTERN = /^\d+-\d+$/;
+
+const ACQUIRE_SCRIPT = `
+if redis.call("EXISTS", KEYS[1]) == 1 then
+	return 0
+end
+redis.call("DEL", KEYS[2])
+local result = redis.call("SET", KEYS[1], ARGV[1], "NX", "PX", ARGV[2])
+if result then
+	return 1
+end
+return 0
+`;
+
+const APPEND_SCRIPT = `
+local raw = redis.call("GET", KEYS[1])
+if not raw then
+	return {"missing"}
+end
+local meta = cjson.decode(raw)
+if meta.status ~= "streaming" then
+	return {"finalized"}
+end
+if meta.producerToken ~= ARGV[6] then
+	return {"not_producer"}
+end
+local eventBytes = string.len(ARGV[1])
+if eventBytes > tonumber(ARGV[2]) then
+	return {"event_too_large"}
+end
+local appendId = ARGV[5]
+local digest = redis.sha1hex(ARGV[1])
+if appendId ~= "" and meta.lastAppendId == appendId then
+	if meta.lastAppendDigest ~= digest then
+		return {"append_retry_conflict"}
+	end
+	redis.call("SET", KEYS[1], cjson.encode(meta), "PX", meta.ttlMs)
+	if redis.call("EXISTS", KEYS[2]) == 1 then
+		redis.call("PEXPIRE", KEYS[2], meta.ttlMs)
+	end
+	return {"ok", meta.lastCursor, "retry"}
+end
+local nextBytes = (meta.bytes or 0) + eventBytes
+if nextBytes > tonumber(ARGV[3]) then
+	return {"stream_bytes_exceeded"}
+end
+local nextEntries = (meta.entries or 0) + 1
+if nextEntries > tonumber(ARGV[4]) then
+	return {"stream_events_exceeded"}
+end
+local cursor = redis.call("XADD", KEYS[2], "*", "event", ARGV[1])
+meta.bytes = nextBytes
+meta.entries = nextEntries
+if appendId ~= "" then
+	meta.lastAppendId = appendId
+	meta.lastAppendDigest = digest
+	meta.lastCursor = cursor
+else
+	meta.lastAppendId = nil
+	meta.lastAppendDigest = nil
+	meta.lastCursor = nil
+end
+redis.call("SET", KEYS[1], cjson.encode(meta), "PX", meta.ttlMs)
+redis.call("PEXPIRE", KEYS[2], meta.ttlMs)
+return {"ok", cursor, "append"}
+`;
+
+const FINALIZE_SCRIPT = `
+local raw = redis.call("GET", KEYS[1])
+if not raw then
+	return "missing"
+end
+local meta = cjson.decode(raw)
+if meta.producerToken ~= ARGV[3] then
+	return "not_producer"
+end
+if meta.status ~= "streaming" then
+	if meta.status == ARGV[1] and (ARGV[1] ~= "error" or (meta.error or "") == ARGV[2]) then
+		return "retry"
+	end
+	return "conflict"
+end
+meta.status = ARGV[1]
+if ARGV[1] == "error" then
+	meta.error = ARGV[2]
+else
+	meta.error = nil
+end
+redis.call("SET", KEYS[1], cjson.encode(meta), "PX", meta.ttlMs)
+if redis.call("EXISTS", KEYS[2]) == 1 then
+	redis.call("PEXPIRE", KEYS[2], meta.ttlMs)
+end
+return "finalized"
+`;
+
+const REFRESH_SCRIPT = `
+local raw = redis.call("GET", KEYS[1])
+if not raw then
+	return "missing"
+end
+local meta = cjson.decode(raw)
+if meta.producerToken ~= ARGV[1] then
+	return "not_producer"
+end
+if meta.status ~= "streaming" then
+	return "finalized"
+end
+redis.call("SET", KEYS[1], raw, "PX", meta.ttlMs)
+if redis.call("EXISTS", KEYS[2]) == 1 then
+	redis.call("PEXPIRE", KEYS[2], meta.ttlMs)
+end
+return "refreshed"
+`;
+
+type RedisClient = ReturnType<typeof createClient>;
+const EVENT_ENCODER = new TextEncoder();
+const EVENT_DECODER = new TextDecoder("utf-8", { fatal: true });
+
+export interface RedisLiveStreamStoreOptions {
+	/** Authenticated rediss:// in production; loopback redis:// is test-only. */
+	url: string;
+	deployment: string;
+	/** Lower hard limits for disposable real-Redis contract tests only. */
+	testLimits?: {
+		retentionMs?: number;
+		maxEventBytes?: number;
+		maxStreamBytes?: number;
+		maxEvents?: number;
+	};
+}
+
+export interface LiveStreamStore extends ResumableStreamStore {
+	/** Deduplicate an immediate retry in the sequential producer append path. */
+	appendWithRetryId(
+		streamId: string,
+		retryId: string,
+		chunk: Uint8Array,
+	): Promise<{ cursor: string; appended: boolean }>;
+	refresh(streamId: string): Promise<boolean>;
+	close(): Promise<void>;
+}
+
+export type LiveStreamStoreErrorCode =
+	| "missing"
+	| "finalized"
+	| "not_producer"
+	| "invalid_event"
+	| "append_retry_conflict"
+	| "finalize_conflict"
+	| "event_too_large"
+	| "stream_bytes_exceeded"
+	| "stream_events_exceeded";
+
+export class LiveStreamStoreError extends Error {
+	override readonly name = "LiveStreamStoreError";
+
+	constructor(readonly code: LiveStreamStoreErrorCode) {
+		super(errorMessage(code));
+	}
+}
+
+/**
+ * Validate and serialize one standard AG-UI event. Large text-content deltas
+ * become several complete events; no other event is split or truncated.
+ */
+export function encodeAgUiLiveStreamEvent(event: AGUIEvent): Uint8Array[] {
+	const parsed = EventSchemas.parse(event);
+	const encoded = encodeEvent(parsed);
+	if (parsed.type !== EventType.TEXT_MESSAGE_CONTENT) {
+		if (encoded.byteLength > LIVE_STREAM_MAX_EVENT_BYTES) {
+			throw new LiveStreamStoreError("event_too_large");
+		}
+		return [encoded];
+	}
+	if (encoded.byteLength <= LIVE_STREAM_TEXT_EVENT_TARGET_BYTES) {
+		return [encoded];
+	}
+	return splitTextContentEvent(parsed);
+}
+
+class RedisLiveStreamStore implements LiveStreamStore {
+	readonly #client: RedisClient;
+	readonly #keyPrefix: string;
+	readonly #retentionMs: number;
+	readonly #maxEventBytes: number;
+	readonly #maxStreamBytes: number;
+	readonly #maxEvents: number;
+	readonly #producerTokens = new Map<string, string>();
+	#connecting: Promise<void> | undefined;
+	#closed = false;
+
+	constructor(options: RedisLiveStreamStoreOptions) {
+		if (
+			options.deployment.length < 1 ||
+			options.deployment.length > MAX_DEPLOYMENT_LENGTH ||
+			!DEPLOYMENT_PATTERN.test(options.deployment)
+		) {
+			throw new Error("deployment must be a path-safe identifier");
+		}
+		this.#retentionMs = Math.min(
+			positiveInteger(
+				options.testLimits?.retentionMs ?? LIVE_STREAM_RETENTION_MS,
+				"retentionMs",
+			),
+			LIVE_STREAM_RETENTION_MS,
+		);
+		this.#maxEventBytes = Math.min(
+			positiveInteger(
+				options.testLimits?.maxEventBytes ?? LIVE_STREAM_MAX_EVENT_BYTES,
+				"maxEventBytes",
+			),
+			LIVE_STREAM_MAX_EVENT_BYTES,
+		);
+		this.#maxStreamBytes = Math.min(
+			positiveInteger(
+				options.testLimits?.maxStreamBytes ?? LIVE_STREAM_MAX_BYTES,
+				"maxStreamBytes",
+			),
+			LIVE_STREAM_MAX_BYTES,
+		);
+		this.#maxEvents = Math.min(
+			positiveInteger(
+				options.testLimits?.maxEvents ?? LIVE_STREAM_MAX_EVENTS,
+				"maxEvents",
+			),
+			LIVE_STREAM_MAX_EVENTS,
+		);
+		this.#keyPrefix = `${options.deployment}:mymemo:agui`;
+		this.#client = createClient({
+			url: options.url,
+			socket: {
+				connectTimeout: DEFAULT_REDIS_OPERATION_TIMEOUT_MS,
+				reconnectStrategy: false,
+			},
+		});
+		this.#client.on("error", () => {});
+	}
+
+	async acquire(
+		streamId: string,
+		options: ResumableStreamAcquireOptions = {},
+	): Promise<ResumableStreamRole> {
+		this.#assertOpen();
+		validateRunId(streamId);
+		if (
+			options.ttlMs !== undefined &&
+			positiveInteger(options.ttlMs, "ttlMs") !== this.#retentionMs
+		) {
+			throw new Error("ttlMs is fixed by the Live Stream retention policy");
+		}
+		const ttlMs = this.#retentionMs;
+		const producerToken = randomUUID();
+		const metadata = JSON.stringify({
+			status: "streaming",
+			ttlMs,
+			bytes: 0,
+			entries: 0,
+			producerToken,
+		});
+		const result = await this.#bounded(async () => {
+			await this.#connect();
+			return this.#client.eval(ACQUIRE_SCRIPT, {
+				keys: [this.#metaKey(streamId), this.#streamKey(streamId)],
+				arguments: [metadata, String(ttlMs)],
+			});
+		});
+		if (result === 1) {
+			this.#producerTokens.set(streamId, producerToken);
+			return "producer";
+		}
+		return "consumer";
+	}
+
+	async append(streamId: string, chunk: Uint8Array): Promise<void> {
+		await this.#appendAtomically(streamId, "", chunk);
+	}
+
+	async appendWithRetryId(
+		streamId: string,
+		retryId: string,
+		chunk: Uint8Array,
+	): Promise<{ cursor: string; appended: boolean }> {
+		validateRetryId(retryId);
+		return this.#appendAtomically(streamId, retryId, chunk);
+	}
+
+	async #appendAtomically(
+		streamId: string,
+		appendId: string,
+		chunk: Uint8Array,
+	): Promise<{ cursor: string; appended: boolean }> {
+		this.#assertOpen();
+		validateRunId(streamId);
+		validateEncodedAgUiEvent(chunk);
+		const producerToken = this.#producerToken(streamId);
+		const result = parseArrayReply(
+			await this.#command([
+				"EVAL",
+				APPEND_SCRIPT,
+				"2",
+				this.#metaKey(streamId),
+				this.#streamKey(streamId),
+				toBuffer(chunk),
+				String(this.#maxEventBytes),
+				String(this.#maxStreamBytes),
+				String(this.#maxEvents),
+				appendId,
+				producerToken,
+			]),
+		);
+		if (result[0] !== "ok") throw storeError(result[0]);
+		const cursor = result[1];
+		if (!cursor) throw new LiveStreamStoreError("missing");
+		return { cursor, appended: result[2] !== "retry" };
+	}
+
+	async finalize(
+		streamId: string,
+		status: "done" | "error",
+		error?: string,
+	): Promise<void> {
+		this.#assertOpen();
+		validateRunId(streamId);
+		const producerToken = this.#producerToken(streamId);
+		const result = replyString(
+			await this.#command([
+				"EVAL",
+				FINALIZE_SCRIPT,
+				"2",
+				this.#metaKey(streamId),
+				this.#streamKey(streamId),
+				status,
+				error ?? "Stream errored",
+				producerToken,
+			]),
+		);
+		if (result === "finalized" || result === "retry") return;
+		if (result === "not_producer") {
+			throw new LiveStreamStoreError("not_producer");
+		}
+		if (result === "conflict") {
+			throw new LiveStreamStoreError("finalize_conflict");
+		}
+		throw new LiveStreamStoreError("missing");
+	}
+
+	async refresh(streamId: string): Promise<boolean> {
+		this.#assertOpen();
+		validateRunId(streamId);
+		const producerToken = this.#producerToken(streamId);
+		const result = replyString(
+			await this.#command([
+				"EVAL",
+				REFRESH_SCRIPT,
+				"2",
+				this.#metaKey(streamId),
+				this.#streamKey(streamId),
+				producerToken,
+			]),
+		);
+		if (result === "refreshed") return true;
+		if (result === "finalized") return false;
+		if (result === "not_producer") {
+			throw new LiveStreamStoreError("not_producer");
+		}
+		throw new LiveStreamStoreError("missing");
+	}
+
+	async *read(
+		streamId: string,
+		cursor: string,
+		signal: AbortSignal,
+	): AsyncIterable<ResumableStreamEntry> {
+		this.#assertOpen();
+		validateRunId(streamId);
+		validateCursor(cursor);
+		if (!(await this.#readMetadata(streamId))) {
+			throw new LiveStreamStoreError("missing");
+		}
+		let lastCursor = cursor === "" ? "0-0" : cursor;
+		while (!signal.aborted) {
+			const metadata = await this.#readMetadata(streamId);
+			if (!metadata) return;
+			const entries = parseXReadReply(
+				await this.#command(
+					[
+						"XREAD",
+						"COUNT",
+						"100",
+						"STREAMS",
+						this.#streamKey(streamId),
+						lastCursor,
+					],
+					true,
+				),
+			);
+			for (const entry of entries) {
+				if (signal.aborted) return;
+				lastCursor = entry.cursor;
+				yield entry;
+			}
+			if (entries.length > 0) continue;
+
+			if (metadata.status === "done") return;
+			if (metadata.status === "error") {
+				throw new Error(metadata.error ?? "Stream errored");
+			}
+			await abortableDelay(DEFAULT_REDIS_POLL_INTERVAL_MS, signal);
+		}
+	}
+
+	async status(streamId: string): Promise<ResumableStreamStatus> {
+		this.#assertOpen();
+		validateRunId(streamId);
+		const metadata = await this.#readMetadata(streamId);
+		if (!metadata) return "missing";
+		if (
+			metadata.status === "streaming" ||
+			metadata.status === "done" ||
+			metadata.status === "error"
+		) {
+			return metadata.status;
+		}
+		return "missing";
+	}
+
+	async delete(streamId: string): Promise<void> {
+		this.#assertOpen();
+		validateRunId(streamId);
+		await this.#command([
+			"DEL",
+			this.#metaKey(streamId),
+			this.#streamKey(streamId),
+		]);
+	}
+
+	async close(): Promise<void> {
+		if (this.#closed) return;
+		this.#closed = true;
+		this.#producerTokens.clear();
+		try {
+			this.#client.destroy();
+		} catch {
+			// Closing is idempotent and best-effort.
+		}
+	}
+
+	async #connect(): Promise<void> {
+		if (this.#client.isReady) return;
+		if (!this.#connecting) {
+			this.#connecting = this.#client
+				.connect()
+				.then(() => {})
+				.finally(() => {
+					this.#connecting = undefined;
+				});
+		}
+		await this.#connecting;
+	}
+
+	async #bounded<T>(operation: () => Promise<T>): Promise<T> {
+		let timer: ReturnType<typeof setTimeout> | undefined;
+		const timeout = new Promise<never>((_, reject) => {
+			timer = setTimeout(
+				() => reject(new Error("Live Stream Redis operation timed out")),
+				DEFAULT_REDIS_OPERATION_TIMEOUT_MS,
+			);
+		});
+		try {
+			return await Promise.race([operation(), timeout]);
+		} finally {
+			if (timer !== undefined) clearTimeout(timer);
+		}
+	}
+
+	async #command(
+		args: Array<string | Buffer>,
+		binary = false,
+	): Promise<unknown> {
+		return this.#bounded(async () => {
+			await this.#connect();
+			return this.#client.sendCommand(args, {
+				...(binary ? { typeMapping: { [REDIS_BLOB_STRING]: Buffer } } : {}),
+			});
+		});
+	}
+
+	async #readMetadata(streamId: string): Promise<StreamMetadata | undefined> {
+		const raw = replyString(
+			await this.#command(["GET", this.#metaKey(streamId)]),
+		);
+		if (raw === undefined) return undefined;
+		try {
+			const parsed = JSON.parse(raw) as StreamMetadata;
+			return parsed && typeof parsed === "object" ? parsed : undefined;
+		} catch {
+			return undefined;
+		}
+	}
+
+	#assertOpen(): void {
+		if (this.#closed) throw new Error("Live Stream store is closed");
+	}
+
+	#producerToken(streamId: string): string {
+		const producerToken = this.#producerTokens.get(streamId);
+		if (!producerToken) throw new LiveStreamStoreError("not_producer");
+		return producerToken;
+	}
+
+	#metaKey(streamId: string): string {
+		return `${this.#keyPrefix}:{${streamId}}:meta`;
+	}
+
+	#streamKey(streamId: string): string {
+		return `${this.#keyPrefix}:{${streamId}}:stream`;
+	}
+}
+
+export function createRedisLiveStreamStore(
+	options: RedisLiveStreamStoreOptions,
+): LiveStreamStore {
+	return new RedisLiveStreamStore(options);
+}
+
+function validateRunId(streamId: string): void {
+	if (
+		streamId.length < 1 ||
+		streamId.length > MAX_RUN_ID_LENGTH ||
+		!RUN_ID_PATTERN.test(streamId)
+	) {
+		throw new Error("streamId must be a path-safe Run identifier");
+	}
+}
+
+function validateRetryId(retryId: string): void {
+	if (
+		retryId.length < 1 ||
+		retryId.length > MAX_RUN_ID_LENGTH ||
+		!RUN_ID_PATTERN.test(retryId)
+	) {
+		throw new Error("retryId must be a path-safe identifier");
+	}
+}
+
+function positiveInteger(value: number, name: string): number {
+	if (!Number.isSafeInteger(value) || value < 1) {
+		throw new Error(`${name} must be a positive integer`);
+	}
+	return value;
+}
+
+function encodeEvent(event: AGUIEvent): Uint8Array {
+	return EVENT_ENCODER.encode(JSON.stringify(event));
+}
+
+function validateEncodedAgUiEvent(chunk: Uint8Array): void {
+	try {
+		EventSchemas.parse(JSON.parse(EVENT_DECODER.decode(chunk)));
+	} catch {
+		throw new LiveStreamStoreError("invalid_event");
+	}
+}
+
+function splitTextContentEvent(event: TextMessageContentEvent): Uint8Array[] {
+	const emptyEventBytes = encodeEvent({ ...event, delta: "" }).byteLength;
+	const deltaBudget = LIVE_STREAM_TEXT_EVENT_TARGET_BYTES - emptyEventBytes;
+	if (deltaBudget < 1) {
+		throw new LiveStreamStoreError("event_too_large");
+	}
+
+	const deltas: string[] = [];
+	let current = "";
+	let currentBytes = 0;
+	for (const codePoint of event.delta) {
+		const codePointBytes = jsonStringContentBytes(codePoint);
+		if (codePointBytes > deltaBudget) {
+			throw new LiveStreamStoreError("event_too_large");
+		}
+		if (current && currentBytes + codePointBytes > deltaBudget) {
+			deltas.push(current);
+			current = "";
+			currentBytes = 0;
+		}
+		current += codePoint;
+		currentBytes += codePointBytes;
+	}
+	if (current) deltas.push(current);
+	if (deltas.length === 0) {
+		throw new LiveStreamStoreError("event_too_large");
+	}
+
+	return deltas.map((delta) => {
+		const chunk = encodeEvent({ ...event, delta });
+		if (chunk.byteLength > LIVE_STREAM_TEXT_EVENT_TARGET_BYTES) {
+			throw new LiveStreamStoreError("event_too_large");
+		}
+		return chunk;
+	});
+}
+
+function jsonStringContentBytes(value: string): number {
+	return EVENT_ENCODER.encode(JSON.stringify(value)).byteLength - 2;
+}
+
+interface StreamMetadata {
+	status?: string;
+	error?: string;
+}
+
+function validateCursor(cursor: string): void {
+	if (cursor !== "" && !REDIS_STREAM_ID_PATTERN.test(cursor)) {
+		throw new Error("cursor must be empty or a Redis Stream ID");
+	}
+}
+
+function toBuffer(bytes: Uint8Array): Buffer {
+	if (Buffer.isBuffer(bytes)) return bytes;
+	return Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+}
+
+function replyString(value: unknown): string | undefined {
+	if (typeof value === "string") return value;
+	if (Buffer.isBuffer(value)) return value.toString("utf8");
+	return undefined;
+}
+
+function parseArrayReply(value: unknown): string[] {
+	if (!Array.isArray(value)) return [];
+	return value.flatMap((item) => {
+		const parsed = replyString(item);
+		return parsed === undefined ? [] : [parsed];
+	});
+}
+
+function parseXReadReply(value: unknown): ResumableStreamEntry[] {
+	if (!Array.isArray(value)) return [];
+	const entries: ResumableStreamEntry[] = [];
+	for (const rawStream of value) {
+		if (!Array.isArray(rawStream) || !Array.isArray(rawStream[1])) continue;
+		for (const rawEntry of rawStream[1]) {
+			const entry = parseStreamEntry(rawEntry);
+			if (entry) entries.push(entry);
+		}
+	}
+	return entries;
+}
+
+function parseStreamEntry(rawEntry: unknown): ResumableStreamEntry | undefined {
+	if (!Array.isArray(rawEntry) || rawEntry.length < 2) return undefined;
+	const cursor = replyString(rawEntry[0]);
+	const fields = rawEntry[1];
+	if (!cursor || !Array.isArray(fields)) return undefined;
+	for (let index = 0; index + 1 < fields.length; index += 2) {
+		if (replyString(fields[index]) !== "event") continue;
+		const event = fields[index + 1];
+		if (typeof event === "string") {
+			return { cursor, chunk: EVENT_ENCODER.encode(event) };
+		}
+		if (Buffer.isBuffer(event)) {
+			return {
+				cursor,
+				chunk: new Uint8Array(event.buffer, event.byteOffset, event.byteLength),
+			};
+		}
+	}
+	return undefined;
+}
+
+function storeError(code: string | undefined): LiveStreamStoreError {
+	if (
+		code === "missing" ||
+		code === "finalized" ||
+		code === "not_producer" ||
+		code === "append_retry_conflict" ||
+		code === "event_too_large" ||
+		code === "stream_bytes_exceeded" ||
+		code === "stream_events_exceeded"
+	) {
+		return new LiveStreamStoreError(code);
+	}
+	return new LiveStreamStoreError("missing");
+}
+
+function errorMessage(code: LiveStreamStoreErrorCode): string {
+	switch (code) {
+		case "missing":
+			return "Live Stream is unavailable";
+		case "finalized":
+			return "Live Stream is already finalized";
+		case "not_producer":
+			return "Live Stream producer ownership is required";
+		case "invalid_event":
+			return "Live Stream entry is not a standard AG-UI event";
+		case "append_retry_conflict":
+			return "Live Stream append retry conflicts with its prior event";
+		case "finalize_conflict":
+			return "Live Stream finalization conflicts with its terminal state";
+		case "event_too_large":
+			return "Live Stream event exceeds the size limit";
+		case "stream_bytes_exceeded":
+			return "Live Stream byte limit exceeded";
+		case "stream_events_exceeded":
+			return "Live Stream event limit exceeded";
+	}
+}
+
+function abortableDelay(ms: number, signal: AbortSignal): Promise<void> {
+	return new Promise((resolve) => {
+		if (signal.aborted) return resolve();
+		const timer = setTimeout(done, ms);
+		function done(): void {
+			clearTimeout(timer);
+			signal.removeEventListener("abort", done);
+			resolve();
+		}
+		signal.addEventListener("abort", done, { once: true });
+	});
+}


### PR DESCRIPTION
## Summary

- add a custom `ResumableStreamStore` backed by one bounded Redis Stream per Run, with Redis Stream IDs serving as replay/SSE cursors
- enforce producer ownership, append ordering, idempotent retries, terminal finalization, fixed retention, and hard byte/event caps atomically with Lua
- validate every entry as one standard AG-UI event and split large text deltas into Unicode-safe 16 KiB-targeted events
- cover ownership races, replay, finalization, expiry, deletion, caps, and authenticated Redis outages with real-Redis contract tests

## Impact

Producers and consumers now have the low-level resumable Live Stream boundary required by ADR-0012. Active and terminal Streams remain replayable for the fixed 30-minute window without trimming, while oversized or unauthorized writes fail closed and no token deltas are persisted to Postgres.

## Validation

- `bun run test` (793 tests across the root and all five workspaces)
- `bun test packages/live-text` (27 tests)
- `bunx tsc --noEmit -p tsconfig.json` in agent-db, live-text, agent-worker, chat-api, and worker-scaler
- Biome checks for the new store and contract suite

Closes #334