### PR TITLE
perf(agent-db): index Conversation history paging over terminal Runs

### DIFF
--- a/apps/chat-api/src/db/run-schema.test.ts
+++ b/apps/chat-api/src/db/run-schema.test.ts
@@ -14,6 +14,7 @@ import {
 	documentAccessEvents,
 	runEvents,
 	runs,
+	TERMINAL_RUN_STATUSES,
 } from "./schema";
 
 let tdb: TestDb;
@@ -196,6 +197,33 @@ describe("run queue schema", () => {
 		// Read from the shared tuple, so this asserts that what the database
 		// actually indexes is what admission actually filters on.
 		for (const status of ACTIVE_RUN_STATUSES) {
+			expect(predicate).toContain(status);
+		}
+	});
+
+	it("keeps the history-paging index non-unique and partial", async () => {
+		// History paging reads one Conversation's Outcomes newest-first. Without
+		// this index that read is a sequential scan of every Run ever admitted;
+		// with it, cost tracks the Conversation's own history length instead.
+		const { rows } = await tdb.db.execute(sql`
+			select indexdef from pg_indexes
+			where tablename = 'runs' and indexname = 'runs_history_paging_idx'
+		`);
+		// Empty when the index is missing, which fails the first assertion loudly.
+		const definition = rows[0] ? String(rows[0].indexdef) : "";
+		expect(definition).toContain("CREATE INDEX");
+		expect(definition).not.toContain("UNIQUE");
+		// Exactly the equality pair, and nothing trailing it. The paging query's
+		// `ORDER BY` is over a `date_trunc` expression no btree on the raw column
+		// can match, so ordering columns here would be index width buying nothing.
+		expect(definition).toContain("(user_id, conversation_id)");
+		// Asserted by parts rather than as one string, for the same reason as
+		// `runs_conversation_active_idx` above.
+		const [, predicate = ""] = definition.split(" WHERE ");
+		expect(predicate).toContain("status");
+		// Read from the shared tuple, so this catches a change to what counts as
+		// an Outcome that never reached the migration the database actually ran.
+		for (const status of TERMINAL_RUN_STATUSES) {
 			expect(predicate).toContain(status);
 		}
 	});

--- a/apps/chat-api/src/db/run-schema.test.ts
+++ b/apps/chat-api/src/db/run-schema.test.ts
@@ -201,21 +201,18 @@ describe("run queue schema", () => {
 		}
 	});
 
-	it("keeps the history-paging index non-unique and partial", async () => {
-		// History paging reads one Conversation's Outcomes newest-first. Without
-		// this index that read is a sequential scan of every Run ever admitted;
-		// with it, cost tracks the Conversation's own history length instead.
+	it("keeps the history-paging index partial on Outcomes", async () => {
 		const { rows } = await tdb.db.execute(sql`
 			select indexdef from pg_indexes
 			where tablename = 'runs' and indexname = 'runs_history_paging_idx'
 		`);
 		// Empty when the index is missing, which fails the first assertion loudly.
+		// A unique index would fail it too — `CREATE UNIQUE INDEX` does not contain
+		// this substring.
 		const definition = rows[0] ? String(rows[0].indexdef) : "";
 		expect(definition).toContain("CREATE INDEX");
-		expect(definition).not.toContain("UNIQUE");
-		// Exactly the equality pair, and nothing trailing it. The paging query's
-		// `ORDER BY` is over a `date_trunc` expression no btree on the raw column
-		// can match, so ordering columns here would be index width buying nothing.
+		// Exactly the equality pair, nothing trailing it; the index's own comment
+		// in `schema.ts` carries why ordering columns would buy nothing here.
 		expect(definition).toContain("(user_id, conversation_id)");
 		// Asserted by parts rather than as one string, for the same reason as
 		// `runs_conversation_active_idx` above.

--- a/apps/chat-api/src/features/conversation-history/postgres-conversation-history-store.ts
+++ b/apps/chat-api/src/features/conversation-history/postgres-conversation-history-store.ts
@@ -34,6 +34,10 @@ import { InvalidConversationHistoryCursorError } from "./conversation-history-st
 // node-postgres exposes timestamps as millisecond Date values while Postgres
 // stores microseconds. Use that same precision for ordering and comparison so
 // Run-id tie-breaking cannot be skipped when a cursor round-trips through JSON.
+// What it costs: no btree on the raw column can serve this `ORDER BY`, so
+// `runs_history_paging_idx` indexes only the equality filter and Postgres top-N
+// sorts the page. Retiring this truncation is the thing that would make an
+// ordered index path possible — revisit that index's shape if it ever goes.
 const RUN_ORDER_CREATED_AT = sql<Date>`date_trunc('milliseconds', ${runs.createdAt})`;
 
 type RunRow = typeof runs.$inferSelect;

--- a/packages/agent-db/drizzle/0016_runs_history_paging_index.sql
+++ b/packages/agent-db/drizzle/0016_runs_history_paging_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "runs_history_paging_idx" ON "runs" USING btree ("user_id","conversation_id") WHERE "runs"."status" in ('done', 'error', 'interrupted');

--- a/packages/agent-db/drizzle/meta/0016_snapshot.json
+++ b/packages/agent-db/drizzle/meta/0016_snapshot.json
@@ -1,0 +1,1095 @@
+{
+  "id": "fe132233-cfc6-46ad-a36c-9690a9210279",
+  "prevId": "15278c0a-65e8-4477-aced-1456d86e580e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_sessions": {
+      "name": "agent_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subpath": {
+          "name": "subpath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry": {
+          "name": "entry",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "epoch": {
+          "name": "epoch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_sessions_dedup_idx": {
+          "name": "agent_sessions_dedup_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subpath",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_sessions_transcript_idx": {
+          "name": "agent_sessions_transcript_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subpath",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_sessions_conversation_idx": {
+          "name": "agent_sessions_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artifact_objects": {
+      "name": "artifact_objects",
+      "schema": "",
+      "columns": {
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "artifact_objects_run_idx": {
+          "name": "artifact_objects_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifact_objects_status_idx": {
+          "name": "artifact_objects_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "artifact_objects_status_check": {
+          "name": "artifact_objects_status_check",
+          "value": "\"artifact_objects\".\"status\" in ('pending', 'current', 'superseded')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversation_artifacts": {
+      "name": "conversation_artifacts",
+      "schema": "",
+      "columns": {
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_artifacts_owner_conversation_path_idx": {
+          "name": "conversation_artifacts_owner_conversation_path_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_artifacts_conversation_fk": {
+          "name": "conversation_artifacts_conversation_fk",
+          "tableFrom": "conversation_artifacts",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "user_id",
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "user_id",
+            "conversation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "conversation_artifacts_size_bytes_check": {
+          "name": "conversation_artifacts_size_bytes_check",
+          "value": "\"conversation_artifacts\".\"size_bytes\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversation_runtime": {
+      "name": "conversation_runtime",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_tainted": {
+          "name": "sandbox_tainted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "conversation_runtime_user_id_conversation_id_pk": {
+          "name": "conversation_runtime_user_id_conversation_id_pk",
+          "columns": [
+            "user_id",
+            "conversation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_id": {
+          "name": "summary_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_worker_id": {
+          "name": "owner_worker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_until": {
+          "name": "owner_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "epoch": {
+          "name": "epoch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "conversations_regular_activity_idx": {
+          "name": "conversations_regular_activity_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversations\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_archived_activity_idx": {
+          "name": "conversations_archived_activity_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversations\".\"archived_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_reclamation_idx": {
+          "name": "conversations_reclamation_idx",
+          "columns": [
+            {
+              "expression": "owner_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversations\".\"owner_until\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "conversations_user_id_conversation_id_pk": {
+          "name": "conversations_user_id_conversation_id_pk",
+          "columns": [
+            "user_id",
+            "conversation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "conversations_scope_check": {
+          "name": "conversations_scope_check",
+          "value": "\"conversations\".\"scope\" in ('general', 'collection', 'document')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.document_access_events": {
+      "name": "document_access_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_ids": {
+          "name": "document_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_count": {
+          "name": "result_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_access_events_run_id_idx": {
+          "name": "document_access_events_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_access_events_created_at_idx": {
+          "name": "document_access_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "document_access_events_operation_check": {
+          "name": "document_access_events_operation_check",
+          "value": "\"document_access_events\".\"operation\" in ('search', 'list', 'load')"
+        },
+        "document_access_events_scope_type_check": {
+          "name": "document_access_events_scope_type_check",
+          "value": "\"document_access_events\".\"scope_type\" in ('general', 'collection', 'document')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.orphan_sandboxes": {
+      "name": "orphan_sandboxes",
+      "schema": "",
+      "columns": {
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_worker_id": {
+          "name": "created_by_worker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_events": {
+      "name": "run_events",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "run_events_run_id_runs_run_id_fk": {
+          "name": "run_events_run_id_runs_run_id_fk",
+          "tableFrom": "run_events",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "run_events_run_id_seq_pk": {
+          "name": "run_events_run_id_seq_pk",
+          "columns": [
+            "run_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runs": {
+      "name": "runs",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_input": {
+          "name": "normalized_input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locked_by": {
+          "name": "locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executed_by_worker_id": {
+          "name": "executed_by_worker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interrupt_requested_at": {
+          "name": "interrupt_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_stream_failed_at": {
+          "name": "live_stream_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_event_seq": {
+          "name": "next_event_seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "runs_conversation_active_idx": {
+          "name": "runs_conversation_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runs\".\"status\" in ('queued', 'running', 'interrupt_requested')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_queue_claim_idx": {
+          "name": "runs_queue_claim_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runs\".\"status\" = 'queued'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_stale_recovery_idx": {
+          "name": "runs_stale_recovery_idx",
+          "columns": [
+            {
+              "expression": "locked_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runs\".\"status\" in ('running', 'interrupt_requested')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_cleanup_idx": {
+          "name": "runs_cleanup_idx",
+          "columns": [
+            {
+              "expression": "terminal_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runs\".\"status\" in ('done', 'error', 'interrupted')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_history_paging_idx": {
+          "name": "runs_history_paging_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runs\".\"status\" in ('done', 'error', 'interrupted')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runs_conversation_fk": {
+          "name": "runs_conversation_fk",
+          "tableFrom": "runs",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "user_id",
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "user_id",
+            "conversation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runs_status_check": {
+          "name": "runs_status_check",
+          "value": "\"runs\".\"status\" in ('queued', 'running', 'interrupt_requested', 'done', 'error', 'interrupted')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/agent-db/drizzle/meta/_journal.json
+++ b/packages/agent-db/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1785398597823,
       "tag": "0015_runs_conversation_active_index",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1785481024853,
+      "tag": "0016_runs_history_paging_index",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/agent-db/src/schema.ts
+++ b/packages/agent-db/src/schema.ts
@@ -386,8 +386,8 @@ export const runs = pgTable(
 		// at realistic lengths; a Conversation reaching thousands of Runs is when the
 		// indexable `date_trunc(... AT TIME ZONE 'UTC')` would start to earn the
 		// app-visible expression rewrite it requires.
-		// Partial on the same tuple as `runs_cleanup_idx`, which makes this the exact
-		// complement of `runs_conversation_active_idx`.
+		// The predicate makes this the exact complement of
+		// `runs_conversation_active_idx`: between them they partition the table.
 		index("runs_history_paging_idx")
 			.on(t.userId, t.conversationId)
 			.where(sql`${t.status} in (${statusList(TERMINAL_RUN_STATUSES)})`),

--- a/packages/agent-db/src/schema.ts
+++ b/packages/agent-db/src/schema.ts
@@ -373,6 +373,24 @@ export const runs = pgTable(
 		index("runs_cleanup_idx")
 			.on(t.terminalAt)
 			.where(sql`${t.status} in (${statusList(TERMINAL_RUN_STATUSES)})`),
+		// History paging: one Conversation's Outcomes. The equality pair plus the
+		// partial predicate is the whole access path — it turns a sequential scan of
+		// every Run ever admitted into an index scan of one Conversation's.
+		// It deliberately stops there. The paging query orders by
+		// `date_trunc('milliseconds', created_at)` (`RUN_ORDER_CREATED_AT` in
+		// chat-api's history store), and no btree on the raw column can match an
+		// expression sort key, so Postgres top-N sorts either way — trailing
+		// `created_at, run_id` measured as pure index width: same `Index Cond`,
+		// same buffers, same sort.
+		// So cost tracks the Conversation's history length, not the page size. Fine
+		// at realistic lengths; a Conversation reaching thousands of Runs is when the
+		// indexable `date_trunc(... AT TIME ZONE 'UTC')` would start to earn the
+		// app-visible expression rewrite it requires.
+		// Partial on the same tuple as `runs_cleanup_idx`, which makes this the exact
+		// complement of `runs_conversation_active_idx`.
+		index("runs_history_paging_idx")
+			.on(t.userId, t.conversationId)
+			.where(sql`${t.status} in (${statusList(TERMINAL_RUN_STATUSES)})`),
 	],
 );
 


### PR DESCRIPTION
Adds the missing index behind `GET /v1/conversations/:id/history`. Follow-up to #404, which noted the gap; #393 is the record of index decisions for this epic.

## The problem

The history store reads one Conversation's Outcomes ([`postgres-conversation-history-store.ts`](https://github.com/X-GPT/mymemo-agent/blob/main/apps/chat-api/src/features/conversation-history/postgres-conversation-history-store.ts)) with nothing supporting the filter. #404 dropped `runs_one_active_per_conversation` and `0015` restored the `(user_id, conversation_id)` access path only for *Active* Runs — the terminal side had no equivalent.

## The change

One partial index, next to `runs_cleanup_idx`:

```sql
CREATE INDEX "runs_history_paging_idx" ON "runs" USING btree ("user_id","conversation_id")
  WHERE "runs"."status" in ('done', 'error', 'interrupted');
```

Measured on PGlite, 400 conversations x 20 terminal Runs, `EXPLAIN (ANALYZE, BUFFERS)` on the real paging query:

| variant | scan | buffers |
|---|---|---|
| before | Seq Scan, 7980 rows removed by filter | 91 |
| after | Index Scan | 22 |

## Why it stops at two columns

This is the part worth a reviewer's attention, because the first draft of this change had four columns and a comment explaining an optimisation that does not occur.

The query orders by `date_trunc('milliseconds', created_at)`, not by the raw column. No btree on `created_at` can match an expression sort key, so a `Sort` node is present either way — Postgres never scans the index backwards to serve the `ORDER BY`. Adding `created_at, run_id` was measured as pure index width: identical `Index Cond`, identical buffer count, identical sort.

```
->  Sort  Sort Key: (date_trunc('milliseconds'::text, created_at)) DESC, run_id DESC
      ->  Index Scan using runs_history_paging_idx on runs
            Index Cond: ((user_id = ...) AND (conversation_id = ...))
```

Making the scan serve the ordering would require `date_trunc(... AT TIME ZONE 'UTC')` — the only indexable form, since the `timestamptz` overload is `STABLE` — plus an app-visible expression rewrite and a cursor type change, for a measured 0.06 ms. Not taken.

**Consequence to know:** cost tracks the Conversation's history length, not the page size. Fine at realistic lengths (tens of Runs); the schema comment records that a Conversation reaching thousands is the point at which that rewrite starts to pay.

## Notes for review

- The predicate reuses `statusList(TERMINAL_RUN_STATUSES)`, so this is the exact complement of `runs_conversation_active_idx`, not a fourth spelling of the status set.
- The test asserts by parts and never pins Postgres's `= ANY (ARRAY[...])` rendering, which is server-version-dependent. Since [`testing.ts`](https://github.com/X-GPT/mymemo-agent/blob/main/packages/agent-db/src/testing.ts) replays the real `drizzle/*.sql` files rather than push-creating from `schema.ts`, it also fails if `TERMINAL_RUN_STATUSES` changes without a migration.
- `db:generate` re-run reports `No schema changes, nothing to migrate` — `0016` is the only DDL in the diff.
- Three workspace typechecks clean; full suite 859 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)