### PR TITLE
fix(chat-api): end attached readers on silent producer death (#370)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y ripgrep redis-server
       - run: bun install --frozen-lockfile
       - run: bun run test
+      - run: bun test e2e/relay-failure-matrix.integration.test.ts
 
   # Build the final production-pruned image and exercise the SDK's native CLI
   # inside it. This needs no runtime credentials and catches both optional-dep
@@ -39,9 +40,9 @@ jobs:
 
   # Split-runtime AG-UI integration: runs chat-api plus a deterministic
   # test-only worker against real Postgres and Redis, so atomic admission,
-  # durable completion, and the retained per-Run stream are exercised on every
-  # PR without live provider credentials. Task 9.7 owns the production SDK
-  # path's credentialed smoke.
+  # durable completion, and relay-backed streaming are exercised on every PR
+  # without live provider credentials. Task 9.7 owns the production SDK path's
+  # credentialed smoke.
   # `e2e/integration.test.ts` is gated on AGENT_DATABASE_URL.
   integration:
     runs-on: ubuntu-latest

--- a/apps/agent-worker/src/run-live-stream.test.ts
+++ b/apps/agent-worker/src/run-live-stream.test.ts
@@ -4,6 +4,7 @@ import {
 	createInMemoryLiveStreamRelay,
 	decodeAgUiLiveStreamEvent,
 	type LiveStreamMetricEvent,
+	type LiveStreamRelayOptions,
 	type LiveStreamTelemetry,
 } from "@mymemo/live-text";
 import type { WorkerLogger } from "./logger";
@@ -63,7 +64,10 @@ it("observes a payload-safe degradation transition separately from Run outcome",
 	};
 	const relay = createInMemoryLiveStreamRelay({
 		telemetry,
-		testHooks: { failEventPublishAtOrdinal: 0 },
+		testHooks: {
+			failEventPublishWhen: ({ eventType }) =>
+				eventType === EventType.RUN_STARTED,
+		},
 	});
 	const stream = await RunLiveStream.open({
 		relay,
@@ -127,7 +131,10 @@ it("observes a payload-safe degradation transition separately from Run outcome",
 it("retries a transient Live Stream failure-marker write after the Run terminalizes", async () => {
 	let markerAttempts = 0;
 	const relay = createInMemoryLiveStreamRelay({
-		testHooks: { failEventPublishAtOrdinal: 0 },
+		testHooks: {
+			failEventPublishWhen: ({ eventType }) =>
+				eventType === EventType.RUN_STARTED,
+		},
 	});
 	const stream = await RunLiveStream.open({
 		relay,
@@ -148,7 +155,13 @@ it("retries a transient Live Stream failure-marker write after the Run terminali
 });
 
 it.each([
-	["terminal publish", { failEventPublishAtOrdinal: 1 }, undefined],
+	[
+		"terminal publish",
+		{
+			failEventPublishWhen: ({ terminal }) => terminal,
+		} satisfies NonNullable<LiveStreamRelayOptions["testHooks"]>,
+		undefined,
+	],
 	["buffer overflow", undefined, { maxEvents: 1 }],
 ] as const)("latches %s failure while the Run still reaches its durable outcome", async (_name, testHooks, testLimits) => {
 	let markerAttempts = 0;

--- a/apps/agent-worker/src/run-loop.test.ts
+++ b/apps/agent-worker/src/run-loop.test.ts
@@ -392,7 +392,10 @@ describe("RunLoop — terminal outcomes", () => {
 
 	it("continues durable execution after a mid-text Live Stream write fails", async () => {
 		const liveStreamRelay = createInMemoryLiveStreamRelay({
-			testHooks: { failEventPublishAtOrdinal: 2 },
+			testHooks: {
+				failEventPublishWhen: ({ eventType }) =>
+					eventType === EventType.TEXT_MESSAGE_CONTENT,
+			},
 		});
 		const worker = buildWorker(1);
 		const loop = buildLoop(
@@ -435,7 +438,10 @@ describe("RunLoop — terminal outcomes", () => {
 
 	it("keeps committing Tool events after Live Stream publication fails", async () => {
 		const liveStreamRelay = createInMemoryLiveStreamRelay({
-			testHooks: { failEventPublishAtOrdinal: 1 },
+			testHooks: {
+				failEventPublishWhen: ({ eventType }) =>
+					eventType === EventType.TOOL_CALL_START,
+			},
 		});
 		const worker = buildWorker(1);
 		const loop = buildLoop(
@@ -518,7 +524,9 @@ describe("RunLoop — terminal outcomes", () => {
 
 	it("marks the Live Stream failed after durable terminalization without changing the Outcome", async () => {
 		const liveStreamRelay = createInMemoryLiveStreamRelay({
-			testHooks: { failEventPublishAtOrdinal: 1 },
+			testHooks: {
+				failEventPublishWhen: ({ terminal }) => terminal,
+			},
 		});
 		const worker = buildWorker(1);
 		const loop = buildLoop(worker, appendMessageProcessor, liveStreamRelay);

--- a/apps/chat-api/src/features/conversations/conversations.route.test.ts
+++ b/apps/chat-api/src/features/conversations/conversations.route.test.ts
@@ -1200,7 +1200,10 @@ describe("POST /v1/conversations/:id/runs", () => {
 			}),
 		});
 		const relay = createInMemoryLiveStreamRelay({
-			testHooks: { failEventPublishAtOrdinal: 1 },
+			testHooks: {
+				failEventPublishWhen: ({ eventType }) =>
+					eventType === EventType.TEXT_MESSAGE_CONTENT,
+			},
 		});
 		const producer = await relay.openProducer("client-run-1");
 		const [started] = encodeAgUiLiveStreamEvent({
@@ -1754,7 +1757,10 @@ describe("GET /v1/conversations/:id/runs/:runId/events", () => {
 		};
 		fakeRuns.runOwners.set("run-1", owner);
 		const relay = createInMemoryLiveStreamRelay({
-			testHooks: { failEventPublishAtOrdinal: 1 },
+			testHooks: {
+				failEventPublishWhen: ({ eventType }) =>
+					eventType === EventType.TEXT_MESSAGE_CONTENT,
+			},
 		});
 		const producer = await relay.openProducer("run-1");
 		const [started] = encodeAgUiLiveStreamEvent({

--- a/apps/chat-api/src/features/conversations/conversations.route.ts
+++ b/apps/chat-api/src/features/conversations/conversations.route.ts
@@ -45,10 +45,15 @@ const conversationBodyLimit = bodyLimit({
 const LIVE_STREAM_START_POLL_MS = 100;
 const LIVE_STREAM_MAX_RETRY_MS = 1_000;
 const LIVE_STREAM_KEEPALIVE_MS = 5_000;
+const LIVE_STREAM_RECOVERY_POLL_MS = LIVE_STREAM_KEEPALIVE_MS;
 const liveStreamDecoder = new TextDecoder("utf-8", { fatal: true });
 
 function isTerminalRunStatus(status: RunRecord["status"]): boolean {
 	return status === "done" || status === "error" || status === "canceled";
+}
+
+function needsLiveStreamRecovery(run: RunRecord): boolean {
+	return run.liveStreamFailedAt !== null || isTerminalRunStatus(run.status);
 }
 
 function liveStreamRecoveryResponse(c: Context<AppEnv>) {
@@ -67,10 +72,7 @@ async function liveStreamReadFailureResponse(
 		runId: run.runId,
 	});
 	if (currentRun === null) return c.json({ error: "Run not found" }, 404);
-	if (
-		currentRun.liveStreamFailedAt !== null ||
-		isTerminalRunStatus(currentRun.status)
-	) {
+	if (needsLiveStreamRecovery(currentRun)) {
 		return liveStreamRecoveryResponse(c);
 	}
 	c.var.deps.liveStreamTelemetry.record("reconnect_response", "retryable_503", {
@@ -140,6 +142,46 @@ function startAgUiKeepalive(
 	return stop;
 }
 
+function watchRunForLiveStreamRecovery(
+	c: Context<AppEnv>,
+	run: RunRecord,
+	readController: AbortController,
+): () => void {
+	let checking = false;
+	let stopped = false;
+	const interval = setInterval(() => {
+		if (checking || stopped || readController.signal.aborted) return;
+		checking = true;
+		void c.var.deps.runStore
+			.getRun({
+				userId: run.userId,
+				conversationId: run.conversationId,
+				runId: run.runId,
+			})
+			.then((currentRun) => {
+				// Terminal state may commit just before its live terminal publish. If
+				// this poll wins that race, the incomplete close recovers via history.
+				if (currentRun === null || needsLiveStreamRecovery(currentRun)) {
+					readController.abort();
+				}
+			})
+			.catch(() => {
+				c.var.logger.error({
+					message: "AG-UI Live Stream recovery watch failed",
+					runId: run.runId,
+					reason: "run_state_read_failed",
+				});
+			})
+			.finally(() => {
+				checking = false;
+			});
+	}, LIVE_STREAM_RECOVERY_POLL_MS);
+	return () => {
+		stopped = true;
+		clearInterval(interval);
+	};
+}
+
 async function writeAgUiEvents(
 	c: Context<AppEnv>,
 	runId: string,
@@ -175,6 +217,11 @@ async function streamAgUiRun(
 ) {
 	const requestSignal = c.req.raw.signal;
 	const iterator = events[Symbol.asyncIterator]();
+	const stopRecoveryWatch = watchRunForLiveStreamRecovery(
+		c,
+		run,
+		readAbort.controller,
+	);
 	const firstRead = iterator.next().then(
 		(result) => ({ outcome: "read" as const, result }),
 		(error: unknown) => ({ outcome: "error" as const, error }),
@@ -188,6 +235,7 @@ async function streamAgUiRun(
 	]);
 	if (initial.outcome === "error") {
 		const { error } = initial;
+		stopRecoveryWatch();
 		readAbort.dispose();
 		await iterator.return?.();
 		c.var.logger.error({
@@ -203,6 +251,7 @@ async function streamAgUiRun(
 	}
 	if (initial.outcome === "ping") {
 		if (requestSignal.aborted) {
+			stopRecoveryWatch();
 			readAbort.controller.abort(requestSignal.reason);
 			readAbort.dispose();
 			await iterator.return?.();
@@ -243,6 +292,7 @@ async function streamAgUiRun(
 				);
 			} finally {
 				stopKeepalive();
+				stopRecoveryWatch();
 				readAbort.controller.abort();
 				readAbort.dispose();
 				await iterator.return?.();
@@ -251,6 +301,7 @@ async function streamAgUiRun(
 	}
 	first = initial.result;
 	if (first.done) {
+		stopRecoveryWatch();
 		readAbort.dispose();
 		await iterator.return?.();
 		if (requestSignal.aborted) return c.body(null, 204);
@@ -276,6 +327,7 @@ async function streamAgUiRun(
 			);
 		} finally {
 			stopKeepalive();
+			stopRecoveryWatch();
 			readAbort.controller.abort();
 			readAbort.dispose();
 		}
@@ -290,10 +342,7 @@ async function waitForAndStreamAgUiRun(c: Context<AppEnv>, run: RunRecord) {
 		runId: run.runId,
 	});
 	if (currentRun === null) return c.json({ error: "Run not found" }, 404);
-	if (
-		currentRun.liveStreamFailedAt !== null ||
-		isTerminalRunStatus(currentRun.status)
-	) {
+	if (needsLiveStreamRecovery(currentRun)) {
 		return liveStreamRecoveryResponse(c);
 	}
 	return streamSSE(c, async (stream) => {
@@ -320,11 +369,7 @@ async function waitForAndStreamAgUiRun(c: Context<AppEnv>, run: RunRecord) {
 					conversationId: run.conversationId,
 					runId: run.runId,
 				});
-				if (
-					currentRun === null ||
-					currentRun.liveStreamFailedAt !== null ||
-					isTerminalRunStatus(currentRun.status)
-				) {
+				if (currentRun === null || needsLiveStreamRecovery(currentRun)) {
 					return;
 				}
 
@@ -352,26 +397,35 @@ async function waitForAndStreamAgUiRun(c: Context<AppEnv>, run: RunRecord) {
 					continue;
 				}
 				const iterator = attached.events[Symbol.asyncIterator]();
+				const stopRecoveryWatch = watchRunForLiveStreamRecovery(
+					c,
+					run,
+					readAbort.controller,
+				);
 				let first: Awaited<ReturnType<typeof iterator.next>>;
 				try {
-					first = await iterator.next();
-				} catch (error) {
-					c.var.logger.error({
-						message: "AG-UI Live Stream read failed after attaching",
-						runId: run.runId,
-						reason: classifyLiveStreamFailure(error),
-					});
-					await iterator.return?.();
+					try {
+						first = await iterator.next();
+					} catch (error) {
+						c.var.logger.error({
+							message: "AG-UI Live Stream read failed after attaching",
+							runId: run.runId,
+							reason: classifyLiveStreamFailure(error),
+						});
+						await iterator.return?.();
+						return;
+					}
+					if (first.done) {
+						await iterator.return?.();
+						return;
+					}
+					await writeAgUiEvents(c, run.runId, iterator, first, (event) =>
+						stream.writeSSE(event),
+					);
 					return;
+				} finally {
+					stopRecoveryWatch();
 				}
-				if (first.done) {
-					await iterator.return?.();
-					return;
-				}
-				await writeAgUiEvents(c, run.runId, iterator, first, (event) =>
-					stream.writeSSE(event),
-				);
-				return;
 			}
 		} finally {
 			stopKeepalive();
@@ -382,8 +436,7 @@ async function waitForAndStreamAgUiRun(c: Context<AppEnv>, run: RunRecord) {
 }
 
 async function respondWithAgUiRun(c: Context<AppEnv>, run: RunRecord) {
-	if (run.liveStreamFailedAt !== null) return liveStreamRecoveryResponse(c);
-	if (isTerminalRunStatus(run.status)) return liveStreamRecoveryResponse(c);
+	if (needsLiveStreamRecovery(run)) return liveStreamRecoveryResponse(c);
 
 	const readAbort = linkedAbortController(c.req.raw.signal);
 	let attached: LiveStreamAttachResult;

--- a/e2e/ag-ui-sse.ts
+++ b/e2e/ag-ui-sse.ts
@@ -1,0 +1,19 @@
+export interface AgUiSseFrame {
+	data: Record<string, unknown>;
+}
+
+/** Parse cursor-free standard AG-UI SSE with one BaseEvent JSON object per frame. */
+export function parseAgUiSse(raw: string): AgUiSseFrame[] {
+	const frames: AgUiSseFrame[] = [];
+	for (const block of raw.split("\n\n")) {
+		let data = "";
+		for (const line of block.split("\n")) {
+			if (line.startsWith("id:")) {
+				throw new Error("AG-UI SSE frame carried an unexpected id");
+			}
+			if (line.startsWith("data:")) data = line.slice("data:".length).trim();
+		}
+		if (data) frames.push({ data: JSON.parse(data) });
+	}
+	return frames;
+}

--- a/e2e/integration.test.ts
+++ b/e2e/integration.test.ts
@@ -37,8 +37,13 @@ import {
 	it,
 	setDefaultTimeout,
 } from "bun:test";
-import { createServer } from "node:net";
 import { resolve } from "node:path";
+import {
+	findFreePort,
+	type RedisTestServer,
+	startRedisTestServer,
+} from "../test-support/redis-test-server";
+import { type AgUiSseFrame, parseAgUiSse } from "./ag-ui-sse";
 
 const DB_URL = process.env.AGENT_DATABASE_URL;
 const RUN = Boolean(DB_URL);
@@ -69,34 +74,14 @@ const JSON_IDENTITY_HEADERS = {
 	"content-type": "application/json",
 };
 
-interface SSEFrame {
-	data: Record<string, unknown>;
-}
-
-/** Parse cursor-free standard AG-UI SSE with one BaseEvent JSON object per frame. */
-function parseSSE(raw: string): SSEFrame[] {
-	const frames: SSEFrame[] = [];
-	for (const block of raw.split("\n\n")) {
-		let data = "";
-		for (const line of block.split("\n")) {
-			if (line.startsWith("id:")) {
-				throw new Error("AG-UI SSE frame carried an unexpected id");
-			}
-			if (line.startsWith("data:")) data = line.slice("data:".length).trim();
-		}
-		if (data) frames.push({ data: JSON.parse(data) });
-	}
-	return frames;
-}
-
 async function consumeSSE(
 	response: Response,
-	onFrame: (frame: SSEFrame) => Promise<void>,
-): Promise<SSEFrame[]> {
+	onFrame: (frame: AgUiSseFrame) => Promise<void>,
+): Promise<AgUiSseFrame[]> {
 	if (!response.body) throw new Error("SSE response omitted its body");
 	const reader = response.body.getReader();
 	const decoder = new TextDecoder();
-	const frames: SSEFrame[] = [];
+	const frames: AgUiSseFrame[] = [];
 	let buffered = "";
 	for (;;) {
 		const { done, value } = await reader.read();
@@ -105,7 +90,7 @@ async function consumeSSE(
 		while (boundary >= 0) {
 			const block = buffered.slice(0, boundary + 2);
 			buffered = buffered.slice(boundary + 2);
-			for (const frame of parseSSE(block)) {
+			for (const frame of parseAgUiSse(block)) {
 				frames.push(frame);
 				await onFrame(frame);
 			}
@@ -113,7 +98,7 @@ async function consumeSSE(
 		}
 		if (done) break;
 	}
-	for (const frame of parseSSE(buffered)) {
+	for (const frame of parseAgUiSse(buffered)) {
 		frames.push(frame);
 		await onFrame(frame);
 	}
@@ -123,7 +108,7 @@ async function consumeSSE(
 async function readUntilSSEFrameAndCancel(
 	response: Response,
 	eventType: string,
-): Promise<{ frame: SSEFrame; raw: string }> {
+): Promise<{ frame: AgUiSseFrame; raw: string }> {
 	if (!response.body) throw new Error("SSE response omitted its body");
 	const reader = response.body.getReader();
 	const decoder = new TextDecoder();
@@ -138,7 +123,7 @@ async function readUntilSSEFrameAndCancel(
 		while (boundary >= 0) {
 			const block = buffered.slice(0, boundary + 2);
 			buffered = buffered.slice(boundary + 2);
-			const [frame] = parseSSE(block);
+			const [frame] = parseAgUiSse(block);
 			if (frame?.data.type === eventType) {
 				await reader.cancel();
 				return { frame, raw };
@@ -149,7 +134,7 @@ async function readUntilSSEFrameAndCancel(
 	}
 }
 
-function requiredFrame(frames: SSEFrame[], type: string): SSEFrame {
+function requiredFrame(frames: AgUiSseFrame[], type: string): AgUiSseFrame {
 	const frame = frames.find((candidate) => candidate.data.type === type);
 	if (!frame) throw new Error(`SSE response omitted ${type}`);
 	return frame;
@@ -334,56 +319,9 @@ async function waitForHistoryRun(
 	);
 }
 
-async function freePort(): Promise<number> {
-	return new Promise((resolvePort, reject) => {
-		const server = createServer();
-		server.once("error", reject);
-		server.listen(0, "127.0.0.1", () => {
-			const address = server.address();
-			if (!address || typeof address === "string") {
-				server.close();
-				reject(new Error("failed to allocate integration fixture port"));
-				return;
-			}
-			server.close((error) =>
-				error ? reject(error) : resolvePort(address.port),
-			);
-		});
-	});
-}
-
-async function startRedis(port: number): Promise<Bun.Subprocess> {
-	const redis = Bun.spawn(
-		[
-			"redis-server",
-			"--bind",
-			"127.0.0.1",
-			"--port",
-			String(port),
-			"--save",
-			"",
-			"--appendonly",
-			"no",
-		],
-		{ stdout: "inherit", stderr: "inherit" },
-	);
-	const deadline = Date.now() + 10_000;
-	while (Date.now() < deadline) {
-		const ping = Bun.spawn(
-			["redis-cli", "-h", "127.0.0.1", "-p", String(port), "ping"],
-			{ stdout: "ignore", stderr: "ignore" },
-		);
-		if ((await ping.exited) === 0) return redis;
-		await Bun.sleep(50);
-	}
-	redis.kill();
-	throw new Error("Redis did not become ready");
-}
-
 let chat: Bun.Subprocess | undefined;
 let worker: Bun.Subprocess | undefined;
-let redis: Bun.Subprocess | undefined;
-let redisPort: number;
+let redis: RedisTestServer | undefined;
 let workerPort: number;
 let eventWriterEnv: Record<string, string>;
 
@@ -424,12 +362,11 @@ describe.skipIf(!RUN)(
 	() => {
 		beforeAll(async () => {
 			const dbUrl = DB_URL as string;
-			if (configuredChatPort === undefined) chatPort = await freePort();
+			if (configuredChatPort === undefined) chatPort = await findFreePort();
 			CHAT_URL = `http://127.0.0.1:${chatPort}`;
-			redisPort = await freePort();
-			workerPort = await freePort();
-			redis = await startRedis(redisPort);
-			const redisUrl = `redis://127.0.0.1:${redisPort}`;
+			workerPort = await findFreePort();
+			redis = await startRedisTestServer({ stdio: "inherit" });
+			const redisUrl = redis.url;
 			eventWriterEnv = {
 				AGENT_DATABASE_URL: dbUrl,
 				REDIS_URL: redisUrl,
@@ -462,8 +399,7 @@ describe.skipIf(!RUN)(
 		afterAll(async () => {
 			chat?.kill();
 			await stopEventWriter();
-			redis?.kill("SIGTERM");
-			if (redis) await redis.exited;
+			await redis?.stop();
 		});
 
 		it(
@@ -563,7 +499,7 @@ describe.skipIf(!RUN)(
 					afterToolResponsePromise,
 				]);
 				expect(afterToolResponse.status).toBe(200);
-				const afterToolFrames = parseSSE(await afterToolResponse.text());
+				const afterToolFrames = parseAgUiSse(await afterToolResponse.text());
 				const textDisconnectIndex = frames.findIndex(
 					(frame) => frame.data.type === "TEXT_MESSAGE_CONTENT",
 				);
@@ -572,7 +508,7 @@ describe.skipIf(!RUN)(
 				);
 				expect(textDisconnectIndex).toBe(2);
 				expect(toolDisconnectIndex).toBe(5);
-				expect(parseSSE(toolDisconnect.raw)).toEqual(
+				expect(parseAgUiSse(toolDisconnect.raw)).toEqual(
 					frames.slice(0, toolDisconnectIndex + 1),
 				);
 				expect(afterToolFrames).toEqual(frames);
@@ -610,7 +546,7 @@ describe.skipIf(!RUN)(
 					.join("");
 				expect(streamedText).toContain("Synthetic response");
 				expect(streamedText).toContain(runId);
-				expect(parseSSE(textDisconnect.raw)).toEqual(
+				expect(parseAgUiSse(textDisconnect.raw)).toEqual(
 					frames.slice(0, textDisconnectIndex + 1),
 				);
 
@@ -739,7 +675,7 @@ describe.skipIf(!RUN)(
 					},
 				);
 				expect(failedRun.status).toBe(200);
-				const failedFrames = parseSSE(await failedRun.text());
+				const failedFrames = parseAgUiSse(await failedRun.text());
 				expect(failedFrames.map((frame) => frame.data.type)).toEqual([
 					"RUN_STARTED",
 					"TOOL_CALL_START",
@@ -917,7 +853,7 @@ describe.skipIf(!RUN)(
 					status: "cancel_requested",
 				});
 
-				const resumedFrames = parseSSE(await resumed.text());
+				const resumedFrames = parseAgUiSse(await resumed.text());
 				expect(resumedFrames.at(-1)?.data.type).toBe("RUN_CANCELLED");
 				expect(
 					resumedFrames.some((frame) => frame.data.type === "RUN_FINISHED"),
@@ -980,7 +916,7 @@ describe.skipIf(!RUN)(
 
 				const response = await turn.response;
 				expect(response.status).toBe(200);
-				const incompleteFrames = parseSSE(await response.text());
+				const incompleteFrames = parseAgUiSse(await response.text());
 				expect(
 					incompleteFrames.some((frame) =>
 						["RUN_FINISHED", "RUN_ERROR", "RUN_CANCELLED"].includes(
@@ -1035,7 +971,7 @@ describe.skipIf(!RUN)(
 
 				const response = await turn.response;
 				expect(response.status).toBe(200);
-				const liveFrames = parseSSE(await response.text());
+				const liveFrames = parseAgUiSse(await response.text());
 				const messageId = `message-${turn.runId}`;
 				const assistantText = `Synthetic response for run ${turn.runId}`;
 				expect(liveFrames.map((frame) => frame.data)).toEqual([
@@ -1103,13 +1039,14 @@ describe.skipIf(!RUN)(
 			"returns 503 before Stream creation and completes after real Redis recovers",
 			async () => {
 				await stopEventWriter();
+				if (!redis) throw new Error("Redis test server is not running");
 				const pause = Bun.spawn(
 					[
 						"redis-cli",
 						"-h",
 						"127.0.0.1",
 						"-p",
-						String(redisPort),
+						String(redis.port),
 						"CLIENT",
 						"PAUSE",
 						"1500",
@@ -1137,7 +1074,7 @@ describe.skipIf(!RUN)(
 				});
 				expect(replay.status).toBe(200);
 				expect(
-					parseSSE(await replay.text()).map((frame) => frame.data.type),
+					parseAgUiSse(await replay.text()).map((frame) => frame.data.type),
 				).toEqual([
 					"RUN_STARTED",
 					"TEXT_MESSAGE_START",
@@ -1259,7 +1196,7 @@ describe.skipIf(!RUN)(
 				});
 				expect(replay.status).toBe(200);
 				expect(
-					parseSSE(await replay.text()).map((frame) => frame.data.type),
+					parseAgUiSse(await replay.text()).map((frame) => frame.data.type),
 				).toEqual([
 					"RUN_STARTED",
 					"TEXT_MESSAGE_START",
@@ -1307,7 +1244,7 @@ describe.skipIf(!RUN)(
 					signal: AbortSignal.timeout(TURN_TIMEOUT_MS),
 				});
 				expect(resumed.status).toBe(200);
-				const resumedFrames = parseSSE(await resumed.text());
+				const resumedFrames = parseAgUiSse(await resumed.text());
 				expect(resumedFrames.map((frame) => frame.data.type)).toEqual([
 					"RUN_STARTED",
 					"TEXT_MESSAGE_START",
@@ -1364,7 +1301,7 @@ describe.skipIf(!RUN)(
 
 					const response = await turn.response;
 					expect(response.status, cap.label).toBe(200);
-					const partialFrames = parseSSE(await response.text());
+					const partialFrames = parseAgUiSse(await response.text());
 					expect(
 						partialFrames.some((frame) => frame.data.type === "RUN_FINISHED"),
 						cap.label,
@@ -1444,7 +1381,7 @@ describe.skipIf(!RUN)(
 				await stopEventWriter();
 				const staleResponse = await stale.response;
 				expect(staleResponse.status).toBe(200);
-				const staleFrames = parseSSE(await staleResponse.text());
+				const staleFrames = parseAgUiSse(await staleResponse.text());
 				expect(
 					staleFrames.some((frame) => frame.data.type === "RUN_ERROR"),
 				).toBe(false);

--- a/e2e/relay-failure-matrix.integration.test.ts
+++ b/e2e/relay-failure-matrix.integration.test.ts
@@ -1,0 +1,669 @@
+/**
+ * ADR-0014 cross-service verification matrix.
+ *
+ * The production worker RunLoop and chat-api routes share one PGlite database
+ * while separate relay instances communicate through a disposable real Redis.
+ * Tests observe only HTTP/SSE, durable Conversation history, and Run state.
+ */
+
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	describe,
+	expect,
+	it,
+	setDefaultTimeout,
+} from "bun:test";
+import type { WorkerLogger } from "../apps/agent-worker/src/logger";
+import { RunLoop, type RunProcessor } from "../apps/agent-worker/src/run-loop";
+import { Worker } from "../apps/agent-worker/src/worker";
+import type { ApiConfig } from "../apps/chat-api/src/config/env";
+import type { AppDeps } from "../apps/chat-api/src/deps";
+import { PostgresConversationHistoryStore } from "../apps/chat-api/src/features/conversation-history";
+import { PostgresConversationStore } from "../apps/chat-api/src/features/conversation-store";
+import { PostgresRunStore } from "../apps/chat-api/src/features/run-store";
+import {
+	conversationRuntime,
+	conversations,
+	runs,
+} from "../packages/agent-db/src/schema";
+import {
+	createTestDatabase,
+	type TestDb,
+} from "../packages/agent-db/src/testing";
+import {
+	createRedisLiveStreamRelay,
+	disabledLiveStreamTelemetry,
+	type LiveStreamRelay,
+	type LiveStreamRelayOptions,
+	type LiveStreamTelemetry,
+} from "../packages/live-text/src";
+import {
+	findFreePort,
+	type RedisTestServer,
+	startRedisTestServer,
+} from "../test-support/redis-test-server";
+import { parseAgUiSse } from "./ag-ui-sse";
+
+setDefaultTimeout(20_000);
+
+const MEMBER_CODE = "relay-matrix-member";
+const IDENTITY_HEADERS = {
+	"x-member-code": MEMBER_CODE,
+	"x-partner-code": "relay-matrix-partner",
+};
+const silentLogger: WorkerLogger = { info() {}, warn() {}, error() {} };
+
+type TestApp = ReturnType<
+	typeof import("../apps/chat-api/src/app")["createApp"]
+>;
+
+let testDatabase: TestDb;
+let redis: RedisTestServer;
+let createApp: typeof import("../apps/chat-api/src/app")["createApp"];
+const openRelays = new Set<LiveStreamRelay>();
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+	let resolve!: () => void;
+	const promise = new Promise<void>((done) => {
+		resolve = done;
+	});
+	return { promise, resolve };
+}
+
+function telemetryProbe(
+	operation: Parameters<LiveStreamTelemetry["record"]>[0],
+	result: Parameters<LiveStreamTelemetry["record"]>[1],
+): {
+	telemetry: LiveStreamTelemetry;
+	observed: Promise<void>;
+} {
+	const firstObservation = deferred();
+	return {
+		telemetry: {
+			record(seenOperation, seenResult) {
+				if (seenOperation !== operation || seenResult !== result) return;
+				firstObservation.resolve();
+			},
+		},
+		observed: firstObservation.promise,
+	};
+}
+
+function combineTelemetry(
+	...telemetry: LiveStreamTelemetry[]
+): LiveStreamTelemetry {
+	return {
+		record(operation, result, options) {
+			for (const sink of telemetry) sink.record(operation, result, options);
+		},
+	};
+}
+
+beforeAll(async () => {
+	redis = await startRedisTestServer();
+	testDatabase = await createTestDatabase();
+	({ createApp } = await import("../apps/chat-api/src/app"));
+});
+
+afterEach(async () => {
+	await Promise.allSettled([...openRelays].map((relay) => relay.close()));
+	openRelays.clear();
+	await testDatabase.db.delete(runs);
+	await testDatabase.db.delete(conversationRuntime);
+	await testDatabase.db.delete(conversations);
+});
+
+afterAll(async () => {
+	await testDatabase.close();
+	await redis.stop();
+});
+
+function createRelay(
+	options: LiveStreamRelayOptions & {
+		testClientName?: string;
+		url?: string;
+	} = {},
+): LiveStreamRelay {
+	const { url = redis.url, ...relayOptions } = options;
+	const relay = createRedisLiveStreamRelay({
+		url,
+		deployment: "issue-370",
+		operationTimeoutMs: 150,
+		backlogWaitMs: 50,
+		...relayOptions,
+	});
+	openRelays.add(relay);
+	return relay;
+}
+
+async function killRedisClientsByNamePrefix(prefix: string): Promise<void> {
+	const listing = Bun.spawn(
+		[
+			"redis-cli",
+			"-h",
+			"127.0.0.1",
+			"-p",
+			String(redis.port),
+			"CLIENT",
+			"LIST",
+		],
+		{ stdout: "pipe", stderr: "pipe" },
+	);
+	const output = await new Response(listing.stdout).text();
+	if ((await listing.exited) !== 0) {
+		throw new Error("failed to list Redis clients for crash injection");
+	}
+	const clientIds = output
+		.split("\n")
+		.filter((line) =>
+			line
+				.split(" ")
+				.some(
+					(field) =>
+						field === `name=${prefix}:publisher` ||
+						field === `name=${prefix}:subscriber`,
+				),
+		)
+		.map((line) => line.match(/(?:^| )id=(\d+)(?: |$)/)?.[1])
+		.filter((id): id is string => id !== undefined);
+	if (clientIds.length < 2) {
+		throw new Error("producer Redis connections were not both observable");
+	}
+	for (const clientId of clientIds) {
+		const killing = Bun.spawn(
+			[
+				"redis-cli",
+				"-h",
+				"127.0.0.1",
+				"-p",
+				String(redis.port),
+				"CLIENT",
+				"KILL",
+				"ID",
+				clientId,
+			],
+			{ stdout: "ignore", stderr: "ignore" },
+		);
+		if ((await killing.exited) !== 0) {
+			throw new Error(`failed to kill producer Redis client ${clientId}`);
+		}
+	}
+}
+
+function buildApp(
+	liveStreamRelay: LiveStreamRelay,
+	liveStreamTelemetry: LiveStreamTelemetry = disabledLiveStreamTelemetry,
+): TestApp {
+	const conversationStore = new PostgresConversationStore(testDatabase.db);
+	const deps: AppDeps = {
+		config: {} as ApiConfig,
+		artifactMetadataStore: {
+			async listCurrent() {
+				return [];
+			},
+			async getCurrent() {
+				return null;
+			},
+		},
+		artifactDownloadSigner: {
+			async createDownloadUrl() {
+				throw new Error("artifact signing is outside this integration seam");
+			},
+		},
+		conversationStore,
+		conversationHistoryStore: new PostgresConversationHistoryStore(
+			testDatabase.db,
+		),
+		runStore: new PostgresRunStore(testDatabase.db),
+		liveStreamRelay,
+		liveStreamTelemetry,
+		closeLiveResources: () => liveStreamRelay.close(),
+		exposureGate: {
+			async isAgentEnabled() {
+				return true;
+			},
+		},
+	};
+	return createApp({ logLevel: "silent" } as ApiConfig, deps);
+}
+
+function buildLoop(
+	processor: RunProcessor,
+	liveStreamRelay: LiveStreamRelay,
+	workerId = `worker-${crypto.randomUUID()}`,
+): { loop: RunLoop; worker: Worker } {
+	const worker = new Worker({
+		workerId,
+		maxConcurrentRuns: 1,
+		shutdownTimeoutMs: 1_000,
+		logger: silentLogger,
+	});
+	return {
+		worker,
+		loop: new RunLoop({
+			db: testDatabase.db,
+			worker,
+			processor,
+			liveStreamRelay,
+			heartbeatIntervalMs: 15_000,
+			logger: silentLogger,
+		}),
+	};
+}
+
+async function admitRun(message: string): Promise<{
+	conversationId: string;
+	runId: string;
+}> {
+	const conversationId = crypto.randomUUID();
+	const runId = crypto.randomUUID();
+	await new PostgresConversationStore(testDatabase.db).create({
+		userId: MEMBER_CODE,
+		conversationId,
+		scope: "general",
+	});
+	await new PostgresRunStore(testDatabase.db).admitRun({
+		conversation: { userId: MEMBER_CODE, conversationId },
+		runId,
+		messageId: `user-${runId}`,
+		message,
+	});
+	return { conversationId, runId };
+}
+
+function eventsUrl(conversationId: string, runId: string): string {
+	return `/v1/conversations/${conversationId}/runs/${runId}/events`;
+}
+
+interface SseFrame {
+	type: string;
+	[key: string]: unknown;
+}
+
+function parseSse(body: string): SseFrame[] {
+	return parseAgUiSse(body).map(({ data }) => data as SseFrame);
+}
+
+async function readRun(runId: string) {
+	return testDatabase.db.query.runs.findFirst({
+		where: (table, operators) => operators.eq(table.runId, runId),
+	});
+}
+
+interface HistoryRun {
+	runId: string;
+	messages: Array<{ id: string; role: string; content: string }>;
+	terminalEvent: SseFrame | null;
+}
+
+async function readHistory(
+	app: TestApp,
+	conversationId: string,
+): Promise<HistoryRun[]> {
+	const response = await app.request(
+		`/v1/conversations/${conversationId}/history`,
+		{ headers: IDENTITY_HEADERS },
+	);
+	expect(response.status).toBe(200);
+	return ((await response.json()) as { runs: HistoryRun[] }).runs;
+}
+
+function requiredHistoryRun(history: HistoryRun[], runId: string): HistoryRun {
+	const run = history.find((candidate) => candidate.runId === runId);
+	if (!run) throw new Error(`Conversation history omitted Run ${runId}`);
+	return run;
+}
+
+function textResponse(runId: string): { messageId: string; text: string } {
+	return {
+		messageId: `assistant-${runId}`,
+		text: `Durable response for ${runId}`,
+	};
+}
+
+function expectedTextHistoryMessages(
+	runId: string,
+	userContent: string,
+): Array<{ role: string; content: string }> {
+	const response = textResponse(runId);
+	return [
+		{ role: "user", content: userContent },
+		{
+			role: "assistant",
+			content: response.text,
+		},
+	];
+}
+
+function historyMessageContent(
+	run: HistoryRun,
+): Array<{ role: string; content: string }> {
+	return run.messages.map(({ role, content }) => ({ role, content }));
+}
+
+async function expectHistoryRecovery(response: Response): Promise<void> {
+	expect(response.status).toBe(410);
+	expect(await response.json()).toEqual({
+		error: "Live stream unavailable",
+		recovery: "history",
+	});
+}
+
+const completeTextProcessor: RunProcessor = async (ctx) => {
+	const { messageId, text } = textResponse(ctx.run.runId);
+	await ctx.appendLiveEvent({
+		type: "TEXT_MESSAGE_START",
+		messageId,
+		role: "assistant",
+	});
+	await ctx.appendLiveEvent({
+		type: "TEXT_MESSAGE_CONTENT",
+		messageId,
+		delta: text,
+	});
+	await ctx.appendModelContent({
+		kind: "assistant_message",
+		payload: { messageId, text },
+	});
+	await ctx.appendLiveEvent({
+		type: "TEXT_MESSAGE_END",
+		messageId,
+	});
+};
+
+describe("ADR-0014 relay failure matrix", () => {
+	it("streams a queued Run from its first event once the RunLoop claims it", async () => {
+		const queuedAttachRetry = telemetryProbe("attach_attempt", "retry");
+		const readerAttached = telemetryProbe("attach_attempt", "success");
+		const telemetry = combineTelemetry(
+			queuedAttachRetry.telemetry,
+			readerAttached.telemetry,
+		);
+		const consumerRelay = createRelay({ telemetry });
+		const producerRelay = createRelay();
+		const app = buildApp(consumerRelay, telemetry);
+		const { conversationId, runId } = await admitRun("queued attach");
+		const processorStarted = deferred();
+		const continueProcessor = deferred();
+		const { loop, worker } = buildLoop(async (ctx) => {
+			processorStarted.resolve();
+			await continueProcessor.promise;
+			await completeTextProcessor(ctx);
+		}, producerRelay);
+
+		expect((await readRun(runId))?.status).toBe("queued");
+		const responsePromise = app.request(eventsUrl(conversationId, runId), {
+			headers: IDENTITY_HEADERS,
+		});
+
+		await queuedAttachRetry.observed;
+		expect((await readRun(runId))?.status).toBe("queued");
+		expect(await loop.tick()).toBe(1);
+		await processorStarted.promise;
+		await readerAttached.observed;
+		continueProcessor.resolve();
+		await worker.drain();
+		const response = await responsePromise;
+
+		expect(response.status).toBe(200);
+		expect(parseSse(await response.text()).map((frame) => frame.type)).toEqual([
+			"RUN_STARTED",
+			"TEXT_MESSAGE_START",
+			"TEXT_MESSAGE_CONTENT",
+			"TEXT_MESSAGE_END",
+			"RUN_FINISHED",
+		]);
+	});
+
+	it("recovers producer death through stale-Run recovery and Conversation history without fabricating a live Outcome", async () => {
+		const readerAttached = telemetryProbe("attach_attempt", "success");
+		const consumerRelay = createRelay({ telemetry: readerAttached.telemetry });
+		const producerClientName = `issue-370-producer-${crypto.randomUUID()}`;
+		const producerRelay = createRelay({
+			testClientName: producerClientName,
+		});
+		const app = buildApp(consumerRelay, readerAttached.telemetry);
+		const { conversationId, runId } = await admitRun("producer death");
+		const processorStarted = deferred();
+		const releaseCrashedProcessor = deferred();
+		const crashed = buildLoop(
+			async (ctx) => {
+				await ctx.appendLiveEvent({
+					type: "TEXT_MESSAGE_START",
+					messageId: `assistant-${runId}`,
+					role: "assistant",
+				});
+				processorStarted.resolve();
+				await releaseCrashedProcessor.promise;
+			},
+			producerRelay,
+			"crashed-worker",
+		);
+
+		expect(await crashed.loop.tick()).toBe(1);
+		await processorStarted.promise;
+
+		// Intentionally no client timeout: silent producer death must converge
+		// through durable recovery, or the test itself must time out and fail.
+		const responsePromise = app.request(eventsUrl(conversationId, runId), {
+			headers: IDENTITY_HEADERS,
+		});
+		await readerAttached.observed;
+		await killRedisClientsByNamePrefix(producerClientName);
+		// This root-level test uses the underlying PGlite client to avoid importing
+		// a second Drizzle instance; keep the simulated lease expiry Run-scoped.
+		await testDatabase.db.$client.query(
+			"update runs set locked_until = $1 where run_id = $2",
+			[new Date(0), runId],
+		);
+		const recovery = buildLoop(
+			async () => {},
+			createRelay(),
+			"recovery-worker",
+		);
+		expect(await recovery.loop.tick()).toBe(0);
+
+		const response = await responsePromise;
+		expect(response.status).toBe(200);
+		expect(parseSse(await response.text()).map((frame) => frame.type)).toEqual([
+			"RUN_STARTED",
+			"TEXT_MESSAGE_START",
+		]);
+		const reconnect = await app.request(eventsUrl(conversationId, runId), {
+			headers: IDENTITY_HEADERS,
+		});
+		await expectHistoryRecovery(reconnect);
+		const historyRun = requiredHistoryRun(
+			await readHistory(app, conversationId),
+			runId,
+		);
+		expect(historyRun.terminalEvent?.type).toBe("RUN_ERROR");
+		expect(historyMessageContent(historyRun)).toEqual([
+			{ role: "user", content: "producer death" },
+		]);
+
+		releaseCrashedProcessor.resolve();
+		await crashed.worker.drain();
+	});
+
+	it("serves history when attach pauses before its backlog request across terminal close", async () => {
+		const liveSubscribed = deferred();
+		const continueAttach = deferred();
+		const consumerRelay = createRelay({
+			testHooks: {
+				async afterLiveSubscribed() {
+					liveSubscribed.resolve();
+					await continueAttach.promise;
+				},
+			},
+		});
+		const producerRelay = createRelay();
+		const app = buildApp(consumerRelay);
+		const { conversationId, runId } = await admitRun("terminal attach race");
+		const processorStarted = deferred();
+		const continueProcessor = deferred();
+		const { loop, worker } = buildLoop(async (ctx) => {
+			processorStarted.resolve();
+			await continueProcessor.promise;
+			await completeTextProcessor(ctx);
+		}, producerRelay);
+
+		expect(await loop.tick()).toBe(1);
+		await processorStarted.promise;
+		const responsePromise = app.request(eventsUrl(conversationId, runId), {
+			headers: IDENTITY_HEADERS,
+			signal: AbortSignal.timeout(3_000),
+		});
+		await liveSubscribed.promise;
+		continueProcessor.resolve();
+		await worker.drain();
+		continueAttach.resolve();
+
+		const response = await responsePromise;
+		await expectHistoryRecovery(response);
+
+		const historyRun = requiredHistoryRun(
+			await readHistory(app, conversationId),
+			runId,
+		);
+		expect(historyRun.terminalEvent?.type).toBe("RUN_FINISHED");
+	});
+
+	it("streams the live terminal when backlog reply wins the terminal close race", async () => {
+		const backlogRequested = deferred();
+		const continueBacklogReply = deferred();
+		const terminalPublished = deferred();
+		const consumerRelay = createRelay();
+		const producerRelay = createRelay({
+			testHooks: {
+				afterEventPublished({ terminal }) {
+					if (terminal) terminalPublished.resolve();
+				},
+				async beforeBacklogReply() {
+					backlogRequested.resolve();
+					await continueBacklogReply.promise;
+				},
+			},
+		});
+		const app = buildApp(consumerRelay);
+		const { conversationId, runId } = await admitRun("live terminal race");
+		const processorStarted = deferred();
+		const continueProcessor = deferred();
+		const { loop, worker } = buildLoop(async (ctx) => {
+			processorStarted.resolve();
+			await continueProcessor.promise;
+			await completeTextProcessor(ctx);
+		}, producerRelay);
+
+		expect(await loop.tick()).toBe(1);
+		await processorStarted.promise;
+		const responsePromise = app.request(eventsUrl(conversationId, runId), {
+			headers: IDENTITY_HEADERS,
+			signal: AbortSignal.timeout(3_000),
+		});
+		await backlogRequested.promise;
+		continueProcessor.resolve();
+		await terminalPublished.promise;
+		continueBacklogReply.resolve();
+		await worker.drain();
+
+		const response = await responsePromise;
+		expect(response.status).toBe(200);
+		expect(parseSse(await response.text()).map((frame) => frame.type)).toEqual([
+			"RUN_STARTED",
+			"TEXT_MESSAGE_START",
+			"TEXT_MESSAGE_CONTENT",
+			"TEXT_MESSAGE_END",
+			"RUN_FINISHED",
+		]);
+	});
+
+	it("degrades only live delivery when the real producer buffer cap overflows", async () => {
+		const readerAttached = telemetryProbe("attach_attempt", "success");
+		const consumerRelay = createRelay({ telemetry: readerAttached.telemetry });
+		const producerRelay = createRelay({ testLimits: { maxEvents: 2 } });
+		const app = buildApp(consumerRelay, readerAttached.telemetry);
+		const { conversationId, runId } = await admitRun("buffer cap overflow");
+		const processorStarted = deferred();
+		const continueProcessor = deferred();
+		const { loop, worker } = buildLoop(async (ctx) => {
+			processorStarted.resolve();
+			await continueProcessor.promise;
+			await completeTextProcessor(ctx);
+		}, producerRelay);
+
+		const responsePromise = app.request(eventsUrl(conversationId, runId), {
+			headers: IDENTITY_HEADERS,
+		});
+		expect(await loop.tick()).toBe(1);
+		await processorStarted.promise;
+		await readerAttached.observed;
+		continueProcessor.resolve();
+		await worker.drain();
+
+		const response = await responsePromise;
+		expect(response.status).toBe(200);
+		const liveTypes = parseSse(await response.text()).map(
+			(frame) => frame.type,
+		);
+		expect(liveTypes).toEqual(["RUN_STARTED", "TEXT_MESSAGE_START"]);
+		expect(await readRun(runId)).toMatchObject({
+			status: "done",
+			liveStreamFailedAt: expect.any(Date),
+		});
+
+		const historyRun = requiredHistoryRun(
+			await readHistory(app, conversationId),
+			runId,
+		);
+		expect(historyMessageContent(historyRun)).toEqual(
+			expectedTextHistoryMessages(runId, "buffer cap overflow"),
+		);
+		expect(historyRun.terminalEvent?.type).toBe("RUN_FINISHED");
+		const recovery = await app.request(eventsUrl(conversationId, runId), {
+			headers: IDENTITY_HEADERS,
+		});
+		await expectHistoryRecovery(recovery);
+	});
+
+	it("executes durably while Redis is unreachable and preserves the 503-to-410 contract", async () => {
+		const unreachableUrl = `redis://127.0.0.1:${await findFreePort()}`;
+		const consumerRelay = createRelay({ url: unreachableUrl });
+		const producerRelay = createRelay({ url: unreachableUrl });
+		const app = buildApp(consumerRelay);
+		const { conversationId, runId } = await admitRun("Redis unavailable");
+
+		const unavailable = await app.request(eventsUrl(conversationId, runId), {
+			headers: IDENTITY_HEADERS,
+			signal: AbortSignal.timeout(3_000),
+		});
+		expect(unavailable.status).toBe(503);
+		expect(await unavailable.json()).toEqual({
+			error: "Live stream temporarily unavailable",
+		});
+
+		const { loop, worker } = buildLoop(completeTextProcessor, producerRelay);
+		expect(await loop.tick()).toBe(1);
+		await worker.drain();
+		expect(await readRun(runId)).toMatchObject({
+			status: "done",
+			liveStreamFailedAt: expect.any(Date),
+		});
+
+		const historyRun = requiredHistoryRun(
+			await readHistory(app, conversationId),
+			runId,
+		);
+		expect(historyMessageContent(historyRun)).toEqual(
+			expectedTextHistoryMessages(runId, "Redis unavailable"),
+		);
+		expect(historyRun.terminalEvent?.type).toBe("RUN_FINISHED");
+
+		const recovery = await app.request(eventsUrl(conversationId, runId), {
+			headers: IDENTITY_HEADERS,
+		});
+		await expectHistoryRecovery(recovery);
+	});
+});

--- a/e2e/synthetic-worker.ts
+++ b/e2e/synthetic-worker.ts
@@ -62,7 +62,8 @@ const redisLiveStreamRelay = createRedisLiveStreamRelay({
 	...(liveStreamFault && liveStreamFault !== "before_creation"
 		? {
 				testHooks: {
-					failEventPublishAtOrdinal: faultOrdinal(liveStreamFault),
+					failEventPublishWhen: ({ eventType, terminal }) =>
+						matchesLiveStreamFault(liveStreamFault, eventType, terminal),
 				},
 			}
 		: {}),
@@ -236,16 +237,18 @@ function parseLiveStreamFault(
 	return isLiveStreamFault(value) ? value : undefined;
 }
 
-function faultOrdinal(
+function matchesLiveStreamFault(
 	fault: Exclude<LiveStreamFault, "before_creation">,
-): number {
+	eventType: string,
+	terminal: boolean,
+): boolean {
 	switch (fault) {
 		case "mid_text":
-			return 2;
+			return eventType === "TEXT_MESSAGE_CONTENT";
 		case "tool":
-			return 4;
+			return eventType === "TOOL_CALL_START";
 		case "terminal":
-			return 8;
+			return terminal;
 	}
 }
 

--- a/packages/live-text/src/live-stream-relay.contract.test.ts
+++ b/packages/live-text/src/live-stream-relay.contract.test.ts
@@ -1,77 +1,25 @@
 import { afterAll, beforeAll, expect, it } from "bun:test";
 import { createServer, type Socket } from "node:net";
 import {
+	type RedisTestServer,
+	startRedisTestServer,
+} from "../../../test-support/redis-test-server";
+import {
 	createInMemoryLiveStreamRelay,
 	createRedisLiveStreamRelay,
 } from "./index";
 import { liveStreamRelayContract } from "./live-stream-relay.contract";
 
-async function waitUntil(
-	condition: () => boolean | Promise<boolean>,
-	timeoutMs = 3_000,
-): Promise<void> {
-	const deadline = Date.now() + timeoutMs;
-	while (!(await condition())) {
-		if (Date.now() >= deadline) throw new Error("condition timed out");
-		await Bun.sleep(20);
-	}
-}
-
-async function freePort(): Promise<number> {
-	return new Promise((resolve, reject) => {
-		const server = createServer();
-		server.once("error", reject);
-		server.listen(0, "127.0.0.1", () => {
-			const address = server.address();
-			if (!address || typeof address === "string") {
-				server.close();
-				reject(new Error("failed to allocate Redis test port"));
-				return;
-			}
-			server.close((error) => (error ? reject(error) : resolve(address.port)));
-		});
-	});
-}
-
-type RedisProcess = ReturnType<typeof Bun.spawn>;
-
-async function startRedis(port: number): Promise<RedisProcess> {
-	const process = Bun.spawn(
-		[
-			"redis-server",
-			"--bind",
-			"127.0.0.1",
-			"--port",
-			String(port),
-			"--save",
-			"",
-			"--appendonly",
-			"no",
-		],
-		{ stdout: "ignore", stderr: "ignore" },
-	);
-	await waitUntil(async () => {
-		const ping = Bun.spawn(
-			["redis-cli", "-h", "127.0.0.1", "-p", String(port), "ping"],
-			{ stdout: "pipe", stderr: "ignore" },
-		);
-		return (await ping.exited) === 0;
-	});
-	return process;
-}
-
-let redisProcess: RedisProcess;
+let redis: RedisTestServer;
 let redisUrl: string;
 
 beforeAll(async () => {
-	const port = await freePort();
-	redisUrl = `redis://127.0.0.1:${port}`;
-	redisProcess = await startRedis(port);
+	redis = await startRedisTestServer();
+	redisUrl = redis.url;
 });
 
 afterAll(async () => {
-	redisProcess.kill("SIGTERM");
-	await redisProcess.exited;
+	await redis.stop();
 });
 
 liveStreamRelayContract("in-memory", {

--- a/packages/live-text/src/live-stream-relay.contract.ts
+++ b/packages/live-text/src/live-stream-relay.contract.ts
@@ -157,7 +157,10 @@ export function liveStreamRelayContract(
 
 		it("latches a failed publish and ends readers with relay failure", async () => {
 			const relay = await factory.create({
-				testHooks: { failEventPublishAtOrdinal: 1 },
+				testHooks: {
+					failEventPublishWhen: ({ eventType }) =>
+						eventType === EventType.TEXT_MESSAGE_CONTENT,
+				},
 			});
 			const reader = new AbortController();
 			try {
@@ -170,22 +173,33 @@ export function liveStreamRelayContract(
 					() => undefined,
 					(error: unknown) => error,
 				);
-				const textEvent = (delta: string) =>
+				await producer.append(
 					event({
-						type: EventType.TEXT_MESSAGE_CONTENT,
+						type: EventType.TEXT_MESSAGE_START,
 						messageId: "message-1",
-						delta,
-					});
-
-				await producer.append(textEvent("first"));
-				await expect(
-					producer.append(textEvent("failed")),
-				).rejects.toMatchObject({ code: "relay_failed" });
-				await expect(producer.append(textEvent("later"))).rejects.toMatchObject(
-					{
-						code: "producer_failed",
-					},
+						role: "assistant",
+					}),
 				);
+				await expect(
+					producer.append(
+						event({
+							type: EventType.TEXT_MESSAGE_CONTENT,
+							messageId: "message-1",
+							delta: "failed",
+						}),
+					),
+				).rejects.toMatchObject({ code: "relay_failed" });
+				await expect(
+					producer.append(
+						event({
+							type: EventType.TEXT_MESSAGE_CONTENT,
+							messageId: "message-1",
+							delta: "later",
+						}),
+					),
+				).rejects.toMatchObject({
+					code: "producer_failed",
+				});
 				expect(await readerFailure).toMatchObject({
 					code: "relay_failed",
 				});

--- a/packages/live-text/src/live-stream-relay.ts
+++ b/packages/live-text/src/live-stream-relay.ts
@@ -6,6 +6,7 @@ import {
 	LIVE_STREAM_MAX_BYTES,
 	LIVE_STREAM_MAX_EVENT_BYTES,
 	LIVE_STREAM_MAX_EVENTS,
+	type LiveStreamEvent,
 	LiveStreamStoreError,
 	RUN_CANCELLED_EVENT_TYPE,
 } from "./live-stream-events";
@@ -31,10 +32,17 @@ export interface LiveStreamRelayOptions {
 		maxEvents?: number;
 	};
 	testHooks?: {
+		afterEventPublished?: (context: {
+			eventType: LiveStreamEvent["type"];
+			terminal: boolean;
+		}) => void;
 		afterLiveEventBuffered?: (ordinal: number) => void;
 		afterLiveSubscribed?: () => Promise<void>;
 		beforeBacklogReply?: () => Promise<void>;
-		failEventPublishAtOrdinal?: number;
+		failEventPublishWhen?: (context: {
+			eventType: LiveStreamEvent["type"];
+			terminal: boolean;
+		}) => boolean;
 	};
 }
 
@@ -481,7 +489,12 @@ class BufferedLiveStreamProducer implements LiveStreamProducer {
 			this.#events.push(serialized);
 			this.#bufferBytes += event.byteLength;
 			try {
-				if (this.#testHooks?.failEventPublishAtOrdinal === envelope.ordinal) {
+				if (
+					this.#testHooks?.failEventPublishWhen?.({
+						eventType: parsed.type,
+						terminal,
+					})
+				) {
 					throw new Error("injected Live Stream publish failure");
 				}
 				await this.#transport.publish(
@@ -490,6 +503,10 @@ class BufferedLiveStreamProducer implements LiveStreamProducer {
 				);
 				recordTelemetry(this.#telemetry, "publish", "success");
 				if (terminal) this.#terminalPublished = true;
+				this.#testHooks?.afterEventPublished?.({
+					eventType: parsed.type,
+					terminal,
+				});
 			} catch (error) {
 				recordTelemetry(this.#telemetry, "publish", "failure", {
 					reason: classifyLiveStreamFailure(error),

--- a/packages/live-text/src/redis-live-stream-relay.ts
+++ b/packages/live-text/src/redis-live-stream-relay.ts
@@ -21,10 +21,13 @@ export interface RedisLiveStreamRelayOptions extends LiveStreamRelayOptions {
 	deployment: string;
 	/** Bounds each Redis connect/command so Live Stream failure cannot stall a Run. */
 	operationTimeoutMs?: number;
+	/** Names this relay's Redis connections for process-death integration tests. */
+	testClientName?: string;
 }
 
 class RedisRelayTransport implements LiveStreamRelayTransport {
 	readonly #url: string;
+	readonly #clientName: string | undefined;
 	readonly #publisher: RedisClient;
 	readonly #failurePublishers = new Set<RedisClient>();
 	readonly #failurePublishes = new Set<Promise<void>>();
@@ -33,11 +36,17 @@ class RedisRelayTransport implements LiveStreamRelayTransport {
 	#connecting: Promise<void> | undefined;
 	#closed = false;
 
-	constructor(url: string, operationTimeoutMs: number) {
+	constructor(
+		url: string,
+		operationTimeoutMs: number,
+		clientName: string | undefined,
+	) {
 		this.#url = url;
+		this.#clientName = clientName;
 		this.#operationTimeoutMs = operationTimeoutMs;
 		this.#publisher = createClient({
 			url,
+			...(clientName ? { name: `${clientName}:publisher` } : {}),
 			socket: {
 				connectTimeout: operationTimeoutMs,
 				reconnectStrategy: false,
@@ -62,6 +71,9 @@ class RedisRelayTransport implements LiveStreamRelayTransport {
 		this.#assertOpen();
 		const publisher = createClient({
 			url: this.#url,
+			...(this.#clientName
+				? { name: `${this.#clientName}:failure-publisher` }
+				: {}),
 			socket: {
 				connectTimeout: FAILURE_PUBLISH_TIMEOUT_MS,
 				reconnectStrategy: false,
@@ -101,6 +113,7 @@ class RedisRelayTransport implements LiveStreamRelayTransport {
 		this.#assertOpen();
 		const subscriber = createClient({
 			url: this.#url,
+			...(this.#clientName ? { name: `${this.#clientName}:subscriber` } : {}),
 			socket: {
 				connectTimeout: this.#operationTimeoutMs,
 				reconnectStrategy: false,
@@ -174,7 +187,11 @@ export function createRedisLiveStreamRelay(
 		"operationTimeoutMs",
 	);
 	return new ProducerBufferedLiveStreamRelay(
-		new RedisRelayTransport(options.url, operationTimeoutMs),
+		new RedisRelayTransport(
+			options.url,
+			operationTimeoutMs,
+			options.testClientName,
+		),
 		`${options.deployment}:mymemo:agui`,
 		options,
 	);

--- a/packages/live-text/src/redis-live-stream-store.contract.test.ts
+++ b/packages/live-text/src/redis-live-stream-store.contract.test.ts
@@ -1,5 +1,4 @@
 import { expect, it } from "bun:test";
-import { createServer } from "node:net";
 import {
 	EventSchemas,
 	EventType,
@@ -7,6 +6,11 @@ import {
 } from "@ag-ui/core";
 import type { ResumableStreamEntry } from "assistant-stream/resumable";
 import { createClient } from "redis";
+import {
+	findFreePort as freePort,
+	type RedisTestServer,
+	startRedisTestServer,
+} from "../../../test-support/redis-test-server";
 import {
 	createRedisLiveStreamStore,
 	encodeAgUiLiveStreamEvent,
@@ -22,68 +26,15 @@ import {
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
-async function waitUntil(
-	condition: () => boolean | Promise<boolean>,
-	timeoutMs = 3_000,
-): Promise<void> {
-	const deadline = Date.now() + timeoutMs;
-	while (!(await condition())) {
-		if (Date.now() >= deadline) throw new Error("condition timed out");
-		await Bun.sleep(20);
-	}
-}
-
-async function freePort(): Promise<number> {
-	return new Promise((resolve, reject) => {
-		const server = createServer();
-		server.once("error", reject);
-		server.listen(0, "127.0.0.1", () => {
-			const address = server.address();
-			if (!address || typeof address === "string") {
-				server.close();
-				reject(new Error("failed to allocate Redis test port"));
-				return;
-			}
-			server.close((error) => (error ? reject(error) : resolve(address.port)));
-		});
-	});
-}
-
-type RedisProcess = ReturnType<typeof Bun.spawn>;
-
 async function startRedis(
 	port: number,
 	password?: string,
-): Promise<RedisProcess> {
-	const serverArguments = [
-		"redis-server",
-		"--bind",
-		"127.0.0.1",
-		"--port",
-		String(port),
-		"--save",
-		"",
-		"--appendonly",
-		"no",
-	];
-	if (password) serverArguments.push("--requirepass", password);
-	const process = Bun.spawn(serverArguments, {
-		stdout: "ignore",
-		stderr: "ignore",
-	});
-	await waitUntil(async () => {
-		const pingArguments = ["redis-cli", "-h", "127.0.0.1", "-p", String(port)];
-		if (password) pingArguments.push("-a", password);
-		pingArguments.push("ping");
-		const ping = Bun.spawn(pingArguments, { stdout: "pipe", stderr: "ignore" });
-		return (await ping.exited) === 0;
-	});
-	return process;
+): Promise<RedisTestServer> {
+	return startRedisTestServer({ port, password });
 }
 
-async function stopRedis(process: RedisProcess): Promise<void> {
-	process.kill("SIGTERM");
-	await process.exited;
+async function stopRedis(server: RedisTestServer): Promise<void> {
+	await server.stop();
 }
 
 async function collect(

--- a/scripts/deploy-config.test.ts
+++ b/scripts/deploy-config.test.ts
@@ -45,6 +45,10 @@ const redisContractTest = readFileSync(
 	),
 	"utf8",
 );
+const redisTestServer = readFileSync(
+	join(root, "test-support", "redis-test-server.ts"),
+	"utf8",
+);
 const createAgentSecretsScript = readFileSync(
 	join(root, "scripts", "deploy", "create_agent_secrets.sh"),
 	"utf8",
@@ -289,7 +293,10 @@ describe("agent deployment config", () => {
 		expect(composeConfig).not.toMatch(/redis-data|redisdata/);
 		expect(ciWorkflow).toContain("redis-server");
 		expect(ciWorkflow).toContain("bun run test");
-		expect(redisContractTest).toContain('"redis-server"');
+		expect(redisContractTest).toContain(
+			'from "../../../test-support/redis-test-server"',
+		);
+		expect(redisTestServer).toContain('"redis-server"');
 	});
 
 	it("documents the Downloadable artifact operator and downstream contracts", () => {

--- a/test-support/redis-test-server.ts
+++ b/test-support/redis-test-server.ts
@@ -1,0 +1,84 @@
+import { createServer } from "node:net";
+
+export interface RedisTestServer {
+	port: number;
+	url: string;
+	stop(): Promise<void>;
+}
+
+interface RedisTestServerOptions {
+	password?: string;
+	port?: number;
+	stdio?: "ignore" | "inherit";
+}
+
+export async function findFreePort(): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const server = createServer();
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			const address = server.address();
+			if (!address || typeof address === "string") {
+				server.close();
+				reject(new Error("failed to allocate test fixture port"));
+				return;
+			}
+			server.close((error) => (error ? reject(error) : resolve(address.port)));
+		});
+	});
+}
+
+export async function startRedisTestServer(
+	options: RedisTestServerOptions = {},
+): Promise<RedisTestServer> {
+	const port = options.port ?? (await findFreePort());
+	const serverArguments = [
+		"redis-server",
+		"--bind",
+		"127.0.0.1",
+		"--port",
+		String(port),
+		"--save",
+		"",
+		"--appendonly",
+		"no",
+	];
+	if (options.password) {
+		serverArguments.push("--requirepass", options.password);
+	}
+	const stdio = options.stdio ?? "ignore";
+	const process = Bun.spawn(serverArguments, {
+		stdout: stdio,
+		stderr: stdio,
+	});
+	const deadline = Date.now() + 10_000;
+	while (Date.now() < deadline) {
+		const pingArguments = ["redis-cli", "-h", "127.0.0.1", "-p", String(port)];
+		if (options.password) pingArguments.push("-a", options.password);
+		pingArguments.push("ping");
+		const ping = Bun.spawn(pingArguments, {
+			stdout: "ignore",
+			stderr: "ignore",
+		});
+		if ((await ping.exited) === 0) {
+			let stopped = false;
+			const authority = options.password
+				? `:${encodeURIComponent(options.password)}@127.0.0.1`
+				: "127.0.0.1";
+			return {
+				port,
+				url: `redis://${authority}:${port}`,
+				async stop() {
+					if (stopped) return;
+					stopped = true;
+					process.kill("SIGTERM");
+					await process.exited;
+				},
+			};
+		}
+		await Bun.sleep(50);
+	}
+	process.kill("SIGTERM");
+	await process.exited;
+	throw new Error("Redis did not become ready");
+}


### PR DESCRIPTION
## Summary

- exercise the production RunLoop and chat-api attach route against one PGlite database and disposable real Redis
- deterministically cover queued attachment, attached-reader producer death, both terminal attach-race outcomes, buffer-cap overflow, and Redis unavailability
- stop attached API streams when durable Run state proves that Conversation-history recovery is required
- share the Redis lifecycle and cursor-rejecting SSE parser, and use semantic event-type/terminal failure hooks instead of ordinals
- run the PGlite/Redis matrix in the general test job; reserve the Postgres integration job for the real-Postgres suite

## Why

ADR-0014 makes worker memory the active Live Stream backlog and Postgres the durable recovery plane. Issue #370 requires deterministic cross-service proof that relay failure affects only live delivery, never durable Run execution or Conversation-history recovery.

A producer can disappear without publishing a relay-failure notification. The API therefore checks durable Run state at the existing keepalive cadence while a reader is attached and closes the incomplete live response once the Run is terminal or marked degraded, allowing the next attach to recover from history.

## Impact

- attached live responses now converge after silent producer death instead of waiting indefinitely on an otherwise healthy Redis subscription
- no database schema, authorization, admission, durable Run-processing, or public recovery contract changes
- Redis client naming and relay lifecycle hooks are opt-in and used only by deterministic integration tests

## Validation

- `bun run test`: 788 passed, 0 failed
- affected relay, chat-api route, and matrix suites: 90 passed, 0 failed
- ADR-0014 real-Redis failure matrix: 6 passed, 0 failed
- strict TypeScript checks passed for live-text, agent-worker, and chat-api
- standalone synthetic worker bundle passed
- Biome and `git diff --check` passed

Closes #370