### PR TITLE
feat(run): bound SDK interruption and reconcile supervisor outcomes

### DIFF
--- a/apps/agent-worker/src/artifacts/artifact-publication.test.ts
+++ b/apps/agent-worker/src/artifacts/artifact-publication.test.ts
@@ -107,6 +107,7 @@ async function readStream(
 
 function successfulQuery(onStart: () => void): SupervisedQuery {
 	return {
+		close() {},
 		async interrupt() {},
 		async *[Symbol.asyncIterator]() {
 			onStart();
@@ -123,6 +124,7 @@ function successfulQuery(onStart: () => void): SupervisedQuery {
 
 function failedQuery(onStart: () => void, error: Error): SupervisedQuery {
 	return {
+		close() {},
 		async interrupt() {},
 		// biome-ignore lint/correctness/useYield: the fixture fails before producing an SDK message.
 		async *[Symbol.asyncIterator]() {

--- a/apps/agent-worker/src/artifacts/artifact-publication.ts
+++ b/apps/agent-worker/src/artifacts/artifact-publication.ts
@@ -202,6 +202,8 @@ export function withArtifactPublication(
 	let publication: ArtifactPublication | null = null;
 	return {
 		interrupt: () => query.interrupt(),
+		close: () => query.close(),
+		...(query.stopSignal ? { stopSignal: query.stopSignal } : {}),
 		getArtifactPublication: () => publication,
 		async *[Symbol.asyncIterator]() {
 			for await (const message of query) yield message;

--- a/apps/agent-worker/src/artifacts/artifact-publication.ts
+++ b/apps/agent-worker/src/artifacts/artifact-publication.ts
@@ -203,7 +203,9 @@ export function withArtifactPublication(
 	return {
 		interrupt: () => query.interrupt(),
 		close: () => query.close(),
-		...(query.stopSignal ? { stopSignal: query.stopSignal } : {}),
+		...(query.forceCloseSignal
+			? { forceCloseSignal: query.forceCloseSignal }
+			: {}),
 		getArtifactPublication: () => publication,
 		async *[Symbol.asyncIterator]() {
 			for await (const message of query) yield message;

--- a/apps/agent-worker/src/run-loop.test.ts
+++ b/apps/agent-worker/src/run-loop.test.ts
@@ -679,6 +679,7 @@ describe("RunLoop — agent session pointer", () => {
 				workerId: "worker-1",
 			});
 			return {
+				disposition: "completed",
 				streamMetadata: {
 					sessionId: "session-abc",
 					mirrorErrorObserved: false,
@@ -706,6 +707,7 @@ describe("RunLoop — agent session pointer", () => {
 				workerId: "worker-1",
 			});
 			return {
+				disposition: "completed",
 				streamMetadata: {
 					sessionId: "session-unreliable",
 					mirrorErrorObserved: true,

--- a/apps/agent-worker/src/run-loop.test.ts
+++ b/apps/agent-worker/src/run-loop.test.ts
@@ -678,7 +678,12 @@ describe("RunLoop — agent session pointer", () => {
 				runId: ctx.run.runId,
 				workerId: "worker-1",
 			});
-			return { agentSession: { sessionId: "session-abc" } };
+			return {
+				streamMetadata: {
+					sessionId: "session-abc",
+					mirrorErrorObserved: false,
+				},
+			};
 		});
 		await queueRun("run-1", "conv-1");
 
@@ -700,8 +705,12 @@ describe("RunLoop — agent session pointer", () => {
 				runId: ctx.run.runId,
 				workerId: "worker-1",
 			});
-			// A mirror_error turn drops the session id → agentSession is null.
-			return { agentSession: null };
+			return {
+				streamMetadata: {
+					sessionId: "session-unreliable",
+					mirrorErrorObserved: true,
+				},
+			};
 		});
 		await queueRun("run-1", "conv-1");
 

--- a/apps/agent-worker/src/run-loop.ts
+++ b/apps/agent-worker/src/run-loop.ts
@@ -53,7 +53,7 @@ export interface TurnStreamMetadata {
 
 export interface TurnResult {
 	/** Cause-blind processor disposition; the supervisor chooses the Outcome. */
-	disposition?: TurnDisposition;
+	disposition: TurnDisposition;
 	/**
 	 * Cause-blind continuity observations from the SDK stream. The supervisor
 	 * alone decides whether the Outcome permits advancing the resume pointer.

--- a/apps/agent-worker/src/run-loop.ts
+++ b/apps/agent-worker/src/run-loop.ts
@@ -44,22 +44,28 @@ import type { Worker } from "./worker";
  * need no end-of-turn handling (ADR-0007): the sandbox idle-pauses once the
  * turn stops renewing it, and the paused sandbox *is* the persisted workspace.
  */
+export type TurnDisposition = "completed" | "stopped";
+
+export interface TurnStreamMetadata {
+	sessionId: string | null;
+	mirrorErrorObserved: boolean;
+}
+
 export interface TurnResult {
+	/** Cause-blind processor disposition; the supervisor chooses the Outcome. */
+	disposition?: TurnDisposition;
 	/**
-	 * The agent session to record as the conversation's resume pointer once the
-	 * turn terminalizes `done` (ADR-0005). Present only when the SDK produced a
-	 * session id AND no `mirror_error` made the mirrored transcript unreliable —
-	 * a dropped-mirror turn omits it, so the pointer does not advance yet the run
-	 * still succeeds. Absent for synthetic turns that ran no query.
+	 * Cause-blind continuity observations from the SDK stream. The supervisor
+	 * alone decides whether the Outcome permits advancing the resume pointer.
 	 */
-	agentSession?: { sessionId: string } | null;
+	streamMetadata?: TurnStreamMetadata;
 	/** Changed files already ledgered and uploaded under fresh private keys. */
 	artifactPublication?: { artifacts: PublishedArtifact[] } | null;
 }
 
 /** A processor that reports nothing is normalized to a turn with no session
  * pointer to advance (the Milestone 3 synthetic turn). */
-const EMPTY_TURN: TurnResult = {};
+const EMPTY_TURN: TurnResult = { disposition: "completed" };
 
 /**
  * One piece of canonical durable model content a processor can record while
@@ -94,6 +100,9 @@ const MODEL_CONTENT_EVENT_TYPES = {
 export interface RunProcessContext {
 	run: RunRecord;
 	signal: AbortSignal;
+	/** Fires only when the ownership fence is lost. Unlike a normal stop, this
+	 * permits no post-fence drain and must close private SDK resources now. */
+	ownershipLostSignal: AbortSignal;
 	appendModelContent(content: ModelContent): Promise<void>;
 	/** Atomically append an ordered group of model events under one Run fence. */
 	appendModelContents(contents: readonly ModelContent[]): Promise<void>;
@@ -142,6 +151,7 @@ interface RunEndState {
 
 interface ActiveEntry {
 	controller: AbortController;
+	ownershipLostController: AbortController;
 	state: RunEndState;
 	liveStream?: RunLiveStream;
 }
@@ -354,6 +364,7 @@ export class RunLoop {
 				// terminal transition.
 				this.activeRuns.delete(runId);
 				entry.state.lostOwnership = true;
+				entry.ownershipLostController.abort();
 				entry.controller.abort();
 				continue;
 			}
@@ -373,6 +384,7 @@ export class RunLoop {
 			if (!run) break;
 			const entry: ActiveEntry = {
 				controller: new AbortController(),
+				ownershipLostController: new AbortController(),
 				state: { interrupted: false, lostOwnership: false },
 			};
 			this.activeRuns.set(run.runId, entry);
@@ -435,6 +447,7 @@ export class RunLoop {
 				(await this.opts.processor({
 					run,
 					signal: entry.controller.signal,
+					ownershipLostSignal: entry.ownershipLostController.signal,
 					appendModelContent: (content) =>
 						this.appendModelContent(run.runId, content),
 					appendModelContents: (contents) =>
@@ -515,13 +528,24 @@ export class RunLoop {
 				message: GENERIC_RUN_ERROR_MESSAGE,
 			});
 		}
+		if (turnResult.disposition === "stopped") {
+			this.opts.logger.error({
+				message: "run stopped before completion",
+				workerId: this.workerId,
+				userId: run.userId,
+				conversationId: run.conversationId,
+				runId,
+			});
+			return this.terminalize(runId, "error", {
+				message: GENERIC_RUN_ERROR_MESSAGE,
+			});
+		}
 		// Success: terminalize `done` directly — there is no end-of-turn
 		// checkpoint (ADR-0007); the sandbox idle-pauses once renewal stops and is
 		// itself the persisted workspace. The terminal-success transition also
 		// advances the conversation's resume pointer, under the ownership fence
-		// (ADR-0005). Only when the turn reported a session to resume from — a
-		// `mirror_error` turn carries none, so the pointer holds and the run still
-		// terminalizes `done`.
+		// (ADR-0005). Only a reported session with a reliable mirror advances it;
+		// a `mirror_error` keeps the observation but holds the pointer.
 		const owner: RunOwnershipRef = {
 			userId: run.userId,
 			conversationId: run.conversationId,
@@ -531,11 +555,9 @@ export class RunLoop {
 		if (turnResult.artifactPublication) {
 			return this.publishArtifactsAndFinish(owner, turnResult);
 		}
-		if (turnResult.agentSession) {
-			await this.advanceSessionPointer(
-				owner,
-				turnResult.agentSession.sessionId,
-			);
+		const agentSessionId = resumableAgentSessionId(turnResult);
+		if (agentSessionId) {
+			await this.advanceSessionPointer(owner, agentSessionId);
 		}
 		return this.terminalize(runId, "done");
 	}
@@ -547,18 +569,16 @@ export class RunLoop {
 		const publication = turnResult.artifactPublication;
 		if (!publication) return null;
 		try {
+			const agentSessionId = resumableAgentSessionId(turnResult);
 			const result = await publishArtifactsAndTransitionRunDoneTx(
 				this.opts.db,
 				{
 					owner,
 					artifacts: publication.artifacts,
-					agentSessionId: turnResult.agentSession?.sessionId,
+					agentSessionId,
 				},
 			);
-			if (
-				turnResult.agentSession &&
-				result.agentSessionPointerAdvanced === false
-			) {
+			if (agentSessionId && result.agentSessionPointerAdvanced === false) {
 				this.opts.logger.warn({
 					message: "could not advance agent session pointer",
 					workerId: this.workerId,
@@ -710,4 +730,16 @@ function artifactFailureLogFields(error: unknown): Record<string, unknown> {
 		};
 	}
 	return { error: toMessage(error) };
+}
+
+function resumableAgentSessionId(turnResult: TurnResult): string | undefined {
+	const metadata = turnResult.streamMetadata;
+	if (
+		!metadata ||
+		metadata.sessionId === null ||
+		metadata.mirrorErrorObserved
+	) {
+		return undefined;
+	}
+	return metadata.sessionId;
 }

--- a/apps/agent-worker/src/run-loop.ts
+++ b/apps/agent-worker/src/run-loop.ts
@@ -99,7 +99,13 @@ const MODEL_CONTENT_EVENT_TYPES = {
  */
 export interface RunProcessContext {
 	run: RunRecord;
+	/** Cancels active Tool/E2B work for every supervisor stop cause. */
 	signal: AbortSignal;
+	/** Fires only after durable interruption is observed; grants the bounded
+	 * private SDK stop window while the ownership lease remains live. */
+	interruptionSignal: AbortSignal;
+	/** Fires on worker shutdown; private SDK resources must close immediately. */
+	shutdownSignal: AbortSignal;
 	/** Fires only when the ownership fence is lost. Unlike a normal stop, this
 	 * permits no post-fence drain and must close private SDK resources now. */
 	ownershipLostSignal: AbortSignal;
@@ -151,6 +157,8 @@ interface RunEndState {
 
 interface ActiveEntry {
 	controller: AbortController;
+	interruptionController: AbortController;
+	shutdownController: AbortController;
 	ownershipLostController: AbortController;
 	state: RunEndState;
 	liveStream?: RunLiveStream;
@@ -273,13 +281,13 @@ export class RunLoop {
 			clearTimeout(this.recoveryTimer);
 			this.recoveryTimer = undefined;
 		}
-		// Interrupt every in-flight run before draining: aborting the run's
-		// controller is what makes its processor interrupt the live SDK query and
-		// cancel any active E2B command (plan Task 7.2). This is not a user interruption,
-		// so `state.interrupted` stays false — a turn stopped by shutdown drains to
+		// Stop every in-flight run before draining: cancel Tool/E2B work, then
+		// force-close private SDK resources without granting the user-interruption
+		// grace window. `state.interrupted` stays false, so shutdown drains to
 		// `error`, never a false `done`. Snapshot the map: a finishing run deletes itself.
 		for (const entry of [...this.activeRuns.values()]) {
 			entry.controller.abort();
+			entry.shutdownController.abort();
 		}
 		await this.opts.worker.shutdown();
 	}
@@ -364,13 +372,14 @@ export class RunLoop {
 				// terminal transition.
 				this.activeRuns.delete(runId);
 				entry.state.lostOwnership = true;
-				entry.ownershipLostController.abort();
 				entry.controller.abort();
+				entry.ownershipLostController.abort();
 				continue;
 			}
 			if (renewed.status === "interrupt_requested") {
 				entry.state.interrupted = true;
 				entry.controller.abort();
+				entry.interruptionController.abort();
 			}
 		}
 	}
@@ -384,6 +393,8 @@ export class RunLoop {
 			if (!run) break;
 			const entry: ActiveEntry = {
 				controller: new AbortController(),
+				interruptionController: new AbortController(),
+				shutdownController: new AbortController(),
 				ownershipLostController: new AbortController(),
 				state: { interrupted: false, lostOwnership: false },
 			};
@@ -447,6 +458,8 @@ export class RunLoop {
 				(await this.opts.processor({
 					run,
 					signal: entry.controller.signal,
+					interruptionSignal: entry.interruptionController.signal,
+					shutdownSignal: entry.shutdownController.signal,
 					ownershipLostSignal: entry.ownershipLostController.signal,
 					appendModelContent: (content) =>
 						this.appendModelContent(run.runId, content),
@@ -516,29 +529,14 @@ export class RunLoop {
 			return this.terminalize(runId, "interrupted");
 		}
 		if (failure) {
-			this.opts.logger.error({
-				message: "run failed",
-				workerId: this.workerId,
-				userId: run.userId,
-				conversationId: run.conversationId,
-				runId,
-				...artifactFailureLogFields(failure.error),
-			});
-			return this.terminalize(runId, "error", {
-				message: GENERIC_RUN_ERROR_MESSAGE,
-			});
+			return this.failRun(
+				run,
+				"run failed",
+				artifactFailureLogFields(failure.error),
+			);
 		}
 		if (turnResult.disposition === "stopped") {
-			this.opts.logger.error({
-				message: "run stopped before completion",
-				workerId: this.workerId,
-				userId: run.userId,
-				conversationId: run.conversationId,
-				runId,
-			});
-			return this.terminalize(runId, "error", {
-				message: GENERIC_RUN_ERROR_MESSAGE,
-			});
+			return this.failRun(run, "run stopped before completion");
 		}
 		// Success: terminalize `done` directly — there is no end-of-turn
 		// checkpoint (ADR-0007); the sandbox idle-pauses once renewal stops and is
@@ -560,6 +558,24 @@ export class RunLoop {
 			await this.advanceSessionPointer(owner, agentSessionId);
 		}
 		return this.terminalize(runId, "done");
+	}
+
+	private failRun(
+		run: RunRecord,
+		message: string,
+		fields: Record<string, unknown> = {},
+	): Promise<TerminalRunStatus | null> {
+		this.opts.logger.error({
+			message,
+			workerId: this.workerId,
+			userId: run.userId,
+			conversationId: run.conversationId,
+			runId: run.runId,
+			...fields,
+		});
+		return this.terminalize(run.runId, "error", {
+			message: GENERIC_RUN_ERROR_MESSAGE,
+		});
 	}
 
 	private async publishArtifactsAndFinish(

--- a/apps/agent-worker/src/sdk/agent-stream.test.ts
+++ b/apps/agent-worker/src/sdk/agent-stream.test.ts
@@ -1440,7 +1440,7 @@ describe("consumeAgentStream", () => {
 		]);
 	});
 
-	it("stops appending tool events when shutdown aborts a stalled append", async () => {
+	it("stops appending tool events when supervised stop aborts a stalled append", async () => {
 		const appended: ModelContent[] = [];
 		const controller = new AbortController();
 		let markAppendStarted!: () => void;

--- a/apps/agent-worker/src/sdk/agent-stream.test.ts
+++ b/apps/agent-worker/src/sdk/agent-stream.test.ts
@@ -6,7 +6,6 @@ import {
 	AgentResultError,
 	consumeAgentStream,
 	isMirrorError,
-	QueryInterruptedError,
 	type SupervisedQuery,
 	sessionIdFromResult,
 } from "./agent-stream";
@@ -78,6 +77,7 @@ function deferred<T = void>() {
 function fakeQuery(steps: Step[]): SupervisedQuery & { interrupts: number } {
 	const query = {
 		interrupts: 0,
+		close() {},
 		async interrupt() {
 			query.interrupts++;
 		},
@@ -264,6 +264,7 @@ describe("consumeAgentStream", () => {
 		const releaseContent = deferred();
 		const messages = textEnvelope({ completeText: "hello" });
 		const query: SupervisedQuery = {
+			close() {},
 			async interrupt() {},
 			async *[Symbol.asyncIterator]() {
 				for (const message of messages.slice(0, 3)) yield message;
@@ -317,6 +318,7 @@ describe("consumeAgentStream", () => {
 				),
 			}),
 		).resolves.toEqual({
+			disposition: "completed",
 			sessionId: "session-42",
 			mirrorErrorObserved: false,
 		});
@@ -361,16 +363,15 @@ describe("consumeAgentStream", () => {
 			{ message: messageAt(envelope, 5) },
 		]);
 
-		await expect(
-			consumeAgentStream({
-				query,
-				signal: controller.signal,
-				appendModelContents: onAssistantCommit((message) =>
-					appended.push(message),
-				),
-			}),
-		).rejects.toBeInstanceOf(QueryInterruptedError);
+		const outcome = await consumeAgentStream({
+			query,
+			signal: controller.signal,
+			appendModelContents: onAssistantCommit((message) =>
+				appended.push(message),
+			),
+		});
 
+		expect(outcome.disposition).toBe("stopped");
 		expect(appended).toEqual([]);
 		expect(query.interrupts).toBe(1);
 	});
@@ -383,18 +384,101 @@ describe("consumeAgentStream", () => {
 			textEnvelope({ completeText: "never" }).map((message) => ({ message })),
 		);
 
-		await expect(
-			consumeAgentStream({
-				query,
-				signal: controller.signal,
-				appendModelContents: onAssistantCommit((message) =>
-					appended.push(message),
-				),
-			}),
-		).rejects.toBeInstanceOf(QueryInterruptedError);
+		const outcome = await consumeAgentStream({
+			query,
+			signal: controller.signal,
+			appendModelContents: onAssistantCommit((message) =>
+				appended.push(message),
+			),
+		});
 
+		expect(outcome.disposition).toBe("stopped");
 		expect(appended).toEqual([]);
 		expect(query.interrupts).toBe(1);
+	});
+
+	it("does not double-close when ownership is lost during the stop grace", async () => {
+		const stopController = new AbortController();
+		const ownershipController = new AbortController();
+		const releaseStream = deferred();
+		const deadlineElapsed = deferred();
+		let interrupts = 0;
+		let closes = 0;
+		const query: SupervisedQuery = {
+			async interrupt() {
+				interrupts++;
+			},
+			close() {
+				closes++;
+			},
+			// biome-ignore lint/correctness/useYield: the held-open stream exercises stop races.
+			async *[Symbol.asyncIterator]() {
+				await releaseStream.promise;
+			},
+		};
+		const consuming = consumeAgentStream({
+			query,
+			signal: stopController.signal,
+			ownershipLostSignal: ownershipController.signal,
+			appendModelContents: async () => {},
+			startStopDeadline: () => ({
+				elapsed: deadlineElapsed.promise,
+				cancel() {},
+			}),
+		});
+
+		stopController.abort();
+		await Promise.resolve();
+		expect(interrupts).toBe(1);
+		expect(closes).toBe(0);
+
+		ownershipController.abort();
+		expect(closes).toBe(1);
+		deadlineElapsed.resolve();
+		await Promise.resolve();
+		expect(closes).toBe(1);
+
+		releaseStream.resolve();
+		expect((await consuming).disposition).toBe("stopped");
+	});
+
+	it("prioritizes pre-observed ownership loss over regular stop", async () => {
+		const stopController = new AbortController();
+		const ownershipController = new AbortController();
+		stopController.abort();
+		ownershipController.abort();
+		let interrupts = 0;
+		let closes = 0;
+		let deadlines = 0;
+		const query: SupervisedQuery = {
+			async interrupt() {
+				interrupts++;
+			},
+			close() {
+				closes++;
+			},
+			async *[Symbol.asyncIterator]() {
+				yield resultMessage();
+			},
+		};
+
+		const outcome = await consumeAgentStream({
+			query,
+			signal: stopController.signal,
+			ownershipLostSignal: ownershipController.signal,
+			appendModelContents: async () => {},
+			startStopDeadline: () => {
+				deadlines++;
+				return { elapsed: new Promise(() => {}), cancel() {} };
+			},
+		});
+
+		expect(outcome.disposition).toBe("stopped");
+		expect({ interrupts, closes, deadlines }).toEqual({
+			interrupts: 0,
+			closes: 1,
+			deadlines: 0,
+		});
 	});
 
 	it("abandons an open envelope on an SDK error result", async () => {
@@ -673,6 +757,7 @@ describe("consumeAgentStream", () => {
 				appendModelContents: async () => {},
 			}),
 		).resolves.toEqual({
+			disposition: "completed",
 			sessionId: "session-7",
 			mirrorErrorObserved: true,
 		});
@@ -1308,14 +1393,13 @@ describe("consumeAgentStream", () => {
 			},
 		]);
 
-		await expect(
-			consumeAgentStream({
-				query,
-				signal: controller.signal,
-				appendModelContents: captureModelContents(appended),
-			}),
-		).rejects.toBeInstanceOf(QueryInterruptedError);
+		const outcome = await consumeAgentStream({
+			query,
+			signal: controller.signal,
+			appendModelContents: captureModelContents(appended),
+		});
 
+		expect(outcome.disposition).toBe("stopped");
 		expect(appended).toEqual([]);
 	});
 
@@ -1341,14 +1425,13 @@ describe("consumeAgentStream", () => {
 			},
 		]);
 
-		await expect(
-			consumeAgentStream({
-				query,
-				signal: controller.signal,
-				appendModelContents: captureModelContents(appended),
-			}),
-		).rejects.toBeInstanceOf(QueryInterruptedError);
+		const outcome = await consumeAgentStream({
+			query,
+			signal: controller.signal,
+			appendModelContents: captureModelContents(appended),
+		});
 
+		expect(outcome.disposition).toBe("stopped");
 		expect(appended.map((content) => content.kind)).toEqual([
 			"assistant_message",
 			"tool_call_started",
@@ -1400,7 +1483,7 @@ describe("consumeAgentStream", () => {
 		controller.abort();
 		releaseAppend();
 
-		await expect(consuming).rejects.toBeInstanceOf(QueryInterruptedError);
+		expect((await consuming).disposition).toBe("stopped");
 		expect(query.interrupts).toBe(1);
 		expect(appended.map((content) => content.kind)).toEqual([
 			"assistant_message",

--- a/apps/agent-worker/src/sdk/agent-stream.test.ts
+++ b/apps/agent-worker/src/sdk/agent-stream.test.ts
@@ -447,14 +447,23 @@ describe("consumeAgentStream", () => {
 		const streamStarted = deferred();
 		const deadlineElapsed = deferred();
 		let closes = 0;
+		let returns = 0;
 		const query: SupervisedQuery = {
 			async interrupt() {},
 			close() {
 				closes++;
 			},
-			async *[Symbol.asyncIterator]() {
-				streamStarted.resolve();
-				await new Promise<void>(() => {});
+			[Symbol.asyncIterator]() {
+				return {
+					next() {
+						streamStarted.resolve();
+						return new Promise<IteratorResult<SDKMessage>>(() => {});
+					},
+					async return() {
+						returns++;
+						return { done: true, value: undefined };
+					},
+				};
 			},
 		};
 		const consuming = consumeAgentStream({
@@ -473,6 +482,7 @@ describe("consumeAgentStream", () => {
 
 		expect(await consuming).toMatchObject({ disposition: "stopped" });
 		expect(closes).toBe(1);
+		expect(returns).toBe(1);
 	});
 
 	it("logs a late SDK rejection after an operational force-close", async () => {
@@ -517,6 +527,40 @@ describe("consumeAgentStream", () => {
 			runId: undefined,
 			error: "late close failure",
 		});
+	});
+
+	it("does not log an expected AbortError from a clean interruption", async () => {
+		const stopController = new AbortController();
+		const nextMessage = Promise.withResolvers<IteratorResult<SDKMessage>>();
+		const errors: Record<string, unknown>[] = [];
+		const query: SupervisedQuery = {
+			async interrupt() {
+				nextMessage.reject(
+					new DOMException("This operation was aborted", "AbortError"),
+				);
+			},
+			close() {},
+			[Symbol.asyncIterator]() {
+				return { next: () => nextMessage.promise };
+			},
+		};
+		const consuming = consumeAgentStream({
+			query,
+			interruptionSignal: stopController.signal,
+			appendModelContents: async () => {},
+			logger: {
+				info() {},
+				warn() {},
+				error(fields) {
+					errors.push(fields);
+				},
+			},
+		});
+
+		stopController.abort();
+
+		expect(await consuming).toMatchObject({ disposition: "stopped" });
+		expect(errors).toEqual([]);
 	});
 
 	it("prioritizes pre-observed ownership loss over regular stop", async () => {

--- a/apps/agent-worker/src/sdk/agent-stream.test.ts
+++ b/apps/agent-worker/src/sdk/agent-stream.test.ts
@@ -196,7 +196,7 @@ describe("consumeAgentStream", () => {
 			query: fakeQuery(
 				textEnvelope({ completeText: "hello" }).map((message) => ({ message })),
 			),
-			signal: new AbortController().signal,
+			interruptionSignal: new AbortController().signal,
 			appendLiveEvent: async (event) => {
 				if (event.type === EventType.TEXT_MESSAGE_END) {
 					expect(order).toContain("commit:hello");
@@ -234,7 +234,7 @@ describe("consumeAgentStream", () => {
 
 		await consumeAgentStream({
 			query: fakeQuery(messages.map((message) => ({ message }))),
-			signal: new AbortController().signal,
+			interruptionSignal: new AbortController().signal,
 			appendLiveEvent: async (event) => {
 				events.push(event as unknown as Record<string, unknown>);
 			},
@@ -276,7 +276,7 @@ describe("consumeAgentStream", () => {
 
 		const result = consumeAgentStream({
 			query,
-			signal: new AbortController().signal,
+			interruptionSignal: new AbortController().signal,
 			appendLiveEvent: async (event) => {
 				if (event.type !== EventType.TEXT_MESSAGE_CONTENT) return;
 				contentStarted.resolve();
@@ -312,7 +312,7 @@ describe("consumeAgentStream", () => {
 		await expect(
 			consumeAgentStream({
 				query,
-				signal: controller.signal,
+				interruptionSignal: controller.signal,
 				appendModelContents: onAssistantCommit((message) =>
 					appended.push(message),
 				),
@@ -340,7 +340,7 @@ describe("consumeAgentStream", () => {
 
 		await consumeAgentStream({
 			query,
-			signal: new AbortController().signal,
+			interruptionSignal: new AbortController().signal,
 			appendModelContents: onAssistantCommit((message) =>
 				appended.push(message),
 			),
@@ -365,7 +365,7 @@ describe("consumeAgentStream", () => {
 
 		const outcome = await consumeAgentStream({
 			query,
-			signal: controller.signal,
+			interruptionSignal: controller.signal,
 			appendModelContents: onAssistantCommit((message) =>
 				appended.push(message),
 			),
@@ -386,7 +386,7 @@ describe("consumeAgentStream", () => {
 
 		const outcome = await consumeAgentStream({
 			query,
-			signal: controller.signal,
+			interruptionSignal: controller.signal,
 			appendModelContents: onAssistantCommit((message) =>
 				appended.push(message),
 			),
@@ -418,7 +418,7 @@ describe("consumeAgentStream", () => {
 		};
 		const consuming = consumeAgentStream({
 			query,
-			signal: stopController.signal,
+			interruptionSignal: stopController.signal,
 			ownershipLostSignal: ownershipController.signal,
 			appendModelContents: async () => {},
 			startStopDeadline: () => ({
@@ -440,6 +440,83 @@ describe("consumeAgentStream", () => {
 
 		releaseStream.resolve();
 		expect((await consuming).disposition).toBe("stopped");
+	});
+
+	it("settles after forced close even when the SDK iterator stays hung", async () => {
+		const stopController = new AbortController();
+		const streamStarted = deferred();
+		const deadlineElapsed = deferred();
+		let closes = 0;
+		const query: SupervisedQuery = {
+			async interrupt() {},
+			close() {
+				closes++;
+			},
+			async *[Symbol.asyncIterator]() {
+				streamStarted.resolve();
+				await new Promise<void>(() => {});
+			},
+		};
+		const consuming = consumeAgentStream({
+			query,
+			interruptionSignal: stopController.signal,
+			appendModelContents: async () => {},
+			startStopDeadline: () => ({
+				elapsed: deadlineElapsed.promise,
+				cancel() {},
+			}),
+		});
+		await streamStarted.promise;
+
+		stopController.abort();
+		deadlineElapsed.resolve();
+
+		expect(await consuming).toMatchObject({ disposition: "stopped" });
+		expect(closes).toBe(1);
+	});
+
+	it("logs a late SDK rejection after an operational force-close", async () => {
+		const forceCloseController = new AbortController();
+		const streamStarted = deferred();
+		const nextMessage = Promise.withResolvers<IteratorResult<SDKMessage>>();
+		const errors: Record<string, unknown>[] = [];
+		const query: SupervisedQuery = {
+			async interrupt() {},
+			close() {},
+			[Symbol.asyncIterator]() {
+				return {
+					next() {
+						streamStarted.resolve();
+						return nextMessage.promise;
+					},
+				};
+			},
+		};
+		const consuming = consumeAgentStream({
+			query,
+			interruptionSignal: new AbortController().signal,
+			forceCloseSignals: [forceCloseController.signal],
+			appendModelContents: async () => {},
+			logger: {
+				info() {},
+				warn() {},
+				error(fields) {
+					errors.push(fields);
+				},
+			},
+		});
+		await streamStarted.promise;
+
+		forceCloseController.abort();
+		expect(await consuming).toMatchObject({ disposition: "stopped" });
+		nextMessage.reject(new Error("late close failure"));
+		await Promise.resolve();
+
+		expect(errors).toContainEqual({
+			message: "agent query failed while stopping",
+			runId: undefined,
+			error: "late close failure",
+		});
 	});
 
 	it("prioritizes pre-observed ownership loss over regular stop", async () => {
@@ -464,7 +541,7 @@ describe("consumeAgentStream", () => {
 
 		const outcome = await consumeAgentStream({
 			query,
-			signal: stopController.signal,
+			interruptionSignal: stopController.signal,
 			ownershipLostSignal: ownershipController.signal,
 			appendModelContents: async () => {},
 			startStopDeadline: () => {
@@ -494,7 +571,7 @@ describe("consumeAgentStream", () => {
 		await expect(
 			consumeAgentStream({
 				query,
-				signal: controller.signal,
+				interruptionSignal: controller.signal,
 				appendModelContents: onAssistantCommit((message) =>
 					appended.push(message),
 				),
@@ -514,7 +591,7 @@ describe("consumeAgentStream", () => {
 		await expect(
 			consumeAgentStream({
 				query,
-				signal: controller.signal,
+				interruptionSignal: controller.signal,
 				appendModelContents: async () => {},
 			}),
 		).rejects.toBeInstanceOf(AssistantEnvelopeProtocolError);
@@ -533,7 +610,7 @@ describe("consumeAgentStream", () => {
 		await expect(
 			consumeAgentStream({
 				query,
-				signal: new AbortController().signal,
+				interruptionSignal: new AbortController().signal,
 				appendModelContents: async () => {},
 			}),
 		).rejects.toBeInstanceOf(AssistantEnvelopeProtocolError);
@@ -607,7 +684,7 @@ describe("consumeAgentStream", () => {
 			await expect(
 				consumeAgentStream({
 					query,
-					signal: new AbortController().signal,
+					interruptionSignal: new AbortController().signal,
 					appendModelContents: captureModelContents(appended),
 				}),
 			).rejects.toBeInstanceOf(AssistantEnvelopeProtocolError);
@@ -662,7 +739,7 @@ describe("consumeAgentStream", () => {
 
 		await consumeAgentStream({
 			query,
-			signal: new AbortController().signal,
+			interruptionSignal: new AbortController().signal,
 			appendModelContents: onAssistantCommit((message) =>
 				appended.push(message),
 			),
@@ -709,7 +786,7 @@ describe("consumeAgentStream", () => {
 
 		await consumeAgentStream({
 			query,
-			signal: new AbortController().signal,
+			interruptionSignal: new AbortController().signal,
 			appendModelContents: onAssistantCommit((message) =>
 				appended.push(message),
 			),
@@ -734,7 +811,7 @@ describe("consumeAgentStream", () => {
 		await expect(
 			consumeAgentStream({
 				query,
-				signal: controller.signal,
+				interruptionSignal: controller.signal,
 				appendModelContents: async () => {},
 			}),
 		).rejects.toBeInstanceOf(AgentResultError);
@@ -753,7 +830,7 @@ describe("consumeAgentStream", () => {
 		await expect(
 			consumeAgentStream({
 				query,
-				signal: controller.signal,
+				interruptionSignal: controller.signal,
 				appendModelContents: async () => {},
 			}),
 		).resolves.toEqual({
@@ -794,7 +871,7 @@ describe("consumeAgentStream", () => {
 
 		await consumeAgentStream({
 			query: fakeQuery(messages.map((message) => ({ message }))),
-			signal: new AbortController().signal,
+			interruptionSignal: new AbortController().signal,
 			appendModelContents: captureModelContents(appended),
 			logger,
 		});
@@ -873,7 +950,7 @@ describe("consumeAgentStream", () => {
 
 		await consumeAgentStream({
 			query: fakeQuery(messages.map((message) => ({ message }))),
-			signal: new AbortController().signal,
+			interruptionSignal: new AbortController().signal,
 			appendModelContents: async (contents) => {
 				appended.push(...contents);
 				for (const content of contents) {
@@ -987,7 +1064,7 @@ describe("consumeAgentStream", () => {
 
 		await consumeAgentStream({
 			query: fakeQuery(messages.map((message) => ({ message }))),
-			signal: new AbortController().signal,
+			interruptionSignal: new AbortController().signal,
 			appendModelContents: captureModelContents(appended),
 		});
 
@@ -1076,7 +1153,7 @@ describe("consumeAgentStream", () => {
 
 		await consumeAgentStream({
 			query: fakeQuery(messages.map((message) => ({ message }))),
-			signal: new AbortController().signal,
+			interruptionSignal: new AbortController().signal,
 			appendModelContents: captureModelContents(appended),
 		});
 
@@ -1127,7 +1204,7 @@ describe("consumeAgentStream", () => {
 
 		await consumeAgentStream({
 			query: fakeQuery(messages.map((message) => ({ message }))),
-			signal: new AbortController().signal,
+			interruptionSignal: new AbortController().signal,
 			appendModelContents: captureModelContents(appended),
 		});
 
@@ -1160,7 +1237,7 @@ describe("consumeAgentStream", () => {
 
 		await consumeAgentStream({
 			query,
-			signal: new AbortController().signal,
+			interruptionSignal: new AbortController().signal,
 			appendModelContents: captureModelContents(appended),
 		});
 
@@ -1193,7 +1270,7 @@ describe("consumeAgentStream", () => {
 
 		await consumeAgentStream({
 			query: fakeQuery(messages.map((message) => ({ message }))),
-			signal: new AbortController().signal,
+			interruptionSignal: new AbortController().signal,
 			appendModelContents: captureModelContents(appended),
 			logger,
 		});
@@ -1228,7 +1305,7 @@ describe("consumeAgentStream", () => {
 		await consumeAgentStream({
 			runId: "run-1",
 			query: fakeQuery(messages.map((message) => ({ message }))),
-			signal: new AbortController().signal,
+			interruptionSignal: new AbortController().signal,
 			appendModelContents: captureModelContents(appended),
 			logger,
 		});
@@ -1266,7 +1343,7 @@ describe("consumeAgentStream", () => {
 
 		await consumeAgentStream({
 			query: fakeQuery(messages.map((message) => ({ message }))),
-			signal: new AbortController().signal,
+			interruptionSignal: new AbortController().signal,
 			appendModelContents: captureModelContents(appended),
 			logger,
 		});
@@ -1302,7 +1379,7 @@ describe("consumeAgentStream", () => {
 
 		const outcome = await consumeAgentStream({
 			query: fakeQuery(messages.map((message) => ({ message }))),
-			signal: new AbortController().signal,
+			interruptionSignal: new AbortController().signal,
 			appendModelContents: captureModelContents(appended),
 			logger,
 		});
@@ -1339,7 +1416,7 @@ describe("consumeAgentStream", () => {
 
 		await consumeAgentStream({
 			query: fakeQuery(messages.map((message) => ({ message }))),
-			signal: new AbortController().signal,
+			interruptionSignal: new AbortController().signal,
 			appendModelContents: captureModelContents(appended),
 			appendLiveEvent: async (event) => {
 				liveEvents.push(event as unknown as Record<string, unknown>);
@@ -1395,7 +1472,7 @@ describe("consumeAgentStream", () => {
 
 		const outcome = await consumeAgentStream({
 			query,
-			signal: controller.signal,
+			interruptionSignal: controller.signal,
 			appendModelContents: captureModelContents(appended),
 		});
 
@@ -1427,7 +1504,7 @@ describe("consumeAgentStream", () => {
 
 		const outcome = await consumeAgentStream({
 			query,
-			signal: controller.signal,
+			interruptionSignal: controller.signal,
 			appendModelContents: captureModelContents(appended),
 		});
 
@@ -1469,7 +1546,7 @@ describe("consumeAgentStream", () => {
 
 		const consuming = consumeAgentStream({
 			query,
-			signal: controller.signal,
+			interruptionSignal: controller.signal,
 			appendModelContents: async (contents) => {
 				appended.push(...contents);
 				if (appended.length === 1) {
@@ -1506,7 +1583,7 @@ describe("consumeAgentStream", () => {
 		await consumeAgentStream({
 			runId: "run-1",
 			query: fakeQuery(messages.map((message) => ({ message }))),
-			signal: new AbortController().signal,
+			interruptionSignal: new AbortController().signal,
 			appendModelContents: captureModelContents(appended),
 			logger,
 		});
@@ -1538,7 +1615,7 @@ describe("consumeAgentStream", () => {
 
 		const outcome = await consumeAgentStream({
 			query: fakeQuery(messages.map((message) => ({ message }))),
-			signal: new AbortController().signal,
+			interruptionSignal: new AbortController().signal,
 			appendModelContents: captureModelContents(appended),
 		});
 
@@ -1568,7 +1645,7 @@ describe("consumeAgentStream", () => {
 		await expect(
 			consumeAgentStream({
 				query: fakeQuery(messages.map((message) => ({ message }))),
-				signal: new AbortController().signal,
+				interruptionSignal: new AbortController().signal,
 				appendModelContents: async (contents) => {
 					if (contents.some(({ kind }) => kind === "tool_call_started")) {
 						throw boom;
@@ -1598,7 +1675,7 @@ describe("consumeAgentStream", () => {
 		await expect(
 			consumeAgentStream({
 				query: fakeQuery(messages.map((message) => ({ message }))),
-				signal: new AbortController().signal,
+				interruptionSignal: new AbortController().signal,
 				appendModelContents: async (contents) => {
 					if (contents.some(({ kind }) => kind === "tool_call_result")) {
 						throw boom;
@@ -1633,7 +1710,7 @@ describe("consumeAgentStream", () => {
 		await expect(
 			consumeAgentStream({
 				query: fakeQuery(messages.map((message) => ({ message }))),
-				signal: new AbortController().signal,
+				interruptionSignal: new AbortController().signal,
 				appendModelContents: async () => {},
 			}),
 		).rejects.toBeInstanceOf(AssistantEnvelopeProtocolError);
@@ -1652,7 +1729,7 @@ describe("consumeAgentStream", () => {
 		await expect(
 			consumeAgentStream({
 				query,
-				signal: controller.signal,
+				interruptionSignal: controller.signal,
 				appendModelContents: onAssistantCommit((message) =>
 					appended.push(message),
 				),

--- a/apps/agent-worker/src/sdk/agent-stream.ts
+++ b/apps/agent-worker/src/sdk/agent-stream.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import { type AGUIEvent, EventType } from "@ag-ui/core";
 import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 import type { PublicToolName } from "@mymemo/agent-db/run-events";
-import type { WorkerLogger } from "../logger";
+import { toMessage, type WorkerLogger } from "../logger";
 import type {
 	ModelContent,
 	TurnDisposition,
@@ -105,7 +105,7 @@ export interface ConsumeAgentStreamParams {
 	runId?: string;
 	query: SupervisedQuery;
 	/** Fires only for durable interruption; grants the bounded stop window. */
-	signal: AbortSignal;
+	interruptionSignal: AbortSignal;
 	/** Operational stops that must close immediately without a grace deadline. */
 	forceCloseSignals?: readonly AbortSignal[];
 	/** Fires only after the ownership fence is gone; close immediately because
@@ -152,7 +152,7 @@ export interface ConsumeAgentStreamParams {
 export async function consumeAgentStream(
 	params: ConsumeAgentStreamParams,
 ): Promise<AgentStreamOutcome> {
-	const { query, signal, appendModelContents } = params;
+	const { query, interruptionSignal, appendModelContents } = params;
 	const outcome: AgentStreamOutcome = {
 		disposition: "completed",
 		sessionId: null,
@@ -348,6 +348,18 @@ export async function consumeAgentStream(
 	let streamSettled = false;
 	let forceClosed = false;
 	let stopDeadline: StopDeadline | undefined;
+	let resolveForceClosed!: () => void;
+	const forceClosedSignal = new Promise<void>((resolve) => {
+		resolveForceClosed = resolve;
+	});
+	const reportStoppedStreamFailure = (error: unknown): void => {
+		if (error instanceof QueryStoppedError) return;
+		params.logger?.error({
+			message: "agent query failed while stopping",
+			runId: params.runId,
+			error: toMessage(error),
+		});
+	};
 	const stop = (): void => {
 		if (stopRequested) return;
 		stopRequested = true;
@@ -357,13 +369,12 @@ export async function consumeAgentStream(
 		stopDeadline = startStopDeadline(QUERY_STOP_TIMEOUT_MS);
 		void stopDeadline.elapsed.then(() => {
 			if (streamSettled || forceClosed) return;
-			forceClosed = true;
 			params.logger?.warn({
 				message: "agent query exceeded stop deadline; forcing close",
 				runId: params.runId,
 				stopDeadlineMs: QUERY_STOP_TIMEOUT_MS,
 			});
-			query.close();
+			forceClose();
 		});
 	};
 	const forceClose = (): void => {
@@ -371,27 +382,50 @@ export async function consumeAgentStream(
 		stopRequested = true;
 		stopDeadline?.cancel();
 		forceClosed = true;
-		query.close();
+		try {
+			query.close();
+		} catch (error) {
+			params.logger?.error({
+				message: "agent query force-close failed",
+				runId: params.runId,
+				error: toMessage(error),
+			});
+		} finally {
+			resolveForceClosed();
+		}
 	};
 	const settleStream = (): void => {
 		streamSettled = true;
 		stopDeadline?.cancel();
 	};
 	const forceCloseSignals = params.forceCloseSignals ?? [];
-	if (params.ownershipLostSignal?.aborted) forceClose();
-	else
-		params.ownershipLostSignal?.addEventListener("abort", forceClose, {
-			once: true,
-		});
-	for (const forceCloseSignal of forceCloseSignals) {
-		if (forceCloseSignal.aborted) forceClose();
-		else forceCloseSignal.addEventListener("abort", forceClose, { once: true });
-	}
-	if (signal.aborted) stop();
-	else signal.addEventListener("abort", stop, { once: true });
+	const removeAbortListeners = [
+		onAbort(params.ownershipLostSignal, forceClose),
+		...forceCloseSignals.map((forceCloseSignal) =>
+			onAbort(forceCloseSignal, forceClose),
+		),
+		onAbort(interruptionSignal, stop),
+	];
 
 	try {
-		for await (const message of query) {
+		const iterator = query[Symbol.asyncIterator]();
+		while (true) {
+			const nextMessage = Promise.resolve(iterator.next());
+			const next = await Promise.race([
+				nextMessage.then((result) => ({ type: "message" as const, result })),
+				forceClosedSignal.then(() => ({ type: "force_closed" as const })),
+			]);
+			if (next.type === "force_closed") {
+				// `Query.close()` is the terminal SDK cleanup boundary. Do not wait
+				// indefinitely for a misbehaving iterator to acknowledge it; late
+				// rejection is still retained in worker-only diagnostics.
+				void nextMessage.catch(reportStoppedStreamFailure);
+				settleStream();
+				await abandonOpenMessage();
+				return { ...outcome, disposition: "stopped" };
+			}
+			if (next.result.done) break;
+			const message = next.result.value;
 			// Track continuity signals before the abort skip: the pointer decision
 			// reflects the whole stream, not just its pre-interrupt prefix.
 			if (isMirrorError(message)) outcome.mirrorErrorObserved = true;
@@ -457,17 +491,26 @@ export async function consumeAgentStream(
 		settleStream();
 		await abandonOpenMessage();
 		if (stopRequested || error instanceof QueryStoppedError) {
+			reportStoppedStreamFailure(error);
 			return { ...outcome, disposition: "stopped" };
 		}
 		throw error;
 	} finally {
 		settleStream();
-		signal.removeEventListener("abort", stop);
-		for (const forceCloseSignal of forceCloseSignals) {
-			forceCloseSignal.removeEventListener("abort", forceClose);
+		for (const removeAbortListener of removeAbortListeners) {
+			removeAbortListener();
 		}
-		params.ownershipLostSignal?.removeEventListener("abort", forceClose);
 	}
+}
+
+function onAbort(
+	signal: AbortSignal | undefined,
+	listener: () => void,
+): () => void {
+	if (!signal) return () => {};
+	if (signal.aborted) listener();
+	else signal.addEventListener("abort", listener, { once: true });
+	return () => signal.removeEventListener("abort", listener);
 }
 
 function createWallClockStopDeadline(timeoutMs: number): StopDeadline {

--- a/apps/agent-worker/src/sdk/agent-stream.ts
+++ b/apps/agent-worker/src/sdk/agent-stream.ts
@@ -33,8 +33,8 @@ export type SupervisedQuery = AsyncIterable<SDKMessage> & {
 	interrupt(): Promise<unknown>;
 	/** Forcefully terminates the underlying CLI process and resources. */
 	close(): void;
-	/** Optional query-local stop (for example, sandbox-renewal failure). */
-	stopSignal?: AbortSignal;
+	/** Optional query-local immediate close (for example, renewal failure). */
+	forceCloseSignal?: AbortSignal;
 };
 
 /**
@@ -104,8 +104,10 @@ export interface AgentStreamOutcome extends TurnStreamMetadata {
 export interface ConsumeAgentStreamParams {
 	runId?: string;
 	query: SupervisedQuery;
-	/** Fires on interruption, ownership loss, or shutdown; interrupts the query. */
+	/** Fires only for durable interruption; grants the bounded stop window. */
 	signal: AbortSignal;
+	/** Operational stops that must close immediately without a grace deadline. */
+	forceCloseSignals?: readonly AbortSignal[];
 	/** Fires only after the ownership fence is gone; close immediately because
 	 * no private transcript drain is permitted beyond the lease. */
 	ownershipLostSignal?: AbortSignal;
@@ -371,21 +373,22 @@ export async function consumeAgentStream(
 		forceClosed = true;
 		query.close();
 	};
-	const stopSignals = [
-		signal,
-		...(query.stopSignal && query.stopSignal !== signal
-			? [query.stopSignal]
-			: []),
-	];
+	const settleStream = (): void => {
+		streamSettled = true;
+		stopDeadline?.cancel();
+	};
+	const forceCloseSignals = params.forceCloseSignals ?? [];
 	if (params.ownershipLostSignal?.aborted) forceClose();
 	else
 		params.ownershipLostSignal?.addEventListener("abort", forceClose, {
 			once: true,
 		});
-	for (const stopSignal of stopSignals) {
-		if (stopSignal.aborted) stop();
-		else stopSignal.addEventListener("abort", stop, { once: true });
+	for (const forceCloseSignal of forceCloseSignals) {
+		if (forceCloseSignal.aborted) forceClose();
+		else forceCloseSignal.addEventListener("abort", forceClose, { once: true });
 	}
+	if (signal.aborted) stop();
+	else signal.addEventListener("abort", stop, { once: true });
 
 	try {
 		for await (const message of query) {
@@ -443,8 +446,7 @@ export async function consumeAgentStream(
 				liveMessageMatchesCompletion = true;
 			}
 		}
-		streamSettled = true;
-		stopDeadline?.cancel();
+		settleStream();
 		if (stopRequested) {
 			await abandonOpenMessage();
 			return { ...outcome, disposition: "stopped" };
@@ -452,18 +454,17 @@ export async function consumeAgentStream(
 		assembler.finish();
 		return outcome;
 	} catch (error) {
-		streamSettled = true;
-		stopDeadline?.cancel();
+		settleStream();
 		await abandonOpenMessage();
 		if (stopRequested || error instanceof QueryStoppedError) {
 			return { ...outcome, disposition: "stopped" };
 		}
 		throw error;
 	} finally {
-		streamSettled = true;
-		stopDeadline?.cancel();
-		for (const stopSignal of stopSignals) {
-			stopSignal.removeEventListener("abort", stop);
+		settleStream();
+		signal.removeEventListener("abort", stop);
+		for (const forceCloseSignal of forceCloseSignals) {
+			forceCloseSignal.removeEventListener("abort", forceClose);
 		}
 		params.ownershipLostSignal?.removeEventListener("abort", forceClose);
 	}

--- a/apps/agent-worker/src/sdk/agent-stream.ts
+++ b/apps/agent-worker/src/sdk/agent-stream.ts
@@ -349,11 +349,14 @@ export async function consumeAgentStream(
 	let forceClosed = false;
 	let stopDeadline: StopDeadline | undefined;
 	let resolveForceClosed!: () => void;
-	const forceClosedSignal = new Promise<void>((resolve) => {
+	const forceClosedPromise = new Promise<void>((resolve) => {
 		resolveForceClosed = resolve;
 	});
-	const reportStoppedStreamFailure = (error: unknown): void => {
-		if (error instanceof QueryStoppedError) return;
+	const forceClosedResult = forceClosedPromise.then(
+		() => ({ type: "force_closed" }) as const,
+	);
+	const reportUnexpectedStoppedStreamFailure = (error: unknown): void => {
+		if (isExpectedStopError(error)) return;
 		params.logger?.error({
 			message: "agent query failed while stopping",
 			runId: params.runId,
@@ -398,6 +401,11 @@ export async function consumeAgentStream(
 		streamSettled = true;
 		stopDeadline?.cancel();
 	};
+	const settleStopped = async (): Promise<AgentStreamOutcome> => {
+		settleStream();
+		await abandonOpenMessage();
+		return { ...outcome, disposition: "stopped" };
+	};
 	const forceCloseSignals = params.forceCloseSignals ?? [];
 	const removeAbortListeners = [
 		onAbort(params.ownershipLostSignal, forceClose),
@@ -413,16 +421,24 @@ export async function consumeAgentStream(
 			const nextMessage = Promise.resolve(iterator.next());
 			const next = await Promise.race([
 				nextMessage.then((result) => ({ type: "message" as const, result })),
-				forceClosedSignal.then(() => ({ type: "force_closed" as const })),
+				forceClosedResult,
 			]);
 			if (next.type === "force_closed") {
 				// `Query.close()` is the terminal SDK cleanup boundary. Do not wait
 				// indefinitely for a misbehaving iterator to acknowledge it; late
 				// rejection is still retained in worker-only diagnostics.
-				void nextMessage.catch(reportStoppedStreamFailure);
-				settleStream();
-				await abandonOpenMessage();
-				return { ...outcome, disposition: "stopped" };
+				void nextMessage.catch(reportUnexpectedStoppedStreamFailure);
+				try {
+					const returned = iterator.return?.();
+					if (returned) {
+						void Promise.resolve(returned).catch(
+							reportUnexpectedStoppedStreamFailure,
+						);
+					}
+				} catch (error) {
+					reportUnexpectedStoppedStreamFailure(error);
+				}
+				return settleStopped();
 			}
 			if (next.result.done) break;
 			const message = next.result.value;
@@ -480,23 +496,19 @@ export async function consumeAgentStream(
 				liveMessageMatchesCompletion = true;
 			}
 		}
+		if (stopRequested) return settleStopped();
 		settleStream();
-		if (stopRequested) {
-			await abandonOpenMessage();
-			return { ...outcome, disposition: "stopped" };
-		}
 		assembler.finish();
 		return outcome;
 	} catch (error) {
+		if (stopRequested || error instanceof QueryStoppedError) {
+			reportUnexpectedStoppedStreamFailure(error);
+			return settleStopped();
+		}
 		settleStream();
 		await abandonOpenMessage();
-		if (stopRequested || error instanceof QueryStoppedError) {
-			reportStoppedStreamFailure(error);
-			return { ...outcome, disposition: "stopped" };
-		}
 		throw error;
 	} finally {
-		settleStream();
 		for (const removeAbortListener of removeAbortListeners) {
 			removeAbortListener();
 		}
@@ -511,6 +523,13 @@ function onAbort(
 	if (signal.aborted) listener();
 	else signal.addEventListener("abort", listener, { once: true });
 	return () => signal.removeEventListener("abort", listener);
+}
+
+function isExpectedStopError(error: unknown): boolean {
+	return (
+		error instanceof QueryStoppedError ||
+		(error instanceof Error && error.name === "AbortError")
+	);
 }
 
 function createWallClockStopDeadline(timeoutMs: number): StopDeadline {

--- a/apps/agent-worker/src/sdk/agent-stream.ts
+++ b/apps/agent-worker/src/sdk/agent-stream.ts
@@ -3,7 +3,11 @@ import { type AGUIEvent, EventType } from "@ag-ui/core";
 import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 import type { PublicToolName } from "@mymemo/agent-db/run-events";
 import type { WorkerLogger } from "../logger";
-import type { ModelContent } from "../run-loop";
+import type {
+	ModelContent,
+	TurnDisposition,
+	TurnStreamMetadata,
+} from "../run-loop";
 import { AgUiTextStream } from "./ag-ui-text-stream";
 import {
 	AssistantEnvelopeProtocolError,
@@ -18,7 +22,7 @@ import {
 
 /**
  * The subset of the Claude Agent SDK's `Query` handle the run supervisor
- * consumes: an async stream of SDK messages plus `interrupt()`. The real
+ * consumes: an async stream of SDK messages plus its stop controls. The real
  * `query()` result satisfies this structurally, and tests substitute a fake
  * stream — so the supervision logic is verified without a live model (plan
  * Task 7.2: "use a fake SDK stream for deterministic unit tests").
@@ -27,21 +31,32 @@ export type SupervisedQuery = AsyncIterable<SDKMessage> & {
 	// The SDK returns a control receipt from `interrupt()`; supervision only
 	// needs to await completion, not inspect that receipt.
 	interrupt(): Promise<unknown>;
+	/** Forcefully terminates the underlying CLI process and resources. */
+	close(): void;
+	/** Optional query-local stop (for example, sandbox-renewal failure). */
+	stopSignal?: AbortSignal;
 };
 
 /**
- * The run was stopped (user interruption, ownership loss, or worker shutdown)
- * and the SDK stream ended without raising. Thrown so the supervisor never
- * records a clean `done` for work that did not complete on its own; the
- * terminal transition remaps a user interruption to `interrupted` and leaves
- * the rest as `error`.
+ * Internal control flow raised when an in-flight durable append observes that
+ * its query has stopped. The stream consumer converts it to the same neutral
+ * `stopped` disposition as a quietly settled SDK stream.
  */
-export class QueryInterruptedError extends Error {
-	override name = "QueryInterruptedError" as const;
+export class QueryStoppedError extends Error {
+	override name = "QueryStoppedError" as const;
 	constructor() {
-		super("agent query interrupted");
+		super("agent query stopped");
 	}
 }
+
+export interface StopDeadline {
+	elapsed: Promise<void>;
+	cancel(): void;
+}
+
+export type StartStopDeadline = (timeoutMs: number) => StopDeadline;
+
+const QUERY_STOP_TIMEOUT_MS = 30_000;
 
 /** The SDK reports a run failure either by throwing or — on a clean process
  * exit — by emitting a terminal `result` message with `is_error: true`. This
@@ -77,16 +92,13 @@ export function isMirrorError(message: SDKMessage): boolean {
 }
 
 /**
- * What a completed stream reports back for conversation continuity (ADR-0005):
- * the session id to store as the resume pointer, and whether a `mirror_error`
- * made the mirrored transcript unreliable. Only meaningful on the clean-completion
- * path — an interrupted or errored run never advances the pointer.
+ * What a settled stream reports back for supervisor reconciliation and
+ * Conversation continuity (ADR-0005): its neutral disposition, observed
+ * session id, and whether a `mirror_error` made the transcript unreliable.
  */
-export interface AgentStreamOutcome {
-	/** The id from the terminal result message, or `null` if none was seen. */
-	sessionId: string | null;
-	/** A transcript-mirror batch was dropped; do not advance the pointer. */
-	mirrorErrorObserved: boolean;
+export interface AgentStreamOutcome extends TurnStreamMetadata {
+	/** Whether the query completed itself or settled after a stop request. */
+	disposition: TurnDisposition;
 }
 
 export interface ConsumeAgentStreamParams {
@@ -94,6 +106,9 @@ export interface ConsumeAgentStreamParams {
 	query: SupervisedQuery;
 	/** Fires on interruption, ownership loss, or shutdown; interrupts the query. */
 	signal: AbortSignal;
+	/** Fires only after the ownership fence is gone; close immediately because
+	 * no private transcript drain is permitted beyond the lease. */
+	ownershipLostSignal?: AbortSignal;
 	/** Atomically persists canonical model-content events, fenced to `running`
 	 * upstream. Single events use a one-item batch. */
 	appendModelContents: (contents: readonly ModelContent[]) => Promise<void>;
@@ -104,6 +119,8 @@ export interface ConsumeAgentStreamParams {
 	 * unmatched result ids, unprojectable payloads). Optional: omissions
 	 * degrade visibility, never correctness. */
 	logger?: WorkerLogger;
+	/** Injectable only for deterministic supervision tests. */
+	startStopDeadline?: StartStopDeadline;
 }
 
 /**
@@ -126,18 +143,16 @@ export interface ConsumeAgentStreamParams {
  *  - the query is interrupted (once), and
  *  - any further content is ignored — never appended.
  *
- * The function resolves with the run's {@link AgentStreamOutcome} only when the
- * stream completes on its own; it throws on an SDK error (so the supervisor
- * terminalizes `error`) and on an interrupted-then-quietly-ended stream
- * ({@link QueryInterruptedError}) so an interrupted turn is never mistaken for a
- * clean success. Deciding the terminal status — `interrupted` vs `error` — belongs
- * to the supervisor, which knows whether the abort was a user interruption.
+ * The function resolves with a neutral `completed`/`stopped` disposition and
+ * throws only for an unstopped SDK failure. Deciding the terminal status —
+ * `interrupted`, `error`, or no write — belongs to the Run supervisor.
  */
 export async function consumeAgentStream(
 	params: ConsumeAgentStreamParams,
 ): Promise<AgentStreamOutcome> {
 	const { query, signal, appendModelContents } = params;
 	const outcome: AgentStreamOutcome = {
+		disposition: "completed",
 		sessionId: null,
 		mirrorErrorObserved: false,
 	};
@@ -166,12 +181,12 @@ export async function consumeAgentStream(
 	const appendWhileRunning = async (
 		contents: readonly ModelContent[],
 	): Promise<void> => {
-		if (signal.aborted) throw new QueryInterruptedError();
+		if (stopRequested) throw new QueryStoppedError();
 		await appendModelContents(contents);
 		// The append itself is not abortable. Recheck after it settles so shutdown
 		// cannot let the rest of the envelope append while the DB Run is still
 		// fenced as running.
-		if (signal.aborted) throw new QueryInterruptedError();
+		if (stopRequested) throw new QueryStoppedError();
 	};
 
 	const commitEnvelope = async (commit: EnvelopeCommit): Promise<void> => {
@@ -325,14 +340,52 @@ export async function consumeAgentStream(
 		}
 	};
 
-	// Best-effort: interrupt only needs to reach the SDK. Swallow its rejection so
-	// a failed interrupt cannot become an unhandled rejection — the loop stops
-	// appending on the same signal regardless.
-	const interrupt = (): void => {
+	const startStopDeadline =
+		params.startStopDeadline ?? createWallClockStopDeadline;
+	let stopRequested = false;
+	let streamSettled = false;
+	let forceClosed = false;
+	let stopDeadline: StopDeadline | undefined;
+	const stop = (): void => {
+		if (stopRequested) return;
+		stopRequested = true;
+		// The Run signal has already fired, cancelling active Tool work. Invoke the
+		// cause-blind SDK control next, then bound how long its stream may drain.
 		void query.interrupt().catch(() => {});
+		stopDeadline = startStopDeadline(QUERY_STOP_TIMEOUT_MS);
+		void stopDeadline.elapsed.then(() => {
+			if (streamSettled || forceClosed) return;
+			forceClosed = true;
+			params.logger?.warn({
+				message: "agent query exceeded stop deadline; forcing close",
+				runId: params.runId,
+				stopDeadlineMs: QUERY_STOP_TIMEOUT_MS,
+			});
+			query.close();
+		});
 	};
-	if (signal.aborted) interrupt();
-	else signal.addEventListener("abort", interrupt, { once: true });
+	const forceClose = (): void => {
+		if (streamSettled || forceClosed) return;
+		stopRequested = true;
+		stopDeadline?.cancel();
+		forceClosed = true;
+		query.close();
+	};
+	const stopSignals = [
+		signal,
+		...(query.stopSignal && query.stopSignal !== signal
+			? [query.stopSignal]
+			: []),
+	];
+	if (params.ownershipLostSignal?.aborted) forceClose();
+	else
+		params.ownershipLostSignal?.addEventListener("abort", forceClose, {
+			once: true,
+		});
+	for (const stopSignal of stopSignals) {
+		if (stopSignal.aborted) stop();
+		else stopSignal.addEventListener("abort", stop, { once: true });
+	}
 
 	try {
 		for await (const message of query) {
@@ -342,7 +395,7 @@ export async function consumeAgentStream(
 			const sessionId = sessionIdFromResult(message);
 			if (sessionId !== null) outcome.sessionId = sessionId;
 
-			if (signal.aborted) continue;
+			if (stopRequested) continue;
 			const errorText = resultErrorText(message);
 			if (errorText !== null) {
 				throw new AgentResultError(errorText);
@@ -390,15 +443,43 @@ export async function consumeAgentStream(
 				liveMessageMatchesCompletion = true;
 			}
 		}
-		if (signal.aborted) throw new QueryInterruptedError();
+		streamSettled = true;
+		stopDeadline?.cancel();
+		if (stopRequested) {
+			await abandonOpenMessage();
+			return { ...outcome, disposition: "stopped" };
+		}
 		assembler.finish();
 		return outcome;
 	} catch (error) {
+		streamSettled = true;
+		stopDeadline?.cancel();
 		await abandonOpenMessage();
+		if (stopRequested || error instanceof QueryStoppedError) {
+			return { ...outcome, disposition: "stopped" };
+		}
 		throw error;
 	} finally {
-		signal.removeEventListener("abort", interrupt);
+		streamSettled = true;
+		stopDeadline?.cancel();
+		for (const stopSignal of stopSignals) {
+			stopSignal.removeEventListener("abort", stop);
+		}
+		params.ownershipLostSignal?.removeEventListener("abort", forceClose);
 	}
+}
+
+function createWallClockStopDeadline(timeoutMs: number): StopDeadline {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	return {
+		elapsed: new Promise<void>((resolve) => {
+			timer = setTimeout(resolve, timeoutMs);
+		}),
+		cancel() {
+			if (timer) clearTimeout(timer);
+			timer = undefined;
+		},
+	};
 }
 
 /** The SDK marks user messages replayed from a resumed session transcript with

--- a/apps/agent-worker/src/sdk/run-processor.test.ts
+++ b/apps/agent-worker/src/sdk/run-processor.test.ts
@@ -1,6 +1,9 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
 import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
-import { createQueuedRunTx } from "@mymemo/agent-db/run-store";
+import {
+	createQueuedRunTx,
+	requestRunInterruptionTx,
+} from "@mymemo/agent-db/run-store";
 import { createConversationRuntimeTx } from "@mymemo/agent-db/runtime-store";
 import {
 	conversationRuntime,
@@ -15,7 +18,11 @@ import type { WorkerLogger } from "../logger";
 import { RunLoop } from "../run-loop";
 import { Worker } from "../worker";
 import type { SupervisedQuery } from "./agent-stream";
-import { createSdkRunProcessor, type StartRunQuery } from "./run-processor";
+import {
+	createSdkRunProcessor,
+	type StartRunQuery,
+	type SupervisedQueryOptions,
+} from "./run-processor";
 import {
 	assistantBlock,
 	streamEvent,
@@ -135,6 +142,7 @@ function errorResultMessage(text: string): SDKMessage {
 
 function messageQuery(messages: SDKMessage[]): SupervisedQuery {
 	return {
+		close() {},
 		async interrupt() {},
 		async *[Symbol.asyncIterator]() {
 			for (const message of messages) yield message;
@@ -146,6 +154,7 @@ function stepQuery(
 	steps: Array<SDKMessage | { throw: unknown }>,
 ): SupervisedQuery {
 	return {
+		close() {},
 		async interrupt() {},
 		async *[Symbol.asyncIterator]() {
 			for (const step of steps) {
@@ -160,6 +169,7 @@ function buildLoop(
 	worker: Worker,
 	startRunQuery: StartRunQuery,
 	logger: WorkerLogger = silentLogger,
+	supervisedQueryOptions?: SupervisedQueryOptions,
 ) {
 	return new RunLoop({
 		db: tdb.db,
@@ -168,6 +178,7 @@ function buildLoop(
 		processor: createSdkRunProcessor({
 			startRunQuery,
 			logger,
+			supervisedQueryOptions,
 		}),
 		heartbeatIntervalMs: 15_000,
 		logger,
@@ -181,6 +192,28 @@ function buildWorker() {
 		shutdownTimeoutMs: 1_000,
 		logger: silentLogger,
 	});
+}
+
+function virtualStopDeadline(): {
+	options: SupervisedQueryOptions;
+	elapse(): void;
+	started: Promise<number>;
+} {
+	const elapsed = Promise.withResolvers<void>();
+	const started = Promise.withResolvers<number>();
+	return {
+		options: {
+			startStopDeadline(timeoutMs) {
+				started.resolve(timeoutMs);
+				return {
+					elapsed: elapsed.promise,
+					cancel() {},
+				};
+			},
+		},
+		elapse: () => elapsed.resolve(),
+		started: started.promise,
+	};
 }
 
 async function readRun(runId: string) {
@@ -531,6 +564,337 @@ describe("createSdkRunProcessor — through the run loop", () => {
 		expect(seenRunId).toBe("run-1");
 		expect(sawSignal).toBe(true);
 	});
+
+	it("stops an interrupted Run cleanly inside the 30-second deadline", async () => {
+		const worker = buildWorker();
+		const started = Promise.withResolvers<void>();
+		const settled = Promise.withResolvers<void>();
+		const calls: string[] = [];
+		let deadlineMs: number | undefined;
+		let deadlineCancelled = false;
+		const loop = buildLoop(
+			worker,
+			async (_run, signal) => {
+				signal.addEventListener("abort", () => calls.push("tool-abort"), {
+					once: true,
+				});
+				started.resolve();
+				return {
+					async interrupt() {
+						calls.push("interrupt");
+						settled.resolve();
+					},
+					close() {
+						calls.push("close");
+						settled.resolve();
+					},
+					// biome-ignore lint/correctness/useYield: models a silent SDK query that settles after interrupt.
+					async *[Symbol.asyncIterator]() {
+						await settled.promise;
+					},
+				};
+			},
+			silentLogger,
+			{
+				startStopDeadline(timeoutMs) {
+					deadlineMs = timeoutMs;
+					return {
+						elapsed: new Promise<void>(() => {}),
+						cancel() {
+							deadlineCancelled = true;
+						},
+					};
+				},
+			},
+		);
+		await createQueuedRunTx(tdb.db, {
+			runId: "run-1",
+			userId: "user-1",
+			conversationId: "conv-1",
+		});
+
+		await loop.tick();
+		await started.promise;
+		await requestRunInterruptionTx(tdb.db, {
+			runId: "run-1",
+			userId: "user-1",
+			conversationId: "conv-1",
+		});
+		await loop.tick();
+		await worker.drain();
+
+		expect(calls).toEqual(["tool-abort", "interrupt"]);
+		expect(deadlineMs).toBe(30_000);
+		expect(deadlineCancelled).toBe(true);
+		expect((await readRun("run-1"))?.status).toBe("interrupted");
+		expect((await readEvents("run-1")).map((event) => event.type)).toEqual([
+			"run_interrupted",
+		]);
+	});
+
+	it("keeps heartbeating a hung interrupted Run and force-closes it after the deadline", async () => {
+		const worker = buildWorker();
+		const started = Promise.withResolvers<void>();
+		const interrupted = Promise.withResolvers<void>();
+		const closed = Promise.withResolvers<void>();
+		const calls: string[] = [];
+		const warnings: Record<string, unknown>[] = [];
+		const logger: WorkerLogger = {
+			info() {},
+			error() {},
+			warn(fields) {
+				warnings.push(fields);
+			},
+		};
+		const deadline = virtualStopDeadline();
+		const loop = buildLoop(
+			worker,
+			async (_run, signal) => {
+				signal.addEventListener("abort", () => calls.push("tool-abort"), {
+					once: true,
+				});
+				started.resolve();
+				return {
+					async interrupt() {
+						calls.push("interrupt");
+						interrupted.resolve();
+					},
+					close() {
+						calls.push("close");
+						closed.resolve();
+					},
+					// biome-ignore lint/correctness/useYield: models a hung SDK query released only by close.
+					async *[Symbol.asyncIterator]() {
+						await closed.promise;
+					},
+				};
+			},
+			logger,
+			deadline.options,
+		);
+		await createQueuedRunTx(tdb.db, {
+			runId: "run-1",
+			userId: "user-1",
+			conversationId: "conv-1",
+		});
+
+		await loop.tick();
+		await started.promise;
+		await requestRunInterruptionTx(tdb.db, {
+			runId: "run-1",
+			userId: "user-1",
+			conversationId: "conv-1",
+		});
+		await loop.tick();
+		await interrupted.promise;
+		expect(await deadline.started).toBe(30_000);
+		expect(calls).toEqual(["tool-abort", "interrupt"]);
+		expect((await readRun("run-1"))?.status).toBe("interrupt_requested");
+
+		await tdb.db
+			.update(runs)
+			.set({ lockedUntil: new Date(Date.now() + 1_000) })
+			.where(eq(runs.runId, "run-1"));
+		await loop.tick();
+		expect((await readRun("run-1"))?.lockedUntil?.getTime()).toBeGreaterThan(
+			Date.now() + 30_000,
+		);
+		expect(calls).toEqual(["tool-abort", "interrupt"]);
+
+		deadline.elapse();
+		await worker.drain();
+
+		expect(calls).toEqual(["tool-abort", "interrupt", "close"]);
+		expect(warnings).toContainEqual({
+			message: "agent query exceeded stop deadline; forcing close",
+			runId: "run-1",
+			stopDeadlineMs: 30_000,
+		});
+		expect((await readRun("run-1"))?.status).toBe("interrupted");
+	});
+
+	it("force-closes immediately and writes no terminal Outcome after ownership loss", async () => {
+		const worker = buildWorker();
+		const started = Promise.withResolvers<void>();
+		const releaseStream = Promise.withResolvers<void>();
+		const deadline = virtualStopDeadline();
+		const calls: string[] = [];
+		const loop = buildLoop(
+			worker,
+			async () => {
+				started.resolve();
+				return {
+					async interrupt() {
+						calls.push("interrupt");
+					},
+					close() {
+						calls.push("close");
+					},
+					// biome-ignore lint/correctness/useYield: close is intentionally controllable in this fence race.
+					async *[Symbol.asyncIterator]() {
+						await releaseStream.promise;
+					},
+				};
+			},
+			silentLogger,
+			deadline.options,
+		);
+		await createQueuedRunTx(tdb.db, {
+			runId: "run-1",
+			userId: "user-1",
+			conversationId: "conv-1",
+		});
+		await loop.tick();
+		await started.promise;
+		await tdb.db
+			.update(runs)
+			.set({
+				lockedBy: "worker-2",
+				lockedUntil: new Date(Date.now() + 60_000),
+			})
+			.where(eq(runs.runId, "run-1"));
+		await loop.tick();
+		await Promise.resolve();
+
+		expect(calls).toEqual(["close"]);
+		releaseStream.resolve();
+		await worker.drain();
+
+		expect(await readRun("run-1")).toMatchObject({
+			status: "running",
+			lockedBy: "worker-2",
+		});
+		expect(await readEvents("run-1")).toEqual([]);
+	});
+
+	it("maps a query-local stopped disposition to error", async () => {
+		const worker = buildWorker();
+		const started = Promise.withResolvers<void>();
+		const settled = Promise.withResolvers<void>();
+		const stopController = new AbortController();
+		const deadline = virtualStopDeadline();
+		const loop = buildLoop(
+			worker,
+			async () => ({
+				stopSignal: stopController.signal,
+				async interrupt() {
+					settled.resolve();
+				},
+				close() {
+					settled.resolve();
+				},
+				// biome-ignore lint/correctness/useYield: models an infrastructure-stopped SDK query.
+				async *[Symbol.asyncIterator]() {
+					started.resolve();
+					await settled.promise;
+				},
+			}),
+			silentLogger,
+			deadline.options,
+		);
+		await createQueuedRunTx(tdb.db, {
+			runId: "run-1",
+			userId: "user-1",
+			conversationId: "conv-1",
+		});
+
+		await loop.tick();
+		await started.promise;
+		stopController.abort();
+		await worker.drain();
+
+		expect((await readRun("run-1"))?.status).toBe("error");
+		expect((await readEvents("run-1")).map((event) => event.type)).toEqual([
+			"run_error",
+		]);
+	});
+
+	it("maps worker shutdown of a supervised query to error", async () => {
+		const worker = buildWorker();
+		const started = Promise.withResolvers<void>();
+		const settled = Promise.withResolvers<void>();
+		const deadline = virtualStopDeadline();
+		const loop = buildLoop(
+			worker,
+			async () => ({
+				async interrupt() {
+					settled.resolve();
+				},
+				close() {
+					settled.resolve();
+				},
+				// biome-ignore lint/correctness/useYield: models a query stopped by worker shutdown.
+				async *[Symbol.asyncIterator]() {
+					started.resolve();
+					await settled.promise;
+				},
+			}),
+			silentLogger,
+			deadline.options,
+		);
+		await createQueuedRunTx(tdb.db, {
+			runId: "run-1",
+			userId: "user-1",
+			conversationId: "conv-1",
+		});
+		await loop.tick();
+		await started.promise;
+
+		await loop.stop();
+
+		expect((await readRun("run-1"))?.status).toBe("error");
+		expect((await readEvents("run-1")).map((event) => event.type)).toEqual([
+			"run_error",
+		]);
+	});
+
+	for (const lateResult of ["success", "error"] as const) {
+		it(`lets durable interruption beat a late SDK ${lateResult}`, async () => {
+			const worker = buildWorker();
+			const started = Promise.withResolvers<void>();
+			const stopped = Promise.withResolvers<void>();
+			const deadline = virtualStopDeadline();
+			const loop = buildLoop(
+				worker,
+				async () => ({
+					async interrupt() {
+						stopped.resolve();
+					},
+					close() {
+						stopped.resolve();
+					},
+					async *[Symbol.asyncIterator]() {
+						started.resolve();
+						await stopped.promise;
+						if (lateResult === "error") throw new Error("late SDK error");
+						yield resultMessage("late-session");
+					},
+				}),
+				silentLogger,
+				deadline.options,
+			);
+			await createQueuedRunTx(tdb.db, {
+				runId: "run-1",
+				userId: "user-1",
+				conversationId: "conv-1",
+			});
+			await loop.tick();
+			await started.promise;
+			await requestRunInterruptionTx(tdb.db, {
+				runId: "run-1",
+				userId: "user-1",
+				conversationId: "conv-1",
+			});
+
+			await loop.tick();
+			await worker.drain();
+
+			expect((await readRun("run-1"))?.status).toBe("interrupted");
+			expect((await readEvents("run-1")).map((event) => event.type)).toEqual([
+				"run_interrupted",
+			]);
+		});
+	}
 
 	it("terminalizes an SDK failure with the generic client message", async () => {
 		const worker = buildWorker();

--- a/apps/agent-worker/src/sdk/run-processor.test.ts
+++ b/apps/agent-worker/src/sdk/run-processor.test.ts
@@ -17,12 +17,8 @@ import { eq } from "drizzle-orm";
 import type { WorkerLogger } from "../logger";
 import { RunLoop } from "../run-loop";
 import { Worker } from "../worker";
-import type { SupervisedQuery } from "./agent-stream";
-import {
-	createSdkRunProcessor,
-	type StartRunQuery,
-	type SupervisedQueryOptions,
-} from "./run-processor";
+import type { StartStopDeadline, SupervisedQuery } from "./agent-stream";
+import { createSdkRunProcessor, type StartRunQuery } from "./run-processor";
 import {
 	assistantBlock,
 	streamEvent,
@@ -169,7 +165,7 @@ function buildLoop(
 	worker: Worker,
 	startRunQuery: StartRunQuery,
 	logger: WorkerLogger = silentLogger,
-	supervisedQueryOptions?: SupervisedQueryOptions,
+	startStopDeadline?: StartStopDeadline,
 ) {
 	return new RunLoop({
 		db: tdb.db,
@@ -178,7 +174,7 @@ function buildLoop(
 		processor: createSdkRunProcessor({
 			startRunQuery,
 			logger,
-			supervisedQueryOptions,
+			startStopDeadline,
 		}),
 		heartbeatIntervalMs: 15_000,
 		logger,
@@ -195,21 +191,19 @@ function buildWorker() {
 }
 
 function virtualStopDeadline(): {
-	options: SupervisedQueryOptions;
+	startStopDeadline: StartStopDeadline;
 	elapse(): void;
 	started: Promise<number>;
 } {
 	const elapsed = Promise.withResolvers<void>();
 	const started = Promise.withResolvers<number>();
 	return {
-		options: {
-			startStopDeadline(timeoutMs) {
-				started.resolve(timeoutMs);
-				return {
-					elapsed: elapsed.promise,
-					cancel() {},
-				};
-			},
+		startStopDeadline(timeoutMs) {
+			started.resolve(timeoutMs);
+			return {
+				elapsed: elapsed.promise,
+				cancel() {},
+			};
 		},
 		elapse: () => elapsed.resolve(),
 		started: started.promise,
@@ -595,16 +589,14 @@ describe("createSdkRunProcessor — through the run loop", () => {
 				};
 			},
 			silentLogger,
-			{
-				startStopDeadline(timeoutMs) {
-					deadlineMs = timeoutMs;
-					return {
-						elapsed: new Promise<void>(() => {}),
-						cancel() {
-							deadlineCancelled = true;
-						},
-					};
-				},
+			(timeoutMs) => {
+				deadlineMs = timeoutMs;
+				return {
+					elapsed: new Promise<void>(() => {}),
+					cancel() {
+						deadlineCancelled = true;
+					},
+				};
 			},
 		);
 		await createQueuedRunTx(tdb.db, {
@@ -670,7 +662,7 @@ describe("createSdkRunProcessor — through the run loop", () => {
 				};
 			},
 			logger,
-			deadline.options,
+			deadline.startStopDeadline,
 		);
 		await createQueuedRunTx(tdb.db, {
 			runId: "run-1",
@@ -737,7 +729,7 @@ describe("createSdkRunProcessor — through the run loop", () => {
 				};
 			},
 			silentLogger,
-			deadline.options,
+			deadline.startStopDeadline,
 		);
 		await createQueuedRunTx(tdb.db, {
 			runId: "run-1",
@@ -767,30 +759,90 @@ describe("createSdkRunProcessor — through the run loop", () => {
 		expect(await readEvents("run-1")).toEqual([]);
 	});
 
-	it("maps a query-local stopped disposition to error", async () => {
+	it("writes no terminal Outcome when the fence is lost after forced close", async () => {
 		const worker = buildWorker();
 		const started = Promise.withResolvers<void>();
-		const settled = Promise.withResolvers<void>();
-		const stopController = new AbortController();
+		const closeCalled = Promise.withResolvers<void>();
+		const releaseStream = Promise.withResolvers<void>();
 		const deadline = virtualStopDeadline();
 		const loop = buildLoop(
 			worker,
 			async () => ({
-				stopSignal: stopController.signal,
-				async interrupt() {
-					settled.resolve();
-				},
+				async interrupt() {},
 				close() {
-					settled.resolve();
+					closeCalled.resolve();
 				},
-				// biome-ignore lint/correctness/useYield: models an infrastructure-stopped SDK query.
+				// biome-ignore lint/correctness/useYield: stream settlement is held past forced close to revoke the fence.
 				async *[Symbol.asyncIterator]() {
 					started.resolve();
-					await settled.promise;
+					await releaseStream.promise;
 				},
 			}),
 			silentLogger,
-			deadline.options,
+			deadline.startStopDeadline,
+		);
+		await createQueuedRunTx(tdb.db, {
+			runId: "run-1",
+			userId: "user-1",
+			conversationId: "conv-1",
+		});
+		await loop.tick();
+		await started.promise;
+		await requestRunInterruptionTx(tdb.db, {
+			runId: "run-1",
+			userId: "user-1",
+			conversationId: "conv-1",
+		});
+		await loop.tick();
+		deadline.elapse();
+		await closeCalled.promise;
+
+		await tdb.db
+			.update(runs)
+			.set({
+				lockedBy: "worker-2",
+				lockedUntil: new Date(Date.now() + 60_000),
+			})
+			.where(eq(runs.runId, "run-1"));
+		releaseStream.resolve();
+		await worker.drain();
+
+		expect(await readRun("run-1")).toMatchObject({
+			status: "interrupt_requested",
+			lockedBy: "worker-2",
+		});
+		expect(await readEvents("run-1")).toEqual([]);
+	});
+
+	it("force-closes a query-local infrastructure stop and maps it to error", async () => {
+		const worker = buildWorker();
+		const started = Promise.withResolvers<void>();
+		const forceCloseController = new AbortController();
+		const calls: string[] = [];
+		const loop = buildLoop(
+			worker,
+			async () => ({
+				forceCloseSignal: forceCloseController.signal,
+				async interrupt() {
+					calls.push("interrupt");
+				},
+				close() {
+					calls.push("close");
+				},
+				async *[Symbol.asyncIterator]() {
+					started.resolve();
+					if (!forceCloseController.signal.aborted) {
+						await new Promise<void>((resolve) =>
+							forceCloseController.signal.addEventListener(
+								"abort",
+								() => resolve(),
+								{ once: true },
+							),
+						);
+					}
+				},
+			}),
+			silentLogger,
 		);
 		await createQueuedRunTx(tdb.db, {
 			runId: "run-1",
@@ -800,9 +852,10 @@ describe("createSdkRunProcessor — through the run loop", () => {
 
 		await loop.tick();
 		await started.promise;
-		stopController.abort();
+		forceCloseController.abort();
 		await worker.drain();
 
+		expect(calls).toEqual(["close"]);
 		expect((await readRun("run-1"))?.status).toBe("error");
 		expect((await readEvents("run-1")).map((event) => event.type)).toEqual([
 			"run_error",
@@ -813,14 +866,17 @@ describe("createSdkRunProcessor — through the run loop", () => {
 		const worker = buildWorker();
 		const started = Promise.withResolvers<void>();
 		const settled = Promise.withResolvers<void>();
-		const deadline = virtualStopDeadline();
+		const calls: string[] = [];
+		let deadlines = 0;
 		const loop = buildLoop(
 			worker,
-			async () => ({
+			async (_run, _signal) => ({
 				async interrupt() {
+					calls.push("interrupt");
 					settled.resolve();
 				},
 				close() {
+					calls.push("close");
 					settled.resolve();
 				},
 				// biome-ignore lint/correctness/useYield: models a query stopped by worker shutdown.
@@ -830,7 +886,10 @@ describe("createSdkRunProcessor — through the run loop", () => {
 				},
 			}),
 			silentLogger,
-			deadline.options,
+			() => {
+				deadlines++;
+				return { elapsed: new Promise(() => {}), cancel() {} };
+			},
 		);
 		await createQueuedRunTx(tdb.db, {
 			runId: "run-1",
@@ -842,6 +901,8 @@ describe("createSdkRunProcessor — through the run loop", () => {
 
 		await loop.stop();
 
+		expect(calls).toEqual(["close"]);
+		expect(deadlines).toBe(0);
 		expect((await readRun("run-1"))?.status).toBe("error");
 		expect((await readEvents("run-1")).map((event) => event.type)).toEqual([
 			"run_error",
@@ -871,7 +932,7 @@ describe("createSdkRunProcessor — through the run loop", () => {
 					},
 				}),
 				silentLogger,
-				deadline.options,
+				deadline.startStopDeadline,
 			);
 			await createQueuedRunTx(tdb.db, {
 				runId: "run-1",

--- a/apps/agent-worker/src/sdk/run-processor.ts
+++ b/apps/agent-worker/src/sdk/run-processor.ts
@@ -17,9 +17,9 @@ import {
  * run supervision (plan Task 7.2, this module) and everything a query needs that
  * later milestones own: the provisioned E2B sandbox and its clients, the bound
  * executor tools ({@link buildRunTools}), the OpenRouter model client, the docs
- * scope, and the resumed session. The returned handle is consumed under `signal`
- * — which the supervisor aborts on interruption, ownership loss, or shutdown, so the
- * query can be interrupted.
+ * scope, and the resumed session. `signal` cancels Tool/E2B work for any
+ * supervisor stop; the returned query's interrupt/close controls remain under
+ * stream supervision.
  */
 export type StartRunQuery = (
 	run: RunRecord,
@@ -29,10 +29,6 @@ export type StartRunQuery = (
 export interface SdkRunProcessorDeps {
 	startRunQuery: StartRunQuery;
 	logger: WorkerLogger;
-	supervisedQueryOptions?: SupervisedQueryOptions;
-}
-
-export interface SupervisedQueryOptions {
 	startStopDeadline?: StartStopDeadline;
 }
 
@@ -54,12 +50,16 @@ export function createSdkRunProcessor(deps: SdkRunProcessorDeps): RunProcessor {
 		const outcome: AgentStreamOutcome = await consumeAgentStream({
 			runId: ctx.run.runId,
 			query,
-			signal: ctx.signal,
+			signal: ctx.interruptionSignal,
+			forceCloseSignals: [
+				ctx.shutdownSignal,
+				...(query.forceCloseSignal ? [query.forceCloseSignal] : []),
+			],
 			ownershipLostSignal: ctx.ownershipLostSignal,
 			appendModelContents: ctx.appendModelContents,
 			appendLiveEvent: ctx.appendLiveEvent,
 			logger: deps.logger,
-			startStopDeadline: deps.supervisedQueryOptions?.startStopDeadline,
+			startStopDeadline: deps.startStopDeadline,
 		});
 		const { disposition, ...streamMetadata } = outcome;
 		return {

--- a/apps/agent-worker/src/sdk/run-processor.ts
+++ b/apps/agent-worker/src/sdk/run-processor.ts
@@ -50,7 +50,7 @@ export function createSdkRunProcessor(deps: SdkRunProcessorDeps): RunProcessor {
 		const outcome: AgentStreamOutcome = await consumeAgentStream({
 			runId: ctx.run.runId,
 			query,
-			signal: ctx.interruptionSignal,
+			interruptionSignal: ctx.interruptionSignal,
 			forceCloseSignals: [
 				ctx.shutdownSignal,
 				...(query.forceCloseSignal ? [query.forceCloseSignal] : []),

--- a/apps/agent-worker/src/sdk/run-processor.ts
+++ b/apps/agent-worker/src/sdk/run-processor.ts
@@ -8,6 +8,7 @@ import type { RunProcessor } from "../run-loop";
 import {
 	type AgentStreamOutcome,
 	consumeAgentStream,
+	type StartStopDeadline,
 	type SupervisedQuery,
 } from "./agent-stream";
 
@@ -28,6 +29,11 @@ export type StartRunQuery = (
 export interface SdkRunProcessorDeps {
 	startRunQuery: StartRunQuery;
 	logger: WorkerLogger;
+	supervisedQueryOptions?: SupervisedQueryOptions;
+}
+
+export interface SupervisedQueryOptions {
+	startStopDeadline?: StartStopDeadline;
 }
 
 /**
@@ -49,21 +55,21 @@ export function createSdkRunProcessor(deps: SdkRunProcessorDeps): RunProcessor {
 			runId: ctx.run.runId,
 			query,
 			signal: ctx.signal,
+			ownershipLostSignal: ctx.ownershipLostSignal,
 			appendModelContents: ctx.appendModelContents,
 			appendLiveEvent: ctx.appendLiveEvent,
 			logger: deps.logger,
+			startStopDeadline: deps.supervisedQueryOptions?.startStopDeadline,
 		});
+		const { disposition, ...streamMetadata } = outcome;
 		return {
-			// Advance the conversation's resume pointer only when the SDK produced a
-			// session id and no `mirror_error` left the stored transcript unreliable
-			// (ADR-0005); otherwise the run still succeeds but the pointer holds.
-			agentSession:
-				outcome.sessionId !== null && !outcome.mirrorErrorObserved
-					? { sessionId: outcome.sessionId }
-					: null,
+			disposition,
+			streamMetadata,
 			artifactPublication:
-				(query.getArtifactPublication?.() as ArtifactPublication | null) ??
-				null,
+				disposition === "completed"
+					? ((query.getArtifactPublication?.() as ArtifactPublication | null) ??
+						null)
+					: null,
 		};
 	};
 }

--- a/apps/agent-worker/src/sdk/start-run-query.test.ts
+++ b/apps/agent-worker/src/sdk/start-run-query.test.ts
@@ -169,6 +169,7 @@ async function consume(query: SupervisedQuery): Promise<void> {
 function immediateQuery() {
 	const q = {
 		interrupts: 0,
+		close() {},
 		async interrupt() {
 			q.interrupts++;
 		},
@@ -185,9 +186,14 @@ function gatedQuery() {
 	});
 	const q = {
 		interrupts: 0,
+		closes: 0,
 		release: () => release(),
 		async interrupt() {
 			q.interrupts++;
+		},
+		close() {
+			q.closes++;
+			release();
 		},
 		// biome-ignore lint/correctness/useYield: the fixture models a silent, still-running SDK stream.
 		async *[Symbol.asyncIterator]() {
@@ -195,22 +201,6 @@ function gatedQuery() {
 		},
 	};
 	return q;
-}
-
-/** A query that ends CLEANLY once the built options' abort controller fires —
- * the worst-case SDK stream that swallows the abort instead of throwing. */
-function abortEndingQuery(getSignal: () => AbortSignal | undefined) {
-	return {
-		async interrupt() {},
-		async *[Symbol.asyncIterator]() {
-			const signal = getSignal();
-			if (!signal) throw new Error("options were never captured");
-			if (signal.aborted) return;
-			await new Promise<void>((resolve) => {
-				signal.addEventListener("abort", () => resolve(), { once: true });
-			});
-		},
-	};
 }
 
 interface FakeProvisionConfig {
@@ -858,7 +848,7 @@ describe("createStartRunQuery — renewal and abort linkage", () => {
 		expect(h.handle.renews).toBe(renewsAtEnd);
 	});
 
-	it("renewal failure aborts the linked controller and the turn ends in error, never done", async () => {
+	it("renewal failure requests bounded query stop and still ends in error", async () => {
 		const h = buildHarness({
 			provision: {
 				sandboxId: "sb-1",
@@ -867,24 +857,38 @@ describe("createStartRunQuery — renewal and abort linkage", () => {
 			},
 			sandboxIdleMs: 10,
 		});
-		// Worst case: the aborted SDK stream ends cleanly instead of throwing.
-		h.setQuery(
-			abortEndingQuery(() => h.captured.options?.abortController?.signal),
-		);
+		const gated = gatedQuery();
+		h.setQuery(gated);
 		const run = await createClaimedRun({
 			runId: "run-1",
 			conversationId: "conv-1",
 		});
 
 		const query = await h.startRunQuery(run, freshSignal());
+		const consumed = consume(query);
+		await until(() => query.stopSignal?.aborted === true);
 
-		await expect(consume(query)).rejects.toThrow(/renewal/);
-		expect(h.captured.options?.abortController?.signal.aborted).toBe(true);
+		expect(h.captured.options?.abortController?.signal.aborted).toBe(false);
+		query.close();
+		await expect(consumed).rejects.toThrow(/renewal/);
 		expect(h.handle.disposed).toBe(true);
 	});
 
-	it("links the run signal to the SDK abort controller and passes interrupt through", async () => {
-		const h = buildHarness({ provision: { sandboxId: "sb-1", isNew: true } });
+	it("aborts Tool work without hard-aborting the SDK and passes both stop controls through", async () => {
+		let toolSignal: AbortSignal | undefined;
+		const h = buildHarness({
+			provision: { sandboxId: "sb-1", isNew: true },
+			artifactPublisher: {
+				async begin({ signal }) {
+					toolSignal = signal;
+					return {
+						async publish() {
+							return null;
+						},
+					};
+				},
+			},
+		});
 		const gated = gatedQuery();
 		h.setQuery(gated);
 		const controller = new AbortController();
@@ -897,12 +901,14 @@ describe("createStartRunQuery — renewal and abort linkage", () => {
 		const consumed = consume(query);
 
 		controller.abort();
-		expect(h.captured.options?.abortController?.signal.aborted).toBe(true);
+		expect(toolSignal?.aborted).toBe(true);
+		expect(h.captured.options?.abortController?.signal.aborted).toBe(false);
 
 		await query.interrupt();
 		expect(gated.interrupts).toBe(1);
 
-		gated.release();
+		query.close();
+		expect(gated.closes).toBe(1);
 		await consumed;
 		expect(h.handle.disposed).toBe(true);
 	});

--- a/apps/agent-worker/src/sdk/start-run-query.test.ts
+++ b/apps/agent-worker/src/sdk/start-run-query.test.ts
@@ -393,7 +393,7 @@ describe("createStartRunQuery — query configuration (ADR-0006)", () => {
 		expect(typeof options?.systemPrompt).toBe("string");
 		expect(options?.model).toBe("anthropic/claude-test");
 		expect(options?.pathToClaudeCodeExecutable).toBe("/opt/sdk/cli/claude");
-		expect(options?.abortController).toBeInstanceOf(AbortController);
+		expect(options?.abortController).toBeUndefined();
 	});
 
 	it("teaches the model to use inventory separately from passage search and loading", () => {
@@ -848,7 +848,7 @@ describe("createStartRunQuery — renewal and abort linkage", () => {
 		expect(h.handle.renews).toBe(renewsAtEnd);
 	});
 
-	it("renewal failure requests bounded query stop and still ends in error", async () => {
+	it("renewal failure requests immediate query close and still ends in error", async () => {
 		const h = buildHarness({
 			provision: {
 				sandboxId: "sb-1",
@@ -866,15 +866,14 @@ describe("createStartRunQuery — renewal and abort linkage", () => {
 
 		const query = await h.startRunQuery(run, freshSignal());
 		const consumed = consume(query);
-		await until(() => query.stopSignal?.aborted === true);
+		await until(() => query.forceCloseSignal?.aborted === true);
 
-		expect(h.captured.options?.abortController?.signal.aborted).toBe(false);
 		query.close();
 		await expect(consumed).rejects.toThrow(/renewal/);
 		expect(h.handle.disposed).toBe(true);
 	});
 
-	it("aborts Tool work without hard-aborting the SDK and passes both stop controls through", async () => {
+	it("aborts Tool work and passes the query stop controls through", async () => {
 		let toolSignal: AbortSignal | undefined;
 		const h = buildHarness({
 			provision: { sandboxId: "sb-1", isNew: true },
@@ -902,7 +901,6 @@ describe("createStartRunQuery — renewal and abort linkage", () => {
 
 		controller.abort();
 		expect(toolSignal?.aborted).toBe(true);
-		expect(h.captured.options?.abortController?.signal.aborted).toBe(false);
 
 		await query.interrupt();
 		expect(gated.interrupts).toBe(1);

--- a/apps/agent-worker/src/sdk/start-run-query.test.ts
+++ b/apps/agent-worker/src/sdk/start-run-query.test.ts
@@ -848,6 +848,39 @@ describe("createStartRunQuery — renewal and abort linkage", () => {
 		expect(h.handle.renews).toBe(renewsAtEnd);
 	});
 
+	it("settles run resources on close even when the SDK iterator stays hung", async () => {
+		const streamStarted = Promise.withResolvers<void>();
+		const h = buildHarness({
+			provision: { sandboxId: "sb-1", isNew: true },
+			sandboxIdleMs: 20,
+		});
+		h.setQuery({
+			async interrupt() {},
+			close() {},
+			async *[Symbol.asyncIterator]() {
+				streamStarted.resolve();
+				await new Promise<void>(() => {});
+			},
+		});
+		const run = await createClaimedRun({
+			runId: "run-1",
+			conversationId: "conv-1",
+		});
+		const query = await h.startRunQuery(run, freshSignal());
+		const iterator = query[Symbol.asyncIterator]();
+		void iterator.next();
+		await streamStarted.promise;
+		await until(() => h.handle.renews >= 1);
+
+		query.close();
+		await until(() => h.handle.disposed);
+
+		const renewsAtClose = h.handle.renews;
+		await Bun.sleep(30);
+		expect(h.handle.renews).toBe(renewsAtClose);
+		expect(h.disposedClaudeConfigDirs).toEqual(h.createdClaudeConfigDirs);
+	});
+
 	it("renewal failure requests immediate query close and still ends in error", async () => {
 		const h = buildHarness({
 			provision: {

--- a/apps/agent-worker/src/sdk/start-run-query.ts
+++ b/apps/agent-worker/src/sdk/start-run-query.ts
@@ -157,18 +157,14 @@ export function createStartRunQuery(deps: StartRunQueryDeps): StartRunQuery {
 			throw error;
 		}
 
-		// Tool/E2B work stops immediately. The SDK process has a separate hard-abort
-		// controller so Run control can first use interrupt() and the bounded clean
-		// stop window before close() forcefully tears the process down.
+		// Every supervisor stop cancels Tool/E2B work immediately. SDK teardown is
+		// owned by stream supervision: durable interruption gets its bounded clean
+		// window, while operational failures and shutdown close immediately.
 		const toolController = new AbortController();
-		const sdkController = new AbortController();
-		const queryStopController = new AbortController();
-		const stopRun = (): void => {
-			toolController.abort();
-			queryStopController.abort();
-		};
-		if (signal.aborted) stopRun();
-		else signal.addEventListener("abort", stopRun, { once: true });
+		const forceCloseController = new AbortController();
+		const stopToolWork = (): void => toolController.abort();
+		if (signal.aborted) stopToolWork();
+		else signal.addEventListener("abort", stopToolWork, { once: true });
 
 		let renewalFailure: { error: unknown } | null = null;
 		const renewal = startSandboxRenewal({
@@ -182,7 +178,8 @@ export function createStartRunQuery(deps: StartRunQueryDeps): StartRunQuery {
 					sandboxId: provisioned.sandboxId,
 					error: toMessage(error),
 				});
-				stopRun();
+				toolController.abort();
+				forceCloseController.abort();
 			},
 		});
 		let settled = false;
@@ -193,7 +190,7 @@ export function createStartRunQuery(deps: StartRunQueryDeps): StartRunQuery {
 			// The paused sandbox IS the persisted workspace (ADR-0007): dispose
 			// only stops keeping it awake.
 			provisioned.dispose();
-			signal.removeEventListener("abort", stopRun);
+			signal.removeEventListener("abort", stopToolWork);
 			await claudeConfigDir.dispose();
 		};
 
@@ -213,7 +210,6 @@ export function createStartRunQuery(deps: StartRunQueryDeps): StartRunQuery {
 				provisioned,
 				documentScope,
 				toolController,
-				sdkController,
 				claudeConfigDir: claudeConfigDir.path,
 			});
 			const underlying = deps.query({ prompt: started.message, options });
@@ -221,7 +217,7 @@ export function createStartRunQuery(deps: StartRunQueryDeps): StartRunQuery {
 				withArtifactPublication(underlying, artifactPublication),
 				settle,
 				() => renewalFailure,
-				queryStopController.signal,
+				forceCloseController.signal,
 			);
 		} catch (error) {
 			await settle();
@@ -350,7 +346,6 @@ function buildQueryOptions(
 		provisioned: ProvisionedSandbox;
 		documentScope: RunToolDeps["documentScope"];
 		toolController: AbortController;
-		sdkController: AbortController;
 		claudeConfigDir: string;
 	},
 ): Options {
@@ -361,7 +356,6 @@ function buildQueryOptions(
 		provisioned,
 		documentScope,
 		toolController,
-		sdkController,
 		claudeConfigDir,
 	} = input;
 	const binding: RunBinding = {
@@ -428,7 +422,6 @@ function buildQueryOptions(
 		},
 		pathToClaudeCodeExecutable: deps.pathToClaudeCodeExecutable,
 		mcpServers: { [EXECUTOR_SERVER_NAME]: createRunMcpServer(toolDeps) },
-		abortController: sdkController,
 		sessionStore: sessionConfig.sessionStore,
 		cwd: sessionConfig.cwd,
 		...(sessionConfig.resume !== undefined
@@ -440,21 +433,21 @@ function buildQueryOptions(
 /**
  * Wrap the SDK query so the turn's per-run resources settle exactly when its
  * stream does (renewal stops, the sandbox is left to idle-pause), and a
- * renewal failure can never end the turn cleanly: even when the aborted SDK
- * stream ends without raising, the wrapper throws {@link SandboxRenewalError}
- * so the run terminalizes `error`, never `done`.
+ * renewal failure can never end the turn cleanly: even when the force-closed
+ * SDK stream ends without raising, the wrapper throws
+ * {@link SandboxRenewalError} so the run terminalizes `error`, never `done`.
  */
 function superviseTurn(
 	underlying: SupervisedQuery,
 	settle: () => Promise<void>,
 	renewalFailure: () => { error: unknown } | null,
-	stopSignal: AbortSignal,
+	forceCloseSignal: AbortSignal,
 ): SupervisedQuery & Partial<ArtifactAwareQuery> {
 	const artifactQuery = underlying as Partial<ArtifactAwareQuery>;
 	return {
 		interrupt: () => underlying.interrupt(),
 		close: () => underlying.close(),
-		stopSignal,
+		forceCloseSignal,
 		...(artifactQuery.getArtifactPublication
 			? {
 					getArtifactPublication: () =>

--- a/apps/agent-worker/src/sdk/start-run-query.ts
+++ b/apps/agent-worker/src/sdk/start-run-query.ts
@@ -157,13 +157,18 @@ export function createStartRunQuery(deps: StartRunQueryDeps): StartRunQuery {
 			throw error;
 		}
 
-		// One controller links every way this turn can be told to stop: the
-		// supervisor's signal (interruption, ownership loss, shutdown) and a renewal
-		// failure. It aborts the SDK query and kills any running Bash command.
-		const controller = new AbortController();
-		const abortQuery = (): void => controller.abort();
-		if (signal.aborted) abortQuery();
-		else signal.addEventListener("abort", abortQuery, { once: true });
+		// Tool/E2B work stops immediately. The SDK process has a separate hard-abort
+		// controller so Run control can first use interrupt() and the bounded clean
+		// stop window before close() forcefully tears the process down.
+		const toolController = new AbortController();
+		const sdkController = new AbortController();
+		const queryStopController = new AbortController();
+		const stopRun = (): void => {
+			toolController.abort();
+			queryStopController.abort();
+		};
+		if (signal.aborted) stopRun();
+		else signal.addEventListener("abort", stopRun, { once: true });
 
 		let renewalFailure: { error: unknown } | null = null;
 		const renewal = startSandboxRenewal({
@@ -177,7 +182,7 @@ export function createStartRunQuery(deps: StartRunQueryDeps): StartRunQuery {
 					sandboxId: provisioned.sandboxId,
 					error: toMessage(error),
 				});
-				controller.abort();
+				stopRun();
 			},
 		});
 		let settled = false;
@@ -188,7 +193,7 @@ export function createStartRunQuery(deps: StartRunQueryDeps): StartRunQuery {
 			// The paused sandbox IS the persisted workspace (ADR-0007): dispose
 			// only stops keeping it awake.
 			provisioned.dispose();
-			signal.removeEventListener("abort", abortQuery);
+			signal.removeEventListener("abort", stopRun);
 			await claudeConfigDir.dispose();
 		};
 
@@ -199,7 +204,7 @@ export function createStartRunQuery(deps: StartRunQueryDeps): StartRunQuery {
 			const artifactPublication = await deps.artifactPublisher.begin({
 				run,
 				workspace: provisioned.artifactWorkspace,
-				signal: controller.signal,
+				signal: toolController.signal,
 			});
 			const options = buildQueryOptions(deps, {
 				run,
@@ -207,7 +212,8 @@ export function createStartRunQuery(deps: StartRunQueryDeps): StartRunQuery {
 				runtime,
 				provisioned,
 				documentScope,
-				controller,
+				toolController,
+				sdkController,
 				claudeConfigDir: claudeConfigDir.path,
 			});
 			const underlying = deps.query({ prompt: started.message, options });
@@ -215,6 +221,7 @@ export function createStartRunQuery(deps: StartRunQueryDeps): StartRunQuery {
 				withArtifactPublication(underlying, artifactPublication),
 				settle,
 				() => renewalFailure,
+				queryStopController.signal,
 			);
 		} catch (error) {
 			await settle();
@@ -342,7 +349,8 @@ function buildQueryOptions(
 		runtime: ConversationRuntimeRecord;
 		provisioned: ProvisionedSandbox;
 		documentScope: RunToolDeps["documentScope"];
-		controller: AbortController;
+		toolController: AbortController;
+		sdkController: AbortController;
 		claudeConfigDir: string;
 	},
 ): Options {
@@ -352,7 +360,8 @@ function buildQueryOptions(
 		runtime,
 		provisioned,
 		documentScope,
-		controller,
+		toolController,
+		sdkController,
 		claudeConfigDir,
 	} = input;
 	const binding: RunBinding = {
@@ -364,7 +373,7 @@ function buildQueryOptions(
 	const toolDeps: RunToolDeps = {
 		binding,
 		workspaceRoot: provisioned.workspaceRoot,
-		signal: controller.signal,
+		signal: toolController.signal,
 		fileClient: provisioned.fileClient,
 		commandClient: provisioned.commandClient,
 		documentClient: deps.documentClient,
@@ -419,7 +428,7 @@ function buildQueryOptions(
 		},
 		pathToClaudeCodeExecutable: deps.pathToClaudeCodeExecutable,
 		mcpServers: { [EXECUTOR_SERVER_NAME]: createRunMcpServer(toolDeps) },
-		abortController: controller,
+		abortController: sdkController,
 		sessionStore: sessionConfig.sessionStore,
 		cwd: sessionConfig.cwd,
 		...(sessionConfig.resume !== undefined
@@ -439,10 +448,13 @@ function superviseTurn(
 	underlying: SupervisedQuery,
 	settle: () => Promise<void>,
 	renewalFailure: () => { error: unknown } | null,
+	stopSignal: AbortSignal,
 ): SupervisedQuery & Partial<ArtifactAwareQuery> {
 	const artifactQuery = underlying as Partial<ArtifactAwareQuery>;
 	return {
 		interrupt: () => underlying.interrupt(),
+		close: () => underlying.close(),
+		stopSignal,
 		...(artifactQuery.getArtifactPublication
 			? {
 					getArtifactPublication: () =>

--- a/apps/agent-worker/src/sdk/start-run-query.ts
+++ b/apps/agent-worker/src/sdk/start-run-query.ts
@@ -182,16 +182,17 @@ export function createStartRunQuery(deps: StartRunQueryDeps): StartRunQuery {
 				forceCloseController.abort();
 			},
 		});
-		let settled = false;
+		let settlePromise: Promise<void> | undefined;
 		const settle = async (): Promise<void> => {
-			if (settled) return;
-			settled = true;
-			renewal.stop();
-			// The paused sandbox IS the persisted workspace (ADR-0007): dispose
-			// only stops keeping it awake.
-			provisioned.dispose();
-			signal.removeEventListener("abort", stopToolWork);
-			await claudeConfigDir.dispose();
+			settlePromise ??= (async () => {
+				renewal.stop();
+				// The paused sandbox IS the persisted workspace (ADR-0007): dispose
+				// only stops keeping it awake.
+				provisioned.dispose();
+				signal.removeEventListener("abort", stopToolWork);
+				await claudeConfigDir.dispose();
+			})();
+			return settlePromise;
 		};
 
 		try {
@@ -218,6 +219,13 @@ export function createStartRunQuery(deps: StartRunQueryDeps): StartRunQuery {
 				settle,
 				() => renewalFailure,
 				forceCloseController.signal,
+				(error) => {
+					deps.logger.error({
+						message: "run resource cleanup failed after query close",
+						runId: run.runId,
+						error: toMessage(error),
+					});
+				},
 			);
 		} catch (error) {
 			await settle();
@@ -431,10 +439,10 @@ function buildQueryOptions(
 }
 
 /**
- * Wrap the SDK query so the turn's per-run resources settle exactly when its
- * stream does (renewal stops, the sandbox is left to idle-pause), and a
- * renewal failure can never end the turn cleanly: even when the force-closed
- * SDK stream ends without raising, the wrapper throws
+ * Wrap the SDK query so the turn's per-run resources settle when its stream
+ * ends or the query is force-closed (renewal stops, the sandbox is left to
+ * idle-pause), and a renewal failure can never end the turn cleanly: even when
+ * the force-closed SDK stream ends without raising, the wrapper throws
  * {@link SandboxRenewalError} so the run terminalizes `error`, never `done`.
  */
 function superviseTurn(
@@ -442,11 +450,21 @@ function superviseTurn(
 	settle: () => Promise<void>,
 	renewalFailure: () => { error: unknown } | null,
 	forceCloseSignal: AbortSignal,
+	onDetachedSettleError: (error: unknown) => void,
 ): SupervisedQuery & Partial<ArtifactAwareQuery> {
 	const artifactQuery = underlying as Partial<ArtifactAwareQuery>;
 	return {
 		interrupt: () => underlying.interrupt(),
-		close: () => underlying.close(),
+		close: () => {
+			try {
+				underlying.close();
+			} finally {
+				// `close()` is synchronous in the vendor SDK. Start wrapper cleanup
+				// here as well as in the iterator's `finally`: a truly hung iterator
+				// may never process `return()`, but must not keep renewal/config alive.
+				void settle().catch(onDetachedSettleError);
+			}
+		},
 		forceCloseSignal,
 		...(artifactQuery.getArtifactPublication
 			? {


### PR DESCRIPTION
Closes #380. Part of #364 (ADR-0013 is the implementation authority).

Tracer slice 2 of 4: bounded stop mechanics and supervisor-owned cause reconciliation. Slice 1 established the interruption vocabulary/schema/doorbell contract; this slice makes the trusted worker stop live SDK queries within a fixed bound without letting the processor decide the durable Run Outcome.

## What changed

**Bounded SDK stop**
- Split immediate Tool/E2B cancellation from SDK query supervision. Every stop cause aborts active Tool work, while only an observed durable interruption calls `Query.interrupt()` and opens the clean-stop window.
- Added one code-owned, test-injectable 30-second interruption deadline. A query that does not settle is force-closed through `Query.close()` with a structured warning; clean settlement cancels the deadline.
- Kept the Run heartbeat active during the bounded interruption drain so it terminalizes under the live ownership fence.
- Worker shutdown and sandbox-renewal failure close the query immediately instead of consuming the interruption grace period; ownership loss also closes immediately and permits no post-fence transcript drain.
- Removed the now-inert SDK `abortController` plumbing and renamed the internal control-flow error to `QueryStoppedError`.

**Supervisor reconciliation**
- Made the SDK processor report only neutral `completed | stopped` disposition plus observed session/mirror metadata; it never classifies interruption, shutdown, renewal failure, or ownership loss.
- Centralized durable cause precedence in `RunLoop`: accepted interruption wins as `interrupted`; ownership loss writes no terminal; shutdown, sandbox-renewal stop, and other stopped-without-interruption paths end `error`; normal completion ends `done`.
- Suppressed late public model content and Downloadable artifact publication after stop acceptance while allowing bounded private SDK settlement only for an accepted interruption under a live lease.
- Advanced the Agent-session resume pointer only after a clean, successful supervisor outcome with no mirror error.

## Why

The prior path fired the SDK interrupt and hard-abort controller together, leaving no graceful interruption window or forced-close bound. The first implementation separated those controls but granted the new 30-second window to operational shutdown and renewal failure as well, making the default 30-second worker shutdown timeout race the query deadline.

The final design separates mechanics by authority: durable user interruption receives bounded private cleanup; operational failure and shutdown close immediately; ownership loss closes immediately and cannot write. The processor remains cause-blind, while `RunLoop` owns both signals and durable Outcome reconciliation.

## Impact

- Running interruptions stop Tool work promptly and reach a deterministic terminal bound even when the SDK/CLI hangs.
- Heartbeats and ownership fencing remain authoritative throughout an accepted interruption.
- Late SDK success, failure, content, and artifacts cannot override the durable interruption Outcome.
- Worker shutdown and sandbox-renewal failures remain immediate error paths rather than waiting on the interruption grace window or becoming false interruptions.
- No API, database schema, environment variable, or public AG-UI vocabulary changes.

## Tests

- Real `RunLoop` plus fake supervised query covers clean interrupt settlement, virtual 30-second forced close, heartbeat renewal during the window, immediate ownership-loss close, forced-close-then-fence-loss rejection, shutdown, sandbox-renewal stop, late SDK success/error, and the complete cause-precedence matrix.
- Stop-race tests cover pre-observed ownership loss and idempotent close when ownership disappears during an already-started grace period.
- Focused worker matrix: 137 passed / 0 failed.
- Full repository suite: 795 passed / 0 failed (21 credential-gated skips).
- Agent-worker strict TypeScript, Biome, and `git diff --check` passed.

## Reviewer notes

- The initial parallel standards/spec review found and fixed the post-fence drain gap plus close-ordering races before the PR opened.
- The PR two-axis review findings are addressed in `c2b7c38`: the inert SDK controller and one-field supervision-options wrapper were removed; stream settlement and error terminalization were consolidated; the impossible signal-identity guard was deleted; the missing forced-close/fence-loss ordering is tested; and bounded grace is now scoped strictly to accepted interruption so it cannot race the worker shutdown deadline.