### PR TITLE
fix(test): give pglite boots room past bun's 5s hook timeout

### DIFF
--- a/apps/agent-worker/package.json
+++ b/apps/agent-worker/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "agent-worker",
 	"scripts": {
-		"test": "bun test",
+		"test": "bun test --timeout=30000",
 		"dev": "bun run --hot src/index.ts",
 		"start": "bun run src/index.ts",
 		"spike:e2b": "bun run spikes/e2b-semantics/spike.ts",

--- a/apps/chat-api/package.json
+++ b/apps/chat-api/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "chat-api",
 	"scripts": {
-		"test": "bun test",
+		"test": "bun test --timeout=30000",
 		"dev": "bun run --hot src/index.ts",
 		"format": "biome format --write",
 		"lint": "biome lint --write",

--- a/packages/agent-db/package.json
+++ b/packages/agent-db/package.json
@@ -16,7 +16,7 @@
 		"./migrations": "./src/migrations.ts"
 	},
 	"scripts": {
-		"test": "bun test",
+		"test": "bun test --timeout=30000",
 		"db:generate": "drizzle-kit generate",
 		"format": "biome format --write",
 		"lint": "biome lint --write",

--- a/packages/agent-db/src/testing.ts
+++ b/packages/agent-db/src/testing.ts
@@ -34,9 +34,11 @@ export interface TestDb {
 // been seen during instance creation — never after `waitReady` resolves. So
 // creation retries on exactly that trap, on a fresh instance each time;
 // deterministic failures (migration SQL errors, missing files) rethrow on the
-// first attempt. Capped at one retry: bun:test enforces its 5s default
-// timeout on `beforeAll` hooks, and two boots (~2.5s on CI runners) leave
-// comfortable headroom where a third would ride that limit.
+// first attempt. Capped at one retry so a persistent trap surfaces as a failure
+// instead of a long retry loop; the workspace `test` scripts raise bun's
+// per-test timeout (which also governs hooks) to 30s, since the first pglite
+// boot in a `bun test` process pays the one-time postgres.wasm compile and has
+// measured up to ~6.7s on CI runners — past bun's 5s default.
 const BOOT_ATTEMPTS = 2;
 
 function isWasmBootTrap(err: unknown): boolean {


### PR DESCRIPTION
`main` is red — has been since `2188c689`, independent of any open PR.

## Cause

`bun test` enforces a 5s per-test timeout that also governs `beforeAll` hooks. The first pglite file in a `bun test` process pays the one-time `postgres.wasm` compile inside its hook, so that hook blows the default and the workspace exits 1. Every later pglite file reuses the compiled module and boots in ~1.7s.

Three runs, all just past the line:

| Run | Commit | Hook time |
|---|---|---|
| main | `2188c689` | 5451 ms |
| main | `b5eb1054` | 6688 ms |
| PR #386 | `9b519f5` | 5223 ms |

This is a timing cliff CI has drifted past, not an intermittent flake — and it is a third signature, distinct from the two pglite failure modes already on file (the OOM, and the WASM `null reference` boot trap that `createTestDatabase()` retries). A timeout is not a `WebAssembly.RuntimeError`, so that retry never applied.

## Fix

Raise the per-test timeout to 30s in the three workspaces whose tests boot pglite.

Not a timeout argument on the one failing hook: the file order is not stable across machines. On the red runs `conversation-lifecycle-migration.test.ts` booted pglite first; on green run `30077749363` it was `runtime-store.test.ts`. The cost belongs to whichever pglite file bun schedules first, so annotating one hook only relocates the cliff.

`agent-worker` and `chat-api` are included for the same reason — `agent-worker`'s first pglite file took 5.44s on the last green run, passing on luck.

`packages/agent-db/src/testing.ts` gets a comment update only: the `BOOT_ATTEMPTS` note reasoned explicitly off the 5s default, which this change invalidates. Retry behavior is untouched.

## Verification

- Confirmed `--timeout` governs hooks, not just test bodies: a scratch `beforeAll` sleeping 6500 ms fails at the default and passes with `--timeout=30000`.
- `bun run scripts/test-workspaces.ts` (the CI command) — all 5 workspaces pass, 756 tests, 0 fail.
- Biome clean.

No source files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)