### PR TITLE
docs: decide producer-buffered Live Stream over pub/sub (ADR-0014)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -72,19 +72,19 @@ Stream after it commits, but Assistant text deltas are Live Stream entries and
 not Run events.
 
 **Live Stream**:
-The temporary, ordered Redis Stream that carries every standard AG-UI event for
-one active Run. Its entry ids are transport replay cursors: a transient
-reconnect continues after its last id, while a full refresh reconstructs the
-active Run from the beginning. A healthy Live Stream is kept alive and
-untrimmed while its Run is active and retained for 30 minutes after the
-Outcome; a failed Live Stream is retained for at most 30 minutes after being
-declared unavailable. Permanent Conversation history comes from Run events.
-_Avoid_: Live preview, Pub/Sub channel, Conversation history
+The temporary, ordered sequence of standard AG-UI events for one active Run,
+buffered in the producing worker's memory and relayed event-by-event over Redis
+pub/sub. No stream content is stored in Redis: a reader attaches by requesting
+the full backlog from the living producer, and every reconnect rebuilds the
+active Run from that backlog. The Live Stream ends with the Run's Outcome and
+dies with its producer; after either, permanent Conversation history is the
+only source.
+_Avoid_: Live preview, retained stream, replay cursor, Conversation history
 
 **Reconnecting**:
-Resuming consumption of a usable Live Stream after a transient transport
-interruption, continuing after the last observed cursor.
-_Avoid_: Recovering
+Re-attaching to a usable Live Stream after a transient transport interruption,
+rebuilding the active Run from its full backlog.
+_Avoid_: Recovering, resuming after a cursor
 
 **Recovering**:
 Waiting for permanent Conversation history after a Live Stream becomes
@@ -115,9 +115,8 @@ _Avoid_: Conversation API, Assistant Cloud
 
 **Assistant text delta**:
 A bounded, provisional fragment of Assistant text appended to the Run's Live
-Stream before the provider response completes. Its Redis Stream entry id is its
-temporary replay cursor. It is never copied into Postgres as a delta row and
-may disappear after the Live Stream expires.
+Stream before the provider response completes. It is never copied into Postgres
+as a delta row and may disappear when the Live Stream ends.
 _Avoid_: Run event, durable message, token
 
 **Assistant message**:

--- a/docs/adr/0012-expose-a-full-ag-ui-agent-surface.md
+++ b/docs/adr/0012-expose-a-full-ag-ui-agent-surface.md
@@ -2,6 +2,12 @@
 
 Run-control vocabulary and terminal behavior are amended by
 [ADR-0013](./0013-interrupt-runs-without-ending-conversation-continuity.md).
+The retained per-Run Redis Stream transport — entry-id cursors,
+`Last-Event-ID` resumption, `activeRun.lastEventId`, the 30-minute
+post-terminal retention, the `ResumableStreamStore` adapter, and its Lua/cap/
+TTL machinery — is superseded by
+[ADR-0014](./0014-producer-buffered-live-stream-over-pubsub.md); every
+non-transport decision here remains in force.
 
 MyMemo exposes a plug-compatible AG-UI data plane rather than only borrowing AG-UI-shaped event names. A Run endpoint accepts the standard `RunAgentInput` body and returns a standard AG-UI `BaseEvent` stream; active-Run reconnect emits the same event vocabulary from a per-Run Redis Stream. MyMemo also supplies the persistence, replay, interruption, and history endpoints that AG-UI leaves to the server implementation. The surface advertises resumability only after its sequence and replay contract is implemented and verified.
 

--- a/docs/adr/0014-producer-buffered-live-stream-over-pubsub.md
+++ b/docs/adr/0014-producer-buffered-live-stream-over-pubsub.md
@@ -1,0 +1,115 @@
+---
+status: accepted
+---
+
+# Producer-buffered Live Stream over pub/sub
+
+Status: accepted (2026-07-23); implementation not started. Supersedes the
+retained per-Run Redis Stream transport of
+[ADR-0012](./0012-expose-a-full-ag-ui-agent-surface.md); every non-transport
+decision there (admission, authorization, event vocabulary, Postgres-first
+commit ordering, history, interruption) remains in force.
+
+To simplify the live-transport adapter and remove Redis storage, MyMemo
+replaces the retained per-Run Redis Stream with the pattern behind
+`vercel/resumable-stream`: **the producer's memory is the store; Redis is only
+a relay**. The claiming worker buffers each Run's serialized AG-UI events in
+its own heap and publishes each event once over pub/sub; no stream content is
+ever stored in Redis. Per-token Redis command traffic is unchanged — in the
+split runtime chat-api is always a listener, so every event crosses Redis
+either way — the savings are stored bytes and the adapter machinery (the
+`ResumableStreamStore` contract, its Lua scripts, and TTL/cap/trim management).
+
+## Decision
+
+- **Discovery plane is Postgres, not a sentinel key.** `runs.status`, the
+  ownership lease, and `live_stream_failed_at` already answer "is there
+  anything to resume?" authoritatively. A reader that finds the Run terminal
+  goes straight to Conversation history and never touches pub/sub. The
+  reference design's 24-hour sentinel key has no job here and is not ported.
+- **Data plane: one shared per-Run live channel plus a per-reader reply
+  channel.** The producer publishes each event exactly once to the Run's live
+  channel, stamped with an internal ordinal. A reader subscribes to the live
+  channel first, buffers arriving events, then requests the backlog on the
+  producer's per-Run request channel with a private reply channel; the reply
+  carries the full backlog and the count of events it covers, and the reader
+  discards buffered live events below that count. The seam is gapless by
+  arithmetic, not by single-block synchronicity; there is no listener
+  registry, no per-listener fan-out, and nothing to prune.
+- **No cursors on the wire.** SSE `id`s, `Last-Event-ID` handling, and
+  `activeRun.lastEventId` are removed. Every attach — original POST, transient
+  reconnect, full refresh — rebuilds the active Run from the full backlog
+  through the client's existing from-zero rebuild path. Internal ordinals
+  never leave the transport.
+- **Reader retry is Postgres-governed.** chat-api re-requests the backlog with
+  backoff while the Run is active and unfailed, holding the SSE open with the
+  existing comment pings (the queued-Run wait is unchanged). It stops when a
+  producer answers, the Run terminalizes (serve history), or
+  `live_stream_failed_at` is set (`410`). The reference design's one-shot
+  1000 ms timeout — which conflates a dead producer with a busy one — is not
+  ported; a dead producer's Run is terminalized by stale-Run recovery, which
+  ends the loop.
+- **Terminal means history.** The worker publishes the terminal event to the
+  live channel only after its Postgres commit (ordering rule unchanged), then
+  closes the request channel and frees the buffer. The 30-minute post-terminal
+  replay window is removed: a reader arriving after the Outcome always
+  hydrates permanent history. This structurally removes the reference
+  design's done-races (its issues #44 and #47): a reader that blips at the
+  terminal instant retries, observes the terminal status in Postgres, and
+  recovers.
+- **Failure contract and bounds carry over unchanged.** Sequential
+  bounded-timeout publishes in SDK event order; the first publish failure sets
+  `live_stream_failed_at`, disables later publishes for that Run, and never
+  fails the Run. `503` before the first event, `410` on the failure marker,
+  and the Reconnecting/Recovering client states are word-for-word the same.
+  The 10,000-event / 8 MiB per-Run caps now bound the producer's buffer
+  (crossing one follows the live-failure path while the Run continues), and
+  the 32 KiB per-event / 16 KiB text-coalescing caps remain. `REDIS_URL`
+  stays required, authenticated `rediss://`, validated at startup.
+- **Accepted durability loss: the backlog dies with the producer.** If a
+  worker dies mid-Run, a newly attaching reader gets no backlog during the
+  stale window — it retries silently until stale-Run recovery terminalizes the
+  Run, then recovers from history with no partial Assistant text. An
+  already-connected client keeps what it received. The window is bounded by
+  the existing heartbeat/lease/recovery machinery and affects only
+  provisional content on a Run that is terminalizing abnormally. This is the
+  essential price of removing the store.
+- **Bespoke implementation.** The `vercel/resumable-stream` package is not
+  used: its chunks are plain strings with character-count skip, its producer
+  is the HTTP handler that owns the client response, and its lifetime is
+  `waitUntil`-pinned — all three contradict the split runtime. The
+  `assistant-stream/resumable` `ResumableStreamStore` contract and the Lua
+  Redis adapter are dropped with the retained Stream.
+- **Sequencing: after #344.** The legacy events-path transport and two-source
+  projector are deleted first, leaving one transport; then that transport is
+  swapped. No tri-transport state ever exists.
+
+## Considered Options
+
+- **Diet the retained-Stream adapter** — keep Streams and cursors, cut the
+  post-terminal retention and cap machinery. Recommended for lowest risk;
+  rejected by product decision in favor of removing stored stream state
+  entirely.
+- **Pub/sub live plus Postgres-projection replay** — rejected: resurrects the
+  two-source merge projector that ADR-0012 deliberately killed.
+- **Per-listener mailbox fan-out (faithful port)** — rejected: O(listeners)
+  publishes per event, an unprunable listener registry, and a seam whose
+  correctness depends on never inserting an `await` into one synchronous
+  block.
+- **Event-ordinal cursors on the wire** — rejected for maximal wire-contract
+  simplification; every reconnect rebuilds from the full backlog instead.
+
+## Consequences
+
+- The client contract changes: no resume cursor exists, and reconnection is
+  always a full rebuild of the active Run. `mymemo-web`'s transient-reconnect
+  path collapses into its full-refresh path.
+- A transient blip mid-Run re-streams the whole backlog (bounded by the 8 MiB
+  cap) instead of a suffix.
+- ADR-0012's resumability verification matrix is re-targeted: replay-from-zero
+  and after-cursor tests are replaced by backlog/live seam dedupe, retry-until-
+  terminal, queued-Run wait, producer-death recovery, terminal-instant races,
+  and buffer-cap tests against real Redis pub/sub plus Postgres.
+- Redis holds no per-Run keys at all; observability shifts from Stream
+  acquisition/TTL metrics to backlog-request latency, retry counts, and
+  publish-failure rates.


### PR DESCRIPTION
## What changed

Docs-only decision record from a grilling session on adopting the design behind `vercel/resumable-stream` (the engine of the AI SDK's `resume: true`) for MyMemo's live transport:

- **New [ADR-0014](docs/adr/0014-producer-buffered-live-stream-over-pubsub.md)** — replaces ADR-0012's retained per-Run Redis Stream with a producer-buffered pub/sub relay: the claiming worker's memory is the store, Redis stores zero stream content, and Postgres (`runs.status` + `live_stream_failed_at`) is the discovery plane.
- **ADR-0012** — supersession note added; every non-transport decision there (admission, authorization, event vocabulary, Postgres-first commit ordering, history, interruption) remains in force.
- **CONTEXT.md** — redefines **Live Stream**, **Reconnecting**, and **Assistant text delta** for the new model.

## Why

Motivation: simplify the live-transport adapter (drop the `ResumableStreamStore` contract, Lua scripts, and TTL/cap/trim machinery) and remove Redis storage. Per-token Redis command traffic is unchanged — chat-api is always a listener in the split runtime — so the ADR is explicit that the savings are stored bytes and machinery, not commands.

## Key decisions a reviewer should check

- **No cursors on the wire**: SSE `id`s, `Last-Event-ID`, and `activeRun.lastEventId` are removed; every reconnect rebuilds the active Run from the full backlog.
- **Terminal means history**: the 30-minute post-terminal replay window is removed; post-terminal readers always hydrate Postgres history.
- **Accepted durability loss**: the backlog dies with the producer — a reader attaching during the worker-death stale window recovers from history with no partial text.
- **Deliberate deviations from the reference design** (each fixes a defect class the reference is known for): Postgres discovery plane instead of a sentinel key, one shared per-Run live channel with internal ordinals instead of per-listener mailboxes, Postgres-governed retry instead of a one-shot 1000 ms timeout, and front-desk close at terminal without done-races.
- **Sequencing**: implementation is bespoke (neither the Vercel package nor the current Lua adapter) and lands after #344 so three transports never coexist.

No code changes; implementation is deliberately out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)