### PR TITLE
ci: cancel superseded runs and path-filter the worker image build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,21 @@ on:
     branches: [main]
   pull_request:
 
+# Supersede in-flight runs for the same PR. Keyed on the PR number, so pushes
+# to one PR cancel each other and nothing else.
+#
+# A push to main has no pull_request.number and falls back to the unique
+# run id, putting every main run alone in its own group. That is deliberate
+# and load-bearing: release-deploy.yml triggers on `workflow_run` of this
+# workflow per commit, and Actions keeps at most one *pending* run per group —
+# a third arrival evicts the pending one even with cancel-in-progress false.
+# Grouping main at all could therefore silently drop a production deploy.
+#
+# Groups are repository-wide, not per-workflow, hence the `ci-` prefix.
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -23,20 +38,7 @@ jobs:
       - run: bun run test
       - run: bun test e2e/relay-failure-matrix.integration.test.ts
 
-  # Build the final production-pruned image and exercise the SDK's native CLI
-  # inside it. This needs no runtime credentials and catches both optional-dep
-  # pruning and the Debian/glibc vs musl platform-binary trap.
-  worker-image:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: Build agent-worker image
-        run: >-
-          docker build --platform linux/amd64
-          -f apps/agent-worker/Dockerfile
-          -t mymemo-agent-worker:image-check .
-      - name: Exec-verify pinned Claude CLI
-        run: scripts/smoke/agent-worker-image-check.sh mymemo-agent-worker:image-check
+  # The agent-worker image build lives in worker-image.yml, path-filtered.
 
   # Split-runtime AG-UI integration: runs chat-api plus a deterministic
   # test-only worker against real Postgres and Redis, so atomic admission,

--- a/.github/workflows/worker-image.yml
+++ b/.github/workflows/worker-image.yml
@@ -1,0 +1,58 @@
+name: Worker image
+
+# Build the final production-pruned image and exercise the SDK's native CLI
+# inside it. This needs no runtime credentials and catches both optional-dep
+# pruning and the Debian/glibc vs musl platform-binary trap.
+#
+# Split out of ci.yml purely so it can be path-filtered — `paths` is a
+# workflow-level trigger, not a job-level one, and a gate job would bill its
+# own rounded-up minute and save nothing. The list covers every tracked file
+# that can change the built image or the check's outcome: the Dockerfile, the
+# trees that survive into the final image, every workspace manifest
+# (--frozen-lockfile reads them all), .dockerignore (it decides what the COPYs
+# ingest), and the smoke script. The build context is wider than this — `COPY
+# apps apps` reads every app — but the manifests stage prunes it to
+# package.json files, so nothing else reaches the image. Untracked drift in the
+# `oven/bun:1` base image is not path-filterable and is caught by the
+# deploy-time build instead.
+#
+# Pull requests only. A main-push run would be pure duplicate work: nothing
+# gates on this workflow, and release-deploy.yml's plan job already runs the
+# same build and the same smoke check via
+# scripts/deploy/build_and_push_agent_image.sh before pushing to ECR. Coverage
+# is therefore PR-time plus deploy-time, and a post-merge run in between would
+# only buy a few minutes of notice at the cost of a billed minute every time.
+
+on:
+  pull_request:
+    paths:
+      - apps/agent-worker/**
+      - packages/agent-db/**
+      - packages/live-text/**
+      - apps/*/package.json
+      - packages/*/package.json
+      - package.json
+      - bun.lock
+      - .dockerignore
+      - scripts/smoke/agent-worker-image-check.sh
+      - .github/workflows/worker-image.yml
+
+# Plain ref keying is enough here — every run is a pull_request run, so the ref
+# is already per-PR. ci.yml needs its more careful keying only because it also
+# runs on main, where release-deploy.yml's per-commit gate must not lose a run.
+concurrency:
+  group: worker-image-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  worker-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Build agent-worker image
+        run: >-
+          docker build --platform linux/amd64
+          -f apps/agent-worker/Dockerfile
+          -t mymemo-agent-worker:image-check .
+      - name: Exec-verify pinned Claude CLI
+        run: scripts/smoke/agent-worker-image-check.sh mymemo-agent-worker:image-check

--- a/README.md
+++ b/README.md
@@ -163,9 +163,12 @@ for suite contents, target selection, and deterministic harness tests.
 
 ### Worker image check
 
-Every PR builds the final production-pruned worker image and runs this same
-credential-free gate; release deployment also runs it after build and before
-push:
+A PR that touches the worker image's inputs — the Dockerfile and the trees it
+COPYs, any workspace manifest, the lockfile, `.dockerignore`, or the check
+script — builds the final production-pruned image and runs this same
+credential-free gate (`.github/workflows/worker-image.yml`, path-filtered so
+unrelated PRs skip it). Release deployment runs it unconditionally, after
+build and before push:
 
 ```sh
 docker build --platform linux/amd64 \

--- a/scripts/deploy-config.test.ts
+++ b/scripts/deploy-config.test.ts
@@ -972,8 +972,10 @@ describe("agent deployment config", () => {
 			join(root, "scripts", "deploy", "build_and_push_agent_image.sh"),
 			"utf8",
 		);
-		const ciWorkflow = readFileSync(
-			join(root, ".github", "workflows", "ci.yml"),
+		// The pre-merge image build lives in its own path-filtered workflow, not
+		// in ci.yml, so it can be skipped on pushes that cannot change the image.
+		const workerImageWorkflow = readFileSync(
+			join(root, ".github", "workflows", "worker-image.yml"),
 			"utf8",
 		);
 
@@ -981,7 +983,7 @@ describe("agent deployment config", () => {
 		expect(checkScript).toContain("--network none");
 		expect(checkScript).toContain("--entrypoint bun");
 		expect(checkScript).toContain("resolveAndVerifyClaudeCodeExecutable");
-		expect(ciWorkflow).toContain("agent-worker-image-check.sh");
+		expect(workerImageWorkflow).toContain("agent-worker-image-check.sh");
 
 		const buildIndex = buildScript.indexOf("docker build");
 		const checkIndex = buildScript.indexOf("agent-worker-image-check.sh");


### PR DESCRIPTION
## Why

`X-GPT` is on the free GitHub plan and `mymemo-agent` went private on 2026-07-18, so Actions is capped at **2,000 minutes/month org-wide**. Minutes were free while the repo was public — this is a new constraint.

Measured consumption this billing month: **CI 323 runs** vs **Release deploy 59 runs**, roughly 2,600 estimated minutes against the 2,000 cap. CI is ~80% of the burn, and 323 runs is far more than the number of PRs, because every push stacked a fresh run instead of superseding the last.

Per-job durations on recent successful runs, which drove the design:

| job | duration | billed |
|---|---|---|
| `test` | 120–133s | 3 min |
| `integration` | 90–132s | 2–3 min |
| `worker-image` | 33–50s | 1 min |

Actions rounds every job up to a whole minute.

## What changed

**1. Concurrency on [ci.yml](.github/workflows/ci.yml)**

```yaml
concurrency:
  group: ci-${{ github.event.pull_request.number || github.run_id }}
  cancel-in-progress: true
```

Pushes to a PR supersede each other. A push to `main` has no `pull_request.number`, falls back to the unique run id, and sits alone in its own group.

That fallback is load-bearing. [release-deploy.yml](.github/workflows/release-deploy.yml) triggers on `workflow_run` of CI **per commit**, and Actions keeps at most one *pending* run per group — a third arrival evicts the pending one **even with `cancel-in-progress: false`**. Leaving `main` ungrouped is what protects the deploy; a branch-name guard on `cancel-in-progress` alone does not, because grouping itself is the hazard. Group names are repository-wide, not per-workflow, hence the `ci-` prefix.

**2. The worker image build moved to [worker-image.yml](.github/workflows/worker-image.yml)**, `pull_request`-only and path-filtered. The job itself is byte-identical to the one removed from `ci.yml` and still exec-verifies the pinned Claude CLI.

Three things fell out of measuring rather than assuming:

- **Caching was the original plan and is not here.** The job runs in 33–50s and bills a full minute regardless, so layer caching saves *zero* billed minutes, while `setup-buildx-action` plus a `mode=max` cache export risked pushing it past 60s into a second minute.
- **It needed its own file.** `paths:` is a workflow-level trigger with no job-level equivalent, and a gate job inside `ci.yml` would bill its own rounded-up minute and net zero.
- **It runs on PRs only.** A post-merge run is duplicate work: nothing gates on this workflow, and release-deploy's plan job already runs the same build and the same smoke check via [build_and_push_agent_image.sh](scripts/deploy/build_and_push_agent_image.sh) before `docker push`. Coverage is PR-time plus deploy-time.

The filter covers every tracked file that can change the resulting image: the Dockerfile and the trees that survive into it, all workspace manifests, `bun.lock`, `.dockerignore`, and the smoke script. It is deliberately broad — `apps/agent-worker/**` is included because a src change adding a dev-only import is exactly the optional-dep pruning trap this job catches, and `test` cannot see it. ~45% of recent commits touch none of these paths. Base-image drift in `oven/bun:1` is not path-filterable and is caught at deploy time.

**3. Docs and tests follow.** `README.md`'s "Worker image check" section said every PR builds the image, which path-filtering made false. `scripts/deploy-config.test.ts`'s exec-verify assertion now reads `worker-image.yml`; it guards the property that every built worker image is exec-verified, and moving the job had left it red.

## Consequences worth knowing

`release-deploy.yml` watches `workflows: [CI]`, so **CI-green on `main` no longer implies the worker image builds.** No bad image can reach ECR — the deploy's plan job builds and smoke-checks before `docker push` — but the failure now surfaces inside that job, after `terraform -chdir=infra/ecr apply` and after chat-api's image is pushed. That leaves an orphan ECR tag and a failed deploy rather than a failed CI run. No Terraform applies, so this is cleanup cost, not an availability risk.

The narrow case this opens: two PRs that are individually clean and jointly break the image (one touches the worker, one touches the lockfile). Previously the main-push build caught it minutes earlier. Restoring that would cost a billed minute on every qualifying merge, which is the trade this PR is making deliberately.

## Verification

Static checks, all passing:

- `bun test scripts/deploy-config.test.ts` — **36 pass, 0 fail**
- Both workflows parse; `worker-image.yml` has a single `pull_request` trigger with 10 path entries
- Biome: 21 warnings in `deploy-config.test.ts` are pre-existing on `main`, none in the edited range

**Nothing here has run on a runner.** The org is currently over its Actions spending limit, so jobs fail at the gate before allocation. These need confirming before merge:

- [ ] a second push to a PR cancels the first CI run
- [ ] a docs-only PR does **not** start `Worker image`
- [ ] a worker-touching PR **does** start it
- [ ] merge to `main` still triggers `Release deploy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)