### PR TITLE
docs(prototype): generative-UI payload rendering prototype (#323)

### DIFF
--- a/docs/prototypes/generative-ui-payloads.prototype.html
+++ b/docs/prototypes/generative-ui-payloads.prototype.html
@@ -1,0 +1,408 @@
+<!doctype html>
+<!--
+  PROTOTYPE — THROWAWAY. Do not ship.
+  Ticket: https://github.com/X-GPT/mymemo-agent/issues/323 (wayfinder map #320)
+  Plan: three variants of a fake MyMemo thread rendering the same sample generative-UI
+  payloads (decided contract: {component, props, children?} per ≤16 KiB event; chart=Vega-Lite,
+  diagram=Mermaid), switchable via ?variant= / arrow keys, with live byte counts + raw JSON.
+  Run: open this file in a browser (needs network for the mermaid/vega CDNs).
+  Note: renders Vega-Lite via the v5 CDN trio and mermaid securityLevel:'strict' for the
+  throwaway; the contract mandates VL v6 + vega-interpreter/deny-all loader and Mermaid
+  sandbox/SSR — rendering posture here is NOT the contract posture.
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>PROTOTYPE · generative-UI payloads (#323)</title>
+<script src="https://cdn.jsdelivr.net/npm/vega@5.30.0"></script>
+<script src="https://cdn.jsdelivr.net/npm/vega-lite@5.21.0"></script>
+<script src="https://cdn.jsdelivr.net/npm/vega-embed@6.26.0"></script>
+<script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
+<style>
+  :root {
+    --bg: #ffffff; --fg: #1f2430; --muted: #6b7280; --line: #e5e7eb;
+    --accent: #4f46e5; --user-bubble: #f3f4f6; --frame: #fafafa;
+    --ok: #047857; --ok-bg: #ecfdf5; --bad: #b91c1c; --bad-bg: #fef2f2;
+    --warn: #92400e; --warn-bg: #fffbeb;
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; background: var(--bg); color: var(--fg);
+    font: 15px/1.6 -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; }
+  .top { border-bottom: 1px solid var(--line); padding: 10px 20px; display: flex; gap: 12px;
+    align-items: baseline; flex-wrap: wrap; }
+  .top b { font-size: 14px; }
+  .top .tag { font-size: 11px; letter-spacing: .04em; color: #fff; background: var(--accent);
+    border-radius: 4px; padding: 2px 6px; text-transform: uppercase; }
+  .top .hint { color: var(--muted); font-size: 12.5px; }
+  .wrap { display: flex; min-height: calc(100vh - 45px); }
+  .thread { flex: 1; max-width: 780px; margin: 0 auto; padding: 28px 20px 120px; }
+  .side { display: none; }
+  body[data-variant="C"] .wrap { max-width: 1280px; margin: 0 auto; }
+  body[data-variant="C"] .thread { margin: 0; }
+  body[data-variant="C"] .side { display: block; width: 430px; border-left: 1px solid var(--line);
+    padding: 20px 16px 120px; overflow-y: auto; max-height: calc(100vh - 45px);
+    position: sticky; top: 45px; }
+  .msg { margin: 18px 0; }
+  .msg.user { display: flex; justify-content: flex-end; }
+  .msg.user .bubble { background: var(--user-bubble); border-radius: 16px; padding: 10px 16px;
+    max-width: 78%; }
+  .msg.assistant p { margin: 10px 0; }
+  .who { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: .06em;
+    margin-bottom: 2px; }
+  .probe { font-size: 10.5px; color: var(--warn); background: var(--warn-bg);
+    border: 1px solid #fcd34d; padding: 1px 6px; border-radius: 999px; margin-left: 6px; }
+
+  /* payload blocks */
+  .block { margin: 14px 0; }
+  .metaline { display: flex; gap: 10px; align-items: center; font-size: 11.5px;
+    color: var(--muted); margin-top: 4px; flex-wrap: wrap; }
+  .bytes { border-radius: 999px; padding: 1px 8px; font-variant-numeric: tabular-nums; }
+  .bytes.ok { color: var(--ok); background: var(--ok-bg); }
+  .bytes.bad { color: var(--bad); background: var(--bad-bg); }
+  details.raw { font-size: 12px; color: var(--muted); }
+  details.raw summary { cursor: pointer; user-select: none; }
+  details.raw pre { background: #0f172a; color: #e2e8f0; border-radius: 8px; padding: 10px;
+    overflow-x: auto; font-size: 11.5px; line-height: 1.5; max-height: 260px; }
+
+  /* variant B/C frame */
+  .frame { border: 1px solid var(--line); border-radius: 10px; background: var(--frame); }
+  .frame > .fhead { display: flex; align-items: center; gap: 8px; padding: 8px 12px;
+    cursor: pointer; user-select: none; font-size: 13px; color: var(--fg); }
+  .frame > .fhead .kind { color: var(--muted); font-size: 11.5px; text-transform: uppercase;
+    letter-spacing: .05em; }
+  .frame > .fhead .chev { margin-left: auto; color: var(--muted); transition: transform .15s; }
+  .frame.closed > .fbody { display: none; }
+  .frame.closed > .fhead .chev { transform: rotate(-90deg); }
+  .frame > .fbody { padding: 4px 12px 12px; border-top: 1px solid var(--line); }
+
+  /* components */
+  .c-table table { border-collapse: collapse; width: 100%; font-size: 13.5px; }
+  .c-table caption { caption-side: top; text-align: left; font-weight: 600; font-size: 14px;
+    padding-bottom: 6px; }
+  .c-table th, .c-table td { border-bottom: 1px solid var(--line); text-align: left;
+    padding: 6px 10px; }
+  .c-table th { font-size: 11.5px; text-transform: uppercase; letter-spacing: .04em;
+    color: var(--muted); }
+  .c-table td.num, .c-table th.num { text-align: right; font-variant-numeric: tabular-nums; }
+  .c-chart .title, .c-diagram .title { font-weight: 600; font-size: 14px; margin-bottom: 6px; }
+  .c-chart .vega-holder { width: 100%; }
+  .c-diagram .mmd-holder { display: flex; justify-content: center; background: #fff;
+    border: 1px solid var(--line); border-radius: 8px; padding: 10px; overflow-x: auto; }
+  .c-citation { border: 1px solid var(--line); border-left: 3px solid var(--accent);
+    border-radius: 8px; padding: 10px 14px; background: #fff; }
+  .c-citation .t { font-weight: 600; font-size: 14px; }
+  .c-citation .snippet { color: var(--fg); font-size: 13.5px; margin: 6px 0; }
+  .c-citation .src { color: var(--muted); font-size: 12px; display: flex; gap: 14px;
+    flex-wrap: wrap; }
+  .c-card { border: 1px solid #c7d2fe; background: #eef2ff; border-radius: 10px;
+    padding: 12px 16px; }
+  .c-card .t { font-weight: 600; font-size: 14px; margin-bottom: 6px; }
+  .c-card p { margin: 6px 0; font-size: 13.5px; }
+  .c-text p { margin: 6px 0; }
+  .rejected { border: 1px solid #fecaca; background: var(--bad-bg); color: var(--bad);
+    border-radius: 10px; padding: 12px 16px; font-size: 13.5px; }
+  .unknown { border: 1px solid #fcd34d; background: var(--warn-bg); color: var(--warn);
+    border-radius: 10px; padding: 12px 16px; font-size: 13.5px; }
+  .rejected b, .unknown b { display: block; margin-bottom: 4px; }
+
+  /* variant C chips + panel */
+  .chip { display: inline-flex; gap: 6px; align-items: center; border: 1px solid var(--line);
+    background: var(--frame); border-radius: 999px; padding: 4px 12px; font-size: 12.5px;
+    cursor: pointer; margin: 3px 4px 3px 0; }
+  .chip:hover { border-color: var(--accent); color: var(--accent); }
+  .side .frame { margin-bottom: 14px; }
+  .side .frame.flash { outline: 2px solid var(--accent); outline-offset: 2px; }
+  .side h3 { font-size: 12px; text-transform: uppercase; letter-spacing: .06em;
+    color: var(--muted); margin: 4px 0 12px; }
+
+  /* switcher */
+  .switcher { position: fixed; bottom: 18px; left: 50%; transform: translateX(-50%);
+    background: #111827; color: #fff; border-radius: 999px; display: flex; align-items: center;
+    gap: 4px; padding: 6px 10px; box-shadow: 0 8px 24px rgba(0,0,0,.25); z-index: 50;
+    font-size: 13px; user-select: none; }
+  .switcher button { background: none; border: 0; color: #fff; font-size: 15px; cursor: pointer;
+    padding: 2px 8px; border-radius: 999px; }
+  .switcher button:hover { background: #374151; }
+  .switcher .label { min-width: 170px; text-align: center; }
+  @media (prefers-color-scheme: dark) {
+    :root { --bg: #0e1117; --fg: #e6e9ef; --muted: #9aa2b1; --line: #262c38;
+      --user-bubble: #1c2230; --frame: #141925; }
+    .c-citation, .c-diagram .mmd-holder { background: #0e1117; }
+    .c-card { background: #171d33; border-color: #313d6b; }
+    details.raw pre { background: #05070c; }
+  }
+</style>
+</head>
+<body data-variant="A">
+<div class="top">
+  <span class="tag">Prototype</span>
+  <b>Generative-UI payloads in the thread</b>
+  <span class="hint">ticket #323 · same payloads in every variant · switch with ← → or the pill
+    · every block shows bytes vs the 16 KiB event cap · “payload JSON” expands the wire form</span>
+</div>
+<div class="wrap">
+  <main class="thread" id="thread"></main>
+  <aside class="side" id="side"></aside>
+</div>
+<div class="switcher">
+  <button id="prev" title="previous variant">◀</button>
+  <span class="label" id="vlabel"></span>
+  <button id="next" title="next variant">▶</button>
+</div>
+
+<script>
+/* ---------- the sample payloads (the actual wire forms under discussion) ---------- */
+const P = {};
+
+P.chart = { component: "chart", props: { title: "Documents by topic", spec: {
+  "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+  "width": "container", "height": 220,
+  "data": { "values": [
+    { "topic": "Onboarding", "docs": 9 }, { "topic": "Benefits", "docs": 6 },
+    { "topic": "Security", "docs": 5 }, { "topic": "Engineering", "docs": 12 },
+    { "topic": "Legal", "docs": 4 } ] },
+  "mark": { "type": "bar", "cornerRadiusEnd": 3 },
+  "encoding": {
+    "x": { "field": "topic", "type": "nominal", "axis": { "labelAngle": 0 }, "sort": "-y" },
+    "y": { "field": "docs", "type": "quantitative", "title": "documents" },
+    "color": { "value": "#4f46e5" } } } } };
+
+P.table = { component: "table", props: {
+  title: "Largest documents in this collection",
+  columns: [
+    { key: "title", label: "Document" }, { key: "topic", label: "Topic" },
+    { key: "pages", label: "Pages", align: "right" }, { key: "updated", label: "Updated" } ],
+  rows: [
+    { title: "Engineering Handbook", topic: "Engineering", pages: 86, updated: "2026-06-30" },
+    { title: "New Hire Onboarding Guide 2026", topic: "Onboarding", pages: 24, updated: "2026-05-14" },
+    { title: "Security Baseline & Incident Playbook", topic: "Security", pages: 41, updated: "2026-07-02" },
+    { title: "Benefits Enrollment FAQ", topic: "Benefits", pages: 18, updated: "2026-03-21" },
+    { title: "Contractor Agreement Template", topic: "Legal", pages: 12, updated: "2026-01-09" } ] } };
+
+P.cite1 = { component: "citation-card", props: {
+  title: "New Hire Onboarding Guide 2026",
+  snippet: "Every onboarding checklist item must be completed within the first two weeks; managers confirm completion in the HR portal before access reviews run.",
+  source: { collection: "Employee Handbook & Ops", updated: "2026-05-14", pages: 24 },
+  relevance: 0.92 } };
+
+P.cite2 = { component: "citation-card", props: {
+  title: "Engineering Handbook — §3 Onboarding buddies",
+  snippet: "Each new engineer is paired with an onboarding buddy for their first month; the buddy owns the first-week environment setup and the week-four retro.",
+  source: { collection: "Employee Handbook & Ops", updated: "2026-06-30", pages: 86 },
+  relevance: 0.81 } };
+
+P.diagram = { component: "diagram", props: {
+  title: "How a document becomes searchable",
+  source: "flowchart TD\n  A[Upload document] --> B[Extract text & metadata]\n  B --> C[Chunk into passages]\n  C --> D[Index passages for search]\n  D --> E([Searchable document])\n  B -- new file version --> F[Reindex as new version]\n  F --> D" } };
+
+P.cardKids = { component: "card", props: { title: "Key points", tone: "info" }, children: [
+  { component: "text", props: { text: "Indexing is per version — reindexing creates a new indexed version, never a second document." } },
+  { component: "text", props: { text: "Only the highest active version serves search; older versions stay retrievable by id." } } ] };
+
+/* edge probe: a real >16 KiB payload (rows generated deterministically) */
+P.big = { component: "table", props: {
+  title: "2025 annual report — full line items",
+  columns: [
+    { key: "item", label: "Line item" }, { key: "q1", label: "Q1", align: "right" },
+    { key: "q2", label: "Q2", align: "right" }, { key: "q3", label: "Q3", align: "right" },
+    { key: "q4", label: "Q4", align: "right" }, { key: "note", label: "Note" } ],
+  rows: Array.from({ length: 150 }, (_, i) => ({
+    item: "Cost center " + (1000 + i) + " — operating expense line " + (i + 1),
+    q1: 10000 + i * 137, q2: 10450 + i * 141, q3: 11020 + i * 129, q4: 11800 + i * 151,
+    note: "allocated per FY25 policy rev " + (i % 7) })) } };
+
+P.unknown = { component: "timeline", props: {
+  title: "Indexing milestones",
+  items: [ { at: "2026-05-01", label: "v1 indexed" }, { at: "2026-06-12", label: "v2 reindex" } ] } };
+
+const CAP = 16 * 1024;
+const bytesOf = p => new Blob([JSON.stringify(p)]).size;
+const fmtKiB = n => (n / 1024).toFixed(1) + " KiB";
+
+/* ---------- the conversation ---------- */
+const CONVO = [
+  { role: "user", text: "How are the documents in this collection distributed by topic, and which are the largest?" },
+  { role: "assistant", parts: [
+    { t: "text", text: "Across Employee Handbook & Ops I count 36 active documents in five topics. Engineering is the biggest cluster:" },
+    { t: "ui", p: P.chart },
+    { t: "text", text: "The five largest documents account for just over half the collection's pages:" },
+    { t: "ui", p: P.table },
+    { t: "text", text: "Want me to break any topic down further?" } ] },
+  { role: "user", text: "Which guides cover employee onboarding? Show me the sources." },
+  { role: "assistant", parts: [
+    { t: "text", text: "Two documents cover onboarding directly:" },
+    { t: "ui", p: P.cite1 },
+    { t: "ui", p: P.cite2 },
+    { t: "text", text: "The Benefits Enrollment FAQ also references onboarding deadlines in passing, but it isn't a guide." } ] },
+  { role: "user", text: "Explain how a document becomes searchable after I upload it." },
+  { role: "assistant", parts: [
+    { t: "text", text: "Here's the pipeline your upload goes through:" },
+    { t: "ui", p: P.diagram },
+    { t: "ui", p: P.cardKids },
+    { t: "text", text: "So a freshly uploaded file usually turns up in search within a couple of minutes of extraction finishing." } ] },
+  { role: "user", text: "Give me the full line-item table from the 2025 annual report.", probe: true },
+  { role: "assistant", parts: [
+    { t: "text", text: "That table is large — this exchange probes the two failure edges of the contract:" },
+    { t: "ui", p: P.big },
+    { t: "text", text: "And a component name outside the client catalog:" },
+    { t: "ui", p: P.unknown } ] }
+];
+
+/* ---------- component renderers (the client-owned catalog) ---------- */
+const esc = s => String(s).replace(/[&<>"]/g, c => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
+let uid = 0;
+
+const CATALOG = {
+  table(p) {
+    const cols = p.props.columns, rows = p.props.rows;
+    return `<div class="c-table"><table>
+      ${p.props.title ? `<caption>${esc(p.props.title)}</caption>` : ""}
+      <thead><tr>${cols.map(c => `<th class="${c.align === "right" ? "num" : ""}">${esc(c.label)}</th>`).join("")}</tr></thead>
+      <tbody>${rows.map(r => `<tr>${cols.map(c => `<td class="${c.align === "right" ? "num" : ""}">${esc(r[c.key])}</td>`).join("")}</tr>`).join("")}</tbody>
+    </table></div>`;
+  },
+  chart(p) {
+    const id = "vega-" + (++uid);
+    queueMicrotask(() => {
+      const el = document.getElementById(id);
+      if (el && window.vegaEmbed) vegaEmbed("#" + id, p.props.spec, { actions: false, renderer: "svg" })
+        .catch(e => { el.textContent = "chart failed to render: " + e.message; });
+    });
+    return `<div class="c-chart">${p.props.title ? `<div class="title">${esc(p.props.title)}</div>` : ""}
+      <div class="vega-holder" id="${id}"></div></div>`;
+  },
+  diagram(p) {
+    const id = "mmd-" + (++uid);
+    queueMicrotask(async () => {
+      const holder = document.getElementById(id);
+      if (!holder || !window.mermaid) return;
+      try {
+        const { svg } = await mermaid.render(id + "-svg", p.props.source);
+        holder.innerHTML = svg;
+      } catch (e) { holder.textContent = "diagram failed to parse: " + e.message; }
+    });
+    return `<div class="c-diagram">${p.props.title ? `<div class="title">${esc(p.props.title)}</div>` : ""}
+      <div class="mmd-holder" id="${id}"></div></div>`;
+  },
+  "citation-card"(p) {
+    const s = p.props.source || {};
+    return `<div class="c-citation"><div class="t">📄 ${esc(p.props.title)}</div>
+      <div class="snippet">“${esc(p.props.snippet)}”</div>
+      <div class="src">
+        ${s.collection ? `<span>${esc(s.collection)}</span>` : ""}
+        ${s.pages ? `<span>${esc(s.pages)} pages</span>` : ""}
+        ${s.updated ? `<span>updated ${esc(s.updated)}</span>` : ""}
+        ${p.props.relevance != null ? `<span>relevance ${p.props.relevance}</span>` : ""}
+      </div></div>`;
+  },
+  card(p) {
+    const kids = (p.children || []).map(k => renderNodeInner(k)).join("");
+    return `<div class="c-card">${p.props.title ? `<div class="t">${esc(p.props.title)}</div>` : ""}${kids}</div>`;
+  },
+  text(p) { return `<div class="c-text"><p>${esc(p.props.text)}</p></div>`; }
+};
+
+function renderNodeInner(p) {
+  const fn = CATALOG[p.component];
+  return fn ? fn(p) : `<p>[unknown child component: ${esc(p.component)}]</p>`;
+}
+
+/* returns { html, status } — status: ok | oversize | unknown */
+function renderPayload(p) {
+  const size = bytesOf(p);
+  if (size > CAP) return { status: "oversize", size, html:
+    `<div class="rejected"><b>⛔ ${fmtKiB(size)} exceeds the 16 KiB never-split event cap</b>
+     This payload cannot be emitted as one durable event, so nothing renders. What the agent
+     should do instead (truncate? summarize? artifact?) is open — feeds tickets #325 / #413.</div>` };
+  if (!CATALOG[p.component]) return { status: "unknown", size, html:
+    `<div class="unknown"><b>⚠️ Unknown component “${esc(p.component)}”</b>
+     Not in the client catalog — allowlist rejected it and this fallback rendered instead
+     (invalid-payload policy is still fog on the map).</div>` };
+  return { status: "ok", size, html: CATALOG[p.component](p) };
+}
+
+function metaLine(p, size) {
+  const over = size > CAP;
+  return `<div class="metaline">
+    <span class="kind">${esc(p.component)}</span>
+    <span class="bytes ${over ? "bad" : "ok"}">${fmtKiB(size)} / 16 KiB</span>
+    <details class="raw"><summary>payload JSON</summary><pre>${esc(JSON.stringify(p, null, 2))}</pre></details>
+  </div>`;
+}
+
+function frame(p, r, opts = {}) {
+  const label = p.props && p.props.title ? p.props.title : p.component;
+  return `<div class="frame ${opts.closed ? "closed" : ""}" ${opts.id ? `id="${opts.id}"` : ""}>
+    <div class="fhead" onclick="this.parentElement.classList.toggle('closed')">
+      <span class="kind">${esc(p.component)}</span><span>${esc(label)}</span>
+      <span class="chev">▾</span></div>
+    <div class="fbody">${r.html}${metaLine(p, r.size)}</div></div>`;
+}
+
+/* ---------- variants ---------- */
+const VARIANTS = {
+  A: { name: "Inline content",
+    block(p) { const r = renderPayload(p); return `<div class="block">${r.html}${metaLine(p, r.size)}</div>`; } },
+  B: { name: "Framed blocks",
+    block(p) { const r = renderPayload(p); return `<div class="block">${frame(p, r)}</div>`; } },
+  C: { name: "Side panel", panel: [],
+    block(p) {
+      const r = renderPayload(p);
+      const id = "panel-item-" + (++uid);
+      this.panel.push(frame(p, r, { id }));
+      const label = p.props && p.props.title ? p.props.title : p.component;
+      const icon = { chart: "📊", table: "▤", diagram: "🧭", "citation-card": "📄", card: "🗒" }[p.component] || "▣";
+      return `<button class="chip" onclick="focusPanel('${id}')">${icon} ${esc(label)}</button>`;
+    } }
+};
+
+function focusPanel(id) {
+  const el = document.getElementById(id);
+  if (!el) return;
+  el.scrollIntoView({ behavior: "smooth", block: "center" });
+  el.classList.add("flash");
+  setTimeout(() => el.classList.remove("flash"), 1200);
+}
+
+function render(vKey) {
+  const v = VARIANTS[vKey];
+  document.body.dataset.variant = vKey;
+  if (vKey === "C") v.panel = [];
+  uid = 0;
+  const thread = document.getElementById("thread");
+  thread.innerHTML = CONVO.map(m => {
+    if (m.role === "user")
+      return `<div class="msg user"><div class="bubble">${esc(m.text)}${m.probe ? '<span class="probe">edge-case probe</span>' : ""}</div></div>`;
+    const parts = m.parts.map(part =>
+      part.t === "text" ? `<p>${esc(part.text)}</p>` : v.block.call(v, part.p)).join("");
+    return `<div class="msg assistant"><div class="who">MyMemo agent</div>${parts}</div>`;
+  }).join("");
+  const side = document.getElementById("side");
+  side.innerHTML = vKey === "C" ? `<h3>Presented by the agent</h3>${v.panel.join("")}` : "";
+  document.getElementById("vlabel").textContent = `${vKey} — ${v.name}`;
+}
+
+/* ---------- switcher ---------- */
+const KEYS = Object.keys(VARIANTS);
+function current() {
+  const q = new URLSearchParams(location.search).get("variant");
+  return KEYS.includes(q) ? q : "A";
+}
+function go(delta) {
+  const next = KEYS[(KEYS.indexOf(current()) + delta + KEYS.length) % KEYS.length];
+  const u = new URL(location); u.searchParams.set("variant", next);
+  history.replaceState(null, "", u); render(next);
+}
+document.getElementById("prev").onclick = () => go(-1);
+document.getElementById("next").onclick = () => go(1);
+addEventListener("keydown", e => {
+  if (["INPUT", "TEXTAREA"].includes(document.activeElement.tagName)) return;
+  if (e.key === "ArrowLeft") go(-1); if (e.key === "ArrowRight") go(1);
+});
+
+mermaid.initialize({ startOnLoad: false, securityLevel: "strict", theme: "neutral" });
+render(current());
+</script>
+</body>
+</html>


### PR DESCRIPTION
Throwaway asset for wayfinder ticket #323 (map #320): a single self-contained HTML page rendering the decided generative-UI contract payloads in a fake MyMemo thread.

- Three placement variants (`?variant=` A/B/C, arrow keys): inline content, framed blocks, side panel.
- Same payloads everywhere: Vega-Lite chart, table, two citation-cards, Mermaid concept-explainer diagram, card-with-children, plus a real >16 KiB rejection probe and an unknown-component fallback probe.
- Every block shows live bytes vs the 16 KiB never-split cap and its raw wire JSON.

Open `docs/prototypes/generative-ui-payloads.prototype.html` in a browser (needs network for the mermaid/vega CDNs). Rendering posture is prototype-grade (VL v5 CDN, mermaid `strict`) — the contract mandates VL v6 + vega-interpreter/deny-all loader and Mermaid sandbox/SSR.

**Throwaway** — delete once the vocabulary ticket and ADR have consumed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)