### PR TITLE
refactor(agent-worker): surface model event sequences

### DIFF
--- a/apps/agent-worker/src/run-loop.test.ts
+++ b/apps/agent-worker/src/run-loop.test.ts
@@ -1573,6 +1573,53 @@ describe("RunLoop — unowned queue timeout", () => {
 });
 
 describe("RunLoop — model-content append", () => {
+	it("surfaces the durable sequence numbers assigned to single and batched content", async () => {
+		const worker = buildWorker(1);
+		const surfacedSequences: number[] = [];
+		const loop = buildLoop(worker, async (ctx) => {
+			surfacedSequences.push(
+				await ctx.appendModelContent({
+					kind: "assistant_message",
+					payload: { messageId: "message-1", text: "running a command" },
+				}),
+			);
+			surfacedSequences.push(
+				...(await ctx.appendModelContents([
+					{
+						kind: "tool_call_started",
+						payload: {
+							toolCallId: "tool-1",
+							toolCallName: "Bash",
+							parentMessageId: "message-1",
+						},
+					},
+					{
+						kind: "tool_call_args",
+						payload: { toolCallId: "tool-1", delta: '{"command":"pwd"}' },
+					},
+					{
+						kind: "tool_call_completed",
+						payload: { toolCallId: "tool-1" },
+					},
+				])),
+			);
+		});
+		await queueRun("run-1", "conv-1");
+
+		await loop.tick();
+		await worker.drain();
+
+		const durableSequences = await tdb.db
+			.select({ seq: runEvents.seq })
+			.from(runEvents)
+			.where(eq(runEvents.runId, "run-1"))
+			.orderBy(runEvents.seq);
+		expect(surfacedSequences).toEqual(
+			durableSequences.slice(0, -1).map(({ seq }) => seq),
+		);
+		expect((await readRun("run-1"))?.status).toBe("done");
+	});
+
 	it("maps each model-content kind to its durable event type", async () => {
 		const worker = buildWorker(1);
 		// One turn recording an Assistant message, a Tool invocation, and its result;

--- a/apps/agent-worker/src/run-loop.ts
+++ b/apps/agent-worker/src/run-loop.ts
@@ -141,9 +141,9 @@ export interface RunProcessContext {
 	/** Fires only when the ownership fence is lost. Unlike a normal stop, this
 	 * permits no post-fence drain and must close private SDK resources now. */
 	ownershipLostSignal: AbortSignal;
-	appendModelContent(content: ModelContent): Promise<void>;
+	appendModelContent(content: ModelContent): Promise<number>;
 	/** Atomically append an ordered group under one Ownership epoch fence. */
-	appendModelContents(contents: readonly ModelContent[]): Promise<void>;
+	appendModelContents(contents: readonly ModelContent[]): Promise<number[]>;
 	/** Append one standard event to this Run's Live Stream. Failure is
 	 * absorbed by the producer so it cannot change model execution. */
 	appendLiveEvent(event: LiveStreamEvent): Promise<void>;
@@ -889,8 +889,14 @@ export class RunLoop {
 		drain: ActiveDrain,
 		entry: ActiveEntry,
 		content: ModelContent,
-	): Promise<void> {
-		await this.appendModelContents(owner, drain, entry, [content]);
+	): Promise<number> {
+		const [seq] = await this.appendModelContents(owner, drain, entry, [
+			content,
+		]);
+		if (seq === undefined) {
+			throw new Error("single model-content append returned no sequence");
+		}
+		return seq;
 	}
 
 	private async appendModelContents(
@@ -898,7 +904,7 @@ export class RunLoop {
 		drain: ActiveDrain,
 		entry: ActiveEntry,
 		contents: readonly ModelContent[],
-	): Promise<void> {
+	): Promise<number[]> {
 		const result = await appendRunEventsTx(this.opts.db, {
 			owner,
 			events: contents.map((content) => ({
@@ -911,6 +917,7 @@ export class RunLoop {
 			this.noteRejectedActiveRunWrite(drain, entry, result);
 			throw new RunWriteRejectedError();
 		}
+		return result.events.map(({ seq }) => seq);
 	}
 
 	private async finish(

--- a/apps/agent-worker/src/sdk/run-processor.ts
+++ b/apps/agent-worker/src/sdk/run-processor.ts
@@ -74,7 +74,9 @@ export function createSdkRunProcessor(deps: SdkRunProcessorDeps): RunProcessor {
 				],
 				ownershipLostSignal: ctx.ownershipLostSignal,
 				abortRunScopedWork: (reason) => runScopedController.abort(reason),
-				appendModelContents: ctx.appendModelContents,
+				appendModelContents: async (contents) => {
+					await ctx.appendModelContents(contents);
+				},
 				appendLiveEvent: ctx.appendLiveEvent,
 				logger: deps.logger,
 				startStopDeadline: deps.startStopDeadline,


### PR DESCRIPTION
## Summary

- return assigned durable sequence numbers from the processor-facing single and batched model-content append methods
- preserve existing SDK processor behavior for callers that ignore the resolved values
- add Run loop coverage that compares surfaced sequence numbers with the durable `run_events` log

## Why

This prefactor exposes the durable event identity needed by the upcoming ADR-0017 PresentUI tracer slice without changing existing event behavior.

Closes #417

## Validation

- `bunx tsc -p apps/agent-worker/tsconfig.json --noEmit`
- `bunx biome check apps/agent-worker/src/run-loop.ts apps/agent-worker/src/run-loop.test.ts apps/agent-worker/src/sdk/run-processor.ts`
- focused Run loop and SDK processor suites
- full deterministic monorepo suite across all five workspaces (875 passed; optional live E2B tests skipped)
- optional live E2B groups exercised separately