### PR TITLE
feat(streaming): observe Live Stream degradation (#342)

### DIFF
--- a/apps/agent-worker/src/index.ts
+++ b/apps/agent-worker/src/index.ts
@@ -3,7 +3,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { query } from "@anthropic-ai/claude-agent-sdk";
 import { createDatabase } from "@mymemo/agent-db/client";
-import { createRedisLiveStreamStore } from "@mymemo/live-text";
+import {
+	createLiveStreamTelemetry,
+	createRedisLiveStreamStore,
+} from "@mymemo/live-text";
 import { createArtifactPublisher } from "./artifacts/artifact-publication";
 import { createS3ArtifactObjectStore } from "./artifacts/s3-artifact-object-store";
 import type { AdvisoryLockPool } from "./cleanup/advisory-lock";
@@ -36,6 +39,7 @@ const config = loadWorkerConfigFromEnv(Bun.env);
 const logger = createLogger(config.logLevel);
 const workerId = generateWorkerId();
 const liveTextTelemetry = createWorkerLiveTextTelemetry(logger);
+const liveStreamTelemetry = createLiveStreamTelemetry("agent-worker", logger);
 const liveTextTransport = createWorkerLiveTextTransport(
 	config.liveTextRedisUrl,
 	liveTextTelemetry,
@@ -117,6 +121,7 @@ const runLoop = new RunLoop({
 		liveTextTelemetry,
 	}),
 	liveStreamStore,
+	liveStreamTelemetry,
 	heartbeatIntervalMs: config.heartbeatIntervalMs,
 	// Admission commits ring this doorbell (the `runs_notify_queued` trigger),
 	// so pickup latency is milliseconds instead of a poll interval; the timer

--- a/apps/agent-worker/src/run-live-stream.test.ts
+++ b/apps/agent-worker/src/run-live-stream.test.ts
@@ -1,9 +1,179 @@
 import { expect, it } from "bun:test";
+import type {
+	LiveStreamMetricEvent,
+	LiveStreamTelemetry,
+} from "@mymemo/live-text";
 import type { WorkerLogger } from "./logger";
 import { RunLiveStream } from "./run-live-stream";
 import { fakeLiveStreamStore } from "./testing/live-stream-store";
 
 const silentLogger: WorkerLogger = { info() {}, warn() {}, error() {} };
+
+it("classifies producer acquisition when the retained store is not configured", async () => {
+	const metrics: Array<Record<string, unknown>> = [];
+	await RunLiveStream.open({
+		store: undefined,
+		runId: "run-1",
+		conversationId: "conv-1",
+		async markLiveStreamFailed() {
+			throw new Error("must not mark an intentionally disabled Stream");
+		},
+		logger: silentLogger,
+		telemetry: {
+			record(operation, result, options) {
+				metrics.push({ operation, result, ...options });
+			},
+		},
+	});
+
+	expect(metrics).toEqual([
+		{
+			operation: "acquire",
+			result: "failure",
+			reason: "not_configured",
+		},
+	]);
+});
+
+it("measures healthy producer acquisition, publication, refresh, and finalization", async () => {
+	const metrics: Array<Record<string, unknown>> = [];
+	const stream = await RunLiveStream.open({
+		store: fakeLiveStreamStore(),
+		runId: "run-1",
+		conversationId: "conv-1",
+		async markLiveStreamFailed() {
+			throw new Error("must not mark a healthy Stream");
+		},
+		logger: silentLogger,
+		telemetry: {
+			record(operation, result, options) {
+				metrics.push({ operation, result, ...options });
+			},
+		},
+	});
+
+	await stream.refresh();
+	await stream.finish("done");
+
+	expect(metrics).toEqual([
+		expect.objectContaining({
+			operation: "acquire",
+			result: "producer",
+			durationMs: expect.any(Number),
+		}),
+		expect.objectContaining({
+			operation: "append",
+			result: "success",
+			durationMs: expect.any(Number),
+		}),
+		expect.objectContaining({
+			operation: "refresh",
+			result: "success",
+			durationMs: expect.any(Number),
+		}),
+		expect.objectContaining({
+			operation: "append",
+			result: "success",
+			durationMs: expect.any(Number),
+		}),
+		expect.objectContaining({
+			operation: "finalize",
+			result: "success",
+			durationMs: expect.any(Number),
+		}),
+	]);
+});
+
+it("observes a payload-safe degradation transition separately from Run outcome", async () => {
+	const logs: Record<string, unknown>[] = [];
+	const metrics: LiveStreamMetricEvent[] = [];
+	const logger: WorkerLogger = {
+		info: (event) => logs.push(event),
+		warn: (event) => logs.push(event),
+		error: (event) => logs.push(event),
+	};
+	const telemetry: LiveStreamTelemetry = {
+		record(operation, result, options) {
+			metrics.push({
+				message: "Live Stream metric",
+				service: "agent-worker",
+				operation,
+				result,
+				...options,
+				count: 1,
+			});
+		},
+	};
+	const stream = await RunLiveStream.open({
+		store: fakeLiveStreamStore({
+			async append() {
+				throw new Error(
+					"redis://:secret@redis.internal current:mymemo:agui:{run-1}:stream assistant text tool arguments",
+				);
+			},
+		}),
+		runId: "run-1",
+		conversationId: "conv-1",
+		async markLiveStreamFailed() {
+			return {
+				outcome: "marked" as const,
+				failedAt: new Date(Date.now() - 1_000),
+			};
+		},
+		logger,
+		telemetry,
+	});
+
+	await stream.finish("done");
+
+	expect(metrics).toEqual([
+		expect.objectContaining({
+			operation: "acquire",
+			result: "producer",
+			durationMs: expect.any(Number),
+		}),
+		expect.objectContaining({
+			operation: "append",
+			result: "failure",
+			reason: "redis_unavailable",
+			durationMs: expect.any(Number),
+		}),
+		expect.objectContaining({
+			operation: "degradation",
+			result: "started",
+			reason: "redis_unavailable",
+		}),
+		expect.objectContaining({
+			operation: "finalize",
+			result: "success",
+			durationMs: expect.any(Number),
+		}),
+		expect.objectContaining({
+			operation: "degradation",
+			result: "ended",
+			reason: "redis_unavailable",
+			durationMs: expect.any(Number),
+		}),
+	]);
+	expect(logs).toEqual([
+		{
+			message: "Live Stream publication disabled",
+			runId: "run-1",
+			reason: "redis_unavailable",
+		},
+	]);
+	const serialized = JSON.stringify({ logs, metrics });
+	for (const forbidden of [
+		"assistant text",
+		"tool arguments",
+		"redis://",
+		"secret",
+		"mymemo:agui",
+		"conv-1",
+	]) {
+		expect(serialized).not.toContain(forbidden);
+	}
+});
 
 it("retries a transient Live Stream failure-marker write after the Run terminalizes", async () => {
 	let markerAttempts = 0;
@@ -18,6 +188,7 @@ it("retries a transient Live Stream failure-marker write after the Run terminali
 		async markLiveStreamFailed() {
 			markerAttempts += 1;
 			if (markerAttempts === 1) throw new Error("database unavailable");
+			return { outcome: "marked", failedAt: new Date() };
 		},
 		logger: silentLogger,
 	});
@@ -54,6 +225,7 @@ it.each([
 		async markLiveStreamFailed() {
 			markerAttempts += 1;
 			if (markerAttempts === 1) throw new Error("database unavailable");
+			return { outcome: "marked", failedAt: new Date() };
 		},
 		logger: silentLogger,
 	});

--- a/apps/agent-worker/src/run-live-stream.ts
+++ b/apps/agent-worker/src/run-live-stream.ts
@@ -1,13 +1,24 @@
 import { EventType } from "@ag-ui/core";
 import type { TerminalRunStatus } from "@mymemo/agent-db/run-store";
 import {
+	classifyLiveStreamFailure,
+	disabledLiveStreamTelemetry,
 	encodeAgUiLiveStreamEvent,
 	type LiveStreamEvent,
+	type LiveStreamOperation,
+	type LiveStreamReason,
+	type LiveStreamResult,
 	type LiveStreamStore,
 	LiveStreamStoreError,
+	type LiveStreamTelemetry,
 	RUN_CANCELLED_EVENT_TYPE,
 } from "@mymemo/live-text";
-import { toMessage, type WorkerLogger } from "./logger";
+import type { WorkerLogger } from "./logger";
+
+export interface LiveStreamFailureMarker {
+	outcome: "marked" | "already_failed";
+	failedAt: Date;
+}
 
 /** One claimed Run's best-effort AG-UI producer. Redis failure disables every
  * later write but never escapes into model execution or the Postgres Outcome. */
@@ -15,32 +26,49 @@ export class RunLiveStream {
 	#enabled = false;
 	#failed = false;
 	#failureMarked = false;
+	#failureReason: LiveStreamReason = "redis_unavailable";
+	#failedAt: Date | undefined;
+	#degradationEnded = false;
 
 	private constructor(
 		private readonly store: LiveStreamStore | undefined,
 		private readonly runId: string,
 		private readonly conversationId: string,
-		private readonly markLiveStreamFailed: () => Promise<void>,
+		private readonly markLiveStreamFailed: () => Promise<LiveStreamFailureMarker>,
 		private readonly logger: WorkerLogger,
+		private readonly telemetry: LiveStreamTelemetry,
 	) {}
 
 	static async open(options: {
 		store: LiveStreamStore | undefined;
 		runId: string;
 		conversationId: string;
-		markLiveStreamFailed: () => Promise<void>;
+		markLiveStreamFailed: () => Promise<LiveStreamFailureMarker>;
 		logger: WorkerLogger;
+		telemetry?: LiveStreamTelemetry;
 	}): Promise<RunLiveStream> {
+		const store = options.store;
 		const stream = new RunLiveStream(
-			options.store,
+			store,
 			options.runId,
 			options.conversationId,
 			options.markLiveStreamFailed,
 			options.logger,
+			options.telemetry ?? disabledLiveStreamTelemetry,
 		);
-		if (!options.store) return stream;
+		if (!store) {
+			stream.telemetry.record("acquire", "failure", {
+				reason: "not_configured",
+			});
+			return stream;
+		}
 		try {
-			if ((await options.store.acquire(options.runId)) !== "producer") {
+			const role = await stream.#observe(
+				"acquire",
+				(value) => (value === "producer" ? "producer" : "consumer"),
+				() => store.acquire(options.runId),
+			);
+			if (role !== "producer") {
 				await stream.#disable(new LiveStreamStoreError("not_producer"));
 				return stream;
 			}
@@ -57,20 +85,33 @@ export class RunLiveStream {
 	}
 
 	async append(event: LiveStreamEvent): Promise<void> {
-		if (!this.#enabled || !this.store) return;
+		const store = this.store;
+		if (!this.#enabled || !store) return;
 		try {
-			for (const chunk of encodeAgUiLiveStreamEvent(event)) {
-				await this.store.append(this.runId, chunk);
-			}
+			await this.#observe(
+				"append",
+				() => "success",
+				async () => {
+					for (const chunk of encodeAgUiLiveStreamEvent(event)) {
+						await store.append(this.runId, chunk);
+					}
+				},
+			);
 		} catch (error) {
 			await this.#disable(error);
 		}
 	}
 
 	async refresh(): Promise<void> {
-		if (!this.#enabled || !this.store) return;
+		const store = this.store;
+		if (!this.#enabled || !store) return;
 		try {
-			if (!(await this.store.refresh(this.runId))) {
+			const refreshed = await this.#observe(
+				"refresh",
+				(value) => (value ? "success" : "finalized"),
+				() => store.refresh(this.runId),
+			);
+			if (!refreshed) {
 				await this.#disable(new LiveStreamStoreError("finalized"));
 			}
 		} catch (error) {
@@ -80,8 +121,10 @@ export class RunLiveStream {
 
 	/** Publish only after the matching Postgres terminal transaction commits. */
 	async finish(status: TerminalRunStatus): Promise<void> {
-		if (!this.#enabled || !this.store) {
+		const store = this.store;
+		if (!this.#enabled || !store) {
 			await this.#retryFailureMarker();
+			this.#recordDegradationEnded();
 			return;
 		}
 		if (status === "canceled") {
@@ -103,43 +146,61 @@ export class RunLiveStream {
 		}
 		if (!this.#enabled) {
 			await this.#retryFailureMarker();
+			this.#recordDegradationEnded();
 			return;
 		}
 		try {
-			await this.store.finalize(this.runId, "done");
+			await this.#observe(
+				"finalize",
+				() => "success",
+				() => store.finalize(this.runId, "done"),
+			);
 			this.#enabled = false;
 		} catch (error) {
 			await this.#disable(error);
 			await this.#retryFailureMarker();
 		}
+		this.#recordDegradationEnded();
 	}
 
 	async #disable(error: unknown): Promise<void> {
 		const wasEnabled = this.#enabled;
 		this.#enabled = false;
 		this.#failed = true;
+		this.#failureReason = classifyLiveStreamFailure(error);
 		this.logger.warn({
 			message: "Live Stream publication disabled",
 			runId: this.runId,
-			reason:
-				error instanceof LiveStreamStoreError ? error.code : "operation_failed",
+			reason: this.#failureReason,
 		});
 		await this.#persistFailureMarker();
 		if (!wasEnabled || !this.store) return;
-		await this.store
-			.finalize(this.runId, "error", "Live stream unavailable")
-			.catch(() => {});
+		const store = this.store;
+		await this.#observe(
+			"finalize",
+			() => "success",
+			() => store.finalize(this.runId, "error", "Live stream unavailable"),
+		).catch(() => {});
 	}
 
 	async #persistFailureMarker(): Promise<void> {
 		try {
-			await this.markLiveStreamFailed();
+			const marker = await this.markLiveStreamFailed();
 			this.#failureMarked = true;
-		} catch (markerError) {
+			this.#failedAt = marker.failedAt;
+			if (marker.outcome === "marked") {
+				this.telemetry.record("degradation", "started", {
+					reason: this.#failureReason,
+				});
+			}
+		} catch {
 			this.logger.error({
 				message: "could not mark Live Stream failed",
 				runId: this.runId,
-				error: toMessage(markerError),
+				reason: "marker_write_failed",
+			});
+			this.telemetry.record("degradation", "failure", {
+				reason: "marker_write_failed",
 			});
 		}
 	}
@@ -147,6 +208,36 @@ export class RunLiveStream {
 	async #retryFailureMarker(): Promise<void> {
 		if (this.#failed && !this.#failureMarked) {
 			await this.#persistFailureMarker();
+		}
+	}
+
+	#recordDegradationEnded(): void {
+		if (this.#degradationEnded || !this.#failedAt) return;
+		this.#degradationEnded = true;
+		this.telemetry.record("degradation", "ended", {
+			reason: this.#failureReason,
+			durationMs: Date.now() - this.#failedAt.getTime(),
+		});
+	}
+
+	async #observe<T>(
+		operation: LiveStreamOperation,
+		result: (value: T) => LiveStreamResult,
+		execute: () => Promise<T>,
+	): Promise<T> {
+		const startedAt = Date.now();
+		try {
+			const value = await execute();
+			this.telemetry.record(operation, result(value), {
+				durationMs: Date.now() - startedAt,
+			});
+			return value;
+		} catch (error) {
+			this.telemetry.record(operation, "failure", {
+				reason: classifyLiveStreamFailure(error),
+				durationMs: Date.now() - startedAt,
+			});
+			throw error;
 		}
 	}
 }

--- a/apps/agent-worker/src/run-loop.test.ts
+++ b/apps/agent-worker/src/run-loop.test.ts
@@ -18,7 +18,7 @@ import {
 	runs,
 } from "@mymemo/agent-db/schema";
 import { createTestDatabase, type TestDb } from "@mymemo/agent-db/testing";
-import type { LiveStreamStore } from "@mymemo/live-text";
+import type { LiveStreamStore, LiveStreamTelemetry } from "@mymemo/live-text";
 import { eq, sql } from "drizzle-orm";
 import type { WorkerLogger } from "./logger";
 import { RunLoop, type RunProcessor } from "./run-loop";
@@ -67,12 +67,14 @@ function buildLoop(
 	worker: Worker,
 	processor: RunProcessor,
 	liveStreamStore?: LiveStreamStore,
+	liveStreamTelemetry?: LiveStreamTelemetry,
 ) {
 	return new RunLoop({
 		db: tdb.db,
 		worker,
 		processor,
 		liveStreamStore,
+		liveStreamTelemetry,
 		heartbeatIntervalMs: 15_000,
 		logger: silentLogger,
 	});
@@ -806,6 +808,73 @@ describe("RunLoop — shutdown", () => {
 });
 
 describe("RunLoop — stale-run recovery", () => {
+	it("observes the degradation marker and duration created by stale recovery", async () => {
+		await claimRun("run-stale", "conv-1", "stale-worker");
+		await expireOwnership("run-stale");
+		const metrics: Record<string, unknown>[] = [];
+		const telemetry: LiveStreamTelemetry = {
+			record(operation, result, options) {
+				metrics.push({ operation, result, ...options });
+			},
+		};
+		const worker = buildWorker(1);
+		const loop = buildLoop(
+			worker,
+			appendMessageProcessor,
+			undefined,
+			telemetry,
+		);
+
+		await loop.tick();
+
+		expect(metrics).toEqual([
+			{
+				operation: "degradation",
+				result: "started",
+				reason: "stale_worker",
+			},
+			{
+				operation: "degradation",
+				result: "ended",
+				reason: "stale_worker",
+				durationMs: expect.any(Number),
+			},
+		]);
+	});
+
+	it("ends an existing degradation during stale recovery without duplicating its start", async () => {
+		await claimRun("run-stale", "conv-1", "stale-worker");
+		await tdb.db
+			.update(runs)
+			.set({ liveStreamFailedAt: new Date(Date.now() - 1_000) })
+			.where(eq(runs.runId, "run-stale"));
+		await expireOwnership("run-stale");
+		const metrics: Record<string, unknown>[] = [];
+		const telemetry: LiveStreamTelemetry = {
+			record(operation, result, options) {
+				metrics.push({ operation, result, ...options });
+			},
+		};
+		const worker = buildWorker(1);
+		const loop = buildLoop(
+			worker,
+			appendMessageProcessor,
+			undefined,
+			telemetry,
+		);
+
+		await loop.tick();
+
+		expect(metrics).toEqual([
+			{
+				operation: "degradation",
+				result: "ended",
+				reason: "stale_worker",
+				durationMs: expect.any(Number),
+			},
+		]);
+	});
+
 	it("deletes an orphan Live Stream only after stale recovery terminalizes its Run", async () => {
 		await claimRun("run-stale", "conv-1", "stale-worker");
 		await expireOwnership("run-stale");
@@ -842,6 +911,51 @@ describe("RunLoop — stale-run recovery", () => {
 		});
 		expect(await readEventTypes("run-stale")).toEqual(["run_error"]);
 		expect(deleted).toEqual(["run-stale"]);
+	});
+
+	it("logs stale Live Stream cleanup failures without Redis secrets or keys", async () => {
+		await claimRun("run-stale", "conv-1", "stale-worker");
+		await expireOwnership("run-stale");
+		const logs: Record<string, unknown>[] = [];
+		const logger: WorkerLogger = {
+			info: (event) => logs.push(event),
+			warn: (event) => logs.push(event),
+			error: (event) => logs.push(event),
+		};
+		const worker = buildWorker(1);
+		const loop = new RunLoop({
+			db: tdb.db,
+			worker,
+			processor: appendMessageProcessor,
+			liveStreamStore: fakeLiveStreamStore({
+				async delete() {
+					throw new Error(
+						"redis://:secret@redis.internal current:mymemo:agui:{run-stale}:stream assistant text tool arguments",
+					);
+				},
+			}),
+			heartbeatIntervalMs: 15_000,
+			logger,
+		});
+
+		await loop.tick();
+
+		expect(logs).toContainEqual({
+			message: "could not delete stale Run Live Stream",
+			workerId: "worker-1",
+			runId: "run-stale",
+			reason: "redis_unavailable",
+		});
+		const serialized = JSON.stringify(logs);
+		for (const forbidden of [
+			"redis://",
+			"secret",
+			"mymemo:agui",
+			"assistant text",
+			"tool arguments",
+		]) {
+			expect(serialized).not.toContain(forbidden);
+		}
 	});
 
 	it("terminalizes stale running runs as error during a tick", async () => {

--- a/apps/agent-worker/src/run-loop.ts
+++ b/apps/agent-worker/src/run-loop.ts
@@ -27,7 +27,12 @@ import {
 	advanceAgentSessionPointerTx,
 	type RunOwnershipRef,
 } from "@mymemo/agent-db/runtime-store";
-import type { LiveStreamEvent, LiveStreamStore } from "@mymemo/live-text";
+import {
+	classifyLiveStreamFailure,
+	type LiveStreamEvent,
+	type LiveStreamStore,
+	type LiveStreamTelemetry,
+} from "@mymemo/live-text";
 import { ArtifactValidationError } from "./artifacts/artifact-manifest";
 import { ArtifactPublicationError } from "./artifacts/artifact-publication";
 import { toMessage, type WorkerLogger } from "./logger";
@@ -120,6 +125,8 @@ export interface RunLoopOptions {
 	processor: RunProcessor;
 	/** Shared retained AG-UI store. Undefined keeps durable execution available. */
 	liveStreamStore?: LiveStreamStore;
+	/** Payload-free retained Live Stream operation metrics. */
+	liveStreamTelemetry?: LiveStreamTelemetry;
 	/** How often {@link RunLoop.start}'s timer fires a tick (heartbeat + claim). */
 	heartbeatIntervalMs: number;
 	/** Optional doorbell whose ring triggers an immediate tick. */
@@ -307,6 +314,18 @@ export class RunLoop {
 				status: run.status,
 			})),
 		});
+		for (const run of recovered) {
+			if (run.liveStreamFailedAt === null) continue;
+			if (run.liveStreamFailureMarkedByRecovery) {
+				this.opts.liveStreamTelemetry?.record("degradation", "started", {
+					reason: "stale_worker",
+				});
+			}
+			this.opts.liveStreamTelemetry?.record("degradation", "ended", {
+				reason: "stale_worker",
+				durationMs: Math.max(0, Date.now() - run.liveStreamFailedAt.getTime()),
+			});
+		}
 		if (!this.opts.liveStreamStore) return;
 		for (const run of recovered) {
 			if (run.liveStreamFailedAt === null) continue;
@@ -317,7 +336,7 @@ export class RunLoop {
 					message: "could not delete stale Run Live Stream",
 					workerId: this.workerId,
 					runId: run.runId,
-					error: toMessage(error),
+					reason: classifyLiveStreamFailure(error),
 				});
 			}
 		}
@@ -415,8 +434,16 @@ export class RunLoop {
 						"Run fence rejected the Live Stream failure marker",
 					);
 				}
+				if (result.run.liveStreamFailedAt === null) {
+					throw new Error("Live Stream failure marker timestamp is missing");
+				}
+				return {
+					outcome: result.outcome,
+					failedAt: result.run.liveStreamFailedAt,
+				};
 			},
 			logger: this.opts.logger,
+			telemetry: this.opts.liveStreamTelemetry,
 		});
 		entry.liveStream = liveStream;
 		let turnResult: TurnResult = EMPTY_TURN;

--- a/apps/chat-api/src/deps.test.ts
+++ b/apps/chat-api/src/deps.test.ts
@@ -26,7 +26,7 @@ it("keeps the chat-api Live lane disabled without valid Redis configuration", ()
 	});
 	const deps = createDeps(config(undefined), telemetry);
 	expect(deps.liveTextSubscriber).toBe(disabledLiveTextSubscriber);
-	expect(deps.closeLiveText).toBeUndefined();
+	expect(deps.closeLiveResources).toBeUndefined();
 	expect(signals).toEqual([
 		{
 			message: "Live preview signal",
@@ -43,6 +43,6 @@ it("constructs the lazy production subscriber when Redis is configured", async (
 		config("rediss://default:secret@redis.internal:6379"),
 	);
 	expect(deps.liveTextSubscriber).not.toBe(disabledLiveTextSubscriber);
-	expect(deps.closeLiveText).toBeFunction();
-	await deps.closeLiveText?.();
+	expect(deps.closeLiveResources).toBeFunction();
+	await deps.closeLiveResources?.();
 });

--- a/apps/chat-api/src/deps.ts
+++ b/apps/chat-api/src/deps.ts
@@ -1,9 +1,11 @@
 import {
+	createLiveStreamTelemetry,
 	createLiveTextTelemetry,
 	createRedisLiveStreamStore,
 	createRedisLiveTextTransport,
 	disabledLiveTextSubscriber,
 	type LiveStreamReader,
+	type LiveStreamTelemetry,
 	type LiveTextSubscriber,
 	type LiveTextTelemetry,
 	type LiveTextTransport,
@@ -69,8 +71,10 @@ export interface AppDeps {
 	liveStreamReader: LiveStreamReader;
 	/** Cardinality-safe, payload-free Live-lane observability. */
 	liveTextTelemetry: LiveTextTelemetry;
+	/** Cardinality-safe, payload-free retained Live Stream observability. */
+	liveStreamTelemetry: LiveStreamTelemetry;
 	/** Close optional Live transport resources during service shutdown. */
-	closeLiveText?: () => Promise<void>;
+	closeLiveResources?: () => Promise<void>;
 	/**
 	 * Server-side gate controlling who may create new agent work. Consulted on
 	 * the new-work paths (conversation create, `user.message`) after identity is
@@ -90,6 +94,13 @@ export function createDeps(
 		info() {},
 		warn() {},
 	}),
+	liveStreamTelemetry: LiveStreamTelemetry = createLiveStreamTelemetry(
+		"chat-api",
+		{
+			info() {},
+			warn() {},
+		},
+	),
 ): AppDeps {
 	// One Drizzle pool over the writable DB, shared by every store.
 	const database = createDatabase(config.databaseUrl);
@@ -152,7 +163,8 @@ export function createDeps(
 				},
 			} satisfies LiveStreamReader),
 		liveTextTelemetry,
-		closeLiveText:
+		liveStreamTelemetry,
+		closeLiveResources:
 			liveTextTransport || liveStreamStore
 				? async () => {
 						await Promise.all([

--- a/apps/chat-api/src/features/conversations/conversations.route.test.ts
+++ b/apps/chat-api/src/features/conversations/conversations.route.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "bun:test";
 import {
+	createLiveStreamTelemetry,
 	createLiveTextTelemetry,
 	disabledLiveTextSubscriber,
 	InMemoryLiveTextTransport,
 	LiveStreamStoreError,
+	type LiveStreamTelemetry,
 	type LiveTextSubscriber,
 } from "@mymemo/live-text";
 import { eq, sql } from "drizzle-orm";
@@ -37,6 +39,10 @@ import type { InternalIdentity } from "./conversations.schema";
 
 const { createApp } = await import("@/app");
 const silentLiveTextTelemetry = createLiveTextTelemetry("chat-api", {
+	info() {},
+	warn() {},
+});
+const silentLiveStreamTelemetry = createLiveStreamTelemetry("chat-api", {
 	info() {},
 	warn() {},
 });
@@ -108,6 +114,7 @@ function buildApp(
 		},
 		async *read() {},
 	},
+	liveStreamTelemetry: LiveStreamTelemetry = silentLiveStreamTelemetry,
 ) {
 	const deps = {
 		config: {},
@@ -119,6 +126,7 @@ function buildApp(
 		liveTextSubscriber,
 		liveStreamReader,
 		liveTextTelemetry: silentLiveTextTelemetry,
+		liveStreamTelemetry,
 	} as unknown as AppDeps;
 	return createApp({ logLevel: "silent" } as unknown as ApiConfig, deps);
 }
@@ -2085,6 +2093,129 @@ describe("GET /v1/conversations/:id/runs/:runId/events", () => {
 		expect(redisRead).toBe(false);
 	});
 
+	it("classifies retryable reconnect and permanent-history recovery responses", async () => {
+		const { store } = fakeStore([existing]);
+		const metrics: Record<string, unknown>[] = [];
+		const telemetry = createLiveStreamTelemetry("chat-api", {
+			info: (event) => metrics.push(event),
+			warn: (event) => metrics.push(event),
+		});
+		const temporarilyUnavailableRuns = fakeRunStore();
+		temporarilyUnavailableRuns.runOwners.set("run-reconnect", {
+			userId: "member-1",
+			conversationId: "conv-1",
+			status: "running",
+			liveStreamFailedAt: null,
+		});
+		const reconnect = await buildApp(
+			store,
+			gateThatFailsIfConsulted(),
+			temporarilyUnavailableRuns,
+			disabledLiveTextSubscriber,
+			{
+				async status() {
+					throw new Error(
+						"redis://:secret@redis.internal current:mymemo:agui:{run-reconnect}:stream",
+					);
+				},
+				async *read() {},
+			},
+			telemetry,
+		).request("/v1/conversations/conv-1/runs/run-reconnect/events", {
+			method: "GET",
+			headers: identityHeaders,
+		});
+
+		const failedRuns = fakeRunStore();
+		failedRuns.runOwners.set("run-recovery", {
+			userId: "member-1",
+			conversationId: "conv-1",
+			status: "running",
+			liveStreamFailedAt: new Date(),
+		});
+		const recovery = await buildApp(
+			store,
+			gateThatFailsIfConsulted(),
+			failedRuns,
+			disabledLiveTextSubscriber,
+			{
+				async status() {
+					throw new Error("must not read Redis");
+				},
+				async *read() {},
+			},
+			telemetry,
+		).request("/v1/conversations/conv-1/runs/run-recovery/events", {
+			method: "GET",
+			headers: identityHeaders,
+		});
+
+		expect([reconnect.status, recovery.status]).toEqual([503, 410]);
+		expect(metrics).toEqual([
+			expect.objectContaining({
+				operation: "reconnect_response",
+				result: "retryable_503",
+				reason: "redis_unavailable",
+			}),
+			expect.objectContaining({
+				operation: "recovery_response",
+				result: "history_410",
+			}),
+		]);
+		const serialized = JSON.stringify(metrics);
+		for (const forbidden of [
+			"redis://",
+			"secret",
+			"mymemo:agui",
+			"run-reconnect",
+			"run-recovery",
+		]) {
+			expect(serialized).not.toContain(forbidden);
+		}
+	});
+
+	it("does not classify a bounded missing-Stream reconnect as Redis unavailable", async () => {
+		const { store } = fakeStore([existing]);
+		const metrics: Record<string, unknown>[] = [];
+		const telemetry = createLiveStreamTelemetry("chat-api", {
+			info: (event) => metrics.push(event),
+			warn: (event) => metrics.push(event),
+		});
+		const activeRuns = fakeRunStore();
+		activeRuns.runOwners.set("run-1", {
+			userId: "member-1",
+			conversationId: "conv-1",
+			status: "running",
+			liveStreamFailedAt: null,
+		});
+
+		const response = await buildApp(
+			store,
+			gateThatFailsIfConsulted(),
+			activeRuns,
+			disabledLiveTextSubscriber,
+			{
+				async status() {
+					throw new LiveStreamStoreError("missing");
+				},
+				async *read() {},
+			},
+			telemetry,
+		).request("/v1/conversations/conv-1/runs/run-1/events", {
+			method: "GET",
+			headers: identityHeaders,
+		});
+
+		expect(response.status).toBe(503);
+		expect(metrics).toContainEqual(
+			expect.objectContaining({
+				operation: "reconnect_response",
+				result: "retryable_503",
+				reason: "missing",
+			}),
+		);
+	});
+
 	it("returns retryable 503 for a temporary read failure while the Run is active", async () => {
 		const { store } = fakeStore([existing]);
 		const fakeRuns = fakeRunStore();
@@ -2365,6 +2496,11 @@ describe("GET /v1/conversations/:id/runs/:runId/events", () => {
 
 	it("follows a Live Stream that appears just after Postgres terminalizes the Run", async () => {
 		const { store } = fakeStore([existing]);
+		const metrics: Record<string, unknown>[] = [];
+		const telemetry = createLiveStreamTelemetry("chat-api", {
+			info: (event) => metrics.push(event),
+			warn: (event) => metrics.push(event),
+		});
 		const fakeRuns = fakeRunStore();
 		const owner = {
 			userId: "member-1",
@@ -2400,6 +2536,7 @@ describe("GET /v1/conversations/:id/runs/:runId/events", () => {
 					};
 				},
 			},
+			telemetry,
 		).request("/v1/conversations/conv-1/runs/run-1/events", {
 			method: "GET",
 			headers: identityHeaders,
@@ -2409,6 +2546,13 @@ describe("GET /v1/conversations/:id/runs/:runId/events", () => {
 		expect(parseAgUiSse(await res.text())).toEqual([
 			{ id: "1-0", data: terminalEvent },
 		]);
+		expect(metrics).toContainEqual(
+			expect.objectContaining({
+				operation: "read_wait",
+				result: "success",
+				durationMs: expect.any(Number),
+			}),
+		);
 	});
 
 	it("sends cursorless pings while following a quiet active Stream", async () => {

--- a/apps/chat-api/src/features/conversations/conversations.route.ts
+++ b/apps/chat-api/src/features/conversations/conversations.route.ts
@@ -1,4 +1,9 @@
-import { LiveStreamStoreError, parseLiveStreamCursor } from "@mymemo/live-text";
+import {
+	classifyLiveStreamFailure,
+	type LiveStreamReason,
+	LiveStreamStoreError,
+	parseLiveStreamCursor,
+} from "@mymemo/live-text";
 import { type Context, Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
 import { type SSEStreamingApi, streamSSE } from "hono/streaming";
@@ -57,12 +62,14 @@ function isTerminalRunStatus(status: RunRecord["status"]): boolean {
 }
 
 function liveStreamRecoveryResponse(c: Context<AppEnv>) {
+	c.var.deps.liveStreamTelemetry.record("recovery_response", "history_410");
 	return c.json({ error: "Live stream unavailable", recovery: "history" }, 410);
 }
 
 async function liveStreamReadFailureResponse(
 	c: Context<AppEnv>,
 	run: RunRecord,
+	reason: LiveStreamReason,
 ) {
 	const currentRun = await c.var.deps.runStore.getRun({
 		userId: run.userId,
@@ -70,10 +77,16 @@ async function liveStreamReadFailureResponse(
 		runId: run.runId,
 	});
 	if (currentRun === null) return c.json({ error: "Run not found" }, 404);
-	return currentRun.liveStreamFailedAt !== null ||
+	if (
+		currentRun.liveStreamFailedAt !== null ||
 		isTerminalRunStatus(currentRun.status)
-		? liveStreamRecoveryResponse(c)
-		: c.json({ error: "Live stream temporarily unavailable" }, 503);
+	) {
+		return liveStreamRecoveryResponse(c);
+	}
+	c.var.deps.liveStreamTelemetry.record("reconnect_response", "retryable_503", {
+		reason,
+	});
+	return c.json({ error: "Live stream temporarily unavailable" }, 503);
 }
 
 function abortableDelay(ms: number, signal: AbortSignal): Promise<void> {
@@ -114,8 +127,8 @@ function endAgUiStreamOnKeepaliveFailure(
 ): void {
 	c.var.logger.error({
 		message: "AG-UI keepalive write failed",
-		error,
 		runId,
+		reason: "sse_write_failed",
 	});
 	readController.abort(error);
 	stream.abort();
@@ -159,8 +172,8 @@ async function writeAgUiEntries(
 	} catch (error) {
 		c.var.logger.error({
 			message: "AG-UI Live Stream read failed",
-			error,
 			runId,
+			reason: classifyLiveStreamFailure(error),
 		});
 	} finally {
 		await iterator.return?.();
@@ -204,10 +217,14 @@ async function streamAgUiRun(
 		}
 		c.var.logger.error({
 			message: "AG-UI Live Stream initial read failed",
-			error,
 			runId: run.runId,
+			reason: classifyLiveStreamFailure(error),
 		});
-		return liveStreamReadFailureResponse(c, run);
+		return liveStreamReadFailureResponse(
+			c,
+			run,
+			classifyLiveStreamFailure(error),
+		);
 	}
 	if (initial.outcome === "ping") {
 		if (requestSignal.aborted) {
@@ -236,8 +253,8 @@ async function streamAgUiRun(
 				if (delayed.outcome === "error") {
 					c.var.logger.error({
 						message: "AG-UI Live Stream read failed",
-						error: delayed.error,
 						runId: run.runId,
+						reason: classifyLiveStreamFailure(delayed.error),
 					});
 					await iterator.return?.();
 					return;
@@ -266,7 +283,7 @@ async function streamAgUiRun(
 		readAbort.dispose();
 		await iterator.return?.();
 		if (status === "done" && cursor !== "") return c.body(null, 204);
-		return liveStreamReadFailureResponse(c, run);
+		return liveStreamReadFailureResponse(c, run, "missing");
 	}
 
 	return streamSSE(c, async (stream) => {
@@ -296,6 +313,19 @@ async function streamAgUiRun(
 
 function waitForAndStreamAgUiRun(c: Context<AppEnv>, run: RunRecord) {
 	const requestSignal = c.req.raw.signal;
+	const waitStartedAt = Date.now();
+	let waitRecorded = false;
+	const recordWait = (
+		result: "aborted" | "failure" | "success",
+		reason?: LiveStreamReason,
+	) => {
+		if (waitRecorded) return;
+		waitRecorded = true;
+		c.var.deps.liveStreamTelemetry.record("read_wait", result, {
+			...(reason ? { reason } : {}),
+			durationMs: Date.now() - waitStartedAt,
+		});
+	};
 	return streamSSE(c, async (stream) => {
 		const readAbort = linkedAbortController(requestSignal);
 		const readSignal = readAbort.controller.signal;
@@ -313,13 +343,17 @@ function waitForAndStreamAgUiRun(c: Context<AppEnv>, run: RunRecord) {
 		);
 		try {
 			for (;;) {
-				if (readSignal.aborted) return;
+				if (readSignal.aborted) {
+					recordWait("aborted");
+					return;
+				}
 				const currentRun = await c.var.deps.runStore.getRun({
 					userId: run.userId,
 					conversationId: run.conversationId,
 					runId: run.runId,
 				});
 				if (currentRun === null || currentRun.liveStreamFailedAt !== null) {
+					recordWait("failure", "missing");
 					return;
 				}
 
@@ -328,12 +362,22 @@ function waitForAndStreamAgUiRun(c: Context<AppEnv>, run: RunRecord) {
 				>;
 				try {
 					status = await c.var.deps.liveStreamReader.status(run.runId);
-				} catch {
+				} catch (error) {
+					recordWait("failure", classifyLiveStreamFailure(error));
 					return;
 				}
-				if (status === "error") return;
-				if (status === "streaming" || status === "done") break;
-				if (isTerminalRunStatus(currentRun.status)) return;
+				if (status === "error") {
+					recordWait("failure", "missing");
+					return;
+				}
+				if (status === "streaming" || status === "done") {
+					recordWait("success");
+					break;
+				}
+				if (isTerminalRunStatus(currentRun.status)) {
+					recordWait("failure", "missing");
+					return;
+				}
 				await abortableDelay(LIVE_STREAM_START_POLL_MS, readSignal);
 			}
 
@@ -346,8 +390,8 @@ function waitForAndStreamAgUiRun(c: Context<AppEnv>, run: RunRecord) {
 			} catch (error) {
 				c.var.logger.error({
 					message: "AG-UI Live Stream read failed after waiting for creation",
-					error,
 					runId: run.runId,
+					reason: classifyLiveStreamFailure(error),
 				});
 				await iterator.return?.();
 				return;
@@ -360,6 +404,7 @@ function waitForAndStreamAgUiRun(c: Context<AppEnv>, run: RunRecord) {
 				stream.writeSSE(event),
 			);
 		} finally {
+			if (!waitRecorded) recordWait("aborted");
 			stopKeepalive();
 			readAbort.controller.abort();
 			readAbort.dispose();
@@ -377,8 +422,12 @@ async function respondWithAgUiRun(
 	let status: Awaited<ReturnType<typeof c.var.deps.liveStreamReader.status>>;
 	try {
 		status = await c.var.deps.liveStreamReader.status(run.runId);
-	} catch {
-		return liveStreamReadFailureResponse(c, run);
+	} catch (error) {
+		return liveStreamReadFailureResponse(
+			c,
+			run,
+			classifyLiveStreamFailure(error),
+		);
 	}
 	if (status === "error") return liveStreamRecoveryResponse(c);
 	if (status === "missing") {

--- a/apps/chat-api/src/index.ts
+++ b/apps/chat-api/src/index.ts
@@ -1,4 +1,7 @@
-import { createLiveTextTelemetry } from "@mymemo/live-text";
+import {
+	createLiveStreamTelemetry,
+	createLiveTextTelemetry,
+} from "@mymemo/live-text";
 import pino from "pino";
 import { createApp } from "./app";
 import { loadApiConfigFromEnv } from "./config/env";
@@ -15,17 +18,18 @@ const productionLogger = pino({ level: productionConfig.logLevel });
 const productionDeps = createDeps(
 	productionConfig,
 	createLiveTextTelemetry("chat-api", productionLogger),
+	createLiveStreamTelemetry("chat-api", productionLogger),
 );
 const productionApp = createApp(productionConfig, productionDeps);
 let shuttingDown = false;
-async function closeProductionLiveText(): Promise<void> {
+async function closeProductionLiveResources(): Promise<void> {
 	if (shuttingDown) return;
 	shuttingDown = true;
-	await productionDeps.closeLiveText?.().catch(() => {});
+	await productionDeps.closeLiveResources?.().catch(() => {});
 	productionDeps.liveTextTelemetry.close();
 	process.exit(0);
 }
-process.once("SIGINT", () => void closeProductionLiveText());
-process.once("SIGTERM", () => void closeProductionLiveText());
+process.once("SIGINT", () => void closeProductionLiveResources());
+process.once("SIGTERM", () => void closeProductionLiveResources());
 
 export default productionApp;

--- a/docs/runbooks/live-stream.md
+++ b/docs/runbooks/live-stream.md
@@ -1,0 +1,84 @@
+# Live Stream operations
+
+The retained Live Stream is a temporary per-Run Redis Stream. Postgres remains
+authoritative for Run execution, complete messages, Tool activity, and terminal
+Outcomes. A Live Stream alarm is a delivery incident: it must not fail service
+health, restart a Run, or be counted as a model or Run failure.
+
+## Ownership and signals
+
+The CloudWatch namespace `<name-prefix>-<environment>/LiveStream` contains:
+
+- `Operations`, dimensioned by bounded `Service`, `Operation`, and `Result`;
+- `OperationLatencyMs`, dimensioned by `Service` and `Operation`;
+- `RedisUnavailable`, dimensioned only by `Service`;
+- `RecoveryResponses`, dimensioned by `Service` and `Result`;
+- `CapacityFailures`, dimensioned only by `Service`; and
+- `DegradedDurationMs`, dimensioned only by `Service`.
+
+`agent-worker` owns producer acquisition, append, finalization, TTL refresh,
+capacity enforcement, and persistence of `live_stream_failed_at`. `chat-api`
+owns Live Stream reads, reconnect waits, retryable `503` responses, and
+permanent-history recovery `410` responses.
+
+Metric events contain only enumerated classifications, integer duration/count,
+and service name. They never contain Assistant text, Tool arguments or results,
+serialized AG-UI events, user or Conversation identity, Run or message ids,
+Redis credentials, URLs, or full Redis keys. Failure logs may include the Run id
+needed for operational correlation, but use a bounded reason code instead of a
+thrown Redis error.
+
+Use this Logs Insights query across the chat-api and agent-worker log groups:
+
+```text
+fields @timestamp, service, operation, result, reason, durationMs, count
+| filter message = "Live Stream metric"
+| stats sum(count), avg(durationMs), max(durationMs) by bin(5m), service, operation, result, reason
+| sort bin(5m) desc
+```
+
+`degradation/started` is emitted only for a successful null-to-time
+`live_stream_failed_at` transition. `degradation/ended` measures from that
+persisted timestamp until the Run terminalizes. These metrics are deliberately
+separate from Run Outcome metrics; a Run may still have Outcome `done` after
+Live delivery degrades. Stale-run recovery emits the same transition and
+duration pair when it creates the marker after an owner disappears.
+
+## Respond to alarms
+
+### Sustained Redis unavailability
+
+The per-service alarm identifies the owner:
+
+1. For `agent-worker`, inspect `acquire`, `append`, `finalize`, and `refresh`
+   failures and latency. Confirm Runs still terminalize and permanent history
+   remains available.
+2. For `chat-api`, inspect `read_wait`, `reconnect_response`, and
+   `recovery_response`.
+   Confirm ownership checks still precede Redis reads and clients receive `503`
+   while retry is valid or `410` when history recovery is required.
+3. Check ElastiCache availability, connections, CPU, memory, and network
+   reachability from the two trusted ECS services. Do not log or paste
+   `REDIS_URL`.
+
+### Elevated recovery responses
+
+`chat-api` owns this alarm. Inspect `history_410`, then compare it with
+`retryable_503` reconnect results in `Operations`. Check `DegradedDurationMs`
+and the worker's Redis failures. Confirm the target
+Run eventually appears terminal in permanent Conversation history. A rise in
+`410` with healthy Postgres Outcomes indicates delivery degradation, not model
+failure.
+
+### Capacity-bound failures
+
+`agent-worker` owns this alarm. Inspect the bounded reason in logs:
+`event_too_large`, `stream_bytes_exceeded`, or `stream_events_exceeded`. Confirm
+the Run continued through Postgres and that the client recovered from history.
+Do not raise limits before identifying whether an event projection or Run is
+unexpectedly large.
+
+All alarms notify `alarm_action_arns`; production must point it at a confirmed
+incident subscription. After restoration, run a new Conversation turn and
+confirm producer acquisition, successful append/finalize, a terminal AG-UI
+event, and permanent history agree.

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -114,13 +114,16 @@ Assistant messages, terminal Outcomes, and replay.
 
 Set `live_stream_enabled=false` to omit `REDIS_URL` from both trusted service
 task definitions without deleting the cache during the additive rollout. Live
-telemetry is converted into CloudWatch metrics with bounded
-service/signal/outcome dimensions; the alarms detect both repeated per-service
-breaches and multiple services degrading in the same five-minute period, and
-never feed service health. Production must set `alarm_action_arns` to an SNS
-topic with a confirmed incident subscription. See
-[`docs/runbooks/live-preview.md`](../../docs/runbooks/live-preview.md) for
-diagnosis, disable, and restore procedures.
+telemetry is converted into separate CloudWatch namespaces for the legacy
+preview lane and retained Live Stream, using bounded signal/outcome dimensions
+for preview, operation/result dimensions for retained delivery, and bounded
+reason classifications. The retained Stream alarms identify
+agent-worker production failures, chat-api recovery responses, and capacity
+exhaustion without feeding service health. Production must set
+`alarm_action_arns` to an SNS topic with a confirmed incident subscription. See
+[`docs/runbooks/live-stream.md`](../../docs/runbooks/live-stream.md) for retained
+Stream diagnosis and [`docs/runbooks/live-preview.md`](../../docs/runbooks/live-preview.md)
+for the staged legacy lane.
 
 ## Release Deploy Config
 

--- a/infra/terraform/cloudwatch.tf
+++ b/infra/terraform/cloudwatch.tf
@@ -177,6 +177,187 @@ resource "aws_cloudwatch_metric_alarm" "live_preview_overflow" {
   }
 }
 
+resource "aws_cloudwatch_log_metric_filter" "live_stream_operations" {
+  for_each = local.live_preview_log_groups
+
+  name           = "${local.common_name}-${each.key}-live-stream-operations"
+  log_group_name = each.value
+  pattern        = "{ $.message = \"Live Stream metric\" && $.service = \"${each.key}\" && $.operation = * && $.result = * }"
+
+  metric_transformation {
+    name      = "Operations"
+    namespace = "${local.common_name}/LiveStream"
+    value     = "$.count"
+    unit      = "Count"
+
+    dimensions = {
+      Service   = "$.service"
+      Operation = "$.operation"
+      Result    = "$.result"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "live_stream_latency" {
+  for_each = local.live_preview_log_groups
+
+  name           = "${local.common_name}-${each.key}-live-stream-latency"
+  log_group_name = each.value
+  pattern        = "{ $.message = \"Live Stream metric\" && $.service = \"${each.key}\" && $.operation = * && $.durationMs = * }"
+
+  metric_transformation {
+    name      = "OperationLatencyMs"
+    namespace = "${local.common_name}/LiveStream"
+    value     = "$.durationMs"
+    unit      = "Milliseconds"
+
+    dimensions = {
+      Service   = "$.service"
+      Operation = "$.operation"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "live_stream_redis_unavailable" {
+  for_each = local.live_preview_log_groups
+
+  name           = "${local.common_name}-${each.key}-live-stream-redis-unavailable"
+  log_group_name = each.value
+  pattern        = "{ $.message = \"Live Stream metric\" && $.service = \"${each.key}\" && $.reason = \"redis_unavailable\" }"
+
+  metric_transformation {
+    name      = "RedisUnavailable"
+    namespace = "${local.common_name}/LiveStream"
+    value     = "$.count"
+    unit      = "Count"
+
+    dimensions = {
+      Service = "$.service"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "live_stream_recovery" {
+  name           = "${local.common_name}-chat-api-live-stream-recovery"
+  log_group_name = aws_cloudwatch_log_group.chat_api.name
+  pattern        = "{ $.message = \"Live Stream metric\" && $.service = \"chat-api\" && $.operation = \"recovery_response\" && $.result = * }"
+
+  metric_transformation {
+    name      = "RecoveryResponses"
+    namespace = "${local.common_name}/LiveStream"
+    value     = "$.count"
+    unit      = "Count"
+
+    dimensions = {
+      Service = "$.service"
+      Result  = "$.result"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "live_stream_capacity" {
+  for_each = toset([
+    "event_too_large",
+    "stream_bytes_exceeded",
+    "stream_events_exceeded",
+  ])
+
+  name           = "${local.common_name}-agent-worker-live-stream-capacity-${replace(each.key, "_", "-")}"
+  log_group_name = aws_cloudwatch_log_group.agent_worker.name
+  pattern        = "{ $.message = \"Live Stream metric\" && $.service = \"agent-worker\" && $.reason = \"${each.key}\" }"
+
+  metric_transformation {
+    name      = "CapacityFailures"
+    namespace = "${local.common_name}/LiveStream"
+    value     = "$.count"
+    unit      = "Count"
+
+    dimensions = {
+      Service = "$.service"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "live_stream_degraded_duration" {
+  name           = "${local.common_name}-agent-worker-live-stream-degraded-duration"
+  log_group_name = aws_cloudwatch_log_group.agent_worker.name
+  pattern        = "{ $.message = \"Live Stream metric\" && $.service = \"agent-worker\" && $.operation = \"degradation\" && $.result = \"ended\" && $.durationMs = * }"
+
+  metric_transformation {
+    name      = "DegradedDurationMs"
+    namespace = "${local.common_name}/LiveStream"
+    value     = "$.durationMs"
+    unit      = "Milliseconds"
+
+    dimensions = {
+      Service = "$.service"
+    }
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "live_stream_redis_unavailable" {
+  for_each = local.live_preview_log_groups
+
+  alarm_name          = "${local.common_name}-${each.key}-live-stream-redis-unavailable"
+  alarm_description   = "${each.key} has sustained Redis failures. agent-worker owns Live Stream production; chat-api owns reconnect and recovery responses. See docs/runbooks/live-stream.md."
+  namespace           = "${local.common_name}/LiveStream"
+  metric_name         = "RedisUnavailable"
+  statistic           = "Sum"
+  period              = 300
+  evaluation_periods  = 3
+  datapoints_to_alarm = 2
+  threshold           = 3
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = var.alarm_action_arns
+  ok_actions          = var.alarm_action_arns
+
+  dimensions = {
+    Service = each.key
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "live_stream_recovery_rate" {
+  alarm_name          = "${local.common_name}-chat-api-live-stream-recovery-rate"
+  alarm_description   = "chat-api is sending elevated permanent-history recovery responses; chat-api owns reconnect and recovery responses. See docs/runbooks/live-stream.md."
+  namespace           = "${local.common_name}/LiveStream"
+  metric_name         = "RecoveryResponses"
+  statistic           = "Sum"
+  period              = 300
+  evaluation_periods  = 3
+  datapoints_to_alarm = 2
+  threshold           = 5
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = var.alarm_action_arns
+  ok_actions          = var.alarm_action_arns
+
+  dimensions = {
+    Service = "chat-api"
+    Result  = "history_410"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "live_stream_capacity_bound" {
+  alarm_name          = "${local.common_name}-agent-worker-live-stream-capacity-bound"
+  alarm_description   = "Live Stream capacity bounds are repeatedly exhausted; agent-worker owns Live Stream production. See docs/runbooks/live-stream.md."
+  namespace           = "${local.common_name}/LiveStream"
+  metric_name         = "CapacityFailures"
+  statistic           = "Sum"
+  period              = 300
+  evaluation_periods  = 3
+  datapoints_to_alarm = 2
+  threshold           = 1
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = var.alarm_action_arns
+  ok_actions          = var.alarm_action_arns
+
+  dimensions = {
+    Service = "agent-worker"
+  }
+}
+
 resource "aws_cloudwatch_metric_alarm" "chat_api_unhealthy" {
   alarm_name          = "${local.chat_api_name}-unhealthy-hosts"
   alarm_description   = "chat-api has unhealthy targets behind the internal agent ALB."

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -133,7 +133,7 @@ variable "live_stream_enabled" {
 }
 
 variable "alarm_action_arns" {
-  description = "Optional SNS topic ARNs notified by Live preview CloudWatch alarms."
+  description = "Optional SNS topic ARNs notified by Live preview and retained Live Stream CloudWatch alarms."
   type        = list(string)
   default     = []
 }

--- a/packages/agent-db/src/run-store.ts
+++ b/packages/agent-db/src/run-store.ts
@@ -52,6 +52,12 @@ export type RunRecord = Omit<
 	status: RunStatus;
 };
 
+/** A stale Run after terminal recovery, plus whether that transaction created
+ * its null-to-time Live Stream failure marker. */
+export type RecoveredRunRecord = RunRecord & {
+	liveStreamFailureMarkedByRecovery: boolean;
+};
+
 /**
  * Queue admission failed: the conversation already has an active
  * (queued/running/cancel_requested) run. Surfaced as busy/backpressure by the
@@ -776,10 +782,16 @@ export async function markLiveStreamFailedTx(
  * double-terminalized. Returns the runs it recovered so the caller can clean up
  * their sandbox side effects.
  */
-export async function markStaleRunsTx(db: Database): Promise<RunRecord[]> {
+export async function markStaleRunsTx(
+	db: Database,
+): Promise<RecoveredRunRecord[]> {
 	return await db.transaction(async (tx) => {
 		const stale = await tx
-			.select({ runId: runs.runId, status: runs.status })
+			.select({
+				runId: runs.runId,
+				status: runs.status,
+				liveStreamFailedAt: runs.liveStreamFailedAt,
+			})
 			.from(runs)
 			.where(
 				sql`(
@@ -794,7 +806,7 @@ export async function markStaleRunsTx(db: Database): Promise<RunRecord[]> {
 			)
 			.for("update", { skipLocked: true });
 
-		const recovered: RunRecord[] = [];
+		const recovered: RecoveredRunRecord[] = [];
 		for (const candidate of stale) {
 			const status: TerminalRunStatus =
 				candidate.status === "cancel_requested" ? "canceled" : "error";
@@ -827,7 +839,12 @@ export async function markStaleRunsTx(db: Database): Promise<RunRecord[]> {
 				...(status === "error" ? { message: "Run failed" } : {}),
 				reason: "stale_worker",
 			});
-			recovered.push(toRunRecord(row));
+			recovered.push({
+				...toRunRecord(row),
+				liveStreamFailureMarkedByRecovery:
+					candidate.status !== "queued" &&
+					candidate.liveStreamFailedAt === null,
+			});
 		}
 		return recovered;
 	});

--- a/packages/live-text/src/index.ts
+++ b/packages/live-text/src/index.ts
@@ -2,6 +2,7 @@ import { createClient } from "redis";
 import { z } from "zod";
 import type { LiveTextTelemetry } from "./telemetry";
 
+export * from "./live-stream-telemetry";
 export * from "./redis-live-stream-store";
 export * from "./telemetry";
 

--- a/packages/live-text/src/live-stream-telemetry.test.ts
+++ b/packages/live-text/src/live-stream-telemetry.test.ts
@@ -1,0 +1,71 @@
+import { expect, it } from "bun:test";
+import { createLiveStreamTelemetry } from "./live-stream-telemetry";
+
+it("emits bounded payload-safe Live Stream operation metrics", () => {
+	const events: Record<string, unknown>[] = [];
+	const telemetry = createLiveStreamTelemetry("agent-worker", {
+		info: (event) => events.push(event),
+		warn: (event) => events.push(event),
+	});
+
+	telemetry.record("acquire", "producer", { durationMs: 7 });
+	telemetry.record("append", "failure", {
+		reason: "stream_bytes_exceeded",
+		durationMs: 11,
+	});
+	telemetry.record("degradation", "ended", { durationMs: 1_250 });
+
+	expect(events).toEqual([
+		{
+			message: "Live Stream metric",
+			service: "agent-worker",
+			operation: "acquire",
+			result: "producer",
+			durationMs: 7,
+			count: 1,
+		},
+		{
+			message: "Live Stream metric",
+			service: "agent-worker",
+			operation: "append",
+			result: "failure",
+			reason: "stream_bytes_exceeded",
+			durationMs: 11,
+			count: 1,
+		},
+		{
+			message: "Live Stream metric",
+			service: "agent-worker",
+			operation: "degradation",
+			result: "ended",
+			durationMs: 1_250,
+			count: 1,
+		},
+	]);
+	const serialized = JSON.stringify(events);
+	for (const forbidden of [
+		"assistant text",
+		"tool arguments",
+		"runId",
+		"messageId",
+		"redis://",
+		"mymemo:agui",
+	]) {
+		expect(serialized).not.toContain(forbidden);
+	}
+});
+
+it("cannot let a failing metric logger affect Live Stream delivery", () => {
+	const telemetry = createLiveStreamTelemetry("chat-api", {
+		info() {
+			throw new Error("logger unavailable");
+		},
+		warn() {
+			throw new Error("logger unavailable");
+		},
+	});
+
+	expect(() =>
+		telemetry.record("reconnect_response", "retryable_503"),
+	).not.toThrow();
+});

--- a/packages/live-text/src/live-stream-telemetry.ts
+++ b/packages/live-text/src/live-stream-telemetry.ts
@@ -1,0 +1,102 @@
+export type LiveStreamService = "agent-worker" | "chat-api";
+
+export type LiveStreamOperation =
+	| "acquire"
+	| "append"
+	| "degradation"
+	| "finalize"
+	| "read_wait"
+	| "reconnect_response"
+	| "recovery_response"
+	| "refresh";
+
+export type LiveStreamResult =
+	| "aborted"
+	| "consumer"
+	| "ended"
+	| "failure"
+	| "finalized"
+	| "history_410"
+	| "producer"
+	| "retry"
+	| "retryable_503"
+	| "started"
+	| "success";
+
+export type LiveStreamReason =
+	| "append_retry_conflict"
+	| "event_too_large"
+	| "finalize_conflict"
+	| "finalized"
+	| "invalid_cursor"
+	| "invalid_event"
+	| "marker_write_failed"
+	| "missing"
+	| "not_configured"
+	| "not_producer"
+	| "operation_failed"
+	| "redis_unavailable"
+	| "stale_worker"
+	| "stream_bytes_exceeded"
+	| "stream_events_exceeded";
+
+export interface LiveStreamMetricEvent extends Record<string, unknown> {
+	message: "Live Stream metric";
+	service: LiveStreamService;
+	operation: LiveStreamOperation;
+	result: LiveStreamResult;
+	reason?: LiveStreamReason;
+	durationMs?: number;
+	count: 1;
+}
+
+interface LiveStreamTelemetryLogger {
+	info(event: LiveStreamMetricEvent): void;
+	warn(event: LiveStreamMetricEvent): void;
+}
+
+export interface LiveStreamTelemetry {
+	record(
+		operation: LiveStreamOperation,
+		result: LiveStreamResult,
+		options?: { reason?: LiveStreamReason; durationMs?: number },
+	): void;
+}
+
+/**
+ * Emits one cardinality-bounded metric event. The API deliberately accepts no
+ * identifiers, payloads, Redis keys, URLs, or thrown errors.
+ */
+export function createLiveStreamTelemetry(
+	service: LiveStreamService,
+	logger: LiveStreamTelemetryLogger,
+): LiveStreamTelemetry {
+	return {
+		record(operation, result, options = {}) {
+			const event: LiveStreamMetricEvent = {
+				message: "Live Stream metric",
+				service,
+				operation,
+				result,
+				...(options.reason ? { reason: options.reason } : {}),
+				...(options.durationMs === undefined
+					? {}
+					: { durationMs: Math.max(0, Math.round(options.durationMs)) }),
+				count: 1,
+			};
+			try {
+				if (result === "failure" || result === "retryable_503") {
+					logger.warn(event);
+				} else {
+					logger.info(event);
+				}
+			} catch {
+				// Observability must never change Live Stream delivery or Run execution.
+			}
+		},
+	};
+}
+
+export const disabledLiveStreamTelemetry: LiveStreamTelemetry = {
+	record() {},
+};

--- a/packages/live-text/src/redis-live-stream-store.ts
+++ b/packages/live-text/src/redis-live-stream-store.ts
@@ -14,6 +14,7 @@ import type {
 } from "assistant-stream/resumable";
 import { createClient } from "redis";
 import { z } from "zod";
+import type { LiveStreamReason } from "./live-stream-telemetry";
 
 export const LIVE_STREAM_RETENTION_MS = 30 * 60 * 1_000;
 export const LIVE_STREAM_MAX_EVENT_BYTES = 32 * 1_024;
@@ -207,6 +208,14 @@ export class LiveStreamStoreError extends Error {
 	constructor(readonly code: LiveStreamStoreErrorCode) {
 		super(errorMessage(code));
 	}
+}
+
+/** Collapse adapter and infrastructure failures to the bounded reason
+ * vocabulary shared by producer and reconnect telemetry. */
+export function classifyLiveStreamFailure(error: unknown): LiveStreamReason {
+	return error instanceof LiveStreamStoreError
+		? error.code
+		: "redis_unavailable";
 }
 
 /**

--- a/scripts/deploy-config.test.ts
+++ b/scripts/deploy-config.test.ts
@@ -320,7 +320,7 @@ describe("agent deployment config", () => {
 				`resource "aws_cloudwatch_metric_alarm" "${resource}"`,
 			);
 		}
-		expect(cloudwatch.match(/datapoints_to_alarm\s*=\s*2/g)).toHaveLength(4);
+		expect(cloudwatch.match(/datapoints_to_alarm\s*=\s*2/g)).toHaveLength(7);
 		expect(cloudwatch).toMatch(
 			/resource "aws_cloudwatch_metric_alarm" "live_preview_widespread_degraded"[\s\S]*?evaluation_periods\s*=\s*3[\s\S]*?datapoints_to_alarm\s*=\s*2[\s\S]*?threshold\s*=\s*2/,
 		);
@@ -340,6 +340,43 @@ describe("agent deployment config", () => {
 		expect(ecs).not.toMatch(
 			/live_preview_(degraded|drops|overflow)|LivePreview/,
 		);
+	});
+
+	it("alarms on retained Live Stream unavailability, recovery, and capacity exhaustion", () => {
+		const cloudwatch = readFileSync(join(terraformDir, "cloudwatch.tf"), "utf8");
+		const ecs = readFileSync(join(terraformDir, "ecs.tf"), "utf8");
+
+		for (const filter of [
+			"live_stream_operations",
+			"live_stream_latency",
+			"live_stream_redis_unavailable",
+			"live_stream_recovery",
+			"live_stream_capacity",
+			"live_stream_degraded_duration",
+		]) {
+			expect(cloudwatch).toContain(
+				`resource "aws_cloudwatch_log_metric_filter" "${filter}"`,
+			);
+		}
+		for (const alarm of [
+			"live_stream_redis_unavailable",
+			"live_stream_recovery_rate",
+			"live_stream_capacity_bound",
+		]) {
+			expect(cloudwatch).toContain(
+				`resource "aws_cloudwatch_metric_alarm" "${alarm}"`,
+			);
+		}
+		expect(cloudwatch).toContain("Live Stream metric");
+		expect(cloudwatch).toContain("agent-worker owns Live Stream production");
+		expect(cloudwatch).toContain("chat-api owns reconnect and recovery responses");
+		expect(cloudwatch).toContain('namespace = "${local.common_name}/LiveStream"');
+		expect(cloudwatch).toContain('treat_missing_data  = "notBreaching"');
+		expect(cloudwatch).toContain('Result    = "$.result"');
+		expect(cloudwatch).not.toMatch(
+			/LiveStream[\s\S]*?(ConversationId|RunId|MessageId|RedisKey|Payload)/,
+		);
+		expect(ecs).not.toContain("LiveStream");
 	});
 
 	it("example tfvars include required deploy inputs and optional secret-name overrides", () => {


### PR DESCRIPTION
## Summary

- add bounded, payload-free Live Stream metrics for producer acquisition, append/finalize/refresh results and latency, capacity exhaustion, reconnect waits, and 503/410 response classification
- observe `live_stream_failed_at` transitions and degraded duration independently from Run execution and terminal Outcomes, including stale-run recovery
- sanitize Redis failure logging to retain only the Run id and bounded reason codes
- add service-owned CloudWatch alarms and an operator runbook for Redis unavailability, elevated recovery, and capacity failures

## Why

Operators need to distinguish temporary resumable-delivery degradation from model or Run failure without recording Assistant text, Tool arguments or results, credentials, URLs, or full Redis keys.

## Impact

Live Stream failures remain delivery-only: durable Postgres execution and Run Outcomes continue unchanged. The worker and chat-api now emit cardinality-bounded operational signals, while alerts identify the responsible service and recovery path.

## Validation

- `bun test` — 907 passed, 13 credential/infrastructure-gated entries skipped, 0 failed
- real PostgreSQL + Redis split-runtime integration — 3 passed, 107 assertions
- live E2B Bash and file-tool suites — 4 passed
- TypeScript checks passed for agent-worker, chat-api, agent-db, and live-text
- Terraform validation and formatting checks passed
- Biome and `git diff --check` passed
- independent Standards and Spec Compliance reviews found no remaining issues

Closes #342