### PR TITLE
fix(infra): avoid replacing attached Redis security groups

### DIFF
--- a/infra/terraform/redis.tf
+++ b/infra/terraform/redis.tf
@@ -1,12 +1,14 @@
+# Security group descriptions are replacement-only in AWS. These fixed-name
+# groups cannot be replaced while ECS and ElastiCache network interfaces use them.
 resource "aws_security_group" "live_redis" {
   name        = "${local.common_name}-live-redis"
-  description = "Private Redis Live Stream for trusted agent services"
+  description = "Private Redis live preview lane for trusted agent services"
   vpc_id      = local.shared_vpc_id
 }
 
 resource "aws_security_group" "live_redis_clients" {
   name        = "${local.common_name}-live-redis-clients"
-  description = "chat-api and agent-worker clients of the Redis Live Stream"
+  description = "chat-api and agent-worker clients of the Redis live preview lane"
   vpc_id      = local.shared_vpc_id
 }
 


### PR DESCRIPTION
## Summary

- preserve the deployed descriptions of the fixed-name Redis security groups
- document that changing those descriptions forces an unsafe replacement while ECS and ElastiCache ENIs remain attached
- allow Terraform to recreate the Redis ingress rule removed by the failed apply

## Root cause

[Release deploy #29](https://github.com/X-GPT/mymemo-agent/actions/runs/29737937967) changed the descriptions of both Redis security groups. The AWS provider treats those fields as replacement-only, so Terraform attempted destroy-before-create. AWS rejected both deletions with `DependencyViolation` because the groups were still attached to ECS and ElastiCache network interfaces, after Terraform retried for 15 minutes.

The failed apply had already deleted `aws_security_group_rule.live_redis_from_services`, leaving the Redis Live Stream path without ingress.

## Impact

The new application revision was not rolled out. This recovery keeps the existing security-group identities and lets the next deploy restore Redis ingress without deleting attached groups.

## Verification

- `terraform -chdir=infra/terraform fmt -check`
- Terraform configuration validation through the production plan workflow
- pre-fix production plan: both Redis security groups had `delete, create` actions
- post-fix production plan:
  - both Redis security groups are `no-op`
  - the missing ingress rule is `create`
  - `Plan: 1 to add, 1 to change, 0 to destroy`