### PR TITLE
fix(streaming): recover from live stream failures (#339)

### DIFF
--- a/apps/agent-worker/src/run-live-stream.test.ts
+++ b/apps/agent-worker/src/run-live-stream.test.ts
@@ -1,0 +1,63 @@
+import { expect, it } from "bun:test";
+import type { WorkerLogger } from "./logger";
+import { RunLiveStream } from "./run-live-stream";
+import { fakeLiveStreamStore } from "./testing/live-stream-store";
+
+const silentLogger: WorkerLogger = { info() {}, warn() {}, error() {} };
+
+it("retries a transient Live Stream failure-marker write after the Run terminalizes", async () => {
+	let markerAttempts = 0;
+	const stream = await RunLiveStream.open({
+		store: fakeLiveStreamStore({
+			async append() {
+				throw new Error("Redis unavailable");
+			},
+		}),
+		runId: "run-1",
+		conversationId: "conv-1",
+		async markLiveStreamFailed() {
+			markerAttempts += 1;
+			if (markerAttempts === 1) throw new Error("database unavailable");
+		},
+		logger: silentLogger,
+	});
+
+	expect(markerAttempts).toBe(1);
+	await stream.finish("done");
+	expect(markerAttempts).toBe(2);
+});
+
+it.each([
+	"append",
+	"finalization",
+] as const)("retries a transient failure-marker write after terminal %s fails", async (fault) => {
+	let appendAttempts = 0;
+	let finalizeAttempts = 0;
+	let markerAttempts = 0;
+	const stream = await RunLiveStream.open({
+		store: fakeLiveStreamStore({
+			async append() {
+				appendAttempts += 1;
+				if (fault === "append" && appendAttempts === 2) {
+					throw new Error("Redis unavailable");
+				}
+			},
+			async finalize() {
+				finalizeAttempts += 1;
+				if (fault === "finalization" && finalizeAttempts === 1) {
+					throw new Error("Redis unavailable");
+				}
+			},
+		}),
+		runId: "run-1",
+		conversationId: "conv-1",
+		async markLiveStreamFailed() {
+			markerAttempts += 1;
+			if (markerAttempts === 1) throw new Error("database unavailable");
+		},
+		logger: silentLogger,
+	});
+
+	await stream.finish("done");
+	expect(markerAttempts).toBe(2);
+});

--- a/apps/agent-worker/src/run-live-stream.ts
+++ b/apps/agent-worker/src/run-live-stream.ts
@@ -1,21 +1,26 @@
-import { type AGUIEvent, EventType } from "@ag-ui/core";
+import { EventType } from "@ag-ui/core";
 import type { TerminalRunStatus } from "@mymemo/agent-db/run-store";
 import {
 	encodeAgUiLiveStreamEvent,
+	type LiveStreamEvent,
 	type LiveStreamStore,
 	LiveStreamStoreError,
+	RUN_CANCELLED_EVENT_TYPE,
 } from "@mymemo/live-text";
-import type { WorkerLogger } from "./logger";
+import { toMessage, type WorkerLogger } from "./logger";
 
 /** One claimed Run's best-effort AG-UI producer. Redis failure disables every
  * later write but never escapes into model execution or the Postgres Outcome. */
 export class RunLiveStream {
 	#enabled = false;
+	#failed = false;
+	#failureMarked = false;
 
 	private constructor(
 		private readonly store: LiveStreamStore | undefined,
 		private readonly runId: string,
 		private readonly conversationId: string,
+		private readonly markLiveStreamFailed: () => Promise<void>,
 		private readonly logger: WorkerLogger,
 	) {}
 
@@ -23,17 +28,20 @@ export class RunLiveStream {
 		store: LiveStreamStore | undefined;
 		runId: string;
 		conversationId: string;
+		markLiveStreamFailed: () => Promise<void>;
 		logger: WorkerLogger;
 	}): Promise<RunLiveStream> {
 		const stream = new RunLiveStream(
 			options.store,
 			options.runId,
 			options.conversationId,
+			options.markLiveStreamFailed,
 			options.logger,
 		);
 		if (!options.store) return stream;
 		try {
 			if ((await options.store.acquire(options.runId)) !== "producer") {
+				await stream.#disable(new LiveStreamStoreError("not_producer"));
 				return stream;
 			}
 			stream.#enabled = true;
@@ -48,7 +56,7 @@ export class RunLiveStream {
 		return stream;
 	}
 
-	async append(event: AGUIEvent): Promise<void> {
+	async append(event: LiveStreamEvent): Promise<void> {
 		if (!this.#enabled || !this.store) return;
 		try {
 			for (const chunk of encodeAgUiLiveStreamEvent(event)) {
@@ -62,7 +70,9 @@ export class RunLiveStream {
 	async refresh(): Promise<void> {
 		if (!this.#enabled || !this.store) return;
 		try {
-			if (!(await this.store.refresh(this.runId))) this.#enabled = false;
+			if (!(await this.store.refresh(this.runId))) {
+				await this.#disable(new LiveStreamStoreError("finalized"));
+			}
 		} catch (error) {
 			await this.#disable(error);
 		}
@@ -70,43 +80,73 @@ export class RunLiveStream {
 
 	/** Publish only after the matching Postgres terminal transaction commits. */
 	async finish(status: TerminalRunStatus): Promise<void> {
-		if (!this.#enabled || !this.store) return;
-		if (status === "canceled") {
-			// The pinned AG-UI core has no RUN_CANCELLED event. Do not misrepresent
-			// cancellation as success; recovery ticket #339 owns this terminal path.
-			await this.#disable(new Error("canceled Run has no live terminal event"));
+		if (!this.#enabled || !this.store) {
+			await this.#retryFailureMarker();
 			return;
 		}
-		await this.append(
-			status === "done"
-				? {
-						type: EventType.RUN_FINISHED,
-						threadId: this.conversationId,
-						runId: this.runId,
-					}
-				: { type: EventType.RUN_ERROR, message: "Run failed" },
-		);
-		if (!this.#enabled) return;
+		if (status === "canceled") {
+			await this.append({
+				type: RUN_CANCELLED_EVENT_TYPE,
+				threadId: this.conversationId,
+				runId: this.runId,
+			});
+		} else {
+			await this.append(
+				status === "done"
+					? {
+							type: EventType.RUN_FINISHED,
+							threadId: this.conversationId,
+							runId: this.runId,
+						}
+					: { type: EventType.RUN_ERROR, message: "Run failed" },
+			);
+		}
+		if (!this.#enabled) {
+			await this.#retryFailureMarker();
+			return;
+		}
 		try {
 			await this.store.finalize(this.runId, "done");
 			this.#enabled = false;
 		} catch (error) {
 			await this.#disable(error);
+			await this.#retryFailureMarker();
 		}
 	}
 
 	async #disable(error: unknown): Promise<void> {
 		const wasEnabled = this.#enabled;
 		this.#enabled = false;
+		this.#failed = true;
 		this.logger.warn({
 			message: "Live Stream publication disabled",
 			runId: this.runId,
 			reason:
 				error instanceof LiveStreamStoreError ? error.code : "operation_failed",
 		});
+		await this.#persistFailureMarker();
 		if (!wasEnabled || !this.store) return;
 		await this.store
 			.finalize(this.runId, "error", "Live stream unavailable")
 			.catch(() => {});
+	}
+
+	async #persistFailureMarker(): Promise<void> {
+		try {
+			await this.markLiveStreamFailed();
+			this.#failureMarked = true;
+		} catch (markerError) {
+			this.logger.error({
+				message: "could not mark Live Stream failed",
+				runId: this.runId,
+				error: toMessage(markerError),
+			});
+		}
+	}
+
+	async #retryFailureMarker(): Promise<void> {
+		if (this.#failed && !this.#failureMarked) {
+			await this.#persistFailureMarker();
+		}
 	}
 }

--- a/apps/agent-worker/src/run-loop.test.ts
+++ b/apps/agent-worker/src/run-loop.test.ts
@@ -22,6 +22,7 @@ import type { LiveStreamStore } from "@mymemo/live-text";
 import { eq, sql } from "drizzle-orm";
 import type { WorkerLogger } from "./logger";
 import { RunLoop, type RunProcessor } from "./run-loop";
+import { fakeLiveStreamStore } from "./testing/live-stream-store";
 import { Worker } from "./worker";
 
 const silentLogger: WorkerLogger = { info() {}, warn() {}, error() {} };
@@ -62,11 +63,16 @@ function buildWorker(maxConcurrentRuns: number, workerId = "worker-1") {
 	});
 }
 
-function buildLoop(worker: Worker, processor: RunProcessor) {
+function buildLoop(
+	worker: Worker,
+	processor: RunProcessor,
+	liveStreamStore?: LiveStreamStore,
+) {
 	return new RunLoop({
 		db: tdb.db,
 		worker,
 		processor,
+		liveStreamStore,
 		heartbeatIntervalMs: 15_000,
 		logger: silentLogger,
 	});
@@ -262,13 +268,66 @@ describe("RunLoop — heartbeat", () => {
 });
 
 describe("RunLoop — terminal outcomes", () => {
+	it.each([
+		[
+			"Redis fails before Live Stream creation",
+			async (): Promise<never> => {
+				throw new Error("Redis unavailable");
+			},
+		],
+		[
+			"an existing Live Stream rejects producer acquisition",
+			async (): Promise<"consumer"> => "consumer",
+		],
+	] as const)("marks the Live Stream failed and continues when %s", async (_, acquire) => {
+		let appendCalls = 0;
+		let finalizeCalls = 0;
+		const liveStreamStore = fakeLiveStreamStore({
+			acquire,
+			async append() {
+				appendCalls++;
+			},
+			async finalize() {
+				finalizeCalls++;
+			},
+		});
+		const worker = buildWorker(1);
+		const loop = buildLoop(
+			worker,
+			async (ctx) => {
+				await ctx.appendLiveEvent({
+					type: EventType.TEXT_MESSAGE_CONTENT,
+					messageId: "assistant-1",
+					delta: "not published",
+				});
+				await ctx.appendModelContent({
+					kind: "assistant_message",
+					payload: { messageId: "assistant-1", text: "still durable" },
+				});
+			},
+			liveStreamStore,
+		);
+		await queueRun("run-1", "conv-1");
+
+		await loop.tick();
+		await worker.drain();
+
+		expect(await readRun("run-1")).toMatchObject({
+			status: "done",
+			liveStreamFailedAt: expect.any(Date),
+		});
+		expect(await readEventTypes("run-1")).toEqual([
+			"assistant_message_completed",
+			"run_done",
+		]);
+		expect(appendCalls).toBe(0);
+		expect(finalizeCalls).toBe(0);
+	});
+
 	it("commits durable facts before exposing AG-UI completion events", async () => {
 		const observed: unknown[] = [];
 		const decoder = new TextDecoder();
-		const liveStreamStore = {
-			async acquire() {
-				return "producer" as const;
-			},
+		const liveStreamStore = fakeLiveStreamStore({
 			async append(_runId: string, chunk: Uint8Array) {
 				const event = JSON.parse(decoder.decode(chunk)) as { type: string };
 				if (event.type === EventType.TEXT_MESSAGE_END) {
@@ -281,26 +340,11 @@ describe("RunLoop — terminal outcomes", () => {
 				}
 				observed.push(event);
 			},
-			async finalize() {},
-			async refresh() {
-				return true;
-			},
-			async appendWithRetryId() {
-				return { cursor: "1-0", appended: true };
-			},
-			async *read() {},
-			async status() {
-				return "done" as const;
-			},
-			async delete() {},
-			async close() {},
-		} satisfies LiveStreamStore;
+		});
 		const worker = buildWorker(1);
-		const loop = new RunLoop({
-			db: tdb.db,
+		const loop = buildLoop(
 			worker,
-			liveStreamStore,
-			processor: async (ctx) => {
+			async (ctx) => {
 				await ctx.appendLiveEvent({
 					type: EventType.TEXT_MESSAGE_START,
 					messageId: "assistant-1",
@@ -320,9 +364,8 @@ describe("RunLoop — terminal outcomes", () => {
 					messageId: "assistant-1",
 				});
 			},
-			heartbeatIntervalMs: 15_000,
-			logger: silentLogger,
-		});
+			liveStreamStore,
+		);
 		await queueRun("run-1", "conv-1");
 
 		await loop.tick();
@@ -349,39 +392,22 @@ describe("RunLoop — terminal outcomes", () => {
 		]);
 	});
 
-	it("continues durable execution after the first Redis write failure", async () => {
+	it("continues durable execution after a mid-text Live Stream write fails", async () => {
 		let appendCalls = 0;
 		const finalizations: string[] = [];
-		const liveStreamStore = {
-			async acquire() {
-				return "producer" as const;
-			},
+		const liveStreamStore = fakeLiveStreamStore({
 			async append() {
 				appendCalls++;
-				if (appendCalls === 2) throw new Error("Redis unavailable");
+				if (appendCalls === 3) throw new Error("Redis unavailable");
 			},
 			async finalize(_runId: string, status: "done" | "error") {
 				finalizations.push(status);
 			},
-			async refresh() {
-				return true;
-			},
-			async appendWithRetryId() {
-				return { cursor: "1-0", appended: true };
-			},
-			async *read() {},
-			async status() {
-				return "error" as const;
-			},
-			async delete() {},
-			async close() {},
-		} satisfies LiveStreamStore;
+		});
 		const worker = buildWorker(1);
-		const loop = new RunLoop({
-			db: tdb.db,
+		const loop = buildLoop(
 			worker,
-			liveStreamStore,
-			processor: async (ctx) => {
+			async (ctx) => {
 				await ctx.appendLiveEvent({
 					type: EventType.TEXT_MESSAGE_START,
 					messageId: "assistant-1",
@@ -400,21 +426,165 @@ describe("RunLoop — terminal outcomes", () => {
 					},
 				});
 			},
-			heartbeatIntervalMs: 15_000,
-			logger: silentLogger,
-		});
+			liveStreamStore,
+		);
 		await queueRun("run-1", "conv-1");
 
 		await loop.tick();
 		await worker.drain();
 
-		expect((await readRun("run-1"))?.status).toBe("done");
+		expect(await readRun("run-1")).toMatchObject({
+			status: "done",
+			liveStreamFailedAt: expect.any(Date),
+		});
 		expect(await readEventTypes("run-1")).toEqual([
 			"assistant_message_completed",
 			"run_done",
 		]);
+		expect(appendCalls).toBe(3);
+		expect(finalizations).toEqual(["error"]);
+	});
+
+	it("keeps committing Tool events after Live Stream publication fails", async () => {
+		let appendCalls = 0;
+		const finalizations: string[] = [];
+		const liveStreamStore = fakeLiveStreamStore({
+			async append() {
+				appendCalls++;
+				if (appendCalls === 2) throw new Error("Redis unavailable");
+			},
+			async finalize(_runId: string, status: "done" | "error") {
+				finalizations.push(status);
+			},
+		});
+		const worker = buildWorker(1);
+		const loop = buildLoop(
+			worker,
+			async (ctx) => {
+				await ctx.appendModelContent({
+					kind: "tool_use",
+					payload: {
+						tool: "Bash",
+						arguments: { command: "pwd" },
+						truncated: false,
+					},
+				});
+				await ctx.appendLiveEvent({
+					type: EventType.CUSTOM,
+					name: "mymemo.tool_use",
+					value: { tool: "Bash" },
+				});
+				await ctx.appendModelContent({
+					kind: "tool_result",
+					payload: {
+						tool: "Bash",
+						result: { exitCode: 0 },
+						isError: false,
+						truncated: false,
+					},
+				});
+				await ctx.appendLiveEvent({
+					type: EventType.CUSTOM,
+					name: "mymemo.tool_result",
+					value: { tool: "Bash" },
+				});
+			},
+			liveStreamStore,
+		);
+		await queueRun("run-1", "conv-1");
+
+		await loop.tick();
+		await worker.drain();
+
+		expect(await readRun("run-1")).toMatchObject({
+			status: "done",
+			liveStreamFailedAt: expect.any(Date),
+		});
+		expect(await readEventTypes("run-1")).toEqual([
+			"tool_use",
+			"tool_result",
+			"run_done",
+		]);
 		expect(appendCalls).toBe(2);
 		expect(finalizations).toEqual(["error"]);
+	});
+
+	it("marks the Live Stream failed after durable terminalization without changing the Outcome", async () => {
+		const decoder = new TextDecoder();
+		const finalizations: string[] = [];
+		const liveStreamStore = fakeLiveStreamStore({
+			async append(_runId: string, chunk: Uint8Array) {
+				const event = JSON.parse(decoder.decode(chunk)) as { type: string };
+				if (event.type === EventType.RUN_FINISHED) {
+					expect((await readRun("run-1"))?.status).toBe("done");
+					throw new Error("Redis unavailable after terminal commit");
+				}
+			},
+			async finalize(_runId: string, status: "done" | "error") {
+				finalizations.push(status);
+			},
+		});
+		const worker = buildWorker(1);
+		const loop = buildLoop(worker, appendMessageProcessor, liveStreamStore);
+		await queueRun("run-1", "conv-1");
+
+		await loop.tick();
+		await worker.drain();
+
+		expect(await readRun("run-1")).toMatchObject({
+			status: "done",
+			liveStreamFailedAt: expect.any(Date),
+		});
+		expect(await readEventTypes("run-1")).toEqual([
+			"assistant_message_completed",
+			"run_done",
+		]);
+		expect(finalizations).toEqual(["error"]);
+	});
+
+	it("marks the Live Stream failed when heartbeat refresh loses it", async () => {
+		let appendCalls = 0;
+		const processorStarted = deferred();
+		const finishTurn = deferred();
+		const liveStreamStore = fakeLiveStreamStore({
+			async append() {
+				appendCalls++;
+			},
+			async finalize() {},
+			async refresh() {
+				return false;
+			},
+		});
+		const worker = buildWorker(1);
+		const loop = buildLoop(
+			worker,
+			async (ctx) => {
+				processorStarted.resolve();
+				await finishTurn.promise;
+				await ctx.appendModelContent({
+					kind: "assistant_message",
+					payload: { messageId: "assistant-1", text: "still durable" },
+				});
+			},
+			liveStreamStore,
+		);
+		await queueRun("run-1", "conv-1");
+
+		await loop.tick();
+		await processorStarted.promise;
+		await loop.tick();
+		finishTurn.resolve();
+		await worker.drain();
+
+		expect(await readRun("run-1")).toMatchObject({
+			status: "done",
+			liveStreamFailedAt: expect.any(Date),
+		});
+		expect(await readEventTypes("run-1")).toEqual([
+			"assistant_message_completed",
+			"run_done",
+		]);
+		expect(appendCalls).toBe(1);
 	});
 
 	it("ends a synthetic run as done with one durable Assistant message", async () => {
@@ -486,13 +656,28 @@ describe("RunLoop — terminal outcomes", () => {
 
 	it("terminalizes as canceled when cancellation is observed mid-processing", async () => {
 		const worker = buildWorker(1);
-		// A processor that runs until the run is aborted, without appending.
-		const loop = buildLoop(worker, async (ctx) => {
-			await new Promise<void>((resolve) => {
-				if (ctx.signal.aborted) return resolve();
-				ctx.signal.addEventListener("abort", () => resolve(), { once: true });
-			});
+		const decoder = new TextDecoder();
+		const published: unknown[] = [];
+		const finalizations: string[] = [];
+		const liveStreamStore = fakeLiveStreamStore({
+			async append(_runId: string, chunk: Uint8Array) {
+				published.push(JSON.parse(decoder.decode(chunk)) as { type: string });
+			},
+			async finalize(_runId: string, status: "done" | "error") {
+				finalizations.push(status);
+			},
 		});
+		// A processor that runs until the run is aborted, without appending.
+		const loop = buildLoop(
+			worker,
+			async (ctx) => {
+				await new Promise<void>((resolve) => {
+					if (ctx.signal.aborted) return resolve();
+					ctx.signal.addEventListener("abort", () => resolve(), { once: true });
+				});
+			},
+			liveStreamStore,
+		);
 		await queueRun("run-1", "conv-1");
 		await loop.tick(); // claim + dispatch (processor now blocking on abort)
 
@@ -505,8 +690,16 @@ describe("RunLoop — terminal outcomes", () => {
 		await loop.tick(); // heartbeat observes cancel_requested → aborts the run
 		await worker.drain();
 
-		expect((await readRun("run-1"))?.status).toBe("canceled");
+		expect(await readRun("run-1")).toMatchObject({
+			status: "canceled",
+			liveStreamFailedAt: null,
+		});
 		expect(await readEventTypes("run-1")).toEqual(["run_canceled"]);
+		expect(published).toEqual([
+			{ type: EventType.RUN_STARTED, threadId: "conv-1", runId: "run-1" },
+			{ type: "RUN_CANCELLED", threadId: "conv-1", runId: "run-1" },
+		]);
+		expect(finalizations).toEqual(["done"]);
 	});
 });
 
@@ -584,6 +777,44 @@ describe("RunLoop — shutdown", () => {
 });
 
 describe("RunLoop — stale-run recovery", () => {
+	it("deletes an orphan Live Stream only after stale recovery terminalizes its Run", async () => {
+		await claimRun("run-stale", "conv-1", "stale-worker");
+		await expireOwnership("run-stale");
+		const deleted: string[] = [];
+		const liveStreamStore = fakeLiveStreamStore({
+			async acquire() {
+				throw new Error("must not acquire");
+			},
+			async append() {
+				throw new Error("must not append");
+			},
+			async finalize() {
+				throw new Error("must not fabricate a terminal Live Stream event");
+			},
+			async refresh() {
+				throw new Error("must not refresh");
+			},
+			async appendWithRetryId() {
+				throw new Error("must not append");
+			},
+			async delete(runId: string) {
+				deleted.push(runId);
+			},
+		});
+		const worker = buildWorker(1);
+		const loop = buildLoop(worker, appendMessageProcessor, liveStreamStore);
+
+		await loop.tick();
+		await worker.drain();
+
+		expect(await readRun("run-stale")).toMatchObject({
+			status: "error",
+			liveStreamFailedAt: expect.any(Date),
+		});
+		expect(await readEventTypes("run-stale")).toEqual(["run_error"]);
+		expect(deleted).toEqual(["run-stale"]);
+	});
+
 	it("terminalizes stale running runs as error during a tick", async () => {
 		await claimRun("run-stale", "conv-1", "stale-worker");
 		await expireOwnership("run-stale");

--- a/apps/agent-worker/src/run-loop.ts
+++ b/apps/agent-worker/src/run-loop.ts
@@ -1,4 +1,3 @@
-import type { AGUIEvent } from "@ag-ui/core";
 import {
 	ArtifactQuotaError,
 	type PublishedArtifact,
@@ -15,6 +14,7 @@ import {
 	appendRunEventTx,
 	claimNextRunTx,
 	heartbeatRunTx,
+	markLiveStreamFailedTx,
 	markStaleRunsTx,
 	RunFenceError,
 	type RunRecord,
@@ -25,7 +25,7 @@ import {
 	advanceAgentSessionPointerTx,
 	type RunOwnershipRef,
 } from "@mymemo/agent-db/runtime-store";
-import type { LiveStreamStore } from "@mymemo/live-text";
+import type { LiveStreamEvent, LiveStreamStore } from "@mymemo/live-text";
 import { ArtifactValidationError } from "./artifacts/artifact-manifest";
 import { ArtifactPublicationError } from "./artifacts/artifact-publication";
 import { toMessage, type WorkerLogger } from "./logger";
@@ -89,7 +89,7 @@ export interface RunProcessContext {
 	appendModelContent(content: ModelContent): Promise<void>;
 	/** Append one standard event to this Run's retained Live Stream. Failure is
 	 * absorbed by the producer so it cannot change model execution. */
-	appendLiveEvent(event: AGUIEvent): Promise<void>;
+	appendLiveEvent(event: LiveStreamEvent): Promise<void>;
 }
 
 /**
@@ -299,6 +299,20 @@ export class RunLoop {
 				status: run.status,
 			})),
 		});
+		if (!this.opts.liveStreamStore) return;
+		for (const run of recovered) {
+			if (run.liveStreamFailedAt === null) continue;
+			try {
+				await this.opts.liveStreamStore.delete(run.runId);
+			} catch (error) {
+				this.opts.logger.warn({
+					message: "could not delete stale Run Live Stream",
+					workerId: this.workerId,
+					runId: run.runId,
+					error: toMessage(error),
+				});
+			}
+		}
 	}
 
 	private async heartbeatActive(): Promise<void> {
@@ -378,6 +392,22 @@ export class RunLoop {
 			store: this.opts.liveStreamStore,
 			runId: run.runId,
 			conversationId: run.conversationId,
+			markLiveStreamFailed: async () => {
+				const result = await markLiveStreamFailedTx(this.opts.db, {
+					runId: run.runId,
+					workerId: this.workerId,
+				});
+				if (result.outcome === "fence_rejected") {
+					this.opts.logger.warn({
+						message: "could not mark Live Stream failed through Run fence",
+						workerId: this.workerId,
+						runId: run.runId,
+					});
+					throw new RunFenceError(
+						"Run fence rejected the Live Stream failure marker",
+					);
+				}
+			},
 			logger: this.opts.logger,
 		});
 		entry.liveStream = liveStream;

--- a/apps/agent-worker/src/testing/live-stream-store.ts
+++ b/apps/agent-worker/src/testing/live-stream-store.ts
@@ -1,0 +1,26 @@
+import type { LiveStreamStore } from "@mymemo/live-text";
+
+export function fakeLiveStreamStore(
+	overrides: Partial<LiveStreamStore> = {},
+): LiveStreamStore {
+	return {
+		async acquire() {
+			return "producer";
+		},
+		async append() {},
+		async finalize() {},
+		async refresh() {
+			return true;
+		},
+		async appendWithRetryId() {
+			return { cursor: "1-0", appended: true };
+		},
+		async *read() {},
+		async status() {
+			return "streaming";
+		},
+		async delete() {},
+		async close() {},
+		...overrides,
+	};
+}

--- a/apps/chat-api/src/features/conversation-history/conversation-history-store.ts
+++ b/apps/chat-api/src/features/conversation-history/conversation-history-store.ts
@@ -1,4 +1,5 @@
 import type { Message, RunErrorEvent, RunFinishedEvent } from "@ag-ui/core";
+import type { RunCancelledEvent } from "@mymemo/live-text";
 import type { ConversationScope } from "@/features/conversation-store";
 
 export interface ConversationSummary {
@@ -12,14 +13,7 @@ export interface ConversationSummary {
 	archivedAt: Date | null;
 }
 
-/** ADR-0012 names cancellation as its own standard terminal event. The pinned
- * AG-UI package does not expose that type yet, so keep this narrow bridge local
- * to the history contract until the package adds it. */
-export interface RunCancelledEvent {
-	type: "RUN_CANCELLED";
-	threadId: string;
-	runId: string;
-}
+export type { RunCancelledEvent } from "@mymemo/live-text";
 
 export type RunTerminalEvent =
 	| RunFinishedEvent

--- a/apps/chat-api/src/features/conversation-history/postgres-conversation-history-store.test.ts
+++ b/apps/chat-api/src/features/conversation-history/postgres-conversation-history-store.test.ts
@@ -684,7 +684,7 @@ describe("PostgresConversationHistoryStore", () => {
 			status: "done",
 			liveStreamFailedAt: new Date("2026-07-20T01:00:01.000Z"),
 			terminalAt: new Date("2026-07-20T01:00:05.000Z"),
-			nextEventSeq: 3,
+			nextEventSeq: 4,
 		});
 		await tdb.db.insert(runEvents).values([
 			{
@@ -704,6 +704,12 @@ describe("PostgresConversationHistoryStore", () => {
 			{
 				runId: "run-1",
 				seq: 2,
+				type: RunEventType.AssistantMessageCompleted,
+				payload: { messageId: "assistant-1", text: "Durable answer" },
+			},
+			{
+				runId: "run-1",
+				seq: 3,
 				type: RunEventType.Done,
 				payload: { outcome: "done" },
 			},
@@ -716,7 +722,24 @@ describe("PostgresConversationHistoryStore", () => {
 			cursor: null,
 		};
 
-		expect((await historyStore.getPage(input))?.runs).toHaveLength(1);
+		expect((await historyStore.getPage(input))?.runs).toEqual([
+			{
+				runId: "run-1",
+				messages: [
+					{ id: "user-1", role: "user", content: "Question" },
+					{
+						id: "assistant-1",
+						role: "assistant",
+						content: "Durable answer",
+					},
+				],
+				terminalEvent: {
+					type: EventType.RUN_FINISHED,
+					threadId: "conversation-1",
+					runId: "run-1",
+				},
+			},
+		]);
 		await expect(
 			conversationStore.deletePermanently({
 				userId: "member-1",

--- a/apps/chat-api/src/features/conversations/conversations.route.test.ts
+++ b/apps/chat-api/src/features/conversations/conversations.route.test.ts
@@ -1226,6 +1226,11 @@ describe("POST /v1/conversations/:id/runs", () => {
 		let admitted = false;
 		fakeRuns.runStore.admitRun = async (input) => {
 			admitted = true;
+			fakeRuns.runOwners.set(input.runId, {
+				userId: input.conversation.userId,
+				conversationId: input.conversation.conversationId,
+				status: "queued",
+			});
 			return {
 				outcome: "created",
 				run: runRecord({
@@ -2080,6 +2085,150 @@ describe("GET /v1/conversations/:id/runs/:runId/events", () => {
 		expect(redisRead).toBe(false);
 	});
 
+	it("returns retryable 503 for a temporary read failure while the Run is active", async () => {
+		const { store } = fakeStore([existing]);
+		const fakeRuns = fakeRunStore();
+		fakeRuns.runOwners.set("run-1", {
+			userId: "member-1",
+			conversationId: "conv-1",
+			status: "running",
+		});
+		const res = await buildApp(
+			store,
+			gateThatFailsIfConsulted(),
+			fakeRuns,
+			disabledLiveTextSubscriber,
+			{
+				async status() {
+					throw new Error("temporary Redis failure");
+				},
+				async *read() {},
+			},
+		).request("/v1/conversations/conv-1/runs/run-1/events", {
+			method: "GET",
+			headers: identityHeaders,
+		});
+
+		expect(res.status).toBe(503);
+		expect(await res.json()).toEqual({
+			error: "Live stream temporarily unavailable",
+		});
+	});
+
+	it("returns recovery 410 when the failure marker races the first Live Stream read", async () => {
+		const { store } = fakeStore([existing]);
+		const fakeRuns = fakeRunStore();
+		const owner = {
+			userId: "member-1",
+			conversationId: "conv-1",
+			status: "running",
+			liveStreamFailedAt: null as Date | null,
+		};
+		fakeRuns.runOwners.set("run-1", owner);
+		const res = await buildApp(
+			store,
+			gateThatFailsIfConsulted(),
+			fakeRuns,
+			disabledLiveTextSubscriber,
+			{
+				async status() {
+					return "streaming" as const;
+				},
+				read() {
+					return {
+						[Symbol.asyncIterator]() {
+							return {
+								async next() {
+									owner.liveStreamFailedAt = new Date();
+									throw new Error("Redis failed permanently");
+								},
+							};
+						},
+					};
+				},
+			},
+		).request("/v1/conversations/conv-1/runs/run-1/events", {
+			method: "GET",
+			headers: identityHeaders,
+		});
+
+		expect(res.status).toBe(410);
+		expect(await res.json()).toEqual({
+			error: "Live stream unavailable",
+			recovery: "history",
+		});
+	});
+
+	it("closes a failed open Live Stream, then returns the Recovering signal", async () => {
+		const { store } = fakeStore([existing]);
+		const fakeRuns = fakeRunStore();
+		const owner = {
+			userId: "member-1",
+			conversationId: "conv-1",
+			status: "running",
+			liveStreamFailedAt: null as Date | null,
+		};
+		fakeRuns.runOwners.set("run-1", owner);
+		const encoder = new TextEncoder();
+		let statusReads = 0;
+		const app = buildApp(
+			store,
+			gateThatFailsIfConsulted(),
+			fakeRuns,
+			disabledLiveTextSubscriber,
+			{
+				async status() {
+					statusReads++;
+					return "streaming" as const;
+				},
+				async *read() {
+					yield {
+						cursor: "1-0",
+						chunk: encoder.encode(
+							JSON.stringify({
+								type: "RUN_STARTED",
+								threadId: "conv-1",
+								runId: "run-1",
+							}),
+						),
+					};
+					owner.liveStreamFailedAt = new Date();
+					throw new Error("Redis failed mid-stream");
+				},
+			},
+		);
+
+		const first = await app.request(
+			"/v1/conversations/conv-1/runs/run-1/events",
+			{ method: "GET", headers: identityHeaders },
+		);
+		expect(first.status).toBe(200);
+		expect(parseAgUiSse(await first.text())).toEqual([
+			{
+				id: "1-0",
+				data: {
+					type: "RUN_STARTED",
+					threadId: "conv-1",
+					runId: "run-1",
+				},
+			},
+		]);
+
+		const recoveryResponse = await app.request(
+			"/v1/conversations/conv-1/runs/run-1/events",
+			{
+				method: "GET",
+				headers: { ...identityHeaders, "last-event-id": "1-0" },
+			},
+		);
+		expect(recoveryResponse.status).toBe(410);
+		expect(await recoveryResponse.json()).toEqual({
+			error: "Live stream unavailable",
+			recovery: "history",
+		});
+		expect(statusReads).toBe(1);
+	});
+
 	it("returns recovery 410 when a terminal Run's retained Live Stream is missing", async () => {
 		const { store } = fakeStore([existing]);
 		const fakeRuns = fakeRunStore();
@@ -2111,7 +2260,7 @@ describe("GET /v1/conversations/:id/runs/:runId/events", () => {
 		});
 	}, 7_000);
 
-	it("returns recovery 410 when a terminal Stream has no terminal event to replay", async () => {
+	it("returns recovery 410 when a terminal Live Stream has no terminal event to replay", async () => {
 		const { store } = fakeStore([existing]);
 		const fakeRuns = fakeRunStore();
 		fakeRuns.runOwners.set("run-1", {
@@ -2142,7 +2291,7 @@ describe("GET /v1/conversations/:id/runs/:runId/events", () => {
 		});
 	});
 
-	it("returns 400 when an active Run has no Stream that could have issued the cursor", async () => {
+	it("returns 400 when an active Run has no Live Stream that could have issued the cursor", async () => {
 		const { store } = fakeStore([existing]);
 		const fakeRuns = fakeRunStore();
 		fakeRuns.runOwners.set("run-1", {
@@ -2214,7 +2363,7 @@ describe("GET /v1/conversations/:id/runs/:runId/events", () => {
 		expect(parseAgUiSse(body)).toEqual([{ id: "1-0", data: terminalEvent }]);
 	}, 8_000);
 
-	it("follows a Stream that appears just after Postgres terminalizes the Run", async () => {
+	it("follows a Live Stream that appears just after Postgres terminalizes the Run", async () => {
 		const { store } = fakeStore([existing]);
 		const fakeRuns = fakeRunStore();
 		const owner = {

--- a/apps/chat-api/src/features/conversations/conversations.route.ts
+++ b/apps/chat-api/src/features/conversations/conversations.route.ts
@@ -60,6 +60,22 @@ function liveStreamRecoveryResponse(c: Context<AppEnv>) {
 	return c.json({ error: "Live stream unavailable", recovery: "history" }, 410);
 }
 
+async function liveStreamReadFailureResponse(
+	c: Context<AppEnv>,
+	run: RunRecord,
+) {
+	const currentRun = await c.var.deps.runStore.getRun({
+		userId: run.userId,
+		conversationId: run.conversationId,
+		runId: run.runId,
+	});
+	if (currentRun === null) return c.json({ error: "Run not found" }, 404);
+	return currentRun.liveStreamFailedAt !== null ||
+		isTerminalRunStatus(currentRun.status)
+		? liveStreamRecoveryResponse(c)
+		: c.json({ error: "Live stream temporarily unavailable" }, 503);
+}
+
 function abortableDelay(ms: number, signal: AbortSignal): Promise<void> {
 	return new Promise((resolve) => {
 		if (signal.aborted) return resolve();
@@ -191,9 +207,7 @@ async function streamAgUiRun(
 			error,
 			runId: run.runId,
 		});
-		return isTerminalRunStatus(run.status)
-			? liveStreamRecoveryResponse(c)
-			: c.json({ error: "Live stream temporarily unavailable" }, 503);
+		return liveStreamReadFailureResponse(c, run);
 	}
 	if (initial.outcome === "ping") {
 		if (requestSignal.aborted) {
@@ -252,9 +266,7 @@ async function streamAgUiRun(
 		readAbort.dispose();
 		await iterator.return?.();
 		if (status === "done" && cursor !== "") return c.body(null, 204);
-		return isTerminalRunStatus(run.status)
-			? liveStreamRecoveryResponse(c)
-			: c.json({ error: "Live stream temporarily unavailable" }, 503);
+		return liveStreamReadFailureResponse(c, run);
 	}
 
 	return streamSSE(c, async (stream) => {
@@ -366,9 +378,7 @@ async function respondWithAgUiRun(
 	try {
 		status = await c.var.deps.liveStreamReader.status(run.runId);
 	} catch {
-		return isTerminalRunStatus(run.status)
-			? liveStreamRecoveryResponse(c)
-			: c.json({ error: "Live stream temporarily unavailable" }, 503);
+		return liveStreamReadFailureResponse(c, run);
 	}
 	if (status === "error") return liveStreamRecoveryResponse(c);
 	if (status === "missing") {

--- a/e2e/integration.test.ts
+++ b/e2e/integration.test.ts
@@ -40,6 +40,8 @@ import {
 import { createServer } from "node:net";
 import { resolve } from "node:path";
 import { createDatabase } from "../packages/agent-db/src/client";
+import { claimNextRunTx } from "../packages/agent-db/src/run-store";
+import { createRedisLiveStreamStore } from "../packages/live-text/src/redis-live-stream-store";
 
 const DB_URL = process.env.AGENT_DATABASE_URL;
 const RUN = Boolean(DB_URL);
@@ -226,6 +228,118 @@ async function waitForPersistedRun(
 	throw new Error(`Run ${runId} was not admitted before the deadline`);
 }
 
+async function waitForFailedLiveStreamRun(
+	runId: string,
+	timeoutMs: number,
+): Promise<{ status: string; liveStreamFailedAt: Date | null }> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		const run = await acceptanceDb?.query.runs.findFirst({
+			columns: { status: true, liveStreamFailedAt: true },
+			where: (row, { eq }) => eq(row.runId, runId),
+		});
+		if (
+			run &&
+			run.liveStreamFailedAt !== null &&
+			(run.status === "done" ||
+				run.status === "error" ||
+				run.status === "canceled")
+		) {
+			return run;
+		}
+		await Bun.sleep(50);
+	}
+	throw new Error(
+		`Run ${runId} did not terminalize with a failed Live Stream before the deadline`,
+	);
+}
+
+async function admitIntegrationRun(prompt: string): Promise<{
+	conversationId: string;
+	runId: string;
+	response: Promise<Response>;
+}> {
+	const createResponse = await fetch(`${CHAT_URL}/v1/conversations`, {
+		method: "POST",
+		headers: {
+			"content-type": "application/json",
+			"x-member-code": MEMBER_CODE,
+			"x-partner-code": PARTNER_CODE,
+		},
+		body: JSON.stringify({}),
+		signal: AbortSignal.timeout(15_000),
+	});
+	expect(createResponse.status).toBe(201);
+	const conversationId = (await createResponse.json()).conversationId as string;
+	const runId = crypto.randomUUID();
+	const response = fetch(
+		`${CHAT_URL}/v1/conversations/${conversationId}/runs`,
+		{
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				"x-member-code": MEMBER_CODE,
+				"x-partner-code": PARTNER_CODE,
+			},
+			body: JSON.stringify({
+				threadId: conversationId,
+				runId,
+				state: {},
+				messages: [
+					{
+						id: `user-${runId}`,
+						role: "user",
+						content: prompt,
+					},
+				],
+				tools: [],
+				context: [],
+				forwardedProps: {},
+			}),
+			signal: AbortSignal.timeout(TURN_TIMEOUT_MS),
+		},
+	);
+	await waitForPersistedRun(runId, 10_000);
+	return { conversationId, runId, response };
+}
+
+async function liveStreamStatus(runId: string): Promise<string> {
+	const redisUrl = eventWriterEnv?.REDIS_URL;
+	if (!redisUrl) throw new Error("event writer was not configured");
+	const store = createRedisLiveStreamStore({
+		url: redisUrl,
+		deployment: "current",
+	});
+	try {
+		return await store.status(runId);
+	} finally {
+		await store.close();
+	}
+}
+
+async function historyTerminalType(
+	conversationId: string,
+	runId: string,
+): Promise<string | undefined> {
+	const response = await fetch(
+		`${CHAT_URL}/v1/conversations/${conversationId}/history`,
+		{
+			headers: {
+				"x-member-code": MEMBER_CODE,
+				"x-partner-code": PARTNER_CODE,
+			},
+		},
+	);
+	expect(response.status).toBe(200);
+	const history = (await response.json()) as {
+		runs: Array<{
+			runId: string;
+			terminalEvent: { type: string } | null;
+		}>;
+	};
+	return history.runs.find((run) => run.runId === runId)?.terminalEvent?.type;
+}
+
 async function freePort(): Promise<number> {
 	return new Promise((resolvePort, reject) => {
 		const server = createServer();
@@ -278,6 +392,14 @@ let redis: Bun.Subprocess | undefined;
 let eventWriterEnv: Record<string, string> | undefined;
 const acceptanceDb = DB_URL ? createDatabase(DB_URL) : undefined;
 
+async function stopEventWriter(): Promise<void> {
+	const runningWorker = worker;
+	worker = undefined;
+	if (!runningWorker) return;
+	runningWorker.kill("SIGTERM");
+	await runningWorker.exited;
+}
+
 describe.skipIf(!RUN)(
 	"split-runtime integration (real Postgres and Redis)",
 	() => {
@@ -316,7 +438,7 @@ describe.skipIf(!RUN)(
 
 		afterAll(async () => {
 			chat?.kill();
-			worker?.kill();
+			await stopEventWriter();
 			redis?.kill("SIGTERM");
 			if (redis) await redis.exited;
 			await acceptanceDb?.$client.end();
@@ -566,6 +688,198 @@ describe.skipIf(!RUN)(
 				expect(mismatch.status).toBe(409);
 			},
 			TURN_TIMEOUT_MS + 15_000,
+		);
+
+		it(
+			"recovers Conversation history across the real Redis failure matrix",
+			async () => {
+				const faultPoints = [
+					"before_creation",
+					"mid_text",
+					"tool",
+					"terminal",
+				] as const;
+
+				for (const faultPoint of faultPoints) {
+					await stopEventWriter();
+					const {
+						conversationId,
+						runId,
+						response: runResponsePromise,
+					} = await admitIntegrationRun(`Exercise ${faultPoint} recovery`);
+					if (!eventWriterEnv) {
+						throw new Error("event writer was not configured");
+					}
+					worker = spawnEventWriter({
+						...eventWriterEnv,
+						INTEGRATION_LIVE_STREAM_FAIL_AT: faultPoint,
+					});
+
+					const terminal = await waitForFailedLiveStreamRun(
+						runId,
+						TURN_TIMEOUT_MS,
+					);
+					expect(terminal, faultPoint).toMatchObject({
+						status: "done",
+						liveStreamFailedAt: expect.any(Date),
+					});
+					await stopEventWriter();
+
+					const runResponse = await runResponsePromise;
+					expect(runResponse.status, faultPoint).toBe(200);
+					await runResponse.text();
+
+					const durableEvents = await acceptanceDb?.query.runEvents.findMany({
+						columns: { type: true },
+						where: (event, { eq }) => eq(event.runId, runId),
+						orderBy: (event, { asc }) => asc(event.seq),
+					});
+					expect(
+						durableEvents?.map((event) => event.type),
+						faultPoint,
+					).toEqual([
+						"run_started",
+						"assistant_message_completed",
+						"tool_use",
+						"tool_result",
+						"run_done",
+					]);
+
+					const recoveryResponse = await fetchRunEvents(conversationId, runId);
+					expect(recoveryResponse.status, faultPoint).toBe(410);
+					expect(await recoveryResponse.json(), faultPoint).toEqual({
+						error: "Live stream unavailable",
+						recovery: "history",
+					});
+
+					const historyResponse = await fetch(
+						`${CHAT_URL}/v1/conversations/${conversationId}/history`,
+						{
+							headers: {
+								"x-member-code": MEMBER_CODE,
+								"x-partner-code": PARTNER_CODE,
+							},
+						},
+					);
+					expect(historyResponse.status, faultPoint).toBe(200);
+					const history = (await historyResponse.json()) as {
+						runs: Array<{
+							runId: string;
+							messages: Array<{ role: string; content: unknown }>;
+							terminalEvent: { type: string } | null;
+						}>;
+					};
+					const recoveredRun = history.runs.find((run) => run.runId === runId);
+					expect(recoveredRun?.terminalEvent, faultPoint).toMatchObject({
+						type: "RUN_FINISHED",
+					});
+					expect(
+						recoveredRun?.messages.some(
+							(message) =>
+								message.role === "assistant" &&
+								JSON.stringify(message.content).includes("Synthetic response"),
+						),
+						faultPoint,
+					).toBe(true);
+				}
+			},
+			TURN_TIMEOUT_MS * 4 + 30_000,
+		);
+
+		it(
+			"keeps queued cancellation and stale recovery free of fabricated Live Streams",
+			async () => {
+				await stopEventWriter();
+				const queued = await admitIntegrationRun(
+					"Cancel before a worker claims",
+				);
+				const cancellation = await fetch(
+					`${CHAT_URL}/v1/conversations/${queued.conversationId}/events`,
+					{
+						method: "POST",
+						headers: {
+							"content-type": "application/json",
+							"x-member-code": MEMBER_CODE,
+							"x-partner-code": PARTNER_CODE,
+						},
+						body: JSON.stringify({
+							type: "user.interrupt",
+							runId: queued.runId,
+						}),
+					},
+				);
+				expect(cancellation.status).toBe(202);
+				expect(await cancellation.json()).toEqual({
+					runId: queued.runId,
+					status: "canceled",
+				});
+				const queuedResponse = await queued.response;
+				expect(queuedResponse.status).toBe(200);
+				await queuedResponse.text();
+				const queuedRun = await acceptanceDb?.query.runs.findFirst({
+					columns: { status: true, liveStreamFailedAt: true },
+					where: (run, { eq }) => eq(run.runId, queued.runId),
+				});
+				expect(queuedRun).toMatchObject({
+					status: "canceled",
+					liveStreamFailedAt: null,
+				});
+				const queuedEvents = await acceptanceDb?.query.runEvents.findMany({
+					columns: { type: true },
+					where: (event, { eq }) => eq(event.runId, queued.runId),
+					orderBy: (event, { asc }) => asc(event.seq),
+				});
+				expect(queuedEvents?.map((event) => event.type)).toEqual([
+					"run_started",
+					"run_canceled",
+				]);
+				expect(await liveStreamStatus(queued.runId)).toBe("missing");
+				expect(
+					await historyTerminalType(queued.conversationId, queued.runId),
+				).toBe("RUN_CANCELLED");
+
+				const stale = await admitIntegrationRun(
+					"Recover an expired worker claim",
+				);
+				if (!acceptanceDb || !eventWriterEnv) {
+					throw new Error("integration services were not configured");
+				}
+				const claimed = await claimNextRunTx(acceptanceDb, {
+					workerId: "integration-stale-worker",
+				});
+				expect(claimed?.runId).toBe(stale.runId);
+				await acceptanceDb.$client.query(
+					"update runs set locked_until = now() - interval '1 second' where run_id = $1",
+					[stale.runId],
+				);
+				worker = spawnEventWriter(eventWriterEnv);
+				const recovered = await waitForFailedLiveStreamRun(
+					stale.runId,
+					TURN_TIMEOUT_MS,
+				);
+				expect(recovered).toMatchObject({
+					status: "error",
+					liveStreamFailedAt: expect.any(Date),
+				});
+				await stopEventWriter();
+				const staleResponse = await stale.response;
+				expect(staleResponse.status).toBe(200);
+				await staleResponse.text();
+				const staleEvents = await acceptanceDb.query.runEvents.findMany({
+					columns: { type: true },
+					where: (event, { eq }) => eq(event.runId, stale.runId),
+					orderBy: (event, { asc }) => asc(event.seq),
+				});
+				expect(staleEvents.map((event) => event.type)).toEqual([
+					"run_started",
+					"run_error",
+				]);
+				expect(await liveStreamStatus(stale.runId)).toBe("missing");
+				expect(
+					await historyTerminalType(stale.conversationId, stale.runId),
+				).toBe("RUN_ERROR");
+			},
+			TURN_TIMEOUT_MS * 2 + 15_000,
 		);
 	},
 );

--- a/e2e/synthetic-worker.ts
+++ b/e2e/synthetic-worker.ts
@@ -9,7 +9,10 @@ import { createLogger } from "../apps/agent-worker/src/logger";
 import { RunLoop, type RunProcessor } from "../apps/agent-worker/src/run-loop";
 import { Worker } from "../apps/agent-worker/src/worker";
 import { createDatabase } from "../packages/agent-db/src/client";
-import { createRedisLiveStreamStore } from "../packages/live-text/src/redis-live-stream-store";
+import {
+	createRedisLiveStreamStore,
+	type LiveStreamStore,
+} from "../packages/live-text/src/redis-live-stream-store";
 
 const agentDatabaseUrl = process.env.AGENT_DATABASE_URL;
 if (!agentDatabaseUrl) throw new Error("AGENT_DATABASE_URL is required");
@@ -24,10 +27,14 @@ const worker = new Worker({
 	shutdownTimeoutMs: 1_000,
 	logger,
 });
-const liveStreamStore = createRedisLiveStreamStore({
+const redisLiveStreamStore = createRedisLiveStreamStore({
 	url: redisUrl,
 	deployment: "current",
 });
+const liveStreamStore = withInjectedRedisFault(
+	redisLiveStreamStore,
+	process.env.INTEGRATION_LIVE_STREAM_FAIL_AT,
+);
 const resumeDelayMs = Number(process.env.INTEGRATION_RESUME_DELAY_MS ?? 0);
 const processor: RunProcessor = async (ctx) => {
 	const messageId = `message-${ctx.run.runId}`;
@@ -112,3 +119,77 @@ async function shutdown(): Promise<void> {
 
 process.on("SIGINT", () => void shutdown());
 process.on("SIGTERM", () => void shutdown());
+
+type LiveStreamFault = "before_creation" | "mid_text" | "tool" | "terminal";
+
+/** Deterministically faults one operation while retaining a real Redis-backed
+ * store for every operation on either side of the failure. Integration tests
+ * use this to cover process-boundary recovery without timing Redis shutdowns. */
+function withInjectedRedisFault(
+	store: LiveStreamStore,
+	rawFault: string | undefined,
+): LiveStreamStore {
+	const fault = isLiveStreamFault(rawFault) ? rawFault : undefined;
+	let injected = false;
+	const inject = (candidate: LiveStreamFault) => {
+		if (fault !== candidate || injected) return;
+		injected = true;
+		throw new Error(`injected Redis failure at ${candidate}`);
+	};
+	return {
+		async acquire(streamId, options) {
+			inject("before_creation");
+			return store.acquire(streamId, options);
+		},
+		async append(streamId, chunk) {
+			const type = liveEventType(chunk);
+			if (type === "TEXT_MESSAGE_CONTENT") inject("mid_text");
+			if (type === "TOOL_CALL_START") inject("tool");
+			if (type === "RUN_FINISHED") inject("terminal");
+			return store.append(streamId, chunk);
+		},
+		appendWithRetryId(streamId, retryId, chunk) {
+			return store.appendWithRetryId(streamId, retryId, chunk);
+		},
+		finalize(streamId, status, error) {
+			return store.finalize(streamId, status, error);
+		},
+		refresh(streamId) {
+			return store.refresh(streamId);
+		},
+		read(streamId, cursor, signal) {
+			return store.read(streamId, cursor, signal);
+		},
+		status(streamId) {
+			return store.status(streamId);
+		},
+		delete(streamId) {
+			return store.delete(streamId);
+		},
+		close() {
+			return store.close();
+		},
+	};
+}
+
+function isLiveStreamFault(
+	value: string | undefined,
+): value is LiveStreamFault {
+	return (
+		value === "before_creation" ||
+		value === "mid_text" ||
+		value === "tool" ||
+		value === "terminal"
+	);
+}
+
+function liveEventType(chunk: Uint8Array): string | undefined {
+	try {
+		const event = JSON.parse(new TextDecoder().decode(chunk)) as {
+			type?: unknown;
+		};
+		return typeof event.type === "string" ? event.type : undefined;
+	} catch {
+		return undefined;
+	}
+}

--- a/packages/live-text/src/redis-live-stream-store.contract.test.ts
+++ b/packages/live-text/src/redis-live-stream-store.contract.test.ts
@@ -16,6 +16,7 @@ import {
 	LIVE_STREAM_RETENTION_MS,
 	LIVE_STREAM_TEXT_EVENT_TARGET_BYTES,
 	type LiveStreamStore,
+	RUN_CANCELLED_EVENT_TYPE,
 } from "./index";
 
 const encoder = new TextEncoder();
@@ -481,7 +482,38 @@ it("splits large Unicode text deltas into complete standard AG-UI events", () =>
 	expect(textEvents.map((event) => event.delta).join("")).toBe(delta);
 });
 
-it("rejects bytes that are not exactly one standard AG-UI event", async () => {
+it("retains the standard cancellation terminal while the pinned core lacks it", async () => {
+	const port = await freePort();
+	const redis = await startRedis(port);
+	const store = createRedisLiveStreamStore({
+		url: `redis://127.0.0.1:${port}`,
+		deployment: "test",
+	});
+	const [encoded] = encodeAgUiLiveStreamEvent({
+		type: RUN_CANCELLED_EVENT_TYPE,
+		threadId: "conv-1",
+		runId: "run-1",
+	});
+
+	try {
+		if (!encoded) throw new Error("cancellation terminal was not encoded");
+		await store.acquire("run-1");
+		await store.append("run-1", encoded);
+		await store.finalize("run-1", "done");
+		const retained = await collect(store, "run-1");
+		expect(retained).toHaveLength(1);
+		expect(JSON.parse(decoder.decode(retained[0]?.chunk))).toEqual({
+			type: "RUN_CANCELLED",
+			threadId: "conv-1",
+			runId: "run-1",
+		});
+	} finally {
+		await store.close();
+		await stopRedis(redis);
+	}
+}, 10_000);
+
+it("rejects bytes that are not exactly one supported Live Stream event", async () => {
 	const port = await freePort();
 	const redis = await startRedis(port);
 	const store = createRedisLiveStreamStore({

--- a/packages/live-text/src/redis-live-stream-store.ts
+++ b/packages/live-text/src/redis-live-stream-store.ts
@@ -13,6 +13,7 @@ import type {
 	ResumableStreamStore,
 } from "assistant-stream/resumable";
 import { createClient } from "redis";
+import { z } from "zod";
 
 export const LIVE_STREAM_RETENTION_MS = 30 * 60 * 1_000;
 export const LIVE_STREAM_MAX_EVENT_BYTES = 32 * 1_024;
@@ -29,6 +30,20 @@ const DEFAULT_REDIS_POLL_INTERVAL_MS = 100;
 const REDIS_BLOB_STRING = 36;
 const REDIS_STREAM_ID_PATTERN = /^(0|[1-9]\d*)-(0|[1-9]\d*)$/;
 const REDIS_STREAM_ID_PART_MAX = (1n << 64n) - 1n;
+
+/** AG-UI's cancellation terminal is not present in the currently pinned core
+ * package, so keep its standard wire shape at the Live Stream boundary. */
+export const RUN_CANCELLED_EVENT_TYPE = "RUN_CANCELLED" as const;
+const RunCancelledEventSchema = z
+	.object({
+		type: z.literal(RUN_CANCELLED_EVENT_TYPE),
+		threadId: z.string().min(1).max(MAX_RUN_ID_LENGTH),
+		runId: z.string().min(1).max(MAX_RUN_ID_LENGTH),
+	})
+	.strict();
+
+export type RunCancelledEvent = z.infer<typeof RunCancelledEventSchema>;
+export type LiveStreamEvent = AGUIEvent | RunCancelledEvent;
 
 const ACQUIRE_SCRIPT = `
 if redis.call("EXISTS", KEYS[1]) == 1 then
@@ -198,8 +213,10 @@ export class LiveStreamStoreError extends Error {
  * Validate and serialize one standard AG-UI event. Large text-content deltas
  * become several complete events; no other event is split or truncated.
  */
-export function encodeAgUiLiveStreamEvent(event: AGUIEvent): Uint8Array[] {
-	const parsed = EventSchemas.parse(event);
+export function encodeAgUiLiveStreamEvent(
+	event: LiveStreamEvent,
+): Uint8Array[] {
+	const parsed = parseLiveStreamEvent(event);
 	const encoded = encodeEvent(parsed);
 	if (parsed.type !== EventType.TEXT_MESSAGE_CONTENT) {
 		if (encoded.byteLength > LIVE_STREAM_MAX_EVENT_BYTES) {
@@ -611,16 +628,28 @@ function positiveInteger(value: number, name: string): number {
 	return value;
 }
 
-function encodeEvent(event: AGUIEvent): Uint8Array {
+function encodeEvent(event: LiveStreamEvent): Uint8Array {
 	return EVENT_ENCODER.encode(JSON.stringify(event));
 }
 
 function validateEncodedAgUiEvent(chunk: Uint8Array): void {
 	try {
-		EventSchemas.parse(JSON.parse(EVENT_DECODER.decode(chunk)));
+		parseLiveStreamEvent(JSON.parse(EVENT_DECODER.decode(chunk)));
 	} catch {
 		throw new LiveStreamStoreError("invalid_event");
 	}
+}
+
+function parseLiveStreamEvent(event: unknown): LiveStreamEvent {
+	if (
+		typeof event === "object" &&
+		event !== null &&
+		"type" in event &&
+		event.type === RUN_CANCELLED_EVENT_TYPE
+	) {
+		return RunCancelledEventSchema.parse(event);
+	}
+	return EventSchemas.parse(event);
 }
 
 function splitTextContentEvent(event: TextMessageContentEvent): Uint8Array[] {


### PR DESCRIPTION
## Summary

- durably mark a Run when its retained Live Stream becomes unusable and suppress all later producer writes
- preserve Postgres Assistant messages, Tool activity, and Run Outcomes across Redis acquisition, append, refresh, and terminal-publication failures
- emit the cancellation terminal correctly and route reconnect failures to Conversation history once recovery is ready
- clean up stale orphan Streams without fabricating terminal Redis events
- add unit, real-Redis contract, and real Redis/Postgres process-boundary coverage

## Why

A producer-side Redis failure could leave clients waiting on an unusable Live Stream or expose an incomplete suffix even though durable execution continued. Transient failure-marker writes and terminal publication failures also needed a reliable recovery path.

## Impact

Clients remain Reconnecting only while an active Run may still have a usable Stream. Once the Stream is known unusable or permanent history is complete, reconnect returns the Recovering signal and the client can hydrate the authoritative Conversation history.

## Validation

- `bun run test` — 898 tests passed
- real Redis/Postgres integration suite — 3 tests and 86 assertions passed
- TypeScript checks for agent-worker, chat-api, and live-text passed
- Biome and `git diff --check` passed

Closes #339