### PR TITLE
build(chat-api): scope production install to drop unused Agent SDK

### DIFF
--- a/apps/chat-api/Dockerfile
+++ b/apps/chat-api/Dockerfile
@@ -18,8 +18,13 @@ FROM base AS install
 COPY --from=manifests /usr/src/app /temp/dev
 RUN cd /temp/dev && bun install --frozen-lockfile
 
+# Scope the production install to chat-api and its workspace deps. Without the
+# filter, bun installs every workspace member's prod deps into the hoisted root
+# node_modules — chat-api would ship agent-worker's ~459MB Claude Agent SDK
+# (plus e2b) that it never imports. --filter=chat-api keeps only the reachable
+# closure (chat-api + agent-db + live-text), cutting node_modules ~660MB → ~145MB.
 COPY --from=manifests /usr/src/app /temp/prod
-RUN cd /temp/prod && bun install --frozen-lockfile --production
+RUN cd /temp/prod && bun install --frozen-lockfile --production --filter=chat-api
 
 # Assemble the source for the release image. Tests are NOT run here — CI
 # (.github/workflows/ci.yml) is the test gate; the image build just produces the


### PR DESCRIPTION
## Problem

The chat-api Docker image ran `bun install --production` over the entire Bun workspace, so the hoisted root `node_modules` contained **every** workspace member's prod dependencies. The release image copies that whole tree, so chat-api shipped agent-worker's dependency closure it never imports:

| Package | Size | In chat-api's import graph? |
|---|---|---|
| `@anthropic-ai/claude-agent-sdk` | 459MB | No |
| `e2b` | 1.8MB | No |

The SDK is huge because it ships native CLI binaries (the `claude` CLI, ripgrep). It was ~69% of the image's `node_modules`.

## Fix

Add `--filter=chat-api` to the production install so bun resolves only the reachable closure (chat-api + its workspace deps agent-db & live-text). Lockfile stays frozen; no other stage changes.

## Verified (measured)

| | Before | After |
|---|---|---|
| Image (uncompressed) | 832MB | **326MB** |
| `node_modules` | 660MB | 151MB |
| Claude Agent SDK | present | gone |

The scoped image boots and executes its full import graph — it fails only at `AGENT_DATABASE_URL is required` (runtime config validation with no env set), proving every module (workspace symlinks, pg, drizzle, statsig, aws-sdk) resolved. ~506MB / 61% reduction uncompressed.

## Note (not in this PR)

The `/temp/dev` full install still runs at build time (not copied into the release image, so it doesn't affect image size but still pulls the SDK during build). Appears vestigial — candidate for a separate build-speed cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)