### PR TITLE
Provision secure Redis Live Stream infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,10 @@ jobs:
           # Pinned for reproducible CI — match the version the lockfile was
           # generated with. Bump deliberately alongside local upgrades.
           bun-version: 1.3.0
-      # Integration tests drive real ripgrep and disposable Redis processes;
-      # the runner image does not ship either executable.
-      - run: sudo apt-get update && sudo apt-get install -y ripgrep redis-server
+      # Integration tests drive real ripgrep plus disposable Redis processes for
+      # Stream and Lua contracts; the runner image does not ship either executable.
+      - name: Install real Redis and ripgrep test dependencies
+        run: sudo apt-get update && sudo apt-get install -y ripgrep redis-server
       - run: bun install --frozen-lockfile
       - run: bun run test
 

--- a/apps/agent-worker/.env.example
+++ b/apps/agent-worker/.env.example
@@ -46,6 +46,12 @@ AWS_REGION=us-west-2
 
 # ── Optional (defaults shown) ───────────────────────────────────────────────────
 
+# Authenticated TLS Redis URL for temporary Live Stream delivery. During the
+# additive rollout, missing or insecure values leave the integration disabled;
+# the hard cutover will make this required. Inject it from a secret store; it is
+# never included in the E2B sandbox environment.
+# REDIS_URL=rediss://default:password@redis.internal:6379
+
 # Conservative per-task run concurrency; concurrent runs share the task's CPU/memory.
 # WORKER_MAX_CONCURRENT_RUNS=2
 

--- a/apps/agent-worker/src/config/env.test.ts
+++ b/apps/agent-worker/src/config/env.test.ts
@@ -231,8 +231,8 @@ describe("loadWorkerConfigFromEnv — ListDocuments cap", () => {
 	});
 });
 
-describe("loadWorkerConfigFromEnv — optional Live Redis lane", () => {
-	it("enables Live preview only for an authenticated TLS URL", () => {
+describe("loadWorkerConfigFromEnv — additive Live Redis deployment", () => {
+	it("accepts only an authenticated TLS URL", () => {
 		const env = baseEnv();
 		env.REDIS_URL = "rediss://default:secret@redis.internal:6379";
 		expect(loadWorkerConfigFromEnv(env).liveTextRedisUrl).toBe(env.REDIS_URL);

--- a/apps/agent-worker/src/config/env.ts
+++ b/apps/agent-worker/src/config/env.ts
@@ -52,7 +52,7 @@ export interface WorkerConfig {
 		bucket: string;
 		region: string;
 	};
-	/** Optional authenticated TLS Redis secret for best-effort Live preview. */
+	/** Additive authenticated TLS Redis secret for temporary live delivery. */
 	liveTextRedisUrl: string | undefined;
 	/** How long an unrenewed E2B sandbox stays active before idle-pausing. */
 	sandboxIdleMs: number;

--- a/apps/agent-worker/src/sandbox-env.test.ts
+++ b/apps/agent-worker/src/sandbox-env.test.ts
@@ -30,6 +30,7 @@ describe("buildSandboxEnv — credential boundary", () => {
 			OPENROUTER_BASE_URL: "https://openrouter.ai/api",
 			OPENROUTER_DEFAULT_MODEL: "anthropic/claude",
 			E2B_API_KEY: "e2b-secret",
+			REDIS_URL: "rediss://default:redis-secret@redis.internal:6379",
 			WORKER_E2B_TEMPLATE: "mymemo-agent-sandbox",
 			ARTIFACT_BUCKET: "private-artifacts",
 			AWS_REGION: "us-west-2",
@@ -42,6 +43,7 @@ describe("buildSandboxEnv — credential boundary", () => {
 		expect(serialized).not.toContain(config.openrouter.apiKey);
 		expect(serialized).not.toContain("mymemo_kb");
 		expect(serialized).not.toContain(config.e2bApiKey);
+		expect(serialized).not.toContain("redis-secret");
 		for (const forbidden of [
 			"OPENROUTER_API_KEY",
 			"KB_DATABASE_URL",
@@ -49,6 +51,7 @@ describe("buildSandboxEnv — credential boundary", () => {
 			"ANTHROPIC_API_KEY",
 			"ANTHROPIC_AUTH_TOKEN",
 			"E2B_API_KEY",
+			"REDIS_URL",
 			"ARTIFACT_BUCKET",
 			"AWS_REGION",
 			"AWS_ACCESS_KEY_ID",

--- a/apps/chat-api/.env.example
+++ b/apps/chat-api/.env.example
@@ -39,6 +39,11 @@
 # gate fails closed. The local harness sets this true inline in compose.yaml.
 # AGENT_EXPOSURE_BREAK_GLASS=false
 
+# Authenticated TLS Redis URL for temporary Live Stream delivery. During the
+# additive rollout, missing or insecure values leave the integration disabled;
+# the hard cutover will make this required. Always inject it from a secret store.
+# REDIS_URL=rediss://default:password@redis.internal:6379
+
 # Spliced into AGENT_DATABASE_URL when it is passwordless (the platform-injected
 # form). Leave unset when AGENT_DATABASE_URL already carries its password.
 # DB_PASSWORD=

--- a/apps/chat-api/src/config/env.test.ts
+++ b/apps/chat-api/src/config/env.test.ts
@@ -148,8 +148,8 @@ describe("loadApiConfigFromEnv — split-runtime core", () => {
 	});
 });
 
-describe("loadApiConfigFromEnv — optional Live Redis lane", () => {
-	it("enables Live preview only for an authenticated TLS URL", () => {
+describe("loadApiConfigFromEnv — additive Live Redis deployment", () => {
+	it("accepts only an authenticated TLS URL", () => {
 		const env = baseEnv();
 		env.REDIS_URL = "rediss://default:secret@redis.internal:6379";
 		expect(loadApiConfigFromEnv(env).liveTextRedisUrl).toBe(env.REDIS_URL);

--- a/apps/chat-api/src/config/env.ts
+++ b/apps/chat-api/src/config/env.ts
@@ -55,7 +55,7 @@ export interface ApiConfig {
 	 * Statsig secret is required. Identity-independent and explicit.
 	 */
 	agentExposureBreakGlass: boolean;
-	/** Optional authenticated TLS Redis secret for best-effort Live preview. */
+	/** Additive authenticated TLS Redis secret for temporary live delivery. */
 	liveTextRedisUrl: string | undefined;
 }
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -12,6 +12,7 @@
 #   migrate       — one-shot: applies the @mymemo/agent-db migrations, then exits
 #   chat-api      — creates conversations, queues runs, projects run events as SSE
 #   agent-worker  — claims queued runs and serves real SDK turns through E2B
+#   redis         — disposable Redis 7 for real Stream and Lua contract testing
 #
 # The prototype gateway/sandbox services were removed once the split runtime
 # replaced them end to end (ADR-0002). Bring the demo up with:
@@ -108,6 +109,23 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    restart: "no"
+    networks:
+      - mymemo-network
+
+  # Disposable development Redis. It binds only to host loopback, keeps no
+  # volume or persistence, and supports the same Stream and Lua commands used by
+  # the production adapter. Start it alone with `docker compose up redis`.
+  redis:
+    image: redis:7-alpine
+    command: ["redis-server", "--save", "", "--appendonly", "no"]
+    ports:
+      - "127.0.0.1:${REDIS_PORT:-6379}:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 2s
+      timeout: 2s
+      retries: 15
     restart: "no"
     networks:
       - mymemo-network

--- a/docs/runbooks/live-preview.md
+++ b/docs/runbooks/live-preview.md
@@ -84,7 +84,7 @@ deployed image URIs as described in the Terraform README. Then save and apply
 the reviewed plan:
 
 ```bash
-terraform -chdir=infra/terraform plan -var-file=prod.tfvars -var-file=generated.auto.tfvars -var="live_preview_enabled=false" -out=/tmp/live-preview-disable.tfplan
+terraform -chdir=infra/terraform plan -var-file=prod.tfvars -var-file=generated.auto.tfvars -var="live_stream_enabled=false" -out=/tmp/live-preview-disable.tfplan
 terraform -chdir=infra/terraform apply /tmp/live-preview-disable.tfplan
 AWS_PROFILE=mymemo scripts/deploy/roll_ecs_services.sh
 ```
@@ -103,7 +103,7 @@ Set the same variable back to `true`, review the plan, apply, and wait for both
 services to roll:
 
 ```bash
-terraform -chdir=infra/terraform plan -var-file=prod.tfvars -var-file=generated.auto.tfvars -var="live_preview_enabled=true" -out=/tmp/live-preview-restore.tfplan
+terraform -chdir=infra/terraform plan -var-file=prod.tfvars -var-file=generated.auto.tfvars -var="live_stream_enabled=true" -out=/tmp/live-preview-restore.tfplan
 terraform -chdir=infra/terraform apply /tmp/live-preview-restore.tfplan
 AWS_PROFILE=mymemo scripts/deploy/roll_ecs_services.sh
 ```

--- a/docs/verification/adr-0008-hard-cutover.md
+++ b/docs/verification/adr-0008-hard-cutover.md
@@ -59,7 +59,7 @@ commit. Record the command output plus healthy chat-api and agent-worker task
 status in the Live-enabled evidence row.
 
 Then use the [Live preview runbook](../runbooks/live-preview.md#disable-the-redis-lane)
-to set `live_preview_enabled=false`, review/apply the plan, and roll both ECS
+to set `live_stream_enabled=false`, review/apply the plan, and roll both ECS
 services. With the lane disabled:
 
 ```bash

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -29,7 +29,8 @@ the direct remote-state output is absent and the fallback input is present.
 - dedicated RDS Postgres instance for writable agent state
 - EC2 Instance Connect Endpoint and private EC2 bridge for operator access to
   the agent and KB databases
-- single-node ElastiCache Redis replication group for disposable live previews
+- single-node ElastiCache Redis replication group for temporary per-Run Live
+  Streams
 - private S3 bucket for durable Downloadable artifact objects
 - ECS Fargate task definitions and services for chat-api and agent-worker
 - agent DB migration task definition
@@ -55,7 +56,7 @@ RDS-managed secret. This is the writable agent state database for conversations,
 leases, run state, and migrations. It is separate from the read-only KB database
 URL used by `agent-worker`.
 
-Terraform also generates the live preview cache authentication token and stores
+Terraform also generates the Live Stream cache authentication token and stores
 the complete `rediss://` connection URL in the Terraform-managed
 `<name_prefix>-<environment>-REDIS_URL` Secrets Manager secret. ECS injects that
 secret as `REDIS_URL` into `chat-api` and `agent-worker` only. It is not added to
@@ -88,16 +89,16 @@ validates that variable when `SANDBOX_PROVIDER=e2b`. The final split-runtime
 boundary should remove that from chat-api once sandbox creation moves fully to
 `agent-worker`.
 
-## Redis Live Preview Lane
+## Redis Live Stream Infrastructure
 
-The Redis cache is transport infrastructure for provisional Assistant text,
-not a source of truth. It is a single small node with no replicas, Multi-AZ
-failover, automatic snapshots, final snapshot, or backup retention. The cache
-is reachable on its TLS port only from a dedicated client security group
-attached to the trusted `chat-api` and `agent-worker` services; the migration
-task does not receive that group. ElastiCache does not receive a public address
-or a public ingress rule. Authentication and in-transit encryption are
-mandatory.
+The Redis cache is temporary transport infrastructure for one retained AG-UI
+Live Stream per Run, not a permanent history authority. It is a single small
+node with no replicas, Multi-AZ failover, automatic snapshots, final snapshot,
+or backup retention. The cache is reachable on its TLS port only from a
+dedicated client security group attached to the trusted `chat-api` and
+`agent-worker` services; the migration task does not receive that group.
+ElastiCache does not receive a public address or a CIDR-based ingress rule.
+Authentication and in-transit encryption are mandatory.
 
 Before the first cache plan in an existing environment, reapply
 `infra/bootstrap-iam` with the admin profile as shown below. That updates the
@@ -105,16 +106,19 @@ GitHub Actions deploy role with the ElastiCache permissions used by this root.
 
 Redis availability must not participate in chat-api or agent-worker readiness.
 Missing, invalid, or unreachable Redis configuration must degrade only live
-previews and must not prevent either service from booting or staying healthy.
+delivery and must not prevent either service from booting or staying healthy
+until the hard-cutover contract makes missing or insecure configuration a boot
+failure. Runtime Redis availability remains outside readiness in either phase.
 The durable Postgres path remains sufficient for successful Runs, durable
 Assistant messages, terminal Outcomes, and replay.
 
-Set `live_preview_enabled=false` to omit `REDIS_URL` from both trusted service
-task definitions without deleting the cache. Live telemetry is converted into
-CloudWatch metrics with bounded service/signal/outcome dimensions; the alarms
-detect both repeated per-service breaches and multiple services degrading in
-the same five-minute period, and never feed service health. Production must set
-`alarm_action_arns` to an SNS topic with a confirmed incident subscription. See
+Set `live_stream_enabled=false` to omit `REDIS_URL` from both trusted service
+task definitions without deleting the cache during the additive rollout. Live
+telemetry is converted into CloudWatch metrics with bounded
+service/signal/outcome dimensions; the alarms detect both repeated per-service
+breaches and multiple services degrading in the same five-minute period, and
+never feed service health. Production must set `alarm_action_arns` to an SNS
+topic with a confirmed incident subscription. See
 [`docs/runbooks/live-preview.md`](../../docs/runbooks/live-preview.md) for
 diagnosis, disable, and restore procedures.
 

--- a/infra/terraform/examples/prod.tfvars.example
+++ b/infra/terraform/examples/prod.tfvars.example
@@ -33,8 +33,8 @@ openrouter_base_url       = "https://openrouter.ai/api"
 openrouter_default_model  = "anthropic/claude-sonnet-4"
 worker_max_concurrent_runs = 2
 
-# Disposable Pub/Sub only: one small node, with replication and backups disabled
-# in redis.tf.
+# Temporary Live Streams only: one small node, with replication and backups
+# disabled in redis.tf.
 live_redis_node_type      = "cache.t4g.micro"
 live_redis_engine_version = "7.1"
 

--- a/infra/terraform/locals.tf
+++ b/infra/terraform/locals.tf
@@ -58,7 +58,7 @@ locals {
     }
   ]
 
-  live_redis_url_secret = var.live_preview_enabled ? [
+  live_redis_url_secret = var.live_stream_enabled ? [
     { name = "REDIS_URL", valueFrom = local.live_redis_url_secret_arn }
   ] : []
 

--- a/infra/terraform/prod.tfvars
+++ b/infra/terraform/prod.tfvars
@@ -30,8 +30,8 @@ openrouter_base_url        = "https://openrouter.ai/api"
 openrouter_default_model   = "anthropic/claude-sonnet-4"
 worker_max_concurrent_runs = 2
 
-# Disposable Pub/Sub only: one small node, with replication and backups disabled
-# in redis.tf.
+# Temporary Live Streams only: one small node, with replication and backups
+# disabled in redis.tf.
 live_redis_node_type      = "cache.t4g.micro"
 live_redis_engine_version = "7.1"
 

--- a/infra/terraform/redis.tf
+++ b/infra/terraform/redis.tf
@@ -1,18 +1,18 @@
 resource "aws_security_group" "live_redis" {
   name        = "${local.common_name}-live-redis"
-  description = "Private Redis live preview lane for trusted agent services"
+  description = "Private Redis Live Stream for trusted agent services"
   vpc_id      = local.shared_vpc_id
 }
 
 resource "aws_security_group" "live_redis_clients" {
   name        = "${local.common_name}-live-redis-clients"
-  description = "chat-api and agent-worker clients of the Redis live preview lane"
+  description = "chat-api and agent-worker clients of the Redis Live Stream"
   vpc_id      = local.shared_vpc_id
 }
 
 resource "aws_security_group_rule" "live_redis_from_services" {
   type                     = "ingress"
-  description              = "Trusted agent services to the Redis live preview lane"
+  description              = "Trusted agent services to the Redis Live Stream"
   security_group_id        = aws_security_group.live_redis.id
   source_security_group_id = aws_security_group.live_redis_clients.id
   from_port                = var.live_redis_port
@@ -32,7 +32,7 @@ resource "random_password" "live_redis" {
 
 resource "aws_elasticache_replication_group" "live" {
   replication_group_id = substr(replace("${local.common_name}-live", "_", "-"), 0, 40)
-  description          = "Disposable Redis Pub/Sub lane for live assistant text previews"
+  description          = "Temporary per-Run Redis Streams for AG-UI live delivery"
 
   engine         = "redis"
   engine_version = var.live_redis_engine_version
@@ -58,7 +58,7 @@ resource "aws_elasticache_replication_group" "live" {
 
 resource "aws_secretsmanager_secret" "live_redis_url" {
   name                    = "${local.common_name}-REDIS_URL"
-  description             = "Authenticated TLS URL for the ephemeral Redis live preview lane"
+  description             = "Authenticated TLS URL for the temporary Redis Live Stream"
   recovery_window_in_days = 7
 }
 

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -109,25 +109,25 @@ variable "agent_worker_port" {
 }
 
 variable "live_redis_port" {
-  description = "TLS port for the disposable Redis live preview lane."
+  description = "TLS port for the temporary per-Run Redis Live Stream."
   type        = number
   default     = 6379
 }
 
 variable "live_redis_node_type" {
-  description = "ElastiCache node type for ephemeral Pub/Sub traffic."
+  description = "ElastiCache node type for temporary per-Run Redis Streams."
   type        = string
   default     = "cache.t4g.micro"
 }
 
 variable "live_redis_engine_version" {
-  description = "Redis engine version for the ephemeral live preview lane."
+  description = "Redis engine version for the temporary per-Run Live Stream."
   type        = string
   default     = "7.1"
 }
 
-variable "live_preview_enabled" {
-  description = "Inject REDIS_URL into trusted agent services. Set false to disable only the optional Live preview lane while leaving Redis provisioned."
+variable "live_stream_enabled" {
+  description = "Inject REDIS_URL into trusted agent services. Set false to keep the Live Stream additively disabled while leaving Redis provisioned."
   type        = bool
   default     = true
 }

--- a/packages/live-text/src/index.ts
+++ b/packages/live-text/src/index.ts
@@ -10,10 +10,11 @@ export const LIVE_TEXT_MAX_WIRE_BYTES = 100_000;
 const LIVE_TEXT_MAX_ID_LENGTH = 128;
 
 /**
- * Resolve the optional production Live-lane secret. Invalid configuration is
- * deliberately indistinguishable from missing configuration to callers: both
- * disable only Live preview and must never fail service boot. The returned URL
- * is authenticated and TLS-only, but remains a secret and must not be logged.
+ * Resolve the additive production Live-transport secret. Invalid configuration
+ * is deliberately indistinguishable from missing configuration to callers: both
+ * disable only live delivery until the hard cutover makes it required. The
+ * returned URL is authenticated and TLS-only, but remains a secret and must not
+ * be logged.
  */
 export function resolveLiveTextRedisUrl(
 	raw: string | undefined,

--- a/scripts/deploy-config.test.ts
+++ b/scripts/deploy-config.test.ts
@@ -27,6 +27,21 @@ const releaseDeployWorkflow = readFileSync(
 	join(root, ".github", "workflows", "release-deploy.yml"),
 	"utf8",
 );
+const ciWorkflow = readFileSync(
+	join(root, ".github", "workflows", "ci.yml"),
+	"utf8",
+);
+const composeConfig = readFileSync(join(root, "compose.yaml"), "utf8");
+const redisContractTest = readFileSync(
+	join(
+		root,
+		"packages",
+		"live-text",
+		"src",
+		"redis-live-stream-store.contract.test.ts",
+	),
+	"utf8",
+);
 const createAgentSecretsScript = readFileSync(
 	join(root, "scripts", "deploy", "create_agent_secrets.sh"),
 	"utf8",
@@ -187,10 +202,11 @@ describe("agent deployment config", () => {
 		expect(migrationConfig).not.toContain("ARTIFACT_BUCKET");
 	});
 
-	it("provisions the disposable Redis live lane inside the trusted service network", () => {
+	it("provisions the authenticated TLS Redis Live Stream inside the trusted service network", () => {
 		const redisConfig = readFileSync(join(terraformDir, "redis.tf"), "utf8");
 		const locals = readFileSync(join(terraformDir, "locals.tf"), "utf8");
 		const ecsConfig = readFileSync(join(terraformDir, "ecs.tf"), "utf8");
+		const outputs = readFileSync(join(terraformDir, "outputs.tf"), "utf8");
 		const migrationStart = ecsConfig.indexOf(
 			'resource "aws_ecs_task_definition" "agent_migration"',
 		);
@@ -200,7 +216,9 @@ describe("agent deployment config", () => {
 		);
 		const migrationConfig = ecsConfig.slice(migrationStart, migrationEnd);
 
-		expect(redisConfig).toContain('resource "aws_elasticache_replication_group" "live"');
+		expect(redisConfig).toContain(
+			'resource "aws_elasticache_replication_group" "live"',
+		);
 		expect(redisConfig).toMatch(/num_cache_clusters\s*=\s*1/);
 		expect(redisConfig).toMatch(/automatic_failover_enabled\s*=\s*false/);
 		expect(redisConfig).toMatch(/multi_az_enabled\s*=\s*false/);
@@ -213,13 +231,16 @@ describe("agent deployment config", () => {
 		expect(redisConfig).toContain(
 			"source_security_group_id = aws_security_group.live_redis_clients.id",
 		);
-		expect(redisConfig).toContain('resource "aws_secretsmanager_secret" "live_redis_url"');
+		expect(redisConfig).not.toMatch(/\b(?:cidr_blocks|ipv6_cidr_blocks)\b/);
+		expect(redisConfig).toContain(
+			'resource "aws_secretsmanager_secret" "live_redis_url"',
+		);
 		expect(redisConfig).toContain(
 			'"rediss://default:${urlencode(random_password.live_redis.result)}@',
 		);
 		expect(locals.match(/name\s*=\s*"REDIS_URL"/g)).toHaveLength(1);
 		expect(locals).toMatch(
-			/live_redis_url_secret\s*=\s*var\.live_preview_enabled\s*\?/,
+			/live_redis_url_secret\s*=\s*var\.live_stream_enabled\s*\?/,
 		);
 		expect(
 			locals.match(
@@ -228,9 +249,11 @@ describe("agent deployment config", () => {
 		).toHaveLength(2);
 		expect(ecsConfig.match(/aws_security_group\.live_redis_clients\.id/g)).toHaveLength(2);
 		expect(migrationConfig).toContain("secrets = local.agent_db_password_secret");
+		expect(migrationConfig).not.toContain("REDIS_URL");
+		expect(outputs).not.toMatch(/live_redis|REDIS_URL|random_password/);
 	});
 
-	it("documents the Redis live lane as optional transport infrastructure", () => {
+	it("keeps the Redis Live Stream additively deployable until the hard cutover", () => {
 		const readme = readFileSync(join(terraformDir, "README.md"), "utf8");
 
 		expect(readme).toContain(
@@ -239,6 +262,19 @@ describe("agent deployment config", () => {
 		expect(readme).toContain(
 			"The durable Postgres path remains sufficient for successful Runs",
 		);
+		expect(readme).toContain("live_stream_enabled=false");
+	});
+
+	it("provides disposable local and CI Redis for real Stream and Lua contract tests", () => {
+		expect(composeConfig).toMatch(/\n {2}redis:\n[\s\S]*?image: redis:7/);
+		expect(composeConfig).toContain('"127.0.0.1:${REDIS_PORT:-6379}:6379"');
+		expect(composeConfig).toContain(
+			'["redis-server", "--save", "", "--appendonly", "no"]',
+		);
+		expect(composeConfig).not.toMatch(/redis-data|redisdata/);
+		expect(ciWorkflow).toContain("redis-server");
+		expect(ciWorkflow).toContain("bun run test");
+		expect(redisContractTest).toContain('"redis-server"');
 	});
 
 	it("documents the Downloadable artifact operator and downstream contracts", () => {


### PR DESCRIPTION
## Summary

- align the production ElastiCache, security-group, and Secrets Manager contract with the per-Run Redis Live Stream
- keep secure Redis injection additive through `live_stream_enabled` until the hard-cutover ticket makes configuration mandatory
- add disposable loopback-only local Redis and explicit CI support for real Stream and Lua contract tests
- strengthen deployment validation for trusted connectivity, secret injection/output boundaries, and sandbox exclusion

## Acceptance criteria

- [x] Production Redis requires authenticated TLS transport and permits ingress only from the trusted chat-api and agent-worker client security group.
- [x] `REDIS_URL` is injected from Secrets Manager only into the trusted services, is not output, and is excluded from the E2B sandbox.
- [x] Both trusted service loaders accept only authenticated `rediss://` configuration while remaining additive.
- [x] Local Compose and CI provide disposable Redis suitable for real Stream and Lua tests.
- [x] Deployment tests assert security-group, secret, connectivity, and non-exposure behavior.
- [x] `live_stream_enabled=false` omits injection without deleting Redis until the later hard cutover.

## Validation

- `bun run test` — all five workspaces passed after rebasing onto current `main`
- `terraform -chdir=infra/terraform validate`
- `terraform -chdir=infra/terraform fmt -check`
- `docker compose config --quiet`
- real Redis Stream/Lua contract suite: 10/10 passed

Closes #341