### PR TITLE
fix(ci): align correlated tool lifecycle expectations

### DIFF
--- a/apps/agent-worker/src/run-loop.test.ts
+++ b/apps/agent-worker/src/run-loop.test.ts
@@ -462,31 +462,57 @@ describe("RunLoop — terminal outcomes", () => {
 			worker,
 			async (ctx) => {
 				await ctx.appendModelContent({
-					kind: "tool_use",
-					payload: {
-						tool: "Bash",
-						arguments: { command: "pwd" },
-						truncated: false,
+					kind: "assistant_message",
+					payload: { messageId: "assistant-1", text: "" },
+				});
+				await ctx.appendModelContents([
+					{
+						kind: "tool_call_started",
+						payload: {
+							toolCallId: "tool-1",
+							toolCallName: "Bash",
+							parentMessageId: "assistant-1",
+						},
 					},
+					{
+						kind: "tool_call_args",
+						payload: { toolCallId: "tool-1", delta: '{"command":"pwd"}' },
+					},
+					{
+						kind: "tool_call_completed",
+						payload: { toolCallId: "tool-1" },
+					},
+				]);
+				await ctx.appendLiveEvent({
+					type: EventType.TOOL_CALL_START,
+					toolCallId: "tool-1",
+					toolCallName: "Bash",
+					parentMessageId: "assistant-1",
 				});
 				await ctx.appendLiveEvent({
-					type: EventType.CUSTOM,
-					name: "mymemo.tool_use",
-					value: { tool: "Bash" },
+					type: EventType.TOOL_CALL_ARGS,
+					toolCallId: "tool-1",
+					delta: '{"command":"pwd"}',
+				});
+				await ctx.appendLiveEvent({
+					type: EventType.TOOL_CALL_END,
+					toolCallId: "tool-1",
 				});
 				await ctx.appendModelContent({
-					kind: "tool_result",
+					kind: "tool_call_result",
 					payload: {
-						tool: "Bash",
-						result: { exitCode: 0 },
+						messageId: "tool-result-1",
+						toolCallId: "tool-1",
+						content: '{"exitCode":0}',
 						isError: false,
-						truncated: false,
 					},
 				});
 				await ctx.appendLiveEvent({
-					type: EventType.CUSTOM,
-					name: "mymemo.tool_result",
-					value: { tool: "Bash" },
+					type: EventType.TOOL_CALL_RESULT,
+					messageId: "tool-result-1",
+					toolCallId: "tool-1",
+					content: '{"exitCode":0}',
+					role: "tool",
 				});
 			},
 			liveStreamStore,
@@ -501,8 +527,11 @@ describe("RunLoop — terminal outcomes", () => {
 			liveStreamFailedAt: expect.any(Date),
 		});
 		expect(await readEventTypes("run-1")).toEqual([
-			"tool_use",
-			"tool_result",
+			"assistant_message_completed",
+			"tool_call_started",
+			"tool_call_args",
+			"tool_call_completed",
+			"tool_call_result",
 			"run_done",
 		]);
 		expect(appendCalls).toBe(2);

--- a/e2e/integration.test.ts
+++ b/e2e/integration.test.ts
@@ -933,8 +933,10 @@ describe.skipIf(!RUN)(
 					).toEqual([
 						"run_started",
 						"assistant_message_completed",
-						"tool_use",
-						"tool_result",
+						"tool_call_started",
+						"tool_call_args",
+						"tool_call_completed",
+						"tool_call_result",
 						"run_done",
 					]);
 


### PR DESCRIPTION
## Summary

- update the RunLoop Live Stream failure regression to use the correlated ADR-0012 Tool lifecycle
- align the real Postgres/Redis failure-matrix expectation with the canonical durable event vocabulary

## Root cause

The two contributing changes passed independently, but their combined `main` state left two stale test fragments behind. The worker regression still emitted removed `tool_use`/`tool_result` model-content kinds, causing the durable append to reject and the Run to terminalize as `error`. The integration failure matrix likewise still expected the superseded two-event vocabulary.

This is a test-only correction. Production already emits and persists `tool_call_started`, `tool_call_args`, `tool_call_completed`, and `tool_call_result` correctly.

## Impact

Restores CI coverage for the intended invariant: a Live Stream publication failure disables temporary delivery without changing the Run Outcome or preventing durable correlated Tool activity from committing.

## Validation

- `bun test apps/agent-worker/src/run-loop.test.ts`
- `bun run test`
- `env AGENT_DATABASE_URL=postgresql://mymemo:mymemo@127.0.0.1:55433/mymemo_agent DB_SSL=disable CHAT_API_PORT=33100 bun test e2e/integration.test.ts`
- `bunx biome check apps/agent-worker/src/run-loop.test.ts e2e/integration.test.ts`
- `bunx tsc --noEmit -p apps/agent-worker/tsconfig.json`