### PR TITLE
feat(chat-api): resume retained Run streams

### DIFF
--- a/apps/chat-api/src/features/conversations/conversations.route.test.ts
+++ b/apps/chat-api/src/features/conversations/conversations.route.test.ts
@@ -3,6 +3,7 @@ import {
 	createLiveTextTelemetry,
 	disabledLiveTextSubscriber,
 	InMemoryLiveTextTransport,
+	LiveStreamStoreError,
 	type LiveTextSubscriber,
 } from "@mymemo/live-text";
 import type { ApiConfig } from "@/config/env";
@@ -130,6 +131,7 @@ function fakeRunStore() {
 			userId: string;
 			conversationId: string;
 			status: string;
+			liveStreamFailedAt?: Date | null;
 			nextEventSeq?: number;
 		}
 	>();
@@ -243,6 +245,7 @@ function runRecord(input: {
 	userId: string;
 	conversationId: string;
 	status: string;
+	liveStreamFailedAt?: Date | null;
 	nextEventSeq?: number;
 }): RunRecord {
 	const now = new Date();
@@ -258,7 +261,7 @@ function runRecord(input: {
 		lockedUntil: null,
 		heartbeatAt: null,
 		cancelRequestedAt: null,
-		liveStreamFailedAt: null,
+		liveStreamFailedAt: input.liveStreamFailedAt ?? null,
 		nextEventSeq: input.nextEventSeq ?? 1,
 		terminalAt: null,
 	};
@@ -1345,6 +1348,340 @@ describe("GET /v1/conversations/:id/runs/:runId/events", () => {
 		expect(res.status).toBe(404);
 		expect(res.headers.get("content-type")).not.toContain("text/event-stream");
 	});
+
+	it("returns 400 for a malformed Last-Event-ID before reading the Live Stream", async () => {
+		const { store } = fakeStore([existing]);
+		const fakeRuns = fakeRunStore();
+		fakeRuns.runOwners.set("run-1", {
+			userId: "member-1",
+			conversationId: "conv-1",
+			status: "running",
+		});
+		let redisRead = false;
+		const res = await buildApp(
+			store,
+			gateThatFailsIfConsulted(),
+			fakeRuns,
+			disabledLiveTextSubscriber,
+			{
+				async status() {
+					redisRead = true;
+					return "streaming" as const;
+				},
+				read() {
+					redisRead = true;
+					throw new Error("Live Stream must not be read");
+				},
+			},
+		).request("/v1/conversations/conv-1/runs/run-1/events", {
+			method: "GET",
+			headers: { ...identityHeaders, "last-event-id": "not-a-cursor" },
+		});
+
+		expect(res.status).toBe(400);
+		expect(await res.json()).toEqual({ error: "Invalid Last-Event-ID" });
+		expect(redisRead).toBe(false);
+	});
+
+	it("returns 400 for a Redis-shaped Last-Event-ID the Stream never issued", async () => {
+		const { store } = fakeStore([existing]);
+		const fakeRuns = fakeRunStore();
+		fakeRuns.runOwners.set("run-1", {
+			userId: "member-1",
+			conversationId: "conv-1",
+			status: "done",
+		});
+		const res = await buildApp(
+			store,
+			gateThatFailsIfConsulted(),
+			fakeRuns,
+			disabledLiveTextSubscriber,
+			{
+				async status() {
+					return "done" as const;
+				},
+				read() {
+					return {
+						[Symbol.asyncIterator]() {
+							return {
+								async next() {
+									throw new LiveStreamStoreError("invalid_cursor");
+								},
+							};
+						},
+					};
+				},
+			},
+		).request("/v1/conversations/conv-1/runs/run-1/events", {
+			method: "GET",
+			headers: { ...identityHeaders, "last-event-id": "9999999999999-0" },
+		});
+
+		expect(res.status).toBe(400);
+		expect(await res.json()).toEqual({ error: "Invalid Last-Event-ID" });
+	});
+
+	it("returns recovery 410 for a Run whose Live Stream failed without reading Redis", async () => {
+		const { store } = fakeStore([existing]);
+		const fakeRuns = fakeRunStore();
+		fakeRuns.runOwners.set("run-1", {
+			userId: "member-1",
+			conversationId: "conv-1",
+			status: "running",
+			liveStreamFailedAt: new Date("2026-01-01T00:01:00.000Z"),
+		});
+		let redisRead = false;
+		const res = await buildApp(
+			store,
+			gateThatFailsIfConsulted(),
+			fakeRuns,
+			disabledLiveTextSubscriber,
+			{
+				async status() {
+					redisRead = true;
+					return "error" as const;
+				},
+				read() {
+					redisRead = true;
+					throw new Error("Live Stream must not be read");
+				},
+			},
+		).request("/v1/conversations/conv-1/runs/run-1/events", {
+			method: "GET",
+			headers: identityHeaders,
+		});
+
+		expect(res.status).toBe(410);
+		expect(await res.json()).toEqual({
+			error: "Live stream unavailable",
+			recovery: "history",
+		});
+		expect(redisRead).toBe(false);
+	});
+
+	it("returns recovery 410 when a terminal Run's retained Live Stream is missing", async () => {
+		const { store } = fakeStore([existing]);
+		const fakeRuns = fakeRunStore();
+		fakeRuns.runOwners.set("run-1", {
+			userId: "member-1",
+			conversationId: "conv-1",
+			status: "done",
+		});
+		const res = await buildApp(
+			store,
+			gateThatFailsIfConsulted(),
+			fakeRuns,
+			disabledLiveTextSubscriber,
+			{
+				async status() {
+					return "missing" as const;
+				},
+				async *read() {},
+			},
+		).request("/v1/conversations/conv-1/runs/run-1/events", {
+			method: "GET",
+			headers: identityHeaders,
+		});
+
+		expect(res.status).toBe(410);
+		expect(await res.json()).toEqual({
+			error: "Live stream unavailable",
+			recovery: "history",
+		});
+	}, 7_000);
+
+	it("returns recovery 410 when a terminal Stream has no terminal event to replay", async () => {
+		const { store } = fakeStore([existing]);
+		const fakeRuns = fakeRunStore();
+		fakeRuns.runOwners.set("run-1", {
+			userId: "member-1",
+			conversationId: "conv-1",
+			status: "done",
+		});
+		const res = await buildApp(
+			store,
+			gateThatFailsIfConsulted(),
+			fakeRuns,
+			disabledLiveTextSubscriber,
+			{
+				async status() {
+					return "done" as const;
+				},
+				async *read() {},
+			},
+		).request("/v1/conversations/conv-1/runs/run-1/events", {
+			method: "GET",
+			headers: identityHeaders,
+		});
+
+		expect(res.status).toBe(410);
+		expect(await res.json()).toEqual({
+			error: "Live stream unavailable",
+			recovery: "history",
+		});
+	});
+
+	it("returns 400 when an active Run has no Stream that could have issued the cursor", async () => {
+		const { store } = fakeStore([existing]);
+		const fakeRuns = fakeRunStore();
+		fakeRuns.runOwners.set("run-1", {
+			userId: "member-1",
+			conversationId: "conv-1",
+			status: "queued",
+		});
+		const res = await buildApp(
+			store,
+			gateThatFailsIfConsulted(),
+			fakeRuns,
+			disabledLiveTextSubscriber,
+			{
+				async status() {
+					return "missing" as const;
+				},
+				async *read() {},
+			},
+		).request("/v1/conversations/conv-1/runs/run-1/events", {
+			method: "GET",
+			headers: { ...identityHeaders, "last-event-id": "1-0" },
+		});
+
+		expect(res.status).toBe(400);
+		expect(await res.json()).toEqual({ error: "Invalid Last-Event-ID" });
+	}, 7_000);
+
+	it("waits past startup delay with cursorless pings, then streams the terminal event", async () => {
+		const { store } = fakeStore([existing]);
+		const fakeRuns = fakeRunStore();
+		fakeRuns.runOwners.set("run-1", {
+			userId: "member-1",
+			conversationId: "conv-1",
+			status: "queued",
+		});
+		const encoder = new TextEncoder();
+		const readyAt = Date.now() + 5_100;
+		const terminalEvent = {
+			type: "RUN_FINISHED",
+			threadId: "conv-1",
+			runId: "run-1",
+		};
+		const res = await buildApp(
+			store,
+			gateThatFailsIfConsulted(),
+			fakeRuns,
+			disabledLiveTextSubscriber,
+			{
+				async status() {
+					return Date.now() >= readyAt
+						? ("done" as const)
+						: ("missing" as const);
+				},
+				async *read() {
+					yield {
+						cursor: "1-0",
+						chunk: encoder.encode(JSON.stringify(terminalEvent)),
+					};
+				},
+			},
+		).request("/v1/conversations/conv-1/runs/run-1/events", {
+			method: "GET",
+			headers: identityHeaders,
+		});
+
+		expect(res.status).toBe(200);
+		const body = await res.text();
+		expect(body).toContain(": ping\n\n");
+		expect(parseAgUiSse(body)).toEqual([{ id: "1-0", data: terminalEvent }]);
+	}, 8_000);
+
+	it("follows a Stream that appears just after Postgres terminalizes the Run", async () => {
+		const { store } = fakeStore([existing]);
+		const fakeRuns = fakeRunStore();
+		const owner = {
+			userId: "member-1",
+			conversationId: "conv-1",
+			status: "queued",
+		};
+		fakeRuns.runOwners.set("run-1", owner);
+		const encoder = new TextEncoder();
+		const terminalEvent = {
+			type: "RUN_FINISHED",
+			threadId: "conv-1",
+			runId: "run-1",
+		};
+		let statusReads = 0;
+		const res = await buildApp(
+			store,
+			gateThatFailsIfConsulted(),
+			fakeRuns,
+			disabledLiveTextSubscriber,
+			{
+				async status() {
+					statusReads += 1;
+					if (statusReads === 1) {
+						owner.status = "done";
+						return "missing" as const;
+					}
+					return "streaming" as const;
+				},
+				async *read() {
+					yield {
+						cursor: "1-0",
+						chunk: encoder.encode(JSON.stringify(terminalEvent)),
+					};
+				},
+			},
+		).request("/v1/conversations/conv-1/runs/run-1/events", {
+			method: "GET",
+			headers: identityHeaders,
+		});
+
+		expect(res.status).toBe(200);
+		expect(parseAgUiSse(await res.text())).toEqual([
+			{ id: "1-0", data: terminalEvent },
+		]);
+	});
+
+	it("sends cursorless pings while following a quiet active Stream", async () => {
+		const { store } = fakeStore([existing]);
+		const fakeRuns = fakeRunStore();
+		fakeRuns.runOwners.set("run-1", {
+			userId: "member-1",
+			conversationId: "conv-1",
+			status: "running",
+		});
+		const encoder = new TextEncoder();
+		const terminalEvent = {
+			type: "RUN_FINISHED",
+			threadId: "conv-1",
+			runId: "run-1",
+		};
+		const res = await buildApp(
+			store,
+			gateThatFailsIfConsulted(),
+			fakeRuns,
+			disabledLiveTextSubscriber,
+			{
+				async status() {
+					return "streaming" as const;
+				},
+				async *read() {
+					await Bun.sleep(5_100);
+					yield {
+						cursor: "2-0",
+						chunk: encoder.encode(JSON.stringify(terminalEvent)),
+					};
+				},
+			},
+		).request("/v1/conversations/conv-1/runs/run-1/events", {
+			method: "GET",
+			headers: { ...identityHeaders, "last-event-id": "1-0" },
+		});
+
+		expect(res.status).toBe(200);
+		const body = await res.text();
+		expect(body).toContain(": ping\n\n");
+		expect(parseAgUiSse(body)).toEqual([{ id: "2-0", data: terminalEvent }]);
+	}, 8_000);
 
 	it("replays strictly after a retained Live Stream cursor without creating work", async () => {
 		const { store } = fakeStore([existing]);

--- a/apps/chat-api/src/features/conversations/conversations.route.ts
+++ b/apps/chat-api/src/features/conversations/conversations.route.ts
@@ -1,6 +1,7 @@
+import { LiveStreamStoreError, parseLiveStreamCursor } from "@mymemo/live-text";
 import { type Context, Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
-import { streamSSE } from "hono/streaming";
+import { type SSEStreamingApi, streamSSE } from "hono/streaming";
 import { validator as zValidator } from "hono-openapi";
 import { z } from "zod";
 import type { AppEnv } from "@/deps";
@@ -15,6 +16,7 @@ import {
 	ConversationArchivedError,
 	ConversationNotFoundError,
 	RunInputMismatchError,
+	type RunRecord,
 } from "@/features/run-store";
 import { HonoSSESender } from "@/features/streaming/sse-sender";
 import {
@@ -41,72 +43,337 @@ const conversationBodyLimit = bodyLimit({
 	onError: (c) => c.json({ error: "Request body too large" }, 413),
 });
 
-const LIVE_STREAM_START_WAIT_MS = 5_000;
-const LIVE_STREAM_START_POLL_MS = 25;
+const LIVE_STREAM_START_POLL_MS = 100;
+const LIVE_STREAM_KEEPALIVE_MS = 5_000;
 const liveStreamDecoder = new TextDecoder("utf-8", { fatal: true });
 
-async function waitForLiveStream(
-	c: Context<AppEnv>,
-	runId: string,
-): Promise<boolean> {
-	const deadline = Date.now() + LIVE_STREAM_START_WAIT_MS;
-	try {
-		for (;;) {
-			const status = await c.var.deps.liveStreamReader.status(runId);
-			if (status === "streaming" || status === "done") return true;
-			if (status === "error" || Date.now() >= deadline) return false;
-			await new Promise((resolve) =>
-				setTimeout(resolve, LIVE_STREAM_START_POLL_MS),
-			);
-		}
-	} catch {
-		return false;
-	}
+function isTerminalRunStatus(status: RunRecord["status"]): boolean {
+	return status === "done" || status === "error" || status === "canceled";
 }
 
-async function streamAgUiRun(c: Context<AppEnv>, runId: string, cursor = "") {
-	const requestSignal = c.req.raw.signal;
-	const iterator = c.var.deps.liveStreamReader
-		.read(runId, cursor, requestSignal)
-		[Symbol.asyncIterator]();
-	let first: Awaited<ReturnType<typeof iterator.next>>;
+function liveStreamRecoveryResponse(c: Context<AppEnv>) {
+	return c.json({ error: "Live stream unavailable", recovery: "history" }, 410);
+}
+
+function abortableDelay(ms: number, signal: AbortSignal): Promise<void> {
+	return new Promise((resolve) => {
+		if (signal.aborted) return resolve();
+		const timer = setTimeout(done, ms);
+		function done(): void {
+			clearTimeout(timer);
+			signal.removeEventListener("abort", done);
+			resolve();
+		}
+		signal.addEventListener("abort", done, { once: true });
+	});
+}
+
+type LiveStreamEntry = { cursor: string; chunk: Uint8Array };
+
+function linkedAbortController(parent: AbortSignal): {
+	controller: AbortController;
+	dispose: () => void;
+} {
+	const controller = new AbortController();
+	const forwardAbort = () => controller.abort(parent.reason);
+	if (parent.aborted) forwardAbort();
+	else parent.addEventListener("abort", forwardAbort, { once: true });
+	return {
+		controller,
+		dispose: () => parent.removeEventListener("abort", forwardAbort),
+	};
+}
+
+function endAgUiStreamOnKeepaliveFailure(
+	c: Context<AppEnv>,
+	runId: string,
+	stream: SSEStreamingApi,
+	readController: AbortController,
+	error: unknown,
+): void {
+	c.var.logger.error({
+		message: "AG-UI keepalive write failed",
+		error,
+		runId,
+	});
+	readController.abort(error);
+	stream.abort();
+}
+
+function startAgUiKeepalive(
+	writePing: () => Promise<unknown>,
+	onFailure: (error: unknown) => void,
+): () => void {
+	let interval: ReturnType<typeof setInterval> | undefined;
+	const stop = () => {
+		if (interval !== undefined) clearInterval(interval);
+		interval = undefined;
+	};
+	interval = setInterval(() => {
+		writePing().catch((error) => {
+			stop();
+			onFailure(error);
+		});
+	}, LIVE_STREAM_KEEPALIVE_MS);
+	return stop;
+}
+
+async function writeAgUiEntries(
+	c: Context<AppEnv>,
+	runId: string,
+	iterator: AsyncIterator<LiveStreamEntry>,
+	first: IteratorResult<LiveStreamEntry>,
+	writeSSE: (event: { id: string; data: string }) => Promise<unknown>,
+): Promise<void> {
+	let next = first;
 	try {
-		first = await iterator.next();
+		while (!next.done) {
+			if (c.req.raw.signal.aborted) break;
+			await writeSSE({
+				id: next.value.cursor,
+				data: liveStreamDecoder.decode(next.value.chunk),
+			});
+			next = await iterator.next();
+		}
 	} catch (error) {
 		c.var.logger.error({
-			message: "AG-UI Live Stream initial read failed",
+			message: "AG-UI Live Stream read failed",
 			error,
 			runId,
 		});
-		return c.json({ error: "Live stream temporarily unavailable" }, 503);
+	} finally {
+		await iterator.return?.();
 	}
-	if (first.done) return c.body(null, 204);
+}
+
+async function streamAgUiRun(
+	c: Context<AppEnv>,
+	run: RunRecord,
+	cursor: string,
+	status: "streaming" | "done",
+) {
+	const requestSignal = c.req.raw.signal;
+	const readAbort = linkedAbortController(requestSignal);
+	const iterator = c.var.deps.liveStreamReader
+		.read(run.runId, cursor, readAbort.controller.signal)
+		[Symbol.asyncIterator]();
+	const firstRead = iterator.next().then(
+		(result) => ({ outcome: "read" as const, result }),
+		(error: unknown) => ({ outcome: "error" as const, error }),
+	);
+	let first: Awaited<ReturnType<typeof iterator.next>>;
+	const initial =
+		status === "streaming"
+			? await Promise.race([
+					firstRead,
+					abortableDelay(LIVE_STREAM_KEEPALIVE_MS, requestSignal).then(() => ({
+						outcome: "ping" as const,
+					})),
+				])
+			: await firstRead;
+	if (initial.outcome === "error") {
+		const { error } = initial;
+		readAbort.dispose();
+		await iterator.return?.();
+		if (
+			error instanceof LiveStreamStoreError &&
+			error.code === "invalid_cursor"
+		) {
+			return c.json({ error: "Invalid Last-Event-ID" }, 400);
+		}
+		c.var.logger.error({
+			message: "AG-UI Live Stream initial read failed",
+			error,
+			runId: run.runId,
+		});
+		return isTerminalRunStatus(run.status)
+			? liveStreamRecoveryResponse(c)
+			: c.json({ error: "Live stream temporarily unavailable" }, 503);
+	}
+	if (initial.outcome === "ping") {
+		if (requestSignal.aborted) {
+			readAbort.controller.abort(requestSignal.reason);
+			readAbort.dispose();
+			await iterator.return?.();
+			return c.body(null, 204);
+		}
+		return streamSSE(c, async (stream) => {
+			stream.onAbort(() => readAbort.controller.abort());
+			let stopKeepalive = () => {};
+			try {
+				await stream.write(": ping\n\n");
+				stopKeepalive = startAgUiKeepalive(
+					() => stream.write(": ping\n\n"),
+					(error) =>
+						endAgUiStreamOnKeepaliveFailure(
+							c,
+							run.runId,
+							stream,
+							readAbort.controller,
+							error,
+						),
+				);
+				const delayed = await firstRead;
+				if (delayed.outcome === "error") {
+					c.var.logger.error({
+						message: "AG-UI Live Stream read failed",
+						error: delayed.error,
+						runId: run.runId,
+					});
+					await iterator.return?.();
+					return;
+				}
+				if (delayed.result.done) {
+					await iterator.return?.();
+					return;
+				}
+				await writeAgUiEntries(
+					c,
+					run.runId,
+					iterator,
+					delayed.result,
+					(event) => stream.writeSSE(event),
+				);
+			} finally {
+				stopKeepalive();
+				readAbort.controller.abort();
+				readAbort.dispose();
+				await iterator.return?.();
+			}
+		});
+	}
+	first = initial.result;
+	if (first.done) {
+		readAbort.dispose();
+		await iterator.return?.();
+		if (status === "done" && cursor !== "") return c.body(null, 204);
+		return isTerminalRunStatus(run.status)
+			? liveStreamRecoveryResponse(c)
+			: c.json({ error: "Live stream temporarily unavailable" }, 503);
+	}
 
 	return streamSSE(c, async (stream) => {
-		const keepaliveInterval = setInterval(() => {
-			stream.write(": ping\n\n").catch(() => {});
-		}, 5_000);
+		stream.onAbort(() => readAbort.controller.abort());
+		const stopKeepalive = startAgUiKeepalive(
+			() => stream.write(": ping\n\n"),
+			(error) =>
+				endAgUiStreamOnKeepaliveFailure(
+					c,
+					run.runId,
+					stream,
+					readAbort.controller,
+					error,
+				),
+		);
 		try {
-			let next: Awaited<ReturnType<typeof iterator.next>> = first;
-			while (!next.done) {
-				if (requestSignal.aborted) break;
-				await stream.writeSSE({
-					id: next.value.cursor,
-					data: liveStreamDecoder.decode(next.value.chunk),
-				});
-				next = await iterator.next();
-			}
-		} catch (error) {
-			c.var.logger.error({
-				message: "AG-UI Live Stream read failed",
-				error,
-				runId,
-			});
+			await writeAgUiEntries(c, run.runId, iterator, first, (event) =>
+				stream.writeSSE(event),
+			);
 		} finally {
-			clearInterval(keepaliveInterval);
-			await iterator.return?.();
+			stopKeepalive();
+			readAbort.controller.abort();
+			readAbort.dispose();
 		}
 	});
+}
+
+function waitForAndStreamAgUiRun(c: Context<AppEnv>, run: RunRecord) {
+	const requestSignal = c.req.raw.signal;
+	return streamSSE(c, async (stream) => {
+		const readAbort = linkedAbortController(requestSignal);
+		const readSignal = readAbort.controller.signal;
+		stream.onAbort(() => readAbort.controller.abort());
+		const stopKeepalive = startAgUiKeepalive(
+			() => stream.write(": ping\n\n"),
+			(error) =>
+				endAgUiStreamOnKeepaliveFailure(
+					c,
+					run.runId,
+					stream,
+					readAbort.controller,
+					error,
+				),
+		);
+		try {
+			for (;;) {
+				if (readSignal.aborted) return;
+				const currentRun = await c.var.deps.runStore.getRun({
+					userId: run.userId,
+					conversationId: run.conversationId,
+					runId: run.runId,
+				});
+				if (currentRun === null || currentRun.liveStreamFailedAt !== null) {
+					return;
+				}
+
+				let status: Awaited<
+					ReturnType<typeof c.var.deps.liveStreamReader.status>
+				>;
+				try {
+					status = await c.var.deps.liveStreamReader.status(run.runId);
+				} catch {
+					return;
+				}
+				if (status === "error") return;
+				if (status === "streaming" || status === "done") break;
+				if (isTerminalRunStatus(currentRun.status)) return;
+				await abortableDelay(LIVE_STREAM_START_POLL_MS, readSignal);
+			}
+
+			const iterator = c.var.deps.liveStreamReader
+				.read(run.runId, "", readSignal)
+				[Symbol.asyncIterator]();
+			let first: Awaited<ReturnType<typeof iterator.next>>;
+			try {
+				first = await iterator.next();
+			} catch (error) {
+				c.var.logger.error({
+					message: "AG-UI Live Stream read failed after waiting for creation",
+					error,
+					runId: run.runId,
+				});
+				await iterator.return?.();
+				return;
+			}
+			if (first.done) {
+				await iterator.return?.();
+				return;
+			}
+			await writeAgUiEntries(c, run.runId, iterator, first, (event) =>
+				stream.writeSSE(event),
+			);
+		} finally {
+			stopKeepalive();
+			readAbort.controller.abort();
+			readAbort.dispose();
+		}
+	});
+}
+
+async function respondWithAgUiRun(
+	c: Context<AppEnv>,
+	run: RunRecord,
+	cursor: string,
+) {
+	if (run.liveStreamFailedAt !== null) return liveStreamRecoveryResponse(c);
+
+	let status: Awaited<ReturnType<typeof c.var.deps.liveStreamReader.status>>;
+	try {
+		status = await c.var.deps.liveStreamReader.status(run.runId);
+	} catch {
+		return isTerminalRunStatus(run.status)
+			? liveStreamRecoveryResponse(c)
+			: c.json({ error: "Live stream temporarily unavailable" }, 503);
+	}
+	if (status === "error") return liveStreamRecoveryResponse(c);
+	if (status === "missing") {
+		if (isTerminalRunStatus(run.status)) return liveStreamRecoveryResponse(c);
+		if (cursor !== "") {
+			return c.json({ error: "Invalid Last-Event-ID" }, 400);
+		}
+		return waitForAndStreamAgUiRun(c, run);
+	}
+	return streamAgUiRun(c, run, cursor, status);
 }
 
 // POST /v1/conversations — create a conversation, freezing its document scope.
@@ -200,6 +467,7 @@ app.post(
 			return c.json({ error: "Agent is not enabled" }, 403);
 		}
 
+		let admittedRun: RunRecord;
 		try {
 			const admission = await admitAgUiRun(c.var.deps, {
 				conversation,
@@ -208,6 +476,7 @@ app.post(
 			if (admission.outcome === "not_found") {
 				return c.json({ error: "Run not found" }, 404);
 			}
+			admittedRun = admission.run;
 		} catch (error) {
 			if (error instanceof ActiveRunExistsError) {
 				return c.json({ error: "Conversation already has an active Run" }, 409);
@@ -224,10 +493,7 @@ app.post(
 			throw error;
 		}
 
-		if (!(await waitForLiveStream(c, input.runId))) {
-			return c.json({ error: "Live stream temporarily unavailable" }, 503);
-		}
-		return streamAgUiRun(c, input.runId);
+		return respondWithAgUiRun(c, admittedRun, "");
 	},
 );
 
@@ -431,11 +697,13 @@ app.get(
 		if (!run) {
 			return c.json({ error: "Run not found" }, 404);
 		}
-
-		if (!(await waitForLiveStream(c, runId))) {
-			return c.json({ error: "Live stream temporarily unavailable" }, 503);
+		let cursor: string;
+		try {
+			cursor = parseLiveStreamCursor(c.req.header("last-event-id"));
+		} catch {
+			return c.json({ error: "Invalid Last-Event-ID" }, 400);
 		}
-		return streamAgUiRun(c, runId, c.req.header("last-event-id") ?? "");
+		return respondWithAgUiRun(c, run, cursor);
 	},
 );
 

--- a/e2e/integration.test.ts
+++ b/e2e/integration.test.ts
@@ -112,10 +112,61 @@ async function consumeSSE(
 	return frames;
 }
 
+async function readUntilSSEFrameAndCancel(
+	response: Response,
+	eventType: string,
+): Promise<{ frame: SSEFrame; raw: string }> {
+	if (!response.body) throw new Error("SSE response omitted its body");
+	const reader = response.body.getReader();
+	const decoder = new TextDecoder();
+	let buffered = "";
+	let raw = "";
+	for (;;) {
+		const { done, value } = await reader.read();
+		const decoded = decoder.decode(value, { stream: !done });
+		buffered += decoded;
+		raw += decoded;
+		let boundary = buffered.indexOf("\n\n");
+		while (boundary >= 0) {
+			const block = buffered.slice(0, boundary + 2);
+			buffered = buffered.slice(boundary + 2);
+			const [frame] = parseSSE(block);
+			if (frame?.data.type === eventType) {
+				await reader.cancel();
+				return { frame, raw };
+			}
+			boundary = buffered.indexOf("\n\n");
+		}
+		if (done) throw new Error(`SSE response ended before ${eventType}`);
+	}
+}
+
 function requiredFrame(frames: SSEFrame[], type: string): SSEFrame {
 	const frame = frames.find((candidate) => candidate.data.type === type);
 	if (!frame) throw new Error(`SSE response omitted ${type}`);
 	return frame;
+}
+
+function fetchRunEvents(
+	conversationId: string,
+	runId: string,
+	options: {
+		memberCode?: string;
+		cursor?: string;
+		signal?: AbortSignal;
+	} = {},
+): Promise<Response> {
+	const headers: Record<string, string> = {
+		"x-member-code": options.memberCode ?? MEMBER_CODE,
+		"x-partner-code": PARTNER_CODE,
+	};
+	if (options.cursor !== undefined) {
+		headers["last-event-id"] = options.cursor;
+	}
+	return fetch(
+		`${CHAT_URL}/v1/conversations/${conversationId}/runs/${runId}/events`,
+		{ headers, signal: options.signal },
+	);
 }
 
 /** Spawn `bun run src/index.ts` for an app under apps/<name>. Output is inherited
@@ -157,6 +208,22 @@ async function waitForHealthy(timeoutMs: number): Promise<boolean> {
 		await Bun.sleep(500);
 	}
 	return false;
+}
+
+async function waitForPersistedRun(
+	runId: string,
+	timeoutMs: number,
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		const run = await acceptanceDb?.query.runs.findFirst({
+			columns: { runId: true },
+			where: (row, { eq }) => eq(row.runId, runId),
+		});
+		if (run) return;
+		await Bun.sleep(50);
+	}
+	throw new Error(`Run ${runId} was not admitted before the deadline`);
 }
 
 async function freePort(): Promise<number> {
@@ -208,6 +275,7 @@ async function startRedis(port: number): Promise<Bun.Subprocess> {
 let chat: Bun.Subprocess | undefined;
 let worker: Bun.Subprocess | undefined;
 let redis: Bun.Subprocess | undefined;
+let eventWriterEnv: Record<string, string> | undefined;
 const acceptanceDb = DB_URL ? createDatabase(DB_URL) : undefined;
 
 describe.skipIf(!RUN)(
@@ -218,13 +286,14 @@ describe.skipIf(!RUN)(
 			const redisPort = await freePort();
 			redis = await startRedis(redisPort);
 			const redisUrl = `redis://127.0.0.1:${redisPort}`;
-			worker = spawnEventWriter({
+			eventWriterEnv = {
 				AGENT_DATABASE_URL: dbUrl,
 				REDIS_URL: redisUrl,
 				LIVE_STREAM_ALLOW_INSECURE_LOCAL_REDIS: "true",
 				DB_SSL: "disable",
 				LOG_LEVEL: "warn",
-			});
+				INTEGRATION_RESUME_DELAY_MS: "1500",
+			};
 			chat = spawnApp("chat-api", {
 				AGENT_DATABASE_URL: dbUrl,
 				ARTIFACT_BUCKET: "mymemo-agent-integration-artifacts",
@@ -254,7 +323,7 @@ describe.skipIf(!RUN)(
 		});
 
 		it(
-			"admits and idempotently replays a text-only AG-UI Run from real Redis",
+			"waits, disconnects, and replays an authorized AG-UI Run from real Redis",
 			async () => {
 				// Create the conversation (general scope). Proves migrations provisioned
 				// the `conversations` table and chat-api's writable DB is reachable.
@@ -292,7 +361,7 @@ describe.skipIf(!RUN)(
 					context: [],
 					forwardedProps: {},
 				};
-				const res = await fetch(
+				const runResponsePromise = fetch(
 					`${CHAT_URL}/v1/conversations/${conversationId}/runs`,
 					{
 						method: "POST",
@@ -305,34 +374,111 @@ describe.skipIf(!RUN)(
 						signal: AbortSignal.timeout(TURN_TIMEOUT_MS),
 					},
 				);
+				await waitForPersistedRun(runId, 10_000);
+
+				const missingRun = await fetchRunEvents(
+					conversationId,
+					crypto.randomUUID(),
+				);
+				expect(missingRun.status).toBe(404);
+				const foreignRun = await fetchRunEvents(conversationId, runId, {
+					memberCode: "foreign-member",
+				});
+				expect(foreignRun.status).toBe(404);
+				const malformedCursor = await fetchRunEvents(conversationId, runId, {
+					cursor: "not-a-cursor",
+				});
+				expect(malformedCursor.status).toBe(400);
+				const impossibleBeforeCreation = await fetchRunEvents(
+					conversationId,
+					runId,
+					{ cursor: "1-0" },
+				);
+				expect(impossibleBeforeCreation.status).toBe(400);
+
+				const reconnectPromise = fetchRunEvents(conversationId, runId, {
+					signal: AbortSignal.timeout(TURN_TIMEOUT_MS),
+				});
+				await Bun.sleep(5_200);
+				if (!eventWriterEnv) throw new Error("event writer was not configured");
+				worker = spawnEventWriter(eventWriterEnv);
+
+				const reconnect = await reconnectPromise;
+				expect(reconnect.status).toBe(200);
+				const textDisconnect = await readUntilSSEFrameAndCancel(
+					reconnect,
+					"TEXT_MESSAGE_CONTENT",
+				);
+				expect(textDisconnect.raw).toContain(": ping\n\n");
+				expect(textDisconnect.frame.data.type).toBe("TEXT_MESSAGE_CONTENT");
+				expect(textDisconnect.frame.id).toMatch(/^\d+-\d+$/);
+
+				const afterTextResponse = await fetchRunEvents(conversationId, runId, {
+					cursor: textDisconnect.frame.id as string,
+					signal: AbortSignal.timeout(TURN_TIMEOUT_MS),
+				});
+				expect(afterTextResponse.status).toBe(200);
+				const toolDisconnect = await readUntilSSEFrameAndCancel(
+					afterTextResponse,
+					"TOOL_CALL_ARGS",
+				);
+				expect(toolDisconnect.frame.id).toMatch(/^\d+-\d+$/);
+
+				const afterToolResponsePromise = fetchRunEvents(conversationId, runId, {
+					cursor: toolDisconnect.frame.id as string,
+					signal: AbortSignal.timeout(TURN_TIMEOUT_MS),
+				});
+
+				const res = await runResponsePromise;
 				expect(res.status, "unexpected Run response status").toBe(200);
 
-				const frames = await consumeSSE(res, async (frame) => {
-					if (frame.data.type === "TEXT_MESSAGE_END") {
-						const completed = await acceptanceDb?.query.runEvents.findFirst({
-							columns: { type: true },
-							where: (event, { and, eq }) =>
-								and(
-									eq(event.runId, runId),
-									eq(event.type, "assistant_message_completed"),
-								),
-						});
-						expect(completed?.type).toBe("assistant_message_completed");
-					}
-					if (frame.data.type === "RUN_FINISHED") {
-						const terminal = await acceptanceDb?.query.runs.findFirst({
-							columns: { status: true },
-							where: (run, { eq }) => eq(run.runId, runId),
-						});
-						expect(terminal?.status).toBe("done");
-					}
-				});
+				const [frames, afterToolResponse] = await Promise.all([
+					consumeSSE(res, async (frame) => {
+						if (frame.data.type === "TEXT_MESSAGE_END") {
+							const completed = await acceptanceDb?.query.runEvents.findFirst({
+								columns: { type: true },
+								where: (event, { and, eq }) =>
+									and(
+										eq(event.runId, runId),
+										eq(event.type, "assistant_message_completed"),
+									),
+							});
+							expect(completed?.type).toBe("assistant_message_completed");
+						}
+						if (frame.data.type === "RUN_FINISHED") {
+							const terminal = await acceptanceDb?.query.runs.findFirst({
+								columns: { status: true },
+								where: (run, { eq }) => eq(run.runId, runId),
+							});
+							expect(terminal?.status).toBe("done");
+						}
+					}),
+					afterToolResponsePromise,
+				]);
+				expect(afterToolResponse.status).toBe(200);
+				const afterToolFrames = parseSSE(await afterToolResponse.text());
+				const textDisconnectIndex = frames.findIndex(
+					(frame) => frame.id === textDisconnect.frame.id,
+				);
+				const toolDisconnectIndex = frames.findIndex(
+					(frame) => frame.id === toolDisconnect.frame.id,
+				);
+				expect(textDisconnectIndex).toBe(2);
+				expect(toolDisconnectIndex).toBe(5);
+				expect(parseSSE(toolDisconnect.raw)).toEqual(
+					frames.slice(textDisconnectIndex + 1, toolDisconnectIndex + 1),
+				);
+				expect(afterToolFrames).toEqual(frames.slice(toolDisconnectIndex + 1));
 				const eventTypes = frames.map((frame) => frame.data.type);
 				expect(eventTypes).toEqual([
 					"RUN_STARTED",
 					"TEXT_MESSAGE_START",
 					"TEXT_MESSAGE_CONTENT",
 					"TEXT_MESSAGE_END",
+					"TOOL_CALL_START",
+					"TOOL_CALL_ARGS",
+					"TOOL_CALL_END",
+					"TOOL_CALL_RESULT",
 					"RUN_FINISHED",
 				]);
 				expect(requiredFrame(frames, "RUN_STARTED").data).toMatchObject({
@@ -357,6 +503,8 @@ describe.skipIf(!RUN)(
 				expect(durableEvents?.map((event) => event.type)).toEqual([
 					"run_started",
 					"assistant_message_completed",
+					"tool_use",
+					"tool_result",
 					"run_done",
 				]);
 				const durableRun = await acceptanceDb?.query.runs.findFirst({
@@ -364,6 +512,19 @@ describe.skipIf(!RUN)(
 					where: (run, { eq }) => eq(run.runId, runId),
 				});
 				expect(durableRun?.status).toBe("done");
+
+				const replayFromZero = await fetchRunEvents(conversationId, runId, {
+					signal: AbortSignal.timeout(TURN_TIMEOUT_MS),
+				});
+				expect(replayFromZero.status).toBe(200);
+				expect(parseSSE(await replayFromZero.text())).toEqual(frames);
+
+				const impossibleRetainedCursor = await fetchRunEvents(
+					conversationId,
+					runId,
+					{ cursor: "9999999999999-0" },
+				);
+				expect(impossibleRetainedCursor.status).toBe(400);
 
 				const retry = await fetch(
 					`${CHAT_URL}/v1/conversations/${conversationId}/runs`,

--- a/e2e/synthetic-worker.ts
+++ b/e2e/synthetic-worker.ts
@@ -28,8 +28,10 @@ const liveStreamStore = createRedisLiveStreamStore({
 	url: redisUrl,
 	deployment: "current",
 });
+const resumeDelayMs = Number(process.env.INTEGRATION_RESUME_DELAY_MS ?? 0);
 const processor: RunProcessor = async (ctx) => {
 	const messageId = `message-${ctx.run.runId}`;
+	const toolCallId = `tool-${ctx.run.runId}`;
 	const text = `Synthetic response for run ${ctx.run.runId}`;
 	await ctx.appendLiveEvent({
 		type: "TEXT_MESSAGE_START",
@@ -41,6 +43,7 @@ const processor: RunProcessor = async (ctx) => {
 		messageId,
 		delta: text,
 	});
+	if (resumeDelayMs > 0) await Bun.sleep(resumeDelayMs);
 	await ctx.appendModelContent({
 		kind: "assistant_message",
 		payload: {
@@ -49,6 +52,43 @@ const processor: RunProcessor = async (ctx) => {
 		},
 	});
 	await ctx.appendLiveEvent({ type: "TEXT_MESSAGE_END", messageId });
+	await ctx.appendModelContent({
+		kind: "tool_use",
+		payload: {
+			tool: "Read",
+			arguments: { path: "CONTEXT.md" },
+			truncated: false,
+		},
+	});
+	await ctx.appendLiveEvent({
+		type: "TOOL_CALL_START",
+		toolCallId,
+		toolCallName: "Read",
+		parentMessageId: messageId,
+	});
+	await ctx.appendLiveEvent({
+		type: "TOOL_CALL_ARGS",
+		toolCallId,
+		delta: '{"path":"CONTEXT.md"}',
+	});
+	if (resumeDelayMs > 0) await Bun.sleep(resumeDelayMs);
+	await ctx.appendLiveEvent({ type: "TOOL_CALL_END", toolCallId });
+	await ctx.appendModelContent({
+		kind: "tool_result",
+		payload: {
+			tool: "Read",
+			result: { ok: true },
+			isError: false,
+			truncated: false,
+		},
+	});
+	await ctx.appendLiveEvent({
+		type: "TOOL_CALL_RESULT",
+		messageId: `tool-result-${ctx.run.runId}`,
+		toolCallId,
+		content: '{"ok":true}',
+		role: "tool",
+	});
 };
 const runLoop = new RunLoop({
 	db: createDatabase(agentDatabaseUrl),

--- a/packages/live-text/src/redis-live-stream-store.contract.test.ts
+++ b/packages/live-text/src/redis-live-stream-store.contract.test.ts
@@ -180,6 +180,94 @@ it("replays complete AG-UI events from zero and strictly after a Redis cursor", 
 	}
 }, 10_000);
 
+it("rejects a Redis-shaped cursor that the retained Stream never issued", async () => {
+	const port = await freePort();
+	const redis = await startRedis(port);
+	const store = createRedisLiveStreamStore({
+		url: `redis://127.0.0.1:${port}`,
+		deployment: "test",
+	});
+	try {
+		await store.acquire("run-1");
+		await store.append(
+			"run-1",
+			encoder.encode(
+				JSON.stringify({
+					type: EventType.RUN_FINISHED,
+					threadId: "conversation-1",
+					runId: "run-1",
+				}),
+			),
+		);
+		await store.finalize("run-1", "done");
+
+		await expect(
+			collect(store, "run-1", "9999999999999-0"),
+		).rejects.toMatchObject({ code: "invalid_cursor" });
+	} finally {
+		await store.close();
+		await stopRedis(redis);
+	}
+}, 10_000);
+
+it("rejects a cursor before an active Stream has issued its first entry", async () => {
+	const port = await freePort();
+	const redis = await startRedis(port);
+	const store = createRedisLiveStreamStore({
+		url: `redis://127.0.0.1:${port}`,
+		deployment: "test",
+	});
+	try {
+		await store.acquire("run-1");
+		await expect(collect(store, "run-1", "1-0")).rejects.toMatchObject({
+			code: "invalid_cursor",
+		});
+	} finally {
+		await store.close();
+		await stopRedis(redis);
+	}
+}, 10_000);
+
+it("reports a missing Stream when its metadata outlives the retained entries", async () => {
+	const port = await freePort();
+	const redis = await startRedis(port);
+	const url = `redis://127.0.0.1:${port}`;
+	const rawRedis = createClient({ url });
+	const store = createRedisLiveStreamStore({
+		url,
+		deployment: "test",
+	});
+	try {
+		await rawRedis.connect();
+		await store.acquire("run-1");
+		await store.append(
+			"run-1",
+			encoder.encode(
+				JSON.stringify({
+					type: EventType.RUN_FINISHED,
+					threadId: "conversation-1",
+					runId: "run-1",
+				}),
+			),
+		);
+		await store.finalize("run-1", "done");
+		const [terminal] = await collect(store, "run-1");
+		if (!terminal) throw new Error("expected a terminal entry");
+
+		await rawRedis.del("test:mymemo:agui:{run-1}:stream");
+		expect(await store.status("run-1")).toBe("done");
+		await expect(
+			collect(store, "run-1", terminal.cursor),
+		).rejects.toMatchObject({
+			code: "missing",
+		});
+	} finally {
+		if (rawRedis.isOpen) rawRedis.destroy();
+		await store.close();
+		await stopRedis(redis);
+	}
+}, 10_000);
+
 it("does not lose the terminal event when append and finalization race a reader", async () => {
 	const port = await freePort();
 	const redis = await startRedis(port);

--- a/packages/live-text/src/redis-live-stream-store.ts
+++ b/packages/live-text/src/redis-live-stream-store.ts
@@ -27,7 +27,8 @@ const DEPLOYMENT_PATTERN = /^[A-Za-z0-9_-]+$/;
 const DEFAULT_REDIS_OPERATION_TIMEOUT_MS = 250;
 const DEFAULT_REDIS_POLL_INTERVAL_MS = 100;
 const REDIS_BLOB_STRING = 36;
-const REDIS_STREAM_ID_PATTERN = /^\d+-\d+$/;
+const REDIS_STREAM_ID_PATTERN = /^(0|[1-9]\d*)-(0|[1-9]\d*)$/;
+const REDIS_STREAM_ID_PART_MAX = (1n << 64n) - 1n;
 
 const ACQUIRE_SCRIPT = `
 if redis.call("EXISTS", KEYS[1]) == 1 then
@@ -177,6 +178,7 @@ export type LiveStreamStoreErrorCode =
 	| "missing"
 	| "finalized"
 	| "not_producer"
+	| "invalid_cursor"
 	| "invalid_event"
 	| "append_retry_conflict"
 	| "finalize_conflict"
@@ -406,11 +408,37 @@ class RedisLiveStreamStore implements LiveStreamStore {
 	): AsyncIterable<ResumableStreamEntry> {
 		this.#assertOpen();
 		validateRunId(streamId);
-		validateCursor(cursor);
-		if (!(await this.#readMetadata(streamId))) {
+		const normalizedCursor = parseLiveStreamCursor(cursor);
+		const initialMetadata = await this.#readMetadata(streamId);
+		if (!initialMetadata) {
 			throw new LiveStreamStoreError("missing");
 		}
-		let lastCursor = cursor === "" ? "0-0" : cursor;
+		if (normalizedCursor !== "") {
+			const rawEntries = await this.#command(
+				[
+					"XRANGE",
+					this.#streamKey(streamId),
+					normalizedCursor,
+					normalizedCursor,
+					"COUNT",
+					"1",
+				],
+				true,
+			);
+			const exactEntry = Array.isArray(rawEntries)
+				? parseStreamEntry(rawEntries[0])
+				: undefined;
+			if (exactEntry?.cursor !== normalizedCursor) {
+				const streamExists = replyInteger(
+					await this.#command(["EXISTS", this.#streamKey(streamId)]),
+				);
+				if (streamExists === 0 && initialMetadata.status !== "streaming") {
+					throw new LiveStreamStoreError("missing");
+				}
+				throw new LiveStreamStoreError("invalid_cursor");
+			}
+		}
+		let lastCursor = normalizedCursor === "" ? "0-0" : normalizedCursor;
 		while (!signal.aborted) {
 			const metadata = await this.#readMetadata(streamId);
 			if (!metadata) return;
@@ -641,10 +669,18 @@ interface StreamMetadata {
 	error?: string;
 }
 
-function validateCursor(cursor: string): void {
-	if (cursor !== "" && !REDIS_STREAM_ID_PATTERN.test(cursor)) {
-		throw new Error("cursor must be empty or a Redis Stream ID");
+export function parseLiveStreamCursor(cursor: string | undefined): string {
+	if (cursor === undefined || cursor === "" || cursor === "0") return "";
+	const match = REDIS_STREAM_ID_PATTERN.exec(cursor);
+	if (
+		match?.[1] !== undefined &&
+		match[2] !== undefined &&
+		BigInt(match[1]) <= REDIS_STREAM_ID_PART_MAX &&
+		BigInt(match[2]) <= REDIS_STREAM_ID_PART_MAX
+	) {
+		return cursor;
 	}
+	throw new LiveStreamStoreError("invalid_cursor");
 }
 
 function toBuffer(bytes: Uint8Array): Buffer {
@@ -656,6 +692,18 @@ function replyString(value: unknown): string | undefined {
 	if (typeof value === "string") return value;
 	if (Buffer.isBuffer(value)) return value.toString("utf8");
 	return undefined;
+}
+
+function replyInteger(value: unknown): number | undefined {
+	if (typeof value === "number" && Number.isSafeInteger(value)) return value;
+	if (typeof value === "bigint") {
+		const parsed = Number(value);
+		return Number.isSafeInteger(parsed) ? parsed : undefined;
+	}
+	const raw = replyString(value);
+	if (raw === undefined || !/^-?\d+$/.test(raw)) return undefined;
+	const parsed = Number(raw);
+	return Number.isSafeInteger(parsed) ? parsed : undefined;
 }
 
 function parseArrayReply(value: unknown): string[] {
@@ -723,6 +771,8 @@ function errorMessage(code: LiveStreamStoreErrorCode): string {
 			return "Live Stream is already finalized";
 		case "not_producer":
 			return "Live Stream producer ownership is required";
+		case "invalid_cursor":
+			return "Live Stream cursor is invalid";
 		case "invalid_event":
 			return "Live Stream entry is not a standard AG-UI event";
 		case "append_retry_conflict":


### PR DESCRIPTION
## Summary

- add an ownership-checked reconnect endpoint for retained per-Run AG-UI streams
- share Run stream status, cursor handling, encoding, and recovery behavior between POST admission and GET reconnect
- validate malformed, impossible, pre-creation, and expired Redis cursors with the ADR-0012 response contract
- emit cursorless keepalive comments while waiting for stream creation or quiet active work
- preserve terminal streams for the retention grace period and abort readers when an SSE heartbeat fails
- cover replay and disconnect/resume during both Assistant text and Tool activity

## Why

Clients could attach to the original Run admission response, but had no complete server-side path for resuming an active retained stream after the last acknowledged Redis cursor. Cursor validity and unavailable-history recovery also needed to distinguish client errors from expired terminal data.

## Impact

Clients can reconnect to an owned Run without creating another backend attempt. Replay begins strictly after a valid `Last-Event-ID`, while missing or foreign Runs remain indistinguishable through the existing 404 ownership boundary.

Closes #336.

## Validation

- `bun run test`
- chat-api, live-text, and agent-worker TypeScript checks
- Biome checks on all changed files
- 14 focused HTTP/SSE reconnect tests
- 13 real-Redis stream contracts
- real PostgreSQL + Redis process integration: 1 test, 33 assertions
- standards review and ADR/spec review: no unresolved findings