### PR TITLE
feat(chat-api): serve permanent conversation history (#337)

### DIFF
--- a/apps/chat-api/src/deps.ts
+++ b/apps/chat-api/src/deps.ts
@@ -21,6 +21,10 @@ import {
 	PostgresArtifactMetadataStore,
 } from "./features/artifacts";
 import {
+	type ConversationHistoryStore,
+	PostgresConversationHistoryStore,
+} from "./features/conversation-history";
+import {
 	type ConversationStore,
 	PostgresConversationStore,
 } from "./features/conversation-store";
@@ -51,6 +55,8 @@ export interface AppDeps {
 	artifactDownloadSigner: ArtifactDownloadSigner;
 	/** Durable conversation registry (source of truth for frozen scope). */
 	conversationStore: ConversationStore;
+	/** Permanent AG-UI Conversation-history projection over Postgres Runs. */
+	conversationHistoryStore: ConversationHistoryStore;
 	/** Durable split-runtime run queue and event log. */
 	runStore: RunStore;
 	/** Durable run-event replay source for SSE projection. */
@@ -88,6 +94,9 @@ export function createDeps(
 	// One Drizzle pool over the writable DB, shared by every store.
 	const database = createDatabase(config.databaseUrl);
 	const conversationStore = new PostgresConversationStore(database);
+	const conversationHistoryStore = new PostgresConversationHistoryStore(
+		database,
+	);
 	const runStore = new PostgresRunStore(database);
 	const runEventReader = new DrizzleRunEventReader(database);
 	const runNotifier = new PostgresRunNotifier(config.databaseUrl);
@@ -119,6 +128,7 @@ export function createDeps(
 			region: config.artifactRegion,
 		}),
 		conversationStore,
+		conversationHistoryStore,
 		runStore,
 		runEventReader,
 		runNotifier,

--- a/apps/chat-api/src/features/conversation-history/conversation-history-store.ts
+++ b/apps/chat-api/src/features/conversation-history/conversation-history-store.ts
@@ -1,0 +1,63 @@
+import type { Message, RunErrorEvent, RunFinishedEvent } from "@ag-ui/core";
+import type { ConversationScope } from "@/features/conversation-store";
+
+export interface ConversationSummary {
+	conversationId: string;
+	title: string | null;
+	scope: ConversationScope;
+	collectionId: string | null;
+	summaryId: string | null;
+	createdAt: Date;
+	lastActivityAt: Date;
+	archivedAt: Date | null;
+}
+
+/** ADR-0012 names cancellation as its own standard terminal event. The pinned
+ * AG-UI package does not expose that type yet, so keep this narrow bridge local
+ * to the history contract until the package adds it. */
+export interface RunCancelledEvent {
+	type: "RUN_CANCELLED";
+	threadId: string;
+	runId: string;
+}
+
+export type RunTerminalEvent =
+	| RunFinishedEvent
+	| RunErrorEvent
+	| RunCancelledEvent;
+
+export interface ConversationHistoryRun {
+	runId: string;
+	messages: Message[];
+	terminalEvent: RunTerminalEvent | null;
+}
+
+export interface ActiveRunSummary {
+	runId: string;
+	status: "queued" | "running" | "cancel_requested";
+	lastEventId: "0";
+}
+
+export interface ConversationHistoryPage {
+	conversation: ConversationSummary;
+	runs: ConversationHistoryRun[];
+	nextCursor: string | null;
+	activeRun: ActiveRunSummary | null;
+}
+
+export interface ConversationHistoryPageInput {
+	userId: string;
+	conversationId: string;
+	limit: number;
+	cursor: string | null;
+}
+
+export interface ConversationHistoryStore {
+	getPage(
+		input: ConversationHistoryPageInput,
+	): Promise<ConversationHistoryPage | null>;
+}
+
+export class InvalidConversationHistoryCursorError extends Error {
+	override name = "InvalidConversationHistoryCursorError" as const;
+}

--- a/apps/chat-api/src/features/conversation-history/conversation-history.route.test.ts
+++ b/apps/chat-api/src/features/conversation-history/conversation-history.route.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "bun:test";
+import { InvalidRunEventError } from "@mymemo/agent-db/run-events";
+import type { ApiConfig } from "@/config/env";
+import type { AppDeps } from "@/deps";
+import {
+	type ConversationHistoryStore,
+	InvalidConversationHistoryCursorError,
+} from "./conversation-history-store";
+
+const { createApp } = await import("@/app");
+
+const identityHeaders = {
+	"x-member-code": "member-1",
+	"x-partner-code": "partner-1",
+};
+
+describe("GET /v1/conversations/:conversationId/history", () => {
+	it("returns the owned permanent history envelope without consulting exposure", async () => {
+		const calls: unknown[] = [];
+		const historyStore: ConversationHistoryStore = {
+			async getPage(input) {
+				calls.push(input);
+				return {
+					conversation: {
+						conversationId: "conversation-1",
+						title: "Quarterly plan",
+						scope: "general",
+						collectionId: null,
+						summaryId: null,
+						createdAt: new Date("2026-07-20T01:00:00.000Z"),
+						lastActivityAt: new Date("2026-07-20T02:00:00.000Z"),
+						archivedAt: null,
+					},
+					runs: [],
+					nextCursor: null,
+					activeRun: null,
+				};
+			},
+		};
+		const deps = {
+			conversationHistoryStore: historyStore,
+			exposureGate: {
+				async isAgentEnabled() {
+					throw new Error("history reads must not consult exposure");
+				},
+			},
+		} as unknown as AppDeps;
+		const app = createApp({ logLevel: "silent" } as ApiConfig, deps);
+
+		const response = await app.request(
+			"/v1/conversations/conversation-1/history",
+			{ headers: identityHeaders },
+		);
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({
+			conversation: {
+				conversationId: "conversation-1",
+				title: "Quarterly plan",
+				scope: "general",
+				collectionId: null,
+				summaryId: null,
+				createdAt: "2026-07-20T01:00:00.000Z",
+				lastActivityAt: "2026-07-20T02:00:00.000Z",
+				archivedAt: null,
+			},
+			runs: [],
+			nextCursor: null,
+			activeRun: null,
+		});
+		expect(calls).toEqual([
+			{
+				userId: "member-1",
+				conversationId: "conversation-1",
+				limit: 20,
+				cursor: null,
+			},
+		]);
+	});
+
+	it("rejects invalid cursors and hides durable-history corruption", async () => {
+		const historyStore: ConversationHistoryStore = {
+			async getPage({ cursor }) {
+				if (cursor === "bad-cursor") {
+					throw new InvalidConversationHistoryCursorError("cursor detail");
+				}
+				throw new InvalidRunEventError("payload detail must stay private");
+			},
+		};
+		const deps = {
+			conversationHistoryStore: historyStore,
+		} as unknown as AppDeps;
+		const app = createApp({ logLevel: "silent" } as ApiConfig, deps);
+
+		const invalidCursor = await app.request(
+			"/v1/conversations/conversation-1/history?cursor=bad-cursor",
+			{ headers: identityHeaders },
+		);
+		expect(invalidCursor.status).toBe(400);
+		expect(await invalidCursor.json()).toEqual({
+			error: "Invalid history cursor",
+		});
+
+		const corruption = await app.request(
+			"/v1/conversations/conversation-1/history",
+			{ headers: identityHeaders },
+		);
+		expect(corruption.status).toBe(500);
+		expect(await corruption.json()).toEqual({
+			error: "Conversation history is unavailable",
+		});
+	});
+
+	it("requires trusted ownership and validates paging before reading history", async () => {
+		let calls = 0;
+		const historyStore: ConversationHistoryStore = {
+			async getPage() {
+				calls++;
+				return null;
+			},
+		};
+		const deps = {
+			conversationHistoryStore: historyStore,
+		} as unknown as AppDeps;
+		const app = createApp({ logLevel: "silent" } as ApiConfig, deps);
+
+		const missingIdentity = await app.request(
+			"/v1/conversations/conversation-1/history",
+		);
+		expect(missingIdentity.status).toBe(401);
+		expect(calls).toBe(0);
+
+		const invalidPaging = await app.request(
+			"/v1/conversations/conversation-1/history?limit=0",
+			{ headers: identityHeaders },
+		);
+		expect(invalidPaging.status).toBe(400);
+		expect(calls).toBe(0);
+
+		const missingOrForeign = await app.request(
+			"/v1/conversations/conversation-1/history",
+			{ headers: identityHeaders },
+		);
+		expect(missingOrForeign.status).toBe(404);
+		expect(calls).toBe(1);
+	});
+});

--- a/apps/chat-api/src/features/conversation-history/conversation-history.route.ts
+++ b/apps/chat-api/src/features/conversation-history/conversation-history.route.ts
@@ -1,0 +1,82 @@
+import { InvalidRunEventError } from "@mymemo/agent-db/run-events";
+import { Hono } from "hono";
+import { validator as zValidator } from "hono-openapi";
+import { z } from "zod";
+import type { AppEnv } from "@/deps";
+import { ConversationIdParam } from "@/features/conversations/conversations.schema";
+import { identityFromContext } from "@/features/conversations/internal-identity";
+import {
+	type ConversationHistoryPage,
+	InvalidConversationHistoryCursorError,
+} from "./conversation-history-store";
+
+const DEFAULT_HISTORY_LIMIT = 20;
+const MAX_HISTORY_LIMIT = 100;
+
+const HistoryQuery = z
+	.object({
+		limit: z.coerce
+			.number()
+			.int()
+			.min(1)
+			.max(MAX_HISTORY_LIMIT)
+			.default(DEFAULT_HISTORY_LIMIT),
+		cursor: z.string().min(1).max(1024).optional(),
+	})
+	.strict();
+
+const app = new Hono<AppEnv>();
+
+app.get(
+	"/:conversationId/history",
+	zValidator(
+		"param",
+		z.object({ conversationId: ConversationIdParam }),
+		(result, c) => {
+			if (!result.success) {
+				return c.json({ error: "Invalid conversation id" }, 400);
+			}
+		},
+	),
+	zValidator("query", HistoryQuery, (result, c) => {
+		if (!result.success) {
+			return c.json({ error: "Invalid history query" }, 400);
+		}
+	}),
+	async (c) => {
+		const identity = identityFromContext(c);
+		if (!identity.success) {
+			return c.json(
+				{ error: "Missing or invalid internal identity headers" },
+				401,
+			);
+		}
+		const { conversationId } = c.req.valid("param");
+		const query = c.req.valid("query");
+		let page: ConversationHistoryPage | null;
+		try {
+			page = await c.var.deps.conversationHistoryStore.getPage({
+				userId: identity.data.memberCode,
+				conversationId,
+				limit: query.limit,
+				cursor: query.cursor ?? null,
+			});
+		} catch (error) {
+			if (error instanceof InvalidConversationHistoryCursorError) {
+				return c.json({ error: "Invalid history cursor" }, 400);
+			}
+			if (error instanceof InvalidRunEventError) {
+				c.var.logger.error({
+					message: "Conversation history corruption",
+					conversationId,
+				});
+				return c.json({ error: "Conversation history is unavailable" }, 500);
+			}
+			throw error;
+		}
+		if (!page) return c.json({ error: "Conversation not found" }, 404);
+		return c.json(page);
+	},
+);
+
+export default app;

--- a/apps/chat-api/src/features/conversation-history/index.ts
+++ b/apps/chat-api/src/features/conversation-history/index.ts
@@ -1,0 +1,13 @@
+export { default as conversationHistoryRoutes } from "./conversation-history.route";
+export type {
+	ActiveRunSummary,
+	ConversationHistoryPage,
+	ConversationHistoryPageInput,
+	ConversationHistoryRun,
+	ConversationHistoryStore,
+	ConversationSummary,
+	RunCancelledEvent,
+	RunTerminalEvent,
+} from "./conversation-history-store";
+export { InvalidConversationHistoryCursorError } from "./conversation-history-store";
+export { PostgresConversationHistoryStore } from "./postgres-conversation-history-store";

--- a/apps/chat-api/src/features/conversation-history/postgres-conversation-history-store.test.ts
+++ b/apps/chat-api/src/features/conversation-history/postgres-conversation-history-store.test.ts
@@ -1,0 +1,728 @@
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+} from "bun:test";
+import { EventType } from "@ag-ui/core";
+import { and, eq, sql } from "drizzle-orm";
+import { conversations, runEvents, runs } from "@/db/schema";
+import { createTestDatabase, type TestDb } from "@/db/testing";
+import { PostgresConversationStore } from "@/features/conversation-store";
+import { RunEventType } from "@/features/run-events";
+import { PostgresConversationHistoryStore } from "./postgres-conversation-history-store";
+
+let tdb: TestDb;
+
+beforeAll(async () => {
+	tdb = await createTestDatabase();
+});
+
+afterAll(async () => {
+	await tdb.close();
+});
+
+beforeEach(async () => {
+	await tdb.db.delete(conversations);
+});
+
+describe("PostgresConversationHistoryStore", () => {
+	it("projects a complete text Run into standard messages and a separate terminal event", async () => {
+		const createdAt = new Date("2026-07-20T01:00:00.000Z");
+		const lastActivityAt = new Date("2026-07-20T02:00:00.000Z");
+		await tdb.db.insert(conversations).values({
+			userId: "member-1",
+			conversationId: "conversation-1",
+			scope: "collection",
+			collectionId: "collection-1",
+			summaryId: null,
+			title: "Quarterly plan",
+			createdAt,
+			lastActivityAt,
+		});
+		await tdb.db.insert(runs).values({
+			runId: "run-1",
+			userId: "member-1",
+			conversationId: "conversation-1",
+			status: "done",
+			createdAt: lastActivityAt,
+			updatedAt: lastActivityAt,
+			terminalAt: new Date("2026-07-20T02:00:05.000Z"),
+			nextEventSeq: 4,
+		});
+		await tdb.db.insert(runEvents).values([
+			{
+				runId: "run-1",
+				seq: 1,
+				type: RunEventType.Started,
+				payload: {
+					runId: "run-1",
+					conversationId: "conversation-1",
+					messageId: "user-1",
+					message: "Summarize the plan",
+					scope: "collection",
+					collectionId: "collection-1",
+					summaryId: null,
+				},
+			},
+			{
+				runId: "run-1",
+				seq: 2,
+				type: RunEventType.AssistantMessageCompleted,
+				payload: { messageId: "assistant-1", text: "Here is the summary." },
+			},
+			{
+				runId: "run-1",
+				seq: 3,
+				type: RunEventType.Done,
+				payload: { outcome: "done" },
+			},
+		]);
+
+		const store = new PostgresConversationHistoryStore(tdb.db);
+		const page = await store.getPage({
+			userId: "member-1",
+			conversationId: "conversation-1",
+			limit: 20,
+			cursor: null,
+		});
+
+		expect(page).toEqual({
+			conversation: {
+				conversationId: "conversation-1",
+				title: "Quarterly plan",
+				scope: "collection",
+				collectionId: "collection-1",
+				summaryId: null,
+				createdAt,
+				lastActivityAt,
+				archivedAt: null,
+			},
+			runs: [
+				{
+					runId: "run-1",
+					messages: [
+						{ id: "user-1", role: "user", content: "Summarize the plan" },
+						{
+							id: "assistant-1",
+							role: "assistant",
+							content: "Here is the summary.",
+						},
+					],
+					terminalEvent: {
+						type: EventType.RUN_FINISHED,
+						threadId: "conversation-1",
+						runId: "run-1",
+					},
+				},
+			],
+			nextCursor: null,
+			activeRun: null,
+		});
+	});
+
+	it("retains complete legacy Assistant text when it has a stable message id", async () => {
+		await tdb.db.insert(conversations).values({
+			userId: "member-1",
+			conversationId: "conversation-1",
+			scope: "general",
+		});
+		await tdb.db.insert(runs).values({
+			runId: "run-legacy-text",
+			userId: "member-1",
+			conversationId: "conversation-1",
+			status: "done",
+			terminalAt: new Date("2026-07-20T01:00:05.000Z"),
+			nextEventSeq: 4,
+		});
+		await tdb.db.insert(runEvents).values([
+			{
+				runId: "run-legacy-text",
+				seq: 1,
+				type: RunEventType.Started,
+				payload: {
+					runId: "run-legacy-text",
+					conversationId: "conversation-1",
+					messageId: "user-legacy",
+					message: "Legacy question",
+					scope: "general",
+					collectionId: null,
+					summaryId: null,
+				},
+			},
+			{
+				runId: "run-legacy-text",
+				seq: 2,
+				type: RunEventType.AssistantText,
+				payload: { messageId: "assistant-legacy", text: "Legacy answer" },
+			},
+			{
+				runId: "run-legacy-text",
+				seq: 3,
+				type: RunEventType.Done,
+				payload: { outcome: "done" },
+			},
+		]);
+
+		const page = await new PostgresConversationHistoryStore(tdb.db).getPage({
+			userId: "member-1",
+			conversationId: "conversation-1",
+			limit: 20,
+			cursor: null,
+		});
+
+		expect(page?.runs[0]?.messages).toEqual([
+			{ id: "user-legacy", role: "user", content: "Legacy question" },
+			{
+				id: "assistant-legacy",
+				role: "assistant",
+				content: "Legacy answer",
+			},
+		]);
+	});
+
+	it("pages whole terminal Runs newest-first and presents each page chronologically", async () => {
+		await tdb.db.insert(conversations).values({
+			userId: "member-1",
+			conversationId: "conversation-1",
+			scope: "general",
+		});
+		for (const [index, runId] of ["run-1", "run-2", "run-3"].entries()) {
+			const createdAt = new Date(`2026-07-20T0${index + 1}:00:00.000Z`);
+			await tdb.db.insert(runs).values({
+				runId,
+				userId: "member-1",
+				conversationId: "conversation-1",
+				status: "done",
+				createdAt,
+				updatedAt: createdAt,
+				terminalAt: createdAt,
+				nextEventSeq: 3,
+			});
+			await tdb.db.insert(runEvents).values([
+				{
+					runId,
+					seq: 1,
+					type: RunEventType.Started,
+					payload: {
+						runId,
+						conversationId: "conversation-1",
+						messageId: `user-${index + 1}`,
+						message: `Question ${index + 1}`,
+						scope: "general",
+						collectionId: null,
+						summaryId: null,
+					},
+				},
+				{
+					runId,
+					seq: 2,
+					type: RunEventType.Done,
+					payload: { outcome: "done" },
+				},
+			]);
+		}
+
+		const store = new PostgresConversationHistoryStore(tdb.db);
+		const newestPage = await store.getPage({
+			userId: "member-1",
+			conversationId: "conversation-1",
+			limit: 2,
+			cursor: null,
+		});
+
+		expect(newestPage?.runs.map((run) => run.runId)).toEqual([
+			"run-2",
+			"run-3",
+		]);
+		expect(newestPage?.runs.map((run) => run.messages)).toEqual([
+			[{ id: "user-2", role: "user", content: "Question 2" }],
+			[{ id: "user-3", role: "user", content: "Question 3" }],
+		]);
+		expect(newestPage?.nextCursor).toEqual(expect.any(String));
+
+		const olderPage = await store.getPage({
+			userId: "member-1",
+			conversationId: "conversation-1",
+			limit: 2,
+			cursor: newestPage?.nextCursor ?? null,
+		});
+		expect(olderPage?.runs.map((run) => run.runId)).toEqual(["run-1"]);
+		expect(olderPage?.nextCursor).toBeNull();
+	});
+
+	it("does not skip Run-id ties when Postgres timestamps contain microseconds", async () => {
+		await tdb.db.insert(conversations).values({
+			userId: "member-1",
+			conversationId: "conversation-1",
+			scope: "general",
+		});
+		await tdb.db.execute(sql`
+			insert into runs (
+				run_id, user_id, conversation_id, status, created_at, updated_at,
+				terminal_at, next_event_seq
+			) values
+				('run-a', 'member-1', 'conversation-1', 'done',
+				 '2026-07-20 01:00:00.123456+00', '2026-07-20 01:00:00.123456+00',
+				 '2026-07-20 01:00:01+00', 3),
+				('run-b', 'member-1', 'conversation-1', 'done',
+				 '2026-07-20 01:00:00.123456+00', '2026-07-20 01:00:00.123456+00',
+				 '2026-07-20 01:00:01+00', 3)
+		`);
+		for (const runId of ["run-a", "run-b"]) {
+			await tdb.db.insert(runEvents).values([
+				{
+					runId,
+					seq: 1,
+					type: RunEventType.Started,
+					payload: {
+						runId,
+						conversationId: "conversation-1",
+						messageId: `user-${runId}`,
+						message: runId,
+						scope: "general",
+						collectionId: null,
+						summaryId: null,
+					},
+				},
+				{
+					runId,
+					seq: 2,
+					type: RunEventType.Done,
+					payload: { outcome: "done" },
+				},
+			]);
+		}
+		const store = new PostgresConversationHistoryStore(tdb.db);
+
+		const first = await store.getPage({
+			userId: "member-1",
+			conversationId: "conversation-1",
+			limit: 1,
+			cursor: null,
+		});
+		expect(first?.runs.map((run) => run.runId)).toEqual(["run-b"]);
+		const second = await store.getPage({
+			userId: "member-1",
+			conversationId: "conversation-1",
+			limit: 1,
+			cursor: first?.nextCursor ?? null,
+		});
+		expect(second?.runs.map((run) => run.runId)).toEqual(["run-a"]);
+	});
+
+	it("returns the active Run outside the completed-Run limit with replay metadata", async () => {
+		await tdb.db.insert(conversations).values({
+			userId: "member-1",
+			conversationId: "conversation-1",
+			scope: "general",
+		});
+		await tdb.db.insert(runs).values([
+			{
+				runId: "run-complete",
+				userId: "member-1",
+				conversationId: "conversation-1",
+				status: "done",
+				createdAt: new Date("2026-07-20T01:00:00.000Z"),
+				terminalAt: new Date("2026-07-20T01:00:05.000Z"),
+				nextEventSeq: 3,
+			},
+			{
+				runId: "run-active",
+				userId: "member-1",
+				conversationId: "conversation-1",
+				status: "running",
+				createdAt: new Date("2026-07-20T02:00:00.000Z"),
+				nextEventSeq: 3,
+			},
+		]);
+		await tdb.db.insert(runEvents).values([
+			{
+				runId: "run-complete",
+				seq: 1,
+				type: RunEventType.Started,
+				payload: {
+					runId: "run-complete",
+					conversationId: "conversation-1",
+					messageId: "user-complete",
+					message: "Previous question",
+					scope: "general",
+					collectionId: null,
+					summaryId: null,
+				},
+			},
+			{
+				runId: "run-complete",
+				seq: 2,
+				type: RunEventType.Done,
+				payload: { outcome: "done" },
+			},
+			{
+				runId: "run-active",
+				seq: 1,
+				type: RunEventType.Started,
+				payload: {
+					runId: "run-active",
+					conversationId: "conversation-1",
+					messageId: "user-active",
+					message: "Current question",
+					scope: "general",
+					collectionId: null,
+					summaryId: null,
+				},
+			},
+			{
+				runId: "run-active",
+				seq: 2,
+				type: RunEventType.AssistantMessageCompleted,
+				payload: {
+					messageId: "assistant-active",
+					text: "Durable but replayed",
+				},
+			},
+		]);
+
+		const page = await new PostgresConversationHistoryStore(tdb.db).getPage({
+			userId: "member-1",
+			conversationId: "conversation-1",
+			limit: 1,
+			cursor: null,
+		});
+
+		expect(page?.runs.map((run) => run.runId)).toEqual([
+			"run-complete",
+			"run-active",
+		]);
+		expect(page?.runs[1]).toEqual({
+			runId: "run-active",
+			messages: [
+				{ id: "user-active", role: "user", content: "Current question" },
+			],
+			terminalEvent: null,
+		});
+		expect(page?.activeRun).toEqual({
+			runId: "run-active",
+			status: "running",
+			lastEventId: "0",
+		});
+	});
+
+	it("projects a Tool-only response and its correlated error result as standard messages", async () => {
+		await tdb.db.insert(conversations).values({
+			userId: "member-1",
+			conversationId: "conversation-1",
+			scope: "general",
+		});
+		await tdb.db.insert(runs).values({
+			runId: "run-tool",
+			userId: "member-1",
+			conversationId: "conversation-1",
+			status: "done",
+			terminalAt: new Date("2026-07-20T01:00:05.000Z"),
+			nextEventSeq: 8,
+		});
+		await tdb.db.insert(runEvents).values([
+			{
+				runId: "run-tool",
+				seq: 1,
+				type: RunEventType.Started,
+				payload: {
+					runId: "run-tool",
+					conversationId: "conversation-1",
+					messageId: "user-tool",
+					message: "Read the notes",
+					scope: "general",
+					collectionId: null,
+					summaryId: null,
+				},
+			},
+			{
+				runId: "run-tool",
+				seq: 2,
+				type: RunEventType.ToolCallStarted,
+				payload: {
+					toolCallId: "tool-call-1",
+					toolCallName: "Read",
+					parentMessageId: "assistant-tool",
+				},
+			},
+			{
+				runId: "run-tool",
+				seq: 3,
+				type: RunEventType.ToolCallArgs,
+				payload: { toolCallId: "tool-call-1", delta: '{"path":"notes.md"}' },
+			},
+			{
+				runId: "run-tool",
+				seq: 4,
+				type: RunEventType.ToolCallCompleted,
+				payload: { toolCallId: "tool-call-1" },
+			},
+			{
+				runId: "run-tool",
+				seq: 5,
+				type: RunEventType.AssistantMessageCompleted,
+				payload: { messageId: "assistant-tool", text: "" },
+			},
+			{
+				runId: "run-tool",
+				seq: 6,
+				type: RunEventType.ToolCallResult,
+				payload: {
+					messageId: "tool-message-1",
+					toolCallId: "tool-call-1",
+					content: "Tool failed",
+					isError: true,
+				},
+			},
+			{
+				runId: "run-tool",
+				seq: 7,
+				type: RunEventType.Done,
+				payload: { outcome: "done" },
+			},
+		]);
+
+		const page = await new PostgresConversationHistoryStore(tdb.db).getPage({
+			userId: "member-1",
+			conversationId: "conversation-1",
+			limit: 20,
+			cursor: null,
+		});
+
+		expect(page?.runs[0]?.messages).toEqual([
+			{ id: "user-tool", role: "user", content: "Read the notes" },
+			{
+				id: "assistant-tool",
+				role: "assistant",
+				toolCalls: [
+					{
+						id: "tool-call-1",
+						type: "function",
+						function: {
+							name: "Read",
+							arguments: '{"path":"notes.md"}',
+						},
+					},
+				],
+			},
+			{
+				id: "tool-message-1",
+				role: "tool",
+				toolCallId: "tool-call-1",
+				content: "Tool failed",
+				error: "Tool failed",
+			},
+		]);
+	});
+
+	it("keeps error and cancellation Outcomes only in terminal events", async () => {
+		await tdb.db.insert(conversations).values({
+			userId: "member-1",
+			conversationId: "conversation-1",
+			scope: "general",
+		});
+		for (const [index, outcome] of ["error", "canceled"].entries()) {
+			const runId = `run-${outcome}`;
+			const createdAt = new Date(`2026-07-20T0${index + 1}:00:00.000Z`);
+			await tdb.db.insert(runs).values({
+				runId,
+				userId: "member-1",
+				conversationId: "conversation-1",
+				status: outcome,
+				createdAt,
+				terminalAt: createdAt,
+				nextEventSeq: 3,
+			});
+			await tdb.db.insert(runEvents).values([
+				{
+					runId,
+					seq: 1,
+					type: RunEventType.Started,
+					payload: {
+						runId,
+						conversationId: "conversation-1",
+						messageId: `user-${outcome}`,
+						message: `${outcome} question`,
+						scope: "general",
+						collectionId: null,
+						summaryId: null,
+					},
+				},
+				{
+					runId,
+					seq: 2,
+					type:
+						outcome === "error" ? RunEventType.Error : RunEventType.Canceled,
+					payload:
+						outcome === "error"
+							? { outcome: "error", message: "Run failed" }
+							: { outcome: "canceled" },
+				},
+			]);
+		}
+
+		const page = await new PostgresConversationHistoryStore(tdb.db).getPage({
+			userId: "member-1",
+			conversationId: "conversation-1",
+			limit: 20,
+			cursor: null,
+		});
+
+		expect(page?.runs).toEqual([
+			{
+				runId: "run-error",
+				messages: [
+					{ id: "user-error", role: "user", content: "error question" },
+				],
+				terminalEvent: { type: EventType.RUN_ERROR, message: "Run failed" },
+			},
+			{
+				runId: "run-canceled",
+				messages: [
+					{
+						id: "user-canceled",
+						role: "user",
+						content: "canceled question",
+					},
+				],
+				terminalEvent: {
+					type: "RUN_CANCELLED",
+					threadId: "conversation-1",
+					runId: "run-canceled",
+				},
+			},
+		]);
+	});
+
+	it("skips unknown events but rejects a malformed known event as corruption", async () => {
+		await tdb.db.insert(conversations).values({
+			userId: "member-1",
+			conversationId: "conversation-1",
+			scope: "general",
+		});
+		await tdb.db.insert(runs).values({
+			runId: "run-1",
+			userId: "member-1",
+			conversationId: "conversation-1",
+			status: "done",
+			terminalAt: new Date("2026-07-20T01:00:05.000Z"),
+			nextEventSeq: 4,
+		});
+		await tdb.db.insert(runEvents).values([
+			{
+				runId: "run-1",
+				seq: 1,
+				type: RunEventType.Started,
+				payload: {
+					runId: "run-1",
+					conversationId: "conversation-1",
+					messageId: "user-1",
+					message: "Question",
+					scope: "general",
+					collectionId: null,
+					summaryId: null,
+				},
+			},
+			{
+				runId: "run-1",
+				seq: 2,
+				type: "worker_internal_note",
+				payload: { secret: "not projected" },
+			},
+			{
+				runId: "run-1",
+				seq: 3,
+				type: RunEventType.Done,
+				payload: { outcome: "done" },
+			},
+		]);
+		const store = new PostgresConversationHistoryStore(tdb.db);
+
+		const validPage = await store.getPage({
+			userId: "member-1",
+			conversationId: "conversation-1",
+			limit: 20,
+			cursor: null,
+		});
+		expect(validPage?.runs[0]?.messages).toEqual([
+			{ id: "user-1", role: "user", content: "Question" },
+		]);
+
+		await tdb.db
+			.update(runEvents)
+			.set({
+				type: RunEventType.AssistantMessageCompleted,
+				payload: { text: "missing messageId" },
+			})
+			.where(and(eq(runEvents.runId, "run-1"), eq(runEvents.seq, 2)));
+		await expect(
+			store.getPage({
+				userId: "member-1",
+				conversationId: "conversation-1",
+				limit: 20,
+				cursor: null,
+			}),
+		).rejects.toThrow("invalid payload for durable event");
+	});
+
+	it("serves Postgres history after Live Stream failure and removes it on permanent deletion", async () => {
+		const conversationStore = new PostgresConversationStore(tdb.db);
+		await conversationStore.create({
+			userId: "member-1",
+			conversationId: "conversation-1",
+			scope: "general",
+			collectionId: null,
+			summaryId: null,
+		});
+		await tdb.db.insert(runs).values({
+			runId: "run-1",
+			userId: "member-1",
+			conversationId: "conversation-1",
+			status: "done",
+			liveStreamFailedAt: new Date("2026-07-20T01:00:01.000Z"),
+			terminalAt: new Date("2026-07-20T01:00:05.000Z"),
+			nextEventSeq: 3,
+		});
+		await tdb.db.insert(runEvents).values([
+			{
+				runId: "run-1",
+				seq: 1,
+				type: RunEventType.Started,
+				payload: {
+					runId: "run-1",
+					conversationId: "conversation-1",
+					messageId: "user-1",
+					message: "Question",
+					scope: "general",
+					collectionId: null,
+					summaryId: null,
+				},
+			},
+			{
+				runId: "run-1",
+				seq: 2,
+				type: RunEventType.Done,
+				payload: { outcome: "done" },
+			},
+		]);
+		const historyStore = new PostgresConversationHistoryStore(tdb.db);
+		const input = {
+			userId: "member-1",
+			conversationId: "conversation-1",
+			limit: 20,
+			cursor: null,
+		};
+
+		expect((await historyStore.getPage(input))?.runs).toHaveLength(1);
+		await expect(
+			conversationStore.deletePermanently({
+				userId: "member-1",
+				conversationId: "conversation-1",
+			}),
+		).resolves.toEqual({ outcome: "deleted" });
+		await expect(historyStore.getPage(input)).resolves.toBeNull();
+	});
+});

--- a/apps/chat-api/src/features/conversation-history/postgres-conversation-history-store.ts
+++ b/apps/chat-api/src/features/conversation-history/postgres-conversation-history-store.ts
@@ -1,0 +1,347 @@
+import { Buffer } from "node:buffer";
+import {
+	type AssistantMessage,
+	EventType,
+	type Message,
+	type ToolCall,
+} from "@ag-ui/core";
+import {
+	InvalidRunEventError,
+	parseDurableRunEvent,
+	RunEventType,
+	validateDurableRunEventSequence,
+} from "@mymemo/agent-db/run-events";
+import { and, desc, eq, inArray, lt, or, sql } from "drizzle-orm";
+import type { Database } from "@/db/client";
+import { conversations, runEvents, runs } from "@/db/schema";
+import type { ConversationScope } from "@/features/conversation-store";
+import type {
+	ActiveRunSummary,
+	ConversationHistoryPage,
+	ConversationHistoryPageInput,
+	ConversationHistoryRun,
+	ConversationHistoryStore,
+	RunTerminalEvent,
+} from "./conversation-history-store";
+import { InvalidConversationHistoryCursorError } from "./conversation-history-store";
+
+const TERMINAL_STATUSES = ["done", "error", "canceled"] as const;
+const ACTIVE_STATUSES = ["queued", "running", "cancel_requested"] as const;
+// node-postgres exposes timestamps as millisecond Date values while Postgres
+// stores microseconds. Use that same precision for ordering and comparison so
+// Run-id tie-breaking cannot be skipped when a cursor round-trips through JSON.
+const RUN_ORDER_CREATED_AT = sql<Date>`date_trunc('milliseconds', ${runs.createdAt})`;
+
+type RunRow = typeof runs.$inferSelect;
+type RunEventRow = typeof runEvents.$inferSelect;
+interface HistoryCursor {
+	createdAt: Date;
+	runId: string;
+}
+
+export class PostgresConversationHistoryStore
+	implements ConversationHistoryStore
+{
+	constructor(private readonly db: Database) {}
+
+	async getPage(
+		input: ConversationHistoryPageInput,
+	): Promise<ConversationHistoryPage | null> {
+		if (!Number.isSafeInteger(input.limit) || input.limit < 1) {
+			throw new Error("History page limit must be a positive integer");
+		}
+		const cursor = input.cursor === null ? null : decodeCursor(input.cursor);
+
+		const [conversation] = await this.db
+			.select()
+			.from(conversations)
+			.where(
+				and(
+					eq(conversations.userId, input.userId),
+					eq(conversations.conversationId, input.conversationId),
+				),
+			)
+			.limit(1);
+		if (!conversation) return null;
+		// Read active first. If it terminalizes before the complete query below, the
+		// complete projection wins and the captured active copy is suppressed. If it
+		// terminalizes later, replay from cursor zero still bridges to its Outcome.
+		const [capturedActiveRun] =
+			input.cursor === null
+				? await this.db
+						.select()
+						.from(runs)
+						.where(
+							and(
+								eq(runs.userId, input.userId),
+								eq(runs.conversationId, input.conversationId),
+								inArray(runs.status, ACTIVE_STATUSES),
+							),
+						)
+						.limit(1)
+				: [];
+
+		const completeRunFilter = and(
+			eq(runs.userId, input.userId),
+			eq(runs.conversationId, input.conversationId),
+			inArray(runs.status, TERMINAL_STATUSES),
+			cursor
+				? or(
+						lt(RUN_ORDER_CREATED_AT, cursor.createdAt),
+						and(
+							eq(RUN_ORDER_CREATED_AT, cursor.createdAt),
+							lt(runs.runId, cursor.runId),
+						),
+					)
+				: undefined,
+		);
+		const completeRuns = await this.db
+			.select()
+			.from(runs)
+			.where(completeRunFilter)
+			.orderBy(desc(RUN_ORDER_CREATED_AT), desc(runs.runId))
+			.limit(input.limit + 1);
+		const pageRows = completeRuns.slice(0, input.limit);
+		const activeRun =
+			capturedActiveRun &&
+			!pageRows.some((run) => run.runId === capturedActiveRun.runId)
+				? capturedActiveRun
+				: null;
+		const eventsByRun = await this.loadEvents([
+			...pageRows.map((run) => run.runId),
+			...(activeRun ? [activeRun.runId] : []),
+		]);
+		const projectedCompleteRuns = pageRows
+			.map((run) => projectCompleteRun(run, eventsByRun.get(run.runId) ?? []))
+			.reverse();
+
+		return {
+			conversation: {
+				conversationId: conversation.conversationId,
+				title: conversation.title,
+				scope: conversation.scope as ConversationScope,
+				collectionId: conversation.collectionId,
+				summaryId: conversation.summaryId,
+				createdAt: conversation.createdAt,
+				lastActivityAt: conversation.lastActivityAt,
+				archivedAt: conversation.archivedAt,
+			},
+			runs: [
+				...projectedCompleteRuns,
+				...(activeRun
+					? [
+							projectActiveRun(
+								activeRun,
+								eventsByRun.get(activeRun.runId) ?? [],
+							),
+						]
+					: []),
+			],
+			nextCursor:
+				completeRuns.length > input.limit
+					? encodeCursor(pageRows[pageRows.length - 1])
+					: null,
+			activeRun: activeRun ? toActiveRunSummary(activeRun) : null,
+		};
+	}
+
+	private async loadEvents(runIds: string[]) {
+		const grouped = new Map<string, RunEventRow[]>();
+		if (runIds.length === 0) return grouped;
+		const rows = await this.db
+			.select()
+			.from(runEvents)
+			.where(inArray(runEvents.runId, runIds))
+			.orderBy(runEvents.runId, runEvents.seq);
+		for (const row of rows) {
+			const events = grouped.get(row.runId) ?? [];
+			events.push(row);
+			grouped.set(row.runId, events);
+		}
+		return grouped;
+	}
+}
+
+function toActiveRunSummary(run: RunRow): ActiveRunSummary {
+	if (!isActiveStatus(run.status)) {
+		throw new InvalidRunEventError("captured active Run has terminal status");
+	}
+	return { runId: run.runId, status: run.status, lastEventId: "0" };
+}
+
+function projectActiveRun(
+	run: RunRow,
+	events: RunEventRow[],
+): ConversationHistoryRun {
+	validateDurableRunEventSequence(events, { allowIncomplete: true });
+	const started = events
+		.map((event) => parseDurableRunEvent(event.type, event.payload))
+		.find((event) => event !== null);
+	if (
+		started?.type !== RunEventType.Started ||
+		started.payload.runId !== run.runId ||
+		started.payload.conversationId !== run.conversationId
+	) {
+		throw new InvalidRunEventError("invalid active durable Run start");
+	}
+	return {
+		runId: run.runId,
+		messages: [
+			{
+				id: started.payload.messageId,
+				role: "user",
+				content: started.payload.message,
+			},
+		],
+		terminalEvent: null,
+	};
+}
+
+function isActiveStatus(status: string): status is ActiveRunSummary["status"] {
+	return ACTIVE_STATUSES.some((activeStatus) => activeStatus === status);
+}
+
+function encodeCursor(run: Pick<RunRow, "createdAt" | "runId"> | undefined) {
+	if (!run) return null;
+	return Buffer.from(
+		JSON.stringify({
+			createdAt: run.createdAt.toISOString(),
+			runId: run.runId,
+		}),
+	).toString("base64url");
+}
+
+function decodeCursor(value: string): HistoryCursor {
+	try {
+		if (!/^[A-Za-z0-9_-]+$/.test(value)) throw new Error("invalid base64url");
+		const decoded = JSON.parse(
+			Buffer.from(value, "base64url").toString("utf8"),
+		);
+		if (
+			typeof decoded !== "object" ||
+			decoded === null ||
+			typeof decoded.createdAt !== "string" ||
+			typeof decoded.runId !== "string" ||
+			decoded.runId.length === 0
+		) {
+			throw new Error("invalid cursor shape");
+		}
+		const createdAt = new Date(decoded.createdAt);
+		if (
+			!Number.isFinite(createdAt.getTime()) ||
+			createdAt.toISOString() !== decoded.createdAt
+		) {
+			throw new Error("invalid cursor timestamp");
+		}
+		return { createdAt, runId: decoded.runId };
+	} catch {
+		throw new InvalidConversationHistoryCursorError("Invalid history cursor");
+	}
+}
+
+function projectCompleteRun(
+	run: RunRow,
+	events: RunEventRow[],
+): ConversationHistoryRun {
+	validateDurableRunEventSequence(events);
+	const parsed = events.flatMap((event) => {
+		const value = parseDurableRunEvent(event.type, event.payload);
+		return value ? [value] : [];
+	});
+	const started = parsed[0];
+	if (
+		started?.type !== RunEventType.Started ||
+		started.payload.runId !== run.runId ||
+		started.payload.conversationId !== run.conversationId
+	) {
+		throw new InvalidRunEventError("invalid durable Run start");
+	}
+
+	const messages: Message[] = [
+		{
+			id: started.payload.messageId,
+			role: "user",
+			content: started.payload.message,
+		},
+	];
+	const assistantMessages = new Map<string, AssistantMessage>();
+	const toolCalls = new Map<string, ToolCall>();
+	const ensureAssistantMessage = (messageId: string) => {
+		const existing = assistantMessages.get(messageId);
+		if (existing) return existing;
+		const message: AssistantMessage = { id: messageId, role: "assistant" };
+		assistantMessages.set(messageId, message);
+		messages.push(message);
+		return message;
+	};
+	let terminalEvent: RunTerminalEvent | null = null;
+	let terminalStatus: "done" | "error" | "canceled" | null = null;
+	for (const event of parsed.slice(1)) {
+		switch (event.type) {
+			case RunEventType.AssistantMessageCompleted:
+			case RunEventType.AssistantText:
+				if (event.payload.text) {
+					ensureAssistantMessage(event.payload.messageId).content =
+						event.payload.text;
+				} else {
+					ensureAssistantMessage(event.payload.messageId);
+				}
+				break;
+			case RunEventType.ToolCallStarted: {
+				const assistant = ensureAssistantMessage(event.payload.parentMessageId);
+				const toolCall: ToolCall = {
+					id: event.payload.toolCallId,
+					type: "function",
+					function: { name: event.payload.toolCallName, arguments: "" },
+				};
+				assistant.toolCalls = [...(assistant.toolCalls ?? []), toolCall];
+				toolCalls.set(toolCall.id, toolCall);
+				break;
+			}
+			case RunEventType.ToolCallArgs: {
+				const toolCall = toolCalls.get(event.payload.toolCallId);
+				if (!toolCall) {
+					throw new InvalidRunEventError("Tool arguments have no invocation");
+				}
+				toolCall.function.arguments += event.payload.delta;
+				break;
+			}
+			case RunEventType.ToolCallResult:
+				messages.push({
+					id: event.payload.messageId,
+					role: "tool",
+					toolCallId: event.payload.toolCallId,
+					content: event.payload.content,
+					...(event.payload.isError ? { error: event.payload.content } : {}),
+				});
+				break;
+			case RunEventType.Done:
+				terminalStatus = "done";
+				terminalEvent = {
+					type: EventType.RUN_FINISHED,
+					threadId: run.conversationId,
+					runId: run.runId,
+				};
+				break;
+			case RunEventType.Error:
+				terminalStatus = "error";
+				terminalEvent = {
+					type: EventType.RUN_ERROR,
+					message: event.payload.message ?? "Run failed",
+				};
+				break;
+			case RunEventType.Canceled:
+				terminalStatus = "canceled";
+				terminalEvent = {
+					type: "RUN_CANCELLED",
+					threadId: run.conversationId,
+					runId: run.runId,
+				};
+				break;
+		}
+	}
+	if (terminalStatus !== run.status || terminalEvent === null) {
+		throw new InvalidRunEventError("durable Run Outcome does not match status");
+	}
+	return { runId: run.runId, messages, terminalEvent };
+}

--- a/apps/chat-api/src/routes/v1.ts
+++ b/apps/chat-api/src/routes/v1.ts
@@ -1,11 +1,13 @@
 import { Hono } from "hono";
 import { artifactRoutes } from "../features/artifacts";
+import { conversationHistoryRoutes } from "../features/conversation-history";
 import { conversationsRoutes } from "../features/conversations";
 
 const app = new Hono();
 
 /* ---------- feature routers ---------- */
 app.route("/conversations", conversationsRoutes);
+app.route("/conversations", conversationHistoryRoutes);
 app.route("/conversations", artifactRoutes);
 
 export default app;


### PR DESCRIPTION
## Summary

- add the owner-scoped `GET /v1/conversations/:conversationId/history` endpoint
- project durable Postgres Runs into chronological AG-UI messages and terminal events
- page complete Runs behind an opaque cursor while exposing the active Run outside the page limit
- fail closed on corrupt known event sequences while skipping unknown extensible events
- cover pagination, Tool-only Runs, terminal outcomes, active refresh, Live Stream expiry, and Permanent deletion

## Why

Conversation history must remain authoritative after the retained Redis Live Stream expires. This implements the permanent AG-UI history contract defined by ADR-0012 and issue #337 without introducing a duplicate message store.

## Impact

Clients can hydrate deep-linked or refreshed Conversations directly from durable Postgres state, then reattach to an active Run from Redis cursor zero when needed.

## Validation

- `bun test`: 860 passed, 11 credential/infrastructure-dependent cases skipped, 0 failed
- real Postgres + Redis split-runtime integration: 1 passed
- live E2B Bash and file-tool integration: 4 passed
- chat-api TypeScript check passed
- Biome check passed
- two-axis standards/spec review: no findings

Closes #337