### PR TITLE
docs: record Conversation-level ownership, its cutover, and the Claim prototype

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -41,28 +41,48 @@ The set of documents a conversation may access — `general`, `collection`, or
 _Avoid_: permissions, access level
 
 **Run**:
-One backend execution attempt serving a user message. At most one run per
-conversation is active at a time, and in v1 a run executes at most once —
+One backend execution attempt serving a user message. A Conversation's Runs are
+executed one at a time in submission order, and a Run executes at most once —
 never requeued or automatically retried.
 _Avoid_: job, task, attempt
 
+**Active Run**:
+A Run that has been admitted but has not yet reached its Outcome. A Conversation
+may hold only a bounded number of them at once; a submission past that bound is
+refused rather than accepted and delayed.
+_Avoid_: pending run, in-flight run, queued run (that is one status among several)
+
 **Run interruption**:
 A user-requested end to one queued or running Run that leaves its Conversation,
-Agent session, and Workspace available for later Runs. Once accepted before
-another Outcome, interruption wins the Run's Outcome and prevents Downloadable
-artifact publication.
+Agent session, and Workspace available for later Runs, and its Conversation's
+other active Runs unaffected. Once accepted before another Outcome, interruption
+wins the Run's Outcome and prevents Downloadable artifact publication.
 _Avoid_: cancellation, Conversation termination, HITL interrupt
 
 **Claim**:
-Taking exclusive execution ownership of a queued run. A v1 run is claimed at
-most once; a stale run is terminalized, never reclaimed.
-_Avoid_: job reservation
+Taking exclusive execution ownership of a Conversation in order to serve, one at
+a time in submission order, the Runs it had active at that moment. A Conversation
+is claimed many times over its life by any worker, and Runs submitted after a
+Claim are left for a later one.
+_Avoid_: job reservation, run claim
 
 **Ownership lease**:
-The time-bounded write authority a worker receives by claiming a Run, represented
-by `locked_by` and `locked_until` and renewed by heartbeat. After expiry, that
-worker's fenced writes are rejected and recovery may terminalize the stale Run.
-_Avoid_: sandbox lease (the decommissioned prototype concept)
+The time-bounded, exclusive write authority over one Conversation and every
+resource scoped to it, obtained by claiming it and kept alive by heartbeat. Once
+it lapses or is superseded, that holder's writes are rejected.
+_Avoid_: run lease, sandbox lease (the decommissioned prototype concept)
+
+**Ownership epoch**:
+The per-Conversation number identifying one Claim, increasing with every Claim.
+It names the holder in every fenced write, so a superseded holder is rejected
+even while it still believes it holds the lease.
+_Avoid_: fencing token, version, generation
+
+**Reclamation**:
+Terminalizing the Runs of a Conversation whose Ownership lease lapsed without
+release, so a Conversation whose worker vanished cannot hold Runs that never
+reach an Outcome. Distinct from Recovering, which is a client behavior.
+_Avoid_: recovery (that word is the client-side term), stale-run recovery
 
 **Run event**:
 One record in a Run's durable, ordered Postgres event log — the source of truth
@@ -90,7 +110,7 @@ _Avoid_: Recovering, resuming after a cursor
 Waiting for permanent Conversation history after a Live Stream becomes
 unusable, then replacing the Run's provisional client state with that durable
 projection.
-_Avoid_: Reconnecting
+_Avoid_: Reconnecting, Reclamation (that is the worker-side term)
 
 **Conversation history**:
 The durable, user-visible record of submitted messages, Assistant messages,

--- a/docs/adr/0015-conversation-level-ownership-with-epoch.md
+++ b/docs/adr/0015-conversation-level-ownership-with-epoch.md
@@ -1,0 +1,113 @@
+# Ownership is claimed per Conversation, fenced by an epoch
+
+Status: accepted
+
+Every resource a Run's execution writes is already Conversation-scoped —
+`conversation_runtime` keyed `(user_id, conversation_id)`, `agent_sessions`
+keyed `conversation_id`, `conversation_artifacts`, and the E2B sandbox
+itself. Execution ownership was the one exception, held on the Run. Nearly
+every awkward thing in the queue code traced to that single mismatch:
+runtime writes borrowed authority by `EXISTS`-ing back into `runs`, the
+sandbox was reconnected once per turn because no authority outlived a turn,
+two ownership predicate variants existed (Run-scoped and user-bound), and
+the `runs_one_active_per_conversation` partial unique index quietly doubled
+as an ownership guarantee it was never declared to provide.
+
+That last point corrects the record. Two comments — on the `runs` table and
+atop `run-store.ts` — stated that v1 deliberately carries no fencing token
+because "a run is claimed exactly once, so `locked_by` + `locked_until` is
+the complete ownership fence." The conclusion held, but the reasoning did
+not: per-statement lease checks do not compose across the multi-statement
+transactions these helpers actually perform. What prevented two workers from
+executing one Conversation was the partial unique index plus the terminal
+NULL-out of the lease columns — structural safety from a constraint nobody
+documented as load-bearing, not from the lease. The lease was closer to
+advisory than the comments claimed.
+
+We therefore move ownership to the Conversation. A worker claims a
+Conversation, serves the Runs it had active at that moment one at a time in
+submission order, and releases. Every Claim increments a per-Conversation
+Ownership epoch, and every fenced write validates
+`(conversation_id, epoch, owner_until > now())` against `conversations`.
+Both conjuncts are required and cover different failures: the epoch fences a
+lease that was superseded by a re-Claim, the deadline fences one that merely
+lapsed with no successor. `owner_worker_id` then carries no safety weight —
+an epoch names exactly one Claim, hence one worker — and survives only for
+log correlation.
+
+**The epoch is necessary here, not optional.** The original no-token argument
+rested on claim-at-most-once. Conversation ownership deliberately breaks that
+premise: a Conversation is claimed many times, by different workers, across
+its life. That is precisely the condition under which a token stops being
+redundant with worker identity.
+
+A Claim serves a snapshot of the Runs active when it was taken; Runs
+submitted mid-drain are deliberately left for a later Claim. This is not a
+missed optimization. It bounds drain length by the admission depth bound
+with no second constant, it sends a mid-drain arrival to the back of the
+global queue by its own `created_at` rather than by policy, and it makes
+release unconditional — `WHERE conversation_id = $c AND epoch = $epoch` —
+where draining to empty would need a conditional release whose "zero rows
+means work arrived, keep the lease and loop" subtlety is load-bearing. The
+cost is that the common case, a follow-up typed while a turn runs, always
+pays a release, a re-Claim, and an E2B reconnect. That is sub-second against
+a turn measured in seconds to minutes.
+
+## Considered options
+
+- **Keep ownership on the Run.** Rejected: it leaves the granularity
+  mismatch, and therefore the borrowed authority and the undeclared
+  index dependency, exactly where they are.
+- **Conversation ownership without a token, relying on worker identity.**
+  Rejected: `generateWorkerId()` is module-scope, so a same-process
+  re-Claim makes the identity byte-identical between a stale holder and the
+  live one, while the live holder's heartbeat makes the deadline true for
+  both. Both conjuncts pass for a definitively stale writer.
+- **Cache the epoch on `runs` to avoid a join per append.** Rejected as
+  unsound: nothing invalidates the cached copy, so a stale worker's epoch
+  still matches its own Run row. It does not fence.
+- **A drain cap `K` bounding Runs served per Claim.** Superseded by
+  snapshot semantics, which bounds it for free.
+
+## Consequences
+
+- The fence check adds one primary-key probe on `conversations` per fenced
+  write. It takes no lock, so fence reads never conflict with each other,
+  only with the brief Claim and release writes. A turn is on the order of
+  15–20 fenced transactions, since a Tool group commits as one batch.
+- Revocation is at-most-one-*after-commit*, not instantaneous: a write
+  already in flight when the epoch bumps can still land. This is inherent to
+  fencing tokens and is harmless here because a Run executes at most once —
+  a late write lands on a Run that Reclamation is about to terminalize, never
+  on one another worker is re-executing.
+- `runs_one_active_per_conversation` is dropped, so at-most-one-executing
+  becomes a program-order property of a single drain loop rather than a
+  distributed invariant. The database still guarantees a single writer; what
+  it no longer guarantees is that the writer starts one Run at a time. That
+  is reviewable in one file and wants a comment saying so.
+- `runs.locked_until` and `runs.heartbeat_at` are dropped —
+  the latter is already write-only dead code today — along with
+  `runs_stale_recovery_idx`. `locked_by` becomes
+  `executed_by_worker_id` and survives the terminal transition as
+  provenance, because a column named for a lock it no longer holds is how
+  the next reader re-acquires the wrong belief this ADR corrects.
+- The drain must distinguish a lost lease (halt, abandon, do not release)
+  from a status rejection (the Run went terminal under us — continue to the
+  next). Today's opaque `RunFenceError` cannot express that difference, so a
+  typed fence outcome is a prerequisite for this work rather than an
+  independent cleanup.
+- The worker scaler must count Conversations, not Runs. Several active Runs
+  on one Conversation are one claimable unit, so a Run-shaped metric would
+  request up to `depth-bound` times the tasks that can help.
+- The Ownership epoch is also recorded on `agent_sessions`, where it is
+  provenance rather than a fence: it makes "which Claim wrote this
+  transcript" answerable, closing a latent hazard where `listSessions`
+  orders by mtime and a dead attempt's transcript is newest. It is
+  deliberately *not* recorded on `conversation_runtime`, where the
+  `conversations` check already prevents the stale write and a copy would
+  only be a second thing to keep in sync.
+- The exact Claim statement — a single `UPDATE` whose candidate subquery
+  joins `runs` and takes `FOR UPDATE OF c SKIP LOCKED` on the
+  `conversations` side alone — is unverified, as is the index shape it wants.
+  The architectural decision does not depend on that form; a different
+  statement would serve. Settle it before the spec.

--- a/docs/adr/0016-gate-closed-cutover-to-conversation-ownership.md
+++ b/docs/adr/0016-gate-closed-cutover-to-conversation-ownership.md
@@ -1,0 +1,43 @@
+# Gate-closed cutover to Conversation ownership
+
+Status: accepted
+
+ADR-0002 refused a coexistence flag between the prototype and split-runtime
+paths because they enforced "one active turn per conversation" with
+different authorities, leaving no single authority for the invariant: two
+turns could run concurrently on one conversation, each legal under its own.
+ADR-0015 recreates that shape during a rolling deploy. An old worker claims
+Runs directly and never consults the Ownership lease; it was safe only
+because `runs_one_active_per_conversation` was an authority both generations
+respected, and ADR-0015 drops that index. Old and new workers would share no
+authority at all.
+
+Unlike ADR-0002 we cannot add "nothing deployed exercises the other path" —
+the split runtime is live. So the cutover closes the exposure gate, lets
+in-flight Runs drain, scales `agent-worker` to zero, applies the migration
+and deploys, then scales up and reopens the gate. There is exactly one
+authority at every instant, because for part of the window there is no
+worker at all.
+
+The alternative was a two-phase rollout: ship the lease alongside Run-level
+claiming with the index and a depth bound of one still in force, then drop
+the index and raise the bound once the fleet is uniform. It avoids downtime
+and it would work. We rejected it because the phase-one shim is *dual
+ownership predicates* — the precise defect ADR-0015 exists to remove. Paying
+to build the disease as a migration step is only worth it if downtime is
+genuinely unavailable, and here it is not: the surface is Statsig-gated, and
+the gate already fails closed, so the window uses machinery we have rather
+than machinery we write.
+
+## Consequences
+
+- Users see `403 Agent is not enabled` for the length of the window, and any
+  turn still running when the drain deadline elapses dies as `error`.
+- This is the assumption to re-test if the product's exposure widens before
+  the work lands. If a maintenance window stops being acceptable, the
+  two-phase rollout becomes correct and this ADR should be superseded rather
+  than worked around.
+- The migration is not additive-only — dropped columns and a dropped index
+  mean the previous worker image cannot run against the new schema. Rollback
+  is a restore, not a redeploy, so the window must not be treated as
+  reversible once workers are back up and writing.

--- a/packages/agent-db/package.json
+++ b/packages/agent-db/package.json
@@ -21,7 +21,13 @@
 		"db:generate": "drizzle-kit generate",
 		"format": "biome format --write",
 		"lint": "biome lint --write",
-		"check": "biome check --write"
+		"check": "biome check --write",
+		"proto:up": "bash prototype-conversation-ownership/up.sh up",
+		"proto:down": "bash prototype-conversation-ownership/up.sh down",
+		"proto:tui": "bun prototype-conversation-ownership/tui.ts",
+		"proto:explain": "bun prototype-conversation-ownership/explain.ts",
+		"proto:race": "bun prototype-conversation-ownership/race.ts",
+		"proto:bench": "bun prototype-conversation-ownership/bench.ts"
 	},
 	"peerDependencies": {
 		"drizzle-orm": "^0.45.2",

--- a/packages/agent-db/prototype-conversation-ownership/README.md
+++ b/packages/agent-db/prototype-conversation-ownership/README.md
@@ -1,0 +1,190 @@
+# PROTOTYPE — Conversation-ownership Claim (ADR-0015)
+
+**Throwaway. Delete this directory once `/to-spec` has consumed the answers below.**
+
+## The question
+
+ADR-0015 moves execution ownership from the Run to the Conversation, fenced by a
+per-Conversation epoch. The architecture is settled; three Postgres behaviours it
+rests on had never been executed. Each could change the Claim statement's *form*;
+none can change the decision.
+
+1. **Is `FOR UPDATE OF c SKIP LOCKED` legal in the Claim's join shape, and does it
+   plan sanely?** And separately — do two concurrent claimants actually *skip*
+   each other rather than block or double-claim?
+2. **Snapshot integrity under concurrent admission.** Admission and Claim both
+   take `conversations` first, so a Run should be either inside the snapshot or
+   deferred to the next Claim. Never lost, never double-served.
+3. **Fence-read cost.** ADR-0015 puts a non-locking `conversations` probe on every
+   fenced write (~15–20 per turn) against ~3 writes per Claim. Do the fence reads
+   and the Claim/release writes interfere?
+
+## Running it
+
+Everything runs against a **scratch Postgres container**, not the compose stack —
+the real migrations are applied to it, then the ADR-0015 schema delta on top, so
+the statements run against the real table shapes, FKs and indexes.
+
+```bash
+bun run --cwd packages/agent-db proto:up
+```
+
+Then, from `packages/agent-db`:
+
+| Command | Answers |
+|---|---|
+| `bun run proto:tui` | The hand-driven interleavings — §3.1 contention, the epoch fence |
+| `bun run proto:explain` | §3.1 legality + plans + head-of-queue skew |
+| `bun run proto:race` | §3.2 snapshot integrity (add `--chaos` for lapsing leases) |
+| `bun run proto:bench` | §3.3 fence-read cost A/B |
+| `bun run proto:down` | Remove the scratch container |
+
+`ownership.ts` is the portable half — the exact SQL under test, pure, no I/O. The
+TUI and the two harnesses are the disposable shell around it.
+
+## Answers
+
+Measured on **PostgreSQL 16.14** in Docker on macOS. Absolute latencies are not
+production numbers; the A/B ratios and the invariant results are the findings.
+Production's server version was not checked — worth confirming it is also 16.x.
+
+### 3.1 — Legal, and it plans better than expected. Use the join shape.
+
+`FOR UPDATE OF c SKIP LOCKED` is accepted and executes. At 2000 conversations ×
+3 queued Runs the plan is:
+
+```
+Limit -> LockRows -> Nested Loop
+                       -> Index Scan using runs_queue_claim_idx on runs r
+                       -> Memoize -> Index Scan conversations_pkey on c
+```
+
+**There is no Sort.** `runs_queue_claim_idx` — which already exists in production
+(`(created_at) WHERE status = 'queued'`) — delivers `runs` in `created_at` order,
+so the planner elides it. That matters for more than cost: LockRows sits directly
+under Limit, so rows are locked one at a time **in queue order**, and SKIP LOCKED
+skips in queue order rather than scan order. 7 buffers, 0.074 ms.
+
+The two alternatives are worse and neither is needed:
+
+| shape | 2000×3 | verdict |
+|---|---|---|
+| `join` (ADR-0015's sketch) | 7 buffers, 0.074 ms | **use this** |
+| `select_then_update` | identical candidate plan | fallback only; one extra round trip |
+| `exists_min` (no join) | 7697 buffers, 19.7 ms | reject — Sort + per-row SubPlan aggregate |
+
+**Contention: claimants skip, they do not block or double-claim.** Driven by hand
+in the TUI, holding real transactions open:
+
+- an **uncommitted admission** holding `conversations FOR UPDATE` makes that
+  Conversation invisible to a Claim — the claimant returns empty rather than
+  waiting;
+- a **held claim transaction** is likewise skipped by the other worker.
+
+Under load (4 admitters hammering one Conversation with zero think time — far
+past anything realistic) **4–6 % of claim attempts skipped a locked row**. The
+claimant just retries on the next tick, so this is latency, not starvation.
+
+**New finding — head-of-queue skew.** Because the scan walks `runs` in *global*
+`created_at` order and probes `conversations` per row, every queued Run belonging
+to an already-owned Conversation is a row the candidate scan walks past:
+
+| queued Runs on the owned Conversation | rows walked | time |
+|---|---|---|
+| 1 | 2 | 0.13 ms |
+| 100 | 101 | 1.29 ms |
+| 1000 | 1001 | 0.70 ms |
+| 5000 | 5001 | 3.44 ms |
+
+So claim cost is **O(queued Runs ahead of the first claimable Conversation)** —
+bounded by (admission depth bound × concurrently-owned Conversations). The
+admission depth bound is therefore load-bearing for *claim cost*, not only for
+drain length. At a small bound this is free; if the bound is ever raised, every
+idle worker pays this on every tick.
+
+### 3.2 — Snapshot integrity holds. Adversarially confirmed.
+
+`race.ts`, 4 admitters vs 4 claimants on a single Conversation, ~700 Runs per
+5 s run. All shapes, both snapshot placements:
+
+```
+PASS  never double-served (no Run started twice under the fence)
+PASS  never double-terminalized
+PASS  never lost (every admitted Run reached some snapshot)
+PASS  each Run in exactly one snapshot
+PASS  every admitted Run reached done
+```
+
+Under `--chaos` (lease 60 ms, so leases lapse mid-drain and a second worker
+re-Claims while the first is still serving): **71 fence rejections, 0
+double-starts, 0 double-terminalizations, 0 lost.** 68 Runs were left stranded in
+`running` by workers whose lease lapsed — that is Reclamation's job, not the
+snapshot's, and it is the expected shape.
+
+**The sharpest result — what the same-transaction snapshot is actually for.**
+Counting Runs whose admission committed *after* their Claim committed yet still
+appeared in that Claim's snapshot, with a 100 ms artificial gap inserted to widen
+the window:
+
+| snapshot placement | Runs served after their own Claim | all safety checks |
+|---|---|---|
+| same transaction (ADR-0015) | **0** | pass |
+| after the Claim commits | **44** | pass |
+
+Both are *safe*. The same-transaction snapshot is load-bearing for the **bound**,
+not for correctness — exactly the property ADR-0015 cites it for ("bounds drain
+length by the admission depth bound with no second constant"). The spec must say
+"same transaction" **and say why**, or a later refactor that splits them will look
+harmless and quietly unbound the drain.
+
+**Also confirmed: unconditional release is safe.** A worker whose epoch has been
+superseded gets `0 rows` from `WHERE conversation_id = $c AND epoch = $epoch` — it
+cannot steal the Conversation back from its successor.
+
+### 3.3 — The probe costs a few ms per turn. It does not interfere with Claim/release.
+
+A/B on one variable: identical work in both arms, only the fenced append's
+predicate differs (`EXISTS` probe on `conversations` vs today's
+`runs.locked_by`/`locked_until`).
+
+| workers | fence p50 epoch | fence p50 lease | claim p50 epoch | claim p50 lease |
+|---|---|---|---|---|
+| 1 | 2.27 ms | 2.00 ms | 1.91 ms | 1.85 ms |
+| 8 | 3.62 ms | 3.18 ms | 2.42 ms | 2.30 ms |
+| 32 | 8.32 ms | 6.75 ms | 3.35 ms | 3.51 ms |
+
+- The probe costs a **consistent ~13–25 % on the fenced-write statement**, holding
+  in both arm orders. At 18 writes per turn that is **~5 ms/turn at low
+  concurrency, ~30 ms/turn at 32 concurrent workers** — against a turn measured in
+  seconds to minutes.
+- **Claim and release latency are unaffected.** An early run showed claim p95 of
+  62 ms vs 11 ms and looked like a real effect; re-running with the arm order
+  flipped showed the anomaly followed *arm position*, not the fence. It was a
+  warm-up artifact. §3.3's actual worry — fence reads interfering with the
+  ownership writes — did not reproduce.
+- Adding 6 background admitters writing the *same* `conversations` rows (the
+  "hottest row" concern) did not change the picture.
+- Throughput is ~20 % lower in the epoch arm at 32 workers, fully accounted for by
+  the per-append cost (appends are 82 % of statements).
+
+## Verdict
+
+**Nothing here contradicts ADR-0015.** The Claim keeps the form the ADR sketches,
+and it wants no new index — `runs_queue_claim_idx` already exists.
+
+Two things the spec should carry that the ADR does not currently say:
+
+1. The snapshot **must** share the Claim's transaction, and the reason is the
+   drain-length bound, not safety. Both placements are safe, so the constraint is
+   invisible to a reviewer who is only checking correctness.
+2. Claim cost is **O(queued Runs ahead of the first claimable Conversation)**, so
+   the admission depth bound also bounds claim cost. Raising it later is not free.
+
+## Cleanup
+
+```bash
+bun run --cwd packages/agent-db proto:down
+rm -rf packages/agent-db/prototype-conversation-ownership
+```
+
+…and drop the four `proto:*` scripts from `packages/agent-db/package.json`.

--- a/packages/agent-db/prototype-conversation-ownership/bench.ts
+++ b/packages/agent-db/prototype-conversation-ownership/bench.ts
@@ -1,0 +1,223 @@
+/**
+ * PROTOTYPE — throwaway. §3.3: does the per-fenced-write `conversations` probe
+ * interfere with the Claim/release writes on the same row?
+ *
+ * A/B on one variable. Both arms do identical work — claim, start, N fenced
+ * appends, terminalize, release. Only the append's fence predicate differs:
+ *
+ *   epoch  — ADR-0015: EXISTS probe on the conversations PK (non-locking)
+ *   lease  — today:    r.locked_by = $me AND r.locked_until > now(), no probe
+ *
+ * If the probe interfered, the epoch arm's tail latency would separate from the
+ * lease arm's as worker count rises — and the Claim/release writes, which DO
+ * take the row lock, would slow down too.
+ *
+ *   bun bench.ts [--conversations N] [--writes N] [--workers 1,8,32]
+ */
+import type pg from "pg";
+import { applyPrototypeDdl, pool, resetData, withTx } from "./db";
+import {
+	admitRun,
+	claimConversation,
+	type FenceKind,
+	fencedAppend,
+	releaseConversation,
+	snapshotRuns,
+	startRun,
+	terminalizeRun,
+} from "./ownership";
+
+const arg = (name: string, fallback: string) => {
+	const i = process.argv.indexOf(`--${name}`);
+	return i >= 0 ? (process.argv[i + 1] ?? fallback) : fallback;
+};
+
+const CONVERSATIONS = Number(arg("conversations", "400"));
+const WRITES_PER_TURN = Number(arg("writes", "18")); // ADR-0015's "15-20"
+const WORKER_COUNTS = arg("workers", "1,8,32").split(",").map(Number);
+/** Background admitters, the THIRD writer of `conversations`: each takes the row
+ * FOR UPDATE and bumps `last_activity_at` while an owner is doing fenced reads
+ * of that same row. This is the "hottest row" concern, tested directly.
+ * Rate-capped: admitting faster than the drain just grows the queue forever and
+ * the measurement never terminates. */
+const ADMITTERS = Number(arg("admitters", "0"));
+const ADMIT_GAP_MS = Number(arg("admit-gap-ms", "25"));
+/** Run the arms in the other order. The first arm always gets a freshly seeded,
+ * freshly ANALYZEd table; without checking both orders an order effect reads as
+ * a fence-cost difference. */
+const FLIP = process.argv.includes("--flip");
+const LEASE_MS = 60_000;
+
+const samples = {
+	fence: [] as number[],
+	claim: [] as number[],
+	release: [] as number[],
+};
+
+function pct(xs: number[], q: number): number {
+	if (xs.length === 0) return Number.NaN;
+	const s = [...xs].sort((a, b) => a - b);
+	return s[Math.min(s.length - 1, Math.floor(q * s.length))] ?? Number.NaN;
+}
+
+async function timed<T>(bucket: number[], fn: () => Promise<T>): Promise<T> {
+	const t0 = performance.now();
+	try {
+		return await fn();
+	} finally {
+		bucket.push(performance.now() - t0);
+	}
+}
+
+const p = pool(Math.max(...WORKER_COUNTS) + 4);
+
+async function seed(conn: pg.PoolClient) {
+	await resetData(conn, { conversations: CONVERSATIONS });
+	await conn.query(
+		`insert into runs (run_id, user_id, conversation_id, status, next_event_seq)
+		 select 'r-' || c.conversation_id, c.user_id, c.conversation_id, 'queued', 2
+		   from conversations c`,
+	);
+	await conn.query("analyze conversations");
+	await conn.query("analyze runs");
+}
+
+/** One worker: claim -> start -> N fenced appends -> terminalize -> release. */
+async function worker(id: number, fence: FenceKind, done: () => boolean) {
+	const workerId = `w${id}`;
+	const conn = await p.connect();
+	try {
+		while (!done()) {
+			await conn.query("begin");
+			const claim = await timed(samples.claim, () =>
+				claimConversation(conn, { workerId, leaseMs: LEASE_MS, shape: "join" }),
+			);
+			const runs = claim ? await snapshotRuns(conn, claim) : [];
+			await conn.query("commit");
+			if (!claim) return;
+
+			for (const { runId } of runs) {
+				const started = await startRun(conn, {
+					runId,
+					workerId,
+					epoch: claim.epoch,
+					alsoSetRunLease: fence === "run_lease",
+				});
+				if (!started.ok) continue;
+				for (let i = 0; i < WRITES_PER_TURN; i++) {
+					await timed(samples.fence, () =>
+						fencedAppend(conn, {
+							runId,
+							fenceValue: fence === "run_lease" ? workerId : claim.epoch,
+							fenceKind: fence,
+						}),
+					);
+				}
+				await terminalizeRun(conn, {
+					runId,
+					epoch: claim.epoch,
+					status: "done",
+				});
+			}
+			await timed(samples.release, () => releaseConversation(conn, claim));
+		}
+	} finally {
+		conn.release();
+	}
+}
+
+async function run(fence: FenceKind, workers: number) {
+	const setup = await p.connect();
+	await seed(setup);
+
+	samples.fence.length = 0;
+	samples.claim.length = 0;
+	samples.release.length = 0;
+
+	let remaining = CONVERSATIONS;
+	const done = () => remaining-- <= 0;
+
+	let admitting = true;
+	const admitters = Array.from({ length: ADMITTERS }, async (_, i) => {
+		const conn = await p.connect();
+		let n = 0;
+		try {
+			while (admitting) {
+				const c = 1 + (n % CONVERSATIONS);
+				await withTx(conn, () =>
+					admitRun(conn, {
+						userId: "u1",
+						conversationId: `c${c}`,
+						runId: `adm-${fence}-${workers}-${i}-${n++}`,
+						message: "bench",
+					}),
+				).catch(() => {});
+				await Bun.sleep(ADMIT_GAP_MS);
+			}
+		} finally {
+			conn.release();
+		}
+	});
+
+	const t0 = performance.now();
+	await Promise.all(
+		Array.from({ length: workers }, (_, i) => worker(i, fence, done)),
+	);
+	const elapsed = performance.now() - t0;
+	admitting = false;
+	await Promise.allSettled(admitters);
+
+	const { rows } = await setup.query<{ n: string }>(
+		"select count(*) as n from runs where status = 'done'",
+	);
+	setup.release();
+
+	return {
+		fence,
+		workers,
+		elapsed,
+		served: Number(rows[0]?.n ?? 0),
+		fenceP50: pct(samples.fence, 0.5),
+		fenceP95: pct(samples.fence, 0.95),
+		fenceP99: pct(samples.fence, 0.99),
+		fenceN: samples.fence.length,
+		claimP50: pct(samples.claim, 0.5),
+		claimP95: pct(samples.claim, 0.95),
+		releaseP95: pct(samples.release, 0.95),
+	};
+}
+
+const setupConn = await p.connect();
+await applyPrototypeDdl(setupConn);
+setupConn.release();
+
+const ms = (n: number) =>
+	Number.isNaN(n) ? "   —  " : n.toFixed(3).padStart(6);
+
+console.log(
+	`\n${CONVERSATIONS} conversations x 1 Run x ${WRITES_PER_TURN} fenced writes per turn` +
+		`, ${ADMITTERS} background admitter(s) writing the same rows\n`,
+);
+console.log(
+	"fence   workers   turns/s   fence p50   p95     p99      claim p50   p95      release p95",
+);
+console.log("-".repeat(94));
+
+for (const workers of WORKER_COUNTS) {
+	const arms: FenceKind[] = FLIP
+		? ["run_lease", "conversation_epoch"]
+		: ["conversation_epoch", "run_lease"];
+	for (const fence of arms) {
+		const r = await run(fence, workers);
+		const label = fence === "conversation_epoch" ? "epoch" : "lease";
+		console.log(
+			`${label.padEnd(7)} ${String(workers).padStart(7)}   ` +
+				`${((r.served / r.elapsed) * 1000).toFixed(0).padStart(7)}   ` +
+				`${ms(r.fenceP50)}ms ${ms(r.fenceP95)}ms ${ms(r.fenceP99)}ms   ` +
+				`${ms(r.claimP50)}ms ${ms(r.claimP95)}ms   ${ms(r.releaseP95)}ms`,
+		);
+	}
+}
+
+await p.end();
+console.log();

--- a/packages/agent-db/prototype-conversation-ownership/db.ts
+++ b/packages/agent-db/prototype-conversation-ownership/db.ts
@@ -1,0 +1,74 @@
+/** PROTOTYPE — throwaway. Scratch-DB wiring for the ownership prototype. */
+import pg from "pg";
+
+export const PROTO_DATABASE_URL =
+	process.env.PROTO_DATABASE_URL ??
+	"postgresql://proto:proto@127.0.0.1:55432/prototype_ownership_wipe_me";
+
+/** Keep timestamps as Date, ints as number — the prototype compares them. */
+pg.types.setTypeParser(20, (v: string) => Number(v));
+
+export function client(): pg.Client {
+	return new pg.Client({ connectionString: PROTO_DATABASE_URL });
+}
+
+export function pool(max: number): pg.Pool {
+	return new pg.Pool({ connectionString: PROTO_DATABASE_URL, max });
+}
+
+/**
+ * The ADR-0015 schema delta, applied on top of the real migrations so the
+ * prototype runs against the real table shapes, FKs and indexes.
+ */
+export const PROTOTYPE_DDL = `
+alter table conversations
+	add column if not exists owner_worker_id text,
+	add column if not exists owner_until     timestamptz,
+	add column if not exists epoch           integer not null default 0;
+
+alter table runs
+	add column if not exists executed_by_worker_id text;
+
+-- ADR-0015 drops this: several queued Runs per Conversation is the point.
+drop index if exists runs_one_active_per_conversation;
+
+-- The index the Claim's candidate scan wants.
+create index if not exists proto_runs_queued_by_conversation_idx
+	on runs (user_id, conversation_id, created_at) where status = 'queued';
+`;
+
+export async function applyPrototypeDdl(c: pg.Client | pg.PoolClient) {
+	await c.query(PROTOTYPE_DDL);
+}
+
+export async function resetData(
+	c: pg.Client | pg.PoolClient,
+	opts: { conversations: number; userId?: string },
+) {
+	const userId = opts.userId ?? "u1";
+	await c.query("delete from run_events");
+	await c.query("delete from runs");
+	await c.query("delete from conversations");
+	for (let i = 1; i <= opts.conversations; i++) {
+		await c.query(
+			`insert into conversations (user_id, conversation_id, scope, epoch)
+			 values ($1, $2, 'general', 0)`,
+			[userId, `c${i}`],
+		);
+	}
+}
+
+export async function withTx<T>(
+	c: pg.Client | pg.PoolClient,
+	fn: () => Promise<T>,
+): Promise<T> {
+	await c.query("begin");
+	try {
+		const out = await fn();
+		await c.query("commit");
+		return out;
+	} catch (e) {
+		await c.query("rollback").catch(() => {});
+		throw e;
+	}
+}

--- a/packages/agent-db/prototype-conversation-ownership/explain.ts
+++ b/packages/agent-db/prototype-conversation-ownership/explain.ts
@@ -1,0 +1,126 @@
+/**
+ * PROTOTYPE — throwaway. §3.1 first half: is `FOR UPDATE OF c SKIP LOCKED` legal
+ * in the Claim's join shape, and does it plan sanely?
+ *
+ * Prints, per candidate shape and per data scale: the server version, whether
+ * the statement parses/executes at all, and the plan — specifically where the
+ * LockRows node sits relative to Sort, which decides whether SKIP LOCKED skips
+ * in queue order or in scan order.
+ */
+
+import { applyPrototypeDdl, client, resetData } from "./db";
+import { CLAIM_SHAPES, claimSql } from "./ownership";
+
+const SCALES = [
+	{ conversations: 5, runsPer: 2 },
+	{ conversations: 2000, runsPer: 3 },
+];
+
+const c = client();
+await c.connect();
+await applyPrototypeDdl(c);
+
+const { rows: version } = await c.query<{ v: string }>("select version() as v");
+console.log(`\n${version[0]?.v}\n`);
+
+for (const scale of SCALES) {
+	await resetData(c, { conversations: scale.conversations });
+	await c.query(
+		`insert into runs (run_id, user_id, conversation_id, status, next_event_seq, created_at)
+		 select 'r-' || c.conversation_id || '-' || g, c.user_id, c.conversation_id,
+		        'queued', 2, now() - (random() * interval '1 hour')
+		   from conversations c, generate_series(1, $1) g`,
+		[scale.runsPer],
+	);
+	await c.query("analyze conversations");
+	await c.query("analyze runs");
+
+	console.log(
+		`${"=".repeat(72)}\nscale: ${scale.conversations} conversations x ${scale.runsPer} queued runs\n${"=".repeat(72)}`,
+	);
+
+	for (const shape of CLAIM_SHAPES) {
+		console.log(`\n--- shape: ${shape} ---`);
+		const sql = claimSql(shape);
+		try {
+			await c.query("begin");
+			const plan = await c.query<{ "QUERY PLAN": string }>(
+				`explain (analyze, buffers, costs off, timing off) ${sql}`,
+				shape === "select_then_update" ? [] : ["w-explain", 60_000],
+			);
+			await c.query("rollback");
+			console.log(plan.rows.map((r) => r["QUERY PLAN"]).join("\n"));
+		} catch (error) {
+			await c.query("rollback").catch(() => {});
+			console.log(`REJECTED: ${(error as Error).message}`);
+			continue;
+		}
+
+		// And actually run it, so "it planned" is not mistaken for "it works".
+		try {
+			await c.query("begin");
+			const claimed = await c.query(
+				sql,
+				shape === "select_then_update" ? [] : ["w-explain", 60_000],
+			);
+			await c.query("rollback");
+			console.log(
+				`executes: ${claimed.rowCount} row(s)` +
+					(shape === "select_then_update" ? " (candidate select only)" : ""),
+			);
+		} catch (error) {
+			await c.query("rollback").catch(() => {});
+			console.log(`EXECUTION FAILED: ${(error as Error).message}`);
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Head-of-queue skew: the `join` shape walks `runs` in GLOBAL created_at order
+// and probes `conversations` per row, so every queued Run belonging to an
+// already-owned Conversation is a row the candidate scan must walk past. This is
+// the one real cost the winning plan carries; measure it rather than assume it.
+// ---------------------------------------------------------------------------
+console.log(`\n${"=".repeat(72)}\nhead-of-queue skew\n${"=".repeat(72)}`);
+
+for (const headDepth of [1, 100, 1000, 5000]) {
+	await resetData(c, { conversations: 2 });
+	// c1 holds the oldest `headDepth` queued Runs and is already owned.
+	await c.query(
+		`insert into runs (run_id, user_id, conversation_id, status, next_event_seq, created_at)
+		 select 'head-' || g, 'u1', 'c1', 'queued', 2, now() - interval '2 hours' + (g * interval '1 ms')
+		   from generate_series(1, $1) g`,
+		[headDepth],
+	);
+	// c2 has a single, newer queued Run — the only claimable candidate.
+	await c.query(
+		`insert into runs (run_id, user_id, conversation_id, status, next_event_seq, created_at)
+		 values ('tail-1', 'u1', 'c2', 'queued', 2, now())`,
+	);
+	await c.query(
+		`update conversations set owner_worker_id = 'other', owner_until = now() + interval '5 minutes', epoch = 1
+		  where conversation_id = 'c1'`,
+	);
+	await c.query("analyze runs");
+	await c.query("analyze conversations");
+
+	await c.query("begin");
+	const plan = await c.query<{ "QUERY PLAN": string }>(
+		`explain (analyze, buffers, costs off, timing off) ${claimSql("join")}`,
+		["w-skew", 60_000],
+	);
+	await c.query("rollback");
+	const text = plan.rows.map((r) => r["QUERY PLAN"]).join("\n");
+	const scanned =
+		/Index Scan using runs_queue_claim_idx on runs r \(actual rows=(\d+)/.exec(
+			text,
+		);
+	const buffers = /^\s*Buffers: shared hit=(\d+)/m.exec(text);
+	const time = /Execution Time: ([\d.]+) ms/.exec(text);
+	console.log(
+		`head depth ${String(headDepth).padStart(5)}  ->  runs rows walked ${String(scanned?.[1] ?? "?").padStart(5)}` +
+			`   buffers ${String(buffers?.[1] ?? "?").padStart(5)}   ${time?.[1] ?? "?"} ms`,
+	);
+}
+
+await c.end();

--- a/packages/agent-db/prototype-conversation-ownership/ownership.ts
+++ b/packages/agent-db/prototype-conversation-ownership/ownership.ts
@@ -1,0 +1,438 @@
+/**
+ * PROTOTYPE — throwaway. See README.md. Delete after `/to-spec`.
+ *
+ * The portable half of the prototype: the exact SQL under test for ADR-0015's
+ * Conversation-level ownership with an epoch fence. Pure — it takes a query
+ * runner, returns data, and does no I/O of its own. The TUI and the two
+ * harnesses are the throwaway shell around this; if a shape survives, this file
+ * is the thing that gets lifted into `run-store.ts` / `runtime-store.ts`.
+ */
+
+/** Structural stand-in for a `pg` Client/PoolClient, so this file needs no deps. */
+export interface Queryable {
+	query<R = Record<string, unknown>>(
+		sql: string,
+		values?: unknown[],
+	): Promise<{ rows: R[]; rowCount: number | null }>;
+}
+
+export interface ConversationRef {
+	userId: string;
+	conversationId: string;
+}
+
+export interface Claim extends ConversationRef {
+	epoch: number;
+	ownerUntil: Date;
+}
+
+export interface RunRef {
+	runId: string;
+	createdAt: Date;
+}
+
+/**
+ * The typed fence outcome ADR-0015 names as a prerequisite (Track A #4). The
+ * drain has to tell "I lost the lease — halt, do not release" from "the Run went
+ * terminal under me — skip it and continue", and today's opaque RunFenceError
+ * cannot.
+ */
+export type FenceOutcome<T> =
+	| { ok: true; value: T }
+	| {
+			ok: false;
+			rejected: "lease";
+			epoch: number | null;
+			ownerUntil: Date | null;
+	  }
+	| { ok: false; rejected: "status"; current: string }
+	| { ok: false; rejected: "gone" };
+
+/** Candidate-selection shapes for the Claim. §3.1 asks which of these are legal
+ * and plan sanely; `join` is the one ADR-0015 sketches. */
+export type ClaimShape = "join" | "select_then_update" | "exists_min";
+
+export const CLAIM_SHAPES: ClaimShape[] = [
+	"join",
+	"select_then_update",
+	"exists_min",
+];
+
+// ---------------------------------------------------------------------------
+// Candidate selection — the part §3.1 is about.
+// ---------------------------------------------------------------------------
+
+/**
+ * ADR-0015's sketch: one UPDATE whose candidate subquery joins `runs`, orders by
+ * `r.created_at`, and locks ONLY the `conversations` side. The open questions are
+ * whether `FOR UPDATE OF c` is legal here at all, and whether the LockRows node
+ * ends up above or below the Sort (which decides whether SKIP LOCKED skips in
+ * queue order or in scan order).
+ */
+const CLAIM_JOIN = `
+update conversations c0
+   set owner_worker_id = $1,
+       owner_until     = now() + ($2::bigint * interval '1 millisecond'),
+       epoch           = c0.epoch + 1
+ where (c0.user_id, c0.conversation_id) = (
+         select c.user_id, c.conversation_id
+           from conversations c
+           join runs r using (user_id, conversation_id)
+          where r.status = 'queued'
+            and (c.owner_until is null or c.owner_until <= now())
+          order by r.created_at
+            for update of c skip locked
+          limit 1)
+returning c0.user_id, c0.conversation_id, c0.epoch, c0.owner_until`;
+
+/** Fallback shape: take the row lock in its own statement, then update by key.
+ * Two statements, same transaction — strictly more portable, one more round trip. */
+const CLAIM_SELECT = `
+  select c.user_id, c.conversation_id
+    from conversations c
+    join runs r using (user_id, conversation_id)
+   where r.status = 'queued'
+     and (c.owner_until is null or c.owner_until <= now())
+   order by r.created_at
+     for update of c skip locked
+   limit 1`;
+
+const CLAIM_UPDATE_BY_KEY = `
+update conversations
+   set owner_worker_id = $1,
+       owner_until     = now() + ($2::bigint * interval '1 millisecond'),
+       epoch           = epoch + 1
+ where user_id = $3 and conversation_id = $4
+returning user_id, conversation_id, epoch, owner_until`;
+
+/**
+ * Third shape: never join, so the candidate scan cannot produce duplicate
+ * conversation rows. Orders by the conversation's oldest queued run via a
+ * correlated scalar subquery.
+ */
+const CLAIM_EXISTS_MIN = `
+update conversations c0
+   set owner_worker_id = $1,
+       owner_until     = now() + ($2::bigint * interval '1 millisecond'),
+       epoch           = c0.epoch + 1
+ where (c0.user_id, c0.conversation_id) = (
+         select c.user_id, c.conversation_id
+           from conversations c
+          where (c.owner_until is null or c.owner_until <= now())
+            and exists (select 1 from runs r
+                         where r.user_id = c.user_id
+                           and r.conversation_id = c.conversation_id
+                           and r.status = 'queued')
+          order by (select min(r.created_at) from runs r
+                     where r.user_id = c.user_id
+                       and r.conversation_id = c.conversation_id
+                       and r.status = 'queued')
+            for update skip locked
+          limit 1)
+returning c0.user_id, c0.conversation_id, c0.epoch, c0.owner_until`;
+
+export function claimSql(shape: ClaimShape): string {
+	if (shape === "join") return CLAIM_JOIN;
+	if (shape === "exists_min") return CLAIM_EXISTS_MIN;
+	return CLAIM_SELECT;
+}
+
+interface ClaimRow {
+	user_id: string;
+	conversation_id: string;
+	epoch: number;
+	owner_until: Date;
+}
+
+/** Take the Ownership lease on one claimable Conversation. Must run inside a
+ * transaction: the lease write and the snapshot below share its commit. */
+export async function claimConversation(
+	tx: Queryable,
+	input: { workerId: string; leaseMs: number; shape: ClaimShape },
+): Promise<Claim | null> {
+	if (input.shape === "select_then_update") {
+		const candidate = await tx.query<{
+			user_id: string;
+			conversation_id: string;
+		}>(CLAIM_SELECT);
+		const row = candidate.rows[0];
+		if (!row) return null;
+		const updated = await tx.query<ClaimRow>(CLAIM_UPDATE_BY_KEY, [
+			input.workerId,
+			input.leaseMs,
+			row.user_id,
+			row.conversation_id,
+		]);
+		return updated.rows[0] ? toClaim(updated.rows[0]) : null;
+	}
+	const claimed = await tx.query<ClaimRow>(claimSql(input.shape), [
+		input.workerId,
+		input.leaseMs,
+	]);
+	return claimed.rows[0] ? toClaim(claimed.rows[0]) : null;
+}
+
+function toClaim(row: ClaimRow): Claim {
+	return {
+		userId: row.user_id,
+		conversationId: row.conversation_id,
+		epoch: Number(row.epoch),
+		ownerUntil: row.owner_until,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot drain — the part §3.2 is about.
+// ---------------------------------------------------------------------------
+
+/**
+ * The Runs this Claim will serve. Run in the SAME transaction as
+ * {@link claimConversation}: the claim's UPDATE holds the `conversations` row
+ * lock, and admission takes that same row `FOR UPDATE` before inserting, so an
+ * admission either committed before the lock (inside the snapshot) or waits for
+ * it (deferred to the next Claim). That is the whole load-bearing argument.
+ */
+export async function snapshotRuns(
+	tx: Queryable,
+	ref: ConversationRef,
+): Promise<RunRef[]> {
+	const { rows } = await tx.query<{ run_id: string; created_at: Date }>(
+		`select run_id, created_at
+		   from runs
+		  where user_id = $1 and conversation_id = $2 and status = 'queued'
+		  order by created_at, run_id`,
+		[ref.userId, ref.conversationId],
+	);
+	return rows.map((r) => ({ runId: r.run_id, createdAt: r.created_at }));
+}
+
+/** Unconditional release — no "zero rows means work arrived, keep the lease"
+ * subtlety, because snapshot drain already deferred mid-drain arrivals. */
+export async function releaseConversation(
+	q: Queryable,
+	claim: Claim,
+): Promise<boolean> {
+	const { rowCount } = await q.query(
+		`update conversations
+		    set owner_worker_id = null, owner_until = null
+		  where user_id = $1 and conversation_id = $2 and epoch = $3`,
+		[claim.userId, claim.conversationId, claim.epoch],
+	);
+	return (rowCount ?? 0) > 0;
+}
+
+export async function renewLease(
+	q: Queryable,
+	claim: Claim,
+	leaseMs: number,
+): Promise<Date | null> {
+	const { rows } = await q.query<{ owner_until: Date }>(
+		`update conversations
+		    set owner_until = now() + ($4::bigint * interval '1 millisecond')
+		  where user_id = $1 and conversation_id = $2 and epoch = $3
+		returning owner_until`,
+		[claim.userId, claim.conversationId, claim.epoch, leaseMs],
+	);
+	return rows[0]?.owner_until ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// The fence — the probe §3.3 measures.
+// ---------------------------------------------------------------------------
+
+/** `EXISTS` probe on the `conversations` primary key. Takes no lock, so fence
+ * reads never conflict with each other — only with Claim and release. */
+const FENCE_EXISTS = `exists (
+	select 1 from conversations c
+	 where c.user_id = r.user_id
+	   and c.conversation_id = r.conversation_id
+	   and c.epoch = $2
+	   and c.owner_until > now())`;
+
+/** Today's shape, kept for the §3.3 A/B: the fence lives on the `runs` row
+ * itself, so there is no `conversations` probe at all. */
+const FENCE_RUN_LEASE = `r.locked_by = $2 and r.locked_until > now()`;
+
+export type FenceKind = "conversation_epoch" | "run_lease";
+
+function fencePredicate(kind: FenceKind): string {
+	return kind === "conversation_epoch" ? FENCE_EXISTS : FENCE_RUN_LEASE;
+}
+
+/**
+ * The representative fenced write: allocate the next event sequence number on
+ * the Run under the fence, exactly as `appendRunEventsTx` does today (fence
+ * rides the counter increment, so a stale worker cannot allocate a seq at all).
+ * ~15–20 of these per turn.
+ */
+export async function fencedAppend(
+	q: Queryable,
+	input: {
+		runId: string;
+		fenceValue: number | string;
+		fenceKind?: FenceKind;
+	},
+): Promise<FenceOutcome<{ seq: number }>> {
+	const kind = input.fenceKind ?? "conversation_epoch";
+	const { rows } = await q.query<{ seq: string }>(
+		`update runs r
+		    set next_event_seq = r.next_event_seq + 1, updated_at = now()
+		  where r.run_id = $1
+		    and r.status in ('running', 'interrupt_requested')
+		    and ${fencePredicate(kind)}
+		returning r.next_event_seq - 1 as seq`,
+		[input.runId, input.fenceValue],
+	);
+	const row = rows[0];
+	if (row) return { ok: true, value: { seq: Number(row.seq) } };
+	return await classifyRejection(q, input.runId, input.fenceValue, kind);
+}
+
+/** Start serving a Run from the snapshot, under the same fence.
+ * `alsoSetRunLease` populates today's `locked_by`/`locked_until` too, purely so
+ * the §3.3 A/B can measure the old fence predicate against the new one. */
+export async function startRun(
+	q: Queryable,
+	input: {
+		runId: string;
+		workerId: string;
+		epoch: number;
+		alsoSetRunLease?: boolean;
+	},
+): Promise<FenceOutcome<{ runId: string }>> {
+	const { rows } = await q.query<{ run_id: string }>(
+		`update runs r
+		    set status = 'running',
+		        executed_by_worker_id = $3,
+		        updated_at = now()${
+							input.alsoSetRunLease
+								? `,
+		        locked_by = $3,
+		        locked_until = now() + interval '60 seconds'`
+								: ""
+						}
+		  where r.run_id = $1
+		    and r.status = 'queued'
+		    and ${FENCE_EXISTS}
+		returning r.run_id`,
+		[input.runId, input.epoch, input.workerId],
+	);
+	const row = rows[0];
+	if (row) return { ok: true, value: { runId: row.run_id } };
+	return await classifyRejection(
+		q,
+		input.runId,
+		input.epoch,
+		"conversation_epoch",
+	);
+}
+
+export async function terminalizeRun(
+	q: Queryable,
+	input: {
+		runId: string;
+		epoch: number;
+		status: "done" | "error" | "interrupted";
+	},
+): Promise<FenceOutcome<{ status: string }>> {
+	const { rows } = await q.query<{ status: string }>(
+		`update runs r
+		    set status = $3, terminal_at = now(), updated_at = now()
+		  where r.run_id = $1
+		    and r.status in ('running', 'interrupt_requested')
+		    and ${FENCE_EXISTS}
+		returning r.status`,
+		[input.runId, input.epoch, input.status],
+	);
+	const row = rows[0];
+	if (row) return { ok: true, value: { status: row.status } };
+	return await classifyRejection(
+		q,
+		input.runId,
+		input.epoch,
+		"conversation_epoch",
+	);
+}
+
+/** One classify read, same transaction, only on the zero-row path. */
+async function classifyRejection<T>(
+	q: Queryable,
+	runId: string,
+	fenceValue: number | string,
+	kind: FenceKind,
+): Promise<FenceOutcome<T>> {
+	const { rows } = await q.query<{
+		status: string;
+		epoch: number | null;
+		owner_until: Date | null;
+		locked_by: string | null;
+		locked_until: Date | null;
+	}>(
+		`select r.status, c.epoch, c.owner_until, r.locked_by, r.locked_until
+		   from runs r
+		   left join conversations c
+		     on c.user_id = r.user_id and c.conversation_id = r.conversation_id
+		  where r.run_id = $1`,
+		[runId],
+	);
+	const row = rows[0];
+	if (!row) return { ok: false, rejected: "gone" };
+	const now = Date.now();
+	const leaseLost =
+		kind === "conversation_epoch"
+			? Number(row.epoch) !== Number(fenceValue) ||
+				!row.owner_until ||
+				row.owner_until.getTime() <= now
+			: row.locked_by !== fenceValue ||
+				!row.locked_until ||
+				row.locked_until.getTime() <= now;
+	if (leaseLost) {
+		return {
+			ok: false,
+			rejected: "lease",
+			epoch: row.epoch === null ? null : Number(row.epoch),
+			ownerUntil: row.owner_until,
+		};
+	}
+	return { ok: false, rejected: "status", current: row.status };
+}
+
+// ---------------------------------------------------------------------------
+// The adversary: admission, exactly as chat-api performs it today.
+// ---------------------------------------------------------------------------
+
+/**
+ * `conversations FOR UPDATE` -> INSERT `runs` -> touch lifecycle metadata, in one
+ * transaction. The lock order (conversations first) is what makes snapshot
+ * integrity work; it is also why a Claim racing a busy admitter SKIP LOCKEDs
+ * straight past the conversation.
+ */
+export async function admitRun(
+	tx: Queryable,
+	input: {
+		userId: string;
+		conversationId: string;
+		runId: string;
+		message: string;
+	},
+): Promise<"created" | "not_found"> {
+	const locked = await tx.query(
+		`select user_id from conversations
+		  where user_id = $1 and conversation_id = $2 for update`,
+		[input.userId, input.conversationId],
+	);
+	if (locked.rows.length === 0) return "not_found";
+	await tx.query(
+		`insert into runs (run_id, user_id, conversation_id, status, next_event_seq)
+		 values ($1, $2, $3, 'queued', 2)
+		 on conflict (run_id) do nothing`,
+		[input.runId, input.userId, input.conversationId],
+	);
+	await tx.query(
+		`update conversations
+		    set title = coalesce(title, $3), last_activity_at = now()
+		  where user_id = $1 and conversation_id = $2`,
+		[input.userId, input.conversationId, input.message],
+	);
+	return "created";
+}

--- a/packages/agent-db/prototype-conversation-ownership/race.ts
+++ b/packages/agent-db/prototype-conversation-ownership/race.ts
@@ -1,0 +1,438 @@
+/**
+ * PROTOTYPE — throwaway. §3.2 (and §3.1's second half): hammer admission against
+ * Claim on the same Conversation and assert every admitted Run lands in exactly
+ * one snapshot — never lost, never double-served.
+ *
+ * The load-bearing claim: admission takes `conversations FOR UPDATE` then INSERTs
+ * `runs`; the Claim takes the same row (via UPDATE / FOR UPDATE OF c) then SELECTs
+ * `runs` in the same transaction. They serialize on that row, so a Run is either
+ * inside the snapshot or deferred to the next Claim.
+ *
+ *   bun race.ts [--conversations N] [--admitters N] [--claimants N]
+ *               [--ms N] [--lease-ms N] [--shape join|select_then_update|exists_min]
+ *               [--chaos]
+ *
+ * --chaos uses a lease far shorter than a turn, so leases lapse mid-drain and a
+ * second worker claims while the first is still serving. That is where the epoch
+ * fence has to earn its keep.
+ */
+import type pg from "pg";
+import { applyPrototypeDdl, pool, resetData, withTx } from "./db";
+import {
+	admitRun,
+	type Claim,
+	type ClaimShape,
+	claimConversation,
+	fencedAppend,
+	type RunRef,
+	releaseConversation,
+	snapshotRuns,
+	startRun,
+	terminalizeRun,
+} from "./ownership";
+
+const arg = (name: string, fallback: string) => {
+	const i = process.argv.indexOf(`--${name}`);
+	return i >= 0 ? (process.argv[i + 1] ?? fallback) : fallback;
+};
+const flag = (name: string) => process.argv.includes(`--${name}`);
+
+const CHAOS = flag("chaos");
+const CONVERSATIONS = Number(arg("conversations", "1"));
+const ADMITTERS = Number(arg("admitters", "4"));
+const CLAIMANTS = Number(arg("claimants", "4"));
+const DURATION_MS = Number(arg("ms", "5000"));
+const LEASE_MS = Number(arg("lease-ms", CHAOS ? "60" : "30000"));
+const SHAPE = arg("shape", "join") as ClaimShape;
+/** `same-tx` is ADR-0015's shape. `after-commit` takes the snapshot in a fresh
+ * statement once the lease is already committed — used to find out which of
+ * snapshot drain's properties actually depend on sharing the transaction. */
+const SNAPSHOT = arg("snapshot", "same-tx") as "same-tx" | "after-commit";
+/** Artificial delay between claim-commit and snapshot in `after-commit` mode. */
+const GAP_MS = Number(arg("gap-ms", "1"));
+const FENCED_WRITES = 4; // stand-in for a turn's ~15-20, kept small for volume
+
+// ---------------------------------------------------------------------------
+
+interface SnapshotRecord {
+	worker: string;
+	conversationId: string;
+	epoch: number;
+	runIds: string[];
+	/** Runs in this snapshot that were admitted AFTER this Claim took the lease.
+	 * Serialization on the `conversations` row is supposed to make this zero. */
+	admittedAfterClaim: number;
+}
+
+/**
+ * Admission-commit order, taken client-side. Postgres `now()` is TRANSACTION
+ * start time, not statement time, so `runs.created_at` vs `conversations
+ * .owner_until` cannot decide "was this Run admitted after the lease was
+ * taken" — both skew earlier. Admitters and claimants share one event loop, so
+ * `performance.now()` readings here are totally ordered and do decide it.
+ */
+const admitCommittedAt = new Map<string, number>();
+let unknownAdmitOrder = 0;
+
+const admitted: string[] = [];
+const snapshots: SnapshotRecord[] = [];
+const successfulStarts = new Map<string, string[]>(); // runId -> ["w1@epoch3"]
+const successfulTerminals = new Map<string, string[]>();
+const rejections = { lease: 0, status: 0, gone: 0 };
+let claimAttempts = 0;
+let claimEmpty = 0;
+/** Empty claim while a Conversation was genuinely claimable — i.e. the candidate
+ * scan SKIP LOCKED past a row an admission held FOR UPDATE. This is the real
+ * starvation number; "empty while some Run was queued" is not, because a
+ * Conversation another worker legitimately owns is correctly invisible. */
+let claimYieldedToAdmission = 0;
+let admitFailures = 0;
+
+const p = pool(ADMITTERS + CLAIMANTS + 4);
+const setup = await p.connect();
+await applyPrototypeDdl(setup);
+await resetData(setup, { conversations: CONVERSATIONS });
+setup.release();
+
+let running = true;
+let seq = 0;
+
+async function admitter(id: number) {
+	const conn = await p.connect();
+	try {
+		while (running) {
+			const runId = `r-${id}-${seq++}`;
+			const conversationId = `c${1 + (seq % CONVERSATIONS)}`;
+			try {
+				await withTx(conn, () =>
+					admitRun(conn, {
+						userId: "u1",
+						conversationId,
+						runId,
+						message: `msg ${runId}`,
+					}),
+				);
+				admitted.push(runId);
+				admitCommittedAt.set(runId, performance.now());
+			} catch {
+				admitFailures++;
+			}
+			await Bun.sleep(1);
+		}
+	} finally {
+		conn.release();
+	}
+}
+
+async function claimant(id: number) {
+	const workerId = `w${id}`;
+	const conn = await p.connect();
+	try {
+		while (running) {
+			claimAttempts++;
+			let claim: Claim | null = null;
+			let runs: RunRef[] = [];
+			let claimCommittedAt = 0;
+			await conn.query("begin");
+			try {
+				claim = await claimConversation(conn, {
+					workerId,
+					leaseMs: LEASE_MS,
+					shape: SHAPE,
+				});
+				// The snapshot shares the Claim's transaction on purpose: the lease
+				// UPDATE holds the conversations row lock that admission must take.
+				if (claim && SNAPSHOT === "same-tx")
+					runs = await snapshotRuns(conn, claim);
+				await conn.query("commit");
+				claimCommittedAt = performance.now();
+				if (claim && SNAPSHOT === "after-commit") {
+					await Bun.sleep(GAP_MS); // window admission can slip through
+					runs = await snapshotRuns(conn, claim);
+				}
+			} catch (error) {
+				await conn.query("rollback").catch(() => {});
+				throw error;
+			}
+
+			if (!claim) {
+				claimEmpty++;
+				if (await claimableConversationExists(conn)) claimYieldedToAdmission++;
+				await Bun.sleep(2);
+				continue;
+			}
+
+			snapshots.push({
+				worker: workerId,
+				conversationId: claim.conversationId,
+				epoch: claim.epoch,
+				runIds: runs.map((r) => r.runId),
+				admittedAfterClaim: runs.filter((r) => {
+					const at = admitCommittedAt.get(r.runId);
+					if (at === undefined) {
+						unknownAdmitOrder++;
+						return false;
+					}
+					return at > claimCommittedAt;
+				}).length,
+			});
+
+			const lostLease = await drain(conn, workerId, claim, runs);
+			// ADR-0015: a lost lease means halt and abandon — do NOT release, the
+			// successor owns the Conversation now.
+			if (!lostLease) await releaseConversation(conn, claim);
+		}
+	} finally {
+		conn.release();
+	}
+}
+
+/** Serve the snapshot one Run at a time. Returns true if the lease was lost. */
+async function drain(
+	conn: pg.PoolClient,
+	workerId: string,
+	claim: Claim,
+	runs: RunRef[],
+): Promise<boolean> {
+	for (const { runId } of runs) {
+		const started = await startRun(conn, {
+			runId,
+			workerId,
+			epoch: claim.epoch,
+		});
+		if (!started.ok) {
+			rejections[started.rejected]++;
+			if (started.rejected === "lease") return true;
+			continue; // status rejection: went terminal under us, next Run
+		}
+		record(successfulStarts, runId, `${workerId}@${claim.epoch}`);
+
+		for (let i = 0; i < FENCED_WRITES; i++) {
+			const appended = await fencedAppend(conn, {
+				runId,
+				fenceValue: claim.epoch,
+			});
+			if (!appended.ok) {
+				rejections[appended.rejected]++;
+				if (appended.rejected === "lease") return true;
+				break;
+			}
+		}
+
+		const terminal = await terminalizeRun(conn, {
+			runId,
+			epoch: claim.epoch,
+			status: "done",
+		});
+		if (!terminal.ok) {
+			rejections[terminal.rejected]++;
+			if (terminal.rejected === "lease") return true;
+			continue;
+		}
+		record(successfulTerminals, runId, `${workerId}@${claim.epoch}`);
+	}
+	return false;
+}
+
+function record(m: Map<string, string[]>, key: string, value: string) {
+	const existing = m.get(key);
+	if (existing) existing.push(value);
+	else m.set(key, [value]);
+}
+
+async function queuedRunsExist(conn: pg.PoolClient): Promise<boolean> {
+	const { rows } = await conn.query(
+		"select 1 from runs where status = 'queued' limit 1",
+	);
+	return rows.length > 0;
+}
+
+/** The Claim's own predicate, minus the row lock. If this is true right after an
+ * empty claim, the candidate scan skipped a locked row rather than finding
+ * nothing to do. */
+async function claimableConversationExists(
+	conn: pg.PoolClient,
+): Promise<boolean> {
+	const { rows } = await conn.query(
+		`select 1 from conversations c
+		  where (c.owner_until is null or c.owner_until <= now())
+		    and exists (select 1 from runs r
+		                 where r.user_id = c.user_id
+		                   and r.conversation_id = c.conversation_id
+		                   and r.status = 'queued')
+		  limit 1`,
+	);
+	return rows.length > 0;
+}
+
+// ---------------------------------------------------------------------------
+
+console.log(
+	`shape=${SHAPE} conversations=${CONVERSATIONS} admitters=${ADMITTERS} ` +
+		`claimants=${CLAIMANTS} lease=${LEASE_MS}ms chaos=${CHAOS} for ${DURATION_MS}ms`,
+);
+
+const workers = [
+	...Array.from({ length: ADMITTERS }, (_, i) => admitter(i)),
+	...Array.from({ length: CLAIMANTS }, (_, i) => claimant(i)),
+];
+await Bun.sleep(DURATION_MS);
+running = false;
+await Promise.allSettled(workers);
+
+// Quiescent final drain: no admitters, long lease, one claimant, until empty.
+const finalConn = await p.connect();
+for (let i = 0; i < 200; i++) {
+	if (!(await queuedRunsExist(finalConn))) break;
+	await finalConn.query("begin");
+	const claim = await claimConversation(finalConn, {
+		workerId: "w-final",
+		leaseMs: 60_000,
+		shape: SHAPE,
+	});
+	const runs = claim ? await snapshotRuns(finalConn, claim) : [];
+	await finalConn.query("commit");
+	if (!claim) {
+		await Bun.sleep(20);
+		continue;
+	}
+	snapshots.push({
+		worker: "w-final",
+		conversationId: claim.conversationId,
+		epoch: claim.epoch,
+		runIds: runs.map((r) => r.runId),
+		admittedAfterClaim: 0,
+	});
+	const lost = await drain(finalConn, "w-final", claim, runs);
+	if (!lost) await releaseConversation(finalConn, claim);
+}
+
+const { rows: finalStates } = await finalConn.query<{
+	status: string;
+	n: string;
+}>("select status, count(*) as n from runs group by status order by status");
+const { rows: epochRows } = await finalConn.query<{
+	conversation_id: string;
+	epoch: number;
+	owner_until: Date | null;
+}>("select conversation_id, epoch, owner_until from conversations order by 1");
+finalConn.release();
+await p.end();
+
+// ---------------------------------------------------------------------------
+// Findings
+// ---------------------------------------------------------------------------
+
+const snapshotOwner = new Map<string, SnapshotRecord[]>();
+for (const s of snapshots) {
+	for (const runId of s.runIds) record2(snapshotOwner, runId, s);
+}
+function record2(
+	m: Map<string, SnapshotRecord[]>,
+	k: string,
+	v: SnapshotRecord,
+) {
+	const e = m.get(k);
+	if (e) e.push(v);
+	else m.set(k, [v]);
+}
+
+const admittedSet = new Set(admitted);
+const neverSnapshotted = [...admittedSet].filter((r) => !snapshotOwner.has(r));
+const multiSnapshotted = [...snapshotOwner.entries()].filter(
+	([, s]) => s.length > 1,
+);
+const doubleStarted = [...successfulStarts.entries()].filter(
+	([, s]) => s.length > 1,
+);
+const doubleTerminalized = [...successfulTerminals.entries()].filter(
+	([, s]) => s.length > 1,
+);
+const neverTerminalized = [...admittedSet].filter(
+	(r) => !successfulTerminals.has(r),
+);
+const drainLengths = snapshots.map((s) => s.runIds.length);
+const maxDrain = drainLengths.length ? Math.max(...drainLengths) : 0;
+const nonEmptyDrains = drainLengths.filter((n) => n > 0);
+
+const p2 = (n: number, d: number) =>
+	d === 0 ? "—" : `${((n / d) * 100).toFixed(1)}%`;
+
+console.log(`
+admitted                 ${admitted.length}  (${admitFailures} failed)
+claims taken             ${snapshots.length}
+claim attempts           ${claimAttempts}  (${claimEmpty} empty; ${claimYieldedToAdmission} of those had a claimable Conversation = ${p2(claimYieldedToAdmission, claimAttempts)} skipped a locked row)
+snapshot size            max ${maxDrain}, mean ${
+	nonEmptyDrains.length
+		? (
+				nonEmptyDrains.reduce((a, b) => a + b, 0) / nonEmptyDrains.length
+			).toFixed(2)
+		: 0
+} over ${nonEmptyDrains.length} non-empty
+served-after-claimed     ${snapshots.reduce((a, s) => a + s.admittedAfterClaim, 0)} Run(s) whose admission committed AFTER their Claim committed, yet inside its snapshot (${unknownAdmitOrder} unordered)
+fence rejections         lease=${rejections.lease} status=${rejections.status} gone=${rejections.gone}
+final run states         ${finalStates.map((r) => `${r.status}=${r.n}`).join(" ") || "(none)"}
+epochs                   ${epochRows.map((r) => `${r.conversation_id}:${r.epoch}${r.owner_until ? "(held)" : ""}`).join(" ")}
+`);
+
+const strict = !CHAOS;
+const checks: [string, boolean, string][] = [
+	[
+		"never double-served (no Run started twice under the fence)",
+		doubleStarted.length === 0,
+		doubleStarted
+			.slice(0, 5)
+			.map(([r, s]) => `${r} by ${s.join(", ")}`)
+			.join(" | "),
+	],
+	[
+		"never double-terminalized",
+		doubleTerminalized.length === 0,
+		doubleTerminalized
+			.slice(0, 5)
+			.map(([r, s]) => `${r} by ${s.join(", ")}`)
+			.join(" | "),
+	],
+	[
+		"never lost (every admitted Run reached some snapshot)",
+		neverSnapshotted.length === 0,
+		`${neverSnapshotted.length} missing: ${neverSnapshotted.slice(0, 5).join(", ")}`,
+	],
+];
+if (strict) {
+	checks.push([
+		"each Run in exactly one snapshot",
+		multiSnapshotted.length === 0,
+		multiSnapshotted
+			.slice(0, 5)
+			.map(
+				([r, s]) =>
+					`${r} in ${s.map((x) => `${x.worker}@${x.epoch}`).join(", ")}`,
+			)
+			.join(" | "),
+	]);
+	checks.push([
+		"every admitted Run reached done",
+		neverTerminalized.length === 0,
+		`${neverTerminalized.length} unfinished: ${neverTerminalized.slice(0, 5).join(", ")}`,
+	]);
+}
+
+let failed = 0;
+for (const [name, ok, detail] of checks) {
+	console.log(`  ${ok ? "PASS" : "FAIL"}  ${name}`);
+	if (!ok) {
+		failed++;
+		console.log(`        ${detail}`);
+	}
+}
+if (CHAOS) {
+	console.log(
+		`\n  (chaos) re-snapshotted after a lapsed lease: ${multiSnapshotted.length} Run(s); ` +
+			`stranded non-terminal: ${neverTerminalized.length} — Reclamation's job, not the snapshot's`,
+	);
+}
+console.log(
+	failed === 0 ? "\nALL CHECKS PASSED\n" : `\n${failed} CHECK(S) FAILED\n`,
+);
+process.exit(failed === 0 ? 0 : 1);

--- a/packages/agent-db/prototype-conversation-ownership/tui.ts
+++ b/packages/agent-db/prototype-conversation-ownership/tui.ts
@@ -1,0 +1,480 @@
+/**
+ * PROTOTYPE — throwaway. The hand-driven half.
+ *
+ * The harnesses (race.ts / bench.ts) answer the statistical questions. This
+ * answers the ones you have to *see*: it holds real transactions open on
+ * separate connections, so you can park an admission mid-transaction and watch
+ * the Claim SKIP LOCKED past it, or freeze a worker mid-drain, expire its lease,
+ * let another worker re-Claim, and then watch the first worker's fenced write
+ * get rejected with a typed outcome.
+ *
+ * That interleaving is exactly what PGlite cannot express (single backend,
+ * in-process) and what the ADR's epoch argument rests on.
+ *
+ *   bun tui.ts
+ */
+import type pg from "pg";
+import { applyPrototypeDdl, client, resetData } from "./db";
+import {
+	admitRun,
+	CLAIM_SHAPES,
+	type Claim,
+	type ClaimShape,
+	claimConversation,
+	type FenceOutcome,
+	fencedAppend,
+	type RunRef,
+	releaseConversation,
+	renewLease,
+	snapshotRuns,
+	startRun,
+	terminalizeRun,
+} from "./ownership";
+
+const B = (s: string) => `\x1b[1m${s}\x1b[0m`;
+const D = (s: string) => `\x1b[2m${s}\x1b[0m`;
+const G = (s: string) => `\x1b[32m${s}\x1b[0m`;
+const R = (s: string) => `\x1b[31m${s}\x1b[0m`;
+const Y = (s: string) => `\x1b[33m${s}\x1b[0m`;
+
+const LEASE_MS = 20_000;
+const USER = "u1";
+
+interface WorkerState {
+	id: string;
+	conn: pg.Client;
+	claim: Claim | null;
+	snapshot: RunRef[];
+	cursor: number;
+	txOpen: boolean;
+	last: string;
+}
+
+const view = client();
+const admitConn = client();
+await view.connect();
+await admitConn.connect();
+await applyPrototypeDdl(view);
+
+const workers: WorkerState[] = [];
+for (const id of ["w1", "w2"]) {
+	const conn = client();
+	await conn.connect();
+	workers.push({
+		id,
+		conn,
+		claim: null,
+		snapshot: [],
+		cursor: 0,
+		txOpen: false,
+		last: "-",
+	});
+}
+
+let focus = 0;
+let shape: ClaimShape = "join";
+let admitTxOpen = false;
+let admitSeq = 0;
+let message = "";
+
+const focused = () => workers[focus] as WorkerState;
+
+async function reset() {
+	for (const w of workers) {
+		if (w.txOpen) await w.conn.query("rollback").catch(() => {});
+		w.claim = null;
+		w.snapshot = [];
+		w.cursor = 0;
+		w.txOpen = false;
+		w.last = "-";
+	}
+	if (admitTxOpen) await admitConn.query("rollback").catch(() => {});
+	admitTxOpen = false;
+	admitSeq = 0;
+	await resetData(view, { conversations: 2 });
+	message = "reset: 2 conversations, no runs";
+}
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+
+function describe(outcome: FenceOutcome<unknown>): string {
+	if (outcome.ok) return G("ok");
+	if (outcome.rejected === "lease")
+		return R(`rejected:lease (row epoch=${outcome.epoch})`);
+	if (outcome.rejected === "status")
+		return Y(`rejected:status (now ${outcome.current})`);
+	return R("rejected:gone");
+}
+
+async function admit(conversationId: string, hold: boolean) {
+	const runId = `r${++admitSeq}`;
+	if (hold) {
+		if (!admitTxOpen) {
+			await admitConn.query("begin");
+			admitTxOpen = true;
+		}
+		await admitRun(admitConn, {
+			userId: USER,
+			conversationId,
+			runId,
+			message: runId,
+		});
+		message = `admission tx OPEN, holding ${conversationId} FOR UPDATE (${runId} uncommitted)`;
+		return;
+	}
+	await admitConn.query("begin");
+	await admitRun(admitConn, {
+		userId: USER,
+		conversationId,
+		runId,
+		message: runId,
+	});
+	await admitConn.query("commit");
+	message = `admitted ${runId} to ${conversationId}`;
+}
+
+async function claim(hold: boolean) {
+	const w = focused();
+	if (w.txOpen) {
+		message = `${w.id} already has an open transaction`;
+		return;
+	}
+	await w.conn.query("begin");
+	w.txOpen = true;
+	const c = await claimConversation(w.conn, {
+		workerId: w.id,
+		leaseMs: LEASE_MS,
+		shape,
+	});
+	if (!c) {
+		await w.conn.query("rollback");
+		w.txOpen = false;
+		message = `${w.id} claimed nothing (candidate scan found no unlocked, unowned Conversation with queued Runs)`;
+		return;
+	}
+	w.claim = c;
+	w.snapshot = await snapshotRuns(w.conn, c);
+	w.cursor = 0;
+	w.last = `claim ${c.conversationId}@${c.epoch}`;
+	if (hold) {
+		message = `${w.id} claim tx OPEN — ${c.conversationId}@${c.epoch}, snapshot ${w.snapshot.length} Run(s). Other worker's claim will SKIP LOCKED past it.`;
+		return;
+	}
+	await w.conn.query("commit");
+	w.txOpen = false;
+	message = `${w.id} claimed ${c.conversationId}@${c.epoch}, snapshot ${w.snapshot.length} Run(s)`;
+}
+
+async function commitTx() {
+	const w = focused();
+	if (!w.txOpen) {
+		message = `${w.id} has no open transaction`;
+		return;
+	}
+	await w.conn.query("commit");
+	w.txOpen = false;
+	message = `${w.id} committed`;
+}
+
+async function serveNext() {
+	const w = focused();
+	if (!w.claim) {
+		message = `${w.id} owns nothing`;
+		return;
+	}
+	const next = w.snapshot[w.cursor];
+	if (!next) {
+		message = `${w.id} snapshot is drained (${w.snapshot.length} served)`;
+		return;
+	}
+	const started = await startRun(w.conn, {
+		runId: next.runId,
+		workerId: w.id,
+		epoch: w.claim.epoch,
+	});
+	if (!started.ok) {
+		w.last = `start ${next.runId}: ${describe(started)}`;
+		message =
+			started.rejected === "lease"
+				? `${w.id} LOST THE LEASE — halt and abandon, do NOT release`
+				: `${w.id} skipping ${next.runId}: ${describe(started)}`;
+		if (started.rejected !== "lease") w.cursor++;
+		return;
+	}
+	const appended = await fencedAppend(w.conn, {
+		runId: next.runId,
+		fenceValue: w.claim.epoch,
+	});
+	const finished = appended.ok
+		? await terminalizeRun(w.conn, {
+				runId: next.runId,
+				epoch: w.claim.epoch,
+				status: "done",
+			})
+		: appended;
+	w.cursor++;
+	w.last = `serve ${next.runId}: ${describe(finished)}`;
+	message = `${w.id} served ${next.runId} -> ${describe(finished)}`;
+}
+
+async function fenceProbe() {
+	const w = focused();
+	if (!w.claim) {
+		message = `${w.id} owns nothing`;
+		return;
+	}
+	const target = w.snapshot[Math.max(0, w.cursor - 1)] ?? w.snapshot[0];
+	if (!target) {
+		message = `${w.id} has no Run to write to`;
+		return;
+	}
+	const outcome = await fencedAppend(w.conn, {
+		runId: target.runId,
+		fenceValue: w.claim.epoch,
+	});
+	w.last = `append ${target.runId}: ${describe(outcome)}`;
+	message = `${w.id} fenced append on ${target.runId} -> ${describe(outcome)}`;
+}
+
+async function release() {
+	const w = focused();
+	if (!w.claim) {
+		message = `${w.id} owns nothing`;
+		return;
+	}
+	const ok = await releaseConversation(w.conn, w.claim);
+	message = ok
+		? `${w.id} released ${w.claim.conversationId}@${w.claim.epoch}`
+		: `${w.id} release matched 0 rows — epoch ${w.claim.epoch} is no longer current`;
+	w.claim = null;
+	w.snapshot = [];
+	w.cursor = 0;
+}
+
+async function heartbeat() {
+	const w = focused();
+	if (!w.claim) {
+		message = `${w.id} owns nothing`;
+		return;
+	}
+	const until = await renewLease(w.conn, w.claim, LEASE_MS);
+	message = until
+		? `${w.id} renewed to ${until.toISOString().slice(11, 19)}`
+		: `${w.id} renew matched 0 rows — lease is gone (epoch superseded)`;
+}
+
+async function expireLease() {
+	const w = focused();
+	if (!w.claim) {
+		message = `${w.id} owns nothing`;
+		return;
+	}
+	await view.query(
+		`update conversations set owner_until = now() - interval '1 second'
+		  where user_id = $1 and conversation_id = $2`,
+		[USER, w.claim.conversationId],
+	);
+	message = `expired ${w.claim.conversationId}'s lease — ${w.id} still believes it owns epoch ${w.claim.epoch}`;
+}
+
+// ---------------------------------------------------------------------------
+// Render
+// ---------------------------------------------------------------------------
+
+async function render() {
+	const { rows: convs } = await view.query<{
+		conversation_id: string;
+		epoch: number;
+		owner_worker_id: string | null;
+		owner_until: Date | null;
+		live: boolean | null;
+	}>(
+		`select conversation_id, epoch, owner_worker_id, owner_until,
+		        owner_until > now() as live
+		   from conversations order by conversation_id`,
+	);
+	const { rows: runRows } = await view.query<{
+		run_id: string;
+		conversation_id: string;
+		status: string;
+		executed_by_worker_id: string | null;
+	}>(
+		`select run_id, conversation_id, status, executed_by_worker_id
+		   from runs order by created_at, run_id`,
+	);
+
+	const lines: string[] = [];
+	lines.push(
+		B("Conversation-ownership prototype") +
+			D(`   claim shape: ${shape}   lease: ${LEASE_MS / 1000}s`),
+	);
+	lines.push("");
+	lines.push(B("CONVERSATIONS"));
+	for (const c of convs) {
+		const owner = c.owner_worker_id
+			? c.live
+				? G(`${c.owner_worker_id} live`)
+				: R(`${c.owner_worker_id} LAPSED`)
+			: D("unowned");
+		lines.push(
+			`  ${c.conversation_id}  epoch ${B(String(c.epoch))}  ${owner}` +
+				D(
+					c.owner_until
+						? `  until ${c.owner_until.toISOString().slice(11, 19)}`
+						: "",
+				),
+		);
+	}
+
+	lines.push("");
+	lines.push(B("RUNS") + D(`  (${runRows.length})`));
+	if (runRows.length === 0) lines.push(D("  none"));
+	for (const r of runRows.slice(0, 12)) {
+		const colour =
+			r.status === "done"
+				? G
+				: r.status === "queued"
+					? D
+					: r.status === "running"
+						? Y
+						: R;
+		lines.push(
+			`  ${r.run_id.padEnd(5)} ${r.conversation_id}  ${colour(r.status.padEnd(9))}` +
+				D(r.executed_by_worker_id ? `  by ${r.executed_by_worker_id}` : ""),
+		);
+	}
+	if (runRows.length > 12) lines.push(D(`  ... ${runRows.length - 12} more`));
+
+	lines.push("");
+	lines.push(B("WORKERS"));
+	for (const [i, w] of workers.entries()) {
+		const marker = i === focus ? B("▸") : " ";
+		const held = w.claim
+			? `${w.claim.conversationId}@${B(String(w.claim.epoch))} snapshot[${w.cursor}/${w.snapshot.length}]`
+			: D("idle");
+		lines.push(
+			`  ${marker} ${B(w.id)}  ${held}${w.txOpen ? R("  TX OPEN") : ""}`,
+		);
+		lines.push(D(`      last: ${w.last}`));
+	}
+	lines.push(
+		`    ${admitTxOpen ? R("admission TX OPEN — holding a conversations row FOR UPDATE") : D("admission: idle")}`,
+	);
+
+	lines.push("");
+	if (message) lines.push(`  ${message}`);
+	lines.push("");
+	lines.push(
+		D("[1/2]") +
+			" focus worker  " +
+			D("[a/b]") +
+			" admit to c1/c2  " +
+			D("[A]") +
+			" admit & HOLD tx  " +
+			D("[x]") +
+			" commit admission",
+	);
+	lines.push(
+		D("[c]") +
+			" claim+snapshot  " +
+			D("[C]") +
+			" claim & HOLD tx  " +
+			D("[k]") +
+			" commit worker tx  " +
+			D("[s]") +
+			" serve next Run",
+	);
+	lines.push(
+		D("[f]") +
+			" fenced append  " +
+			D("[h]") +
+			" heartbeat  " +
+			D("[X]") +
+			" expire lease  " +
+			D("[e]") +
+			" release  " +
+			D("[t]") +
+			" cycle shape",
+	);
+	lines.push(D("[r]") + " reset  " + D("[q]") + " quit");
+
+	console.clear();
+	console.log(lines.join("\n"));
+}
+
+// ---------------------------------------------------------------------------
+
+const actions: Record<string, () => Promise<void>> = {
+	"1": async () => {
+		focus = 0;
+	},
+	"2": async () => {
+		focus = 1;
+	},
+	a: () => admit("c1", false),
+	b: () => admit("c2", false),
+	A: () => admit("c1", true),
+	x: async () => {
+		if (!admitTxOpen) {
+			message = "no open admission transaction";
+			return;
+		}
+		await admitConn.query("commit");
+		admitTxOpen = false;
+		message = "admission committed — its Run is now visible to the next Claim";
+	},
+	c: () => claim(false),
+	C: () => claim(true),
+	k: commitTx,
+	s: serveNext,
+	f: fenceProbe,
+	h: heartbeat,
+	X: expireLease,
+	e: release,
+	t: async () => {
+		const i = CLAIM_SHAPES.indexOf(shape);
+		shape = CLAIM_SHAPES[(i + 1) % CLAIM_SHAPES.length] as ClaimShape;
+		message = `claim shape: ${shape}`;
+	},
+	r: reset,
+};
+
+await reset();
+await render();
+
+const isTty = process.stdin.isTTY === true;
+if (isTty) process.stdin.setRawMode(true);
+process.stdin.resume();
+process.stdin.setEncoding("utf8");
+
+outer: for await (const chunk of process.stdin) {
+	// A TTY delivers one keystroke per chunk; a pipe delivers a whole line, so
+	// `printf 'aacs' | bun tui.ts` drives the same loop for a smoke run.
+	for (const key of String(chunk).replace(/[\r\n]/g, "")) {
+		if (key === "q" || key === "\u0003") break outer;
+		const action = actions[key];
+		if (!action) continue;
+		try {
+			message = "";
+			await action();
+		} catch (error) {
+			message = R(`error: ${(error as Error).message}`);
+			const w = focused();
+			if (w.txOpen) {
+				await w.conn.query("rollback").catch(() => {});
+				w.txOpen = false;
+			}
+		}
+		await render();
+	}
+	if (!isTty) break;
+}
+
+if (isTty) process.stdin.setRawMode(false);
+for (const w of workers) await w.conn.end();
+await admitConn.end();
+await view.end();
+console.log("\nbye\n");
+process.exit(0);

--- a/packages/agent-db/prototype-conversation-ownership/up.sh
+++ b/packages/agent-db/prototype-conversation-ownership/up.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# PROTOTYPE — throwaway. Brings up the scratch Postgres the ownership prototype
+# runs against: a standalone container (compose's postgres is not port-mapped),
+# the real @mymemo/agent-db migrations, then the ADR-0015 schema delta.
+set -euo pipefail
+
+NAME=mymemo-prototype-ownership-wipe-me
+PORT=${PROTO_PG_PORT:-55432}
+URL="postgresql://proto:proto@127.0.0.1:${PORT}/prototype_ownership_wipe_me"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+if [ "${1:-up}" = "down" ]; then
+	docker rm -f "$NAME" >/dev/null 2>&1 || true
+	echo "removed $NAME"
+	exit 0
+fi
+
+if ! docker inspect "$NAME" >/dev/null 2>&1; then
+	docker run -d --name "$NAME" \
+		-e POSTGRES_USER=proto -e POSTGRES_PASSWORD=proto \
+		-e POSTGRES_DB=prototype_ownership_wipe_me \
+		-p "${PORT}:5432" postgres:16 >/dev/null
+	echo "started $NAME on :${PORT}"
+fi
+docker start "$NAME" >/dev/null 2>&1 || true
+
+for _ in $(seq 1 30); do
+	if docker exec "$NAME" pg_isready -U proto -d prototype_ownership_wipe_me >/dev/null 2>&1; then
+		break
+	fi
+	sleep 1
+done
+
+AGENT_DATABASE_URL="$URL" DB_SSL=disable \
+	bun run --cwd "$ROOT/apps/chat-api" db:migrate
+
+echo
+echo "ready: $URL"
+echo "  bun run --cwd packages/agent-db proto:tui"


### PR DESCRIPTION
Docs and a throwaway prototype — no production code changed. Output of a `/grill-with-docs` session on the Run ownership and admission redesign, plus the `/prototype` pass that followed it.

Spec: #393. Tickets: #394–#402.

## Why

Execution ownership lives on the Run today, while every resource a Run's execution writes is already Conversation-scoped — `conversation_runtime`, `agent_sessions`, `conversation_artifacts`, and the E2B sandbox. Nearly every awkward thing in the queue code traces to that one mismatch: runtime writes borrow authority by `EXISTS`-ing back into `runs`, the sandbox is reconnected once per turn, two ownership predicate variants exist, and `runs_one_active_per_conversation` quietly doubles as an ownership guarantee it was never declared to provide.

## What changed

**`docs/adr/0015-conversation-level-ownership-with-epoch.md`** — ownership moves to the Conversation, fenced by a per-Conversation epoch. A worker claims a Conversation, serves the Runs it had active at that moment one at a time, and releases. Covers the fence surface, snapshot drain, considered options, and what dies.

**`docs/adr/0016-gate-closed-cutover-to-conversation-ownership.md`** — the cutover closes the exposure gate, drains, scales workers to zero, migrates, and reopens. Follows ADR-0002's refusal to let two ownership authorities exist at once; rejects a two-phase rollout because its shim is the dual ownership predicates ADR-0015 exists to remove.

**`CONTEXT.md`** — `Claim` and `Ownership lease` become Conversation-scoped and drop the column names they should never have carried; `Run` stops asserting at-most-one-active as an invariant; three terms added.

**`packages/agent-db/prototype-conversation-ownership/`** — the throwaway prototype, deliberately temporary. It answered the three Postgres behaviours ADR-0015 rested on and had never executed: whether `FOR UPDATE OF c SKIP LOCKED` is legal and plans sanely in the join shape, whether snapshot integrity holds under concurrent admission, and what the per-write fence probe costs. Its README carries the measured answers.

## Two vocabulary collisions fixed in passing

- **"Active"** is defined in four places in code with nothing enforcing agreement (`schema.ts`, `run-ownership.ts`, `postgres-conversation-store.ts`, `run-store.ts`). It is also now the admission depth-bound unit, so it gets one glossary definition.
- **"Recovery"** meant two unrelated things: `CONTEXT.md` defined *Recovering* as a client behaviour (waiting for permanent history after a Live Stream dies), while the worker-side sweep is called "stale-run recovery" throughout the code. The worker-side one is now **Reclamation**, disambiguated in both directions.

## For reviewers

- ADR-0015 **corrects the record** on two existing code comments (in `schema.ts` and `run-store.ts`) that claim v1 deliberately carries no fencing token because a Run is claimed exactly once. The conclusion held; the reasoning did not. What actually prevented two workers from executing one Conversation was the partial unique index plus the terminal lease NULL-out — structural safety from a constraint nobody documented as load-bearing. That correction stands whether or not the rest ships.
- **The Claim statement is no longer unverified.** ADR-0015 left its exact SQL and the index it wants unsettled; the prototype settled both. The join shape is legal, plans without a Sort at 7 buffers / 0.074 ms, and **wants no new index** — the existing `runs_queue_claim_idx` is what makes the plan sort-free. The no-join alternative is roughly 270× the buffers and is rejected outright in #394. Nothing the prototype found contradicts the ADR.
- **The prototype is scheduled for deletion**, not maintained. Spec #393 carries every answer it produced, and deleting the directory is a checked acceptance criterion on #394 — whose implementer wants to read and run it first, since its race harness is the model for the real-Postgres contention suite in #396.
- **The glossary leads the code.** `CONTEXT.md` describes the target model; the source still claims Runs. That gap persists until #394–#402 land.
- **`AGENTS.md` is deliberately untouched** — it documents current behaviour accurately today and every relevant description becomes wrong under this design. Updating it is an acceptance criterion on #402, the contract ticket, where the final shape is true.

## CI

The red checks are **pre-existing and repo-wide**, not about this branch: every workflow run since at least 2026-07-27 fails with zero steps executed in ~2 seconds, on `main` as well as on PRs. The jobs never start. This branch changes no production code and adds no test, so it cannot be the cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
