### PR TITLE
feat(agent-db): add canonical UI payload events

### DIFF
--- a/packages/agent-db/src/run-events.test.ts
+++ b/packages/agent-db/src/run-events.test.ts
@@ -152,21 +152,31 @@ describe("parseDurableRunEvent", () => {
 		});
 	});
 
-	it("accepts structurally sound future UI versions and components", () => {
-		const payload = {
+	it("accepts future UI components and preserves unknown versions", () => {
+		const futureComponent = {
 			messageId: "assistant-message-1",
-			version: 2,
+			version: 1,
 			payload: {
 				component: "timeline",
 				props: { entries: [] },
 			},
 		};
+		const futureVersion = {
+			messageId: "assistant-message-1",
+			version: 2,
+			payload: {
+				root: { kind: "timeline", entries: [] },
+			},
+		};
 
-		expect(isUiPayloadEventPayload(payload)).toBe(true);
-		expect(parseDurableRunEvent(RunEventType.UiPayload, payload)).toEqual({
-			type: RunEventType.UiPayload,
-			payload,
-		});
+		expect(isUiPayloadEventPayload(futureComponent)).toBe(true);
+		expect(isUiPayloadEventPayload(futureVersion)).toBe(true);
+		expect(parseDurableRunEvent(RunEventType.UiPayload, futureVersion)).toEqual(
+			{
+				type: RunEventType.UiPayload,
+				payload: futureVersion,
+			},
+		);
 	});
 
 	it("rejects structurally corrupt UI payloads", () => {
@@ -200,6 +210,12 @@ describe("parseDurableRunEvent", () => {
 			isUiPayloadEventPayload({
 				...valid,
 				payload: { component: "chart", props: {}, children: ["invalid"] },
+			}),
+		).toBe(false);
+		expect(
+			isUiPayloadEventPayload({
+				...valid,
+				payload: { component: "chart", props: {}, children: undefined },
 			}),
 		).toBe(false);
 		expect(

--- a/packages/agent-db/src/run-events.test.ts
+++ b/packages/agent-db/src/run-events.test.ts
@@ -3,8 +3,10 @@ import {
 	InvalidRunEventError,
 	isToolResultPayload,
 	isToolUsePayload,
+	isUiPayloadEventPayload,
 	parseDurableRunEvent,
 	RunEventType,
+	type UiPayloadEventPayload,
 	validateDurableRunEventSequence,
 } from "./run-events";
 
@@ -122,6 +124,116 @@ describe("parseDurableRunEvent", () => {
 				text: "obsolete",
 			}),
 		).toBe(null);
+	});
+
+	it("round-trips the v1 UI payload shape", () => {
+		const payload = {
+			messageId: "assistant-message-1",
+			version: 1,
+			payload: {
+				component: "card",
+				props: { title: "Quarterly results", tone: "info" },
+				children: [
+					"Revenue increased.",
+					{
+						component: "table",
+						props: {
+							columns: [{ key: "quarter", label: "Quarter" }],
+							rows: [{ quarter: "Q1" }],
+						},
+					},
+				],
+			},
+		} satisfies UiPayloadEventPayload;
+
+		expect(parseDurableRunEvent(RunEventType.UiPayload, payload)).toEqual({
+			type: RunEventType.UiPayload,
+			payload,
+		});
+	});
+
+	it("accepts structurally sound future UI versions and components", () => {
+		const payload = {
+			messageId: "assistant-message-1",
+			version: 2,
+			payload: {
+				component: "timeline",
+				props: { entries: [] },
+			},
+		};
+
+		expect(isUiPayloadEventPayload(payload)).toBe(true);
+		expect(parseDurableRunEvent(RunEventType.UiPayload, payload)).toEqual({
+			type: RunEventType.UiPayload,
+			payload,
+		});
+	});
+
+	it("rejects structurally corrupt UI payloads", () => {
+		const valid = {
+			messageId: "assistant-message-1",
+			version: 1,
+			payload: { component: "chart", props: { spec: {} } },
+		};
+
+		expect(isUiPayloadEventPayload({ ...valid, messageId: "" })).toBe(false);
+		expect(isUiPayloadEventPayload({ ...valid, version: 0 })).toBe(false);
+		expect(
+			isUiPayloadEventPayload({
+				...valid,
+				payload: { component: "", props: {} },
+			}),
+		).toBe(false);
+		expect(
+			isUiPayloadEventPayload({
+				...valid,
+				payload: { component: "chart", props: [] },
+			}),
+		).toBe(false);
+		expect(
+			isUiPayloadEventPayload({
+				...valid,
+				payload: { component: "card", props: {}, children: [42] },
+			}),
+		).toBe(false);
+		expect(
+			isUiPayloadEventPayload({
+				...valid,
+				payload: { component: "chart", props: {}, children: ["invalid"] },
+			}),
+		).toBe(false);
+		expect(
+			isUiPayloadEventPayload({
+				...valid,
+				payload: {
+					component: "card",
+					props: {},
+					children: [{ component: "card", props: {} }],
+				},
+			}),
+		).toBe(false);
+		expect(
+			isUiPayloadEventPayload({
+				...valid,
+				payload: {
+					component: "card",
+					props: {},
+					children: [
+						{
+							component: "table",
+							props: {},
+							children: ["too deep"],
+						},
+					],
+				},
+			}),
+		).toBe(false);
+		expect(() =>
+			parseDurableRunEvent(RunEventType.UiPayload, {
+				...valid,
+				payload: { component: "table" },
+			}),
+		).toThrow(InvalidRunEventError);
 	});
 });
 

--- a/packages/agent-db/src/run-events.ts
+++ b/packages/agent-db/src/run-events.ts
@@ -68,39 +68,33 @@ export type UiComponent =
 	| "citation-card"
 	| "card";
 
-export interface UiChildNode<
-	TComponent extends string = Exclude<UiComponent, "card">,
-> {
-	component: TComponent;
+export interface UiChildNode {
+	component: Exclude<UiComponent, "card">;
 	props: Record<string, unknown>;
 }
 
-export interface UiNode<
-	TComponent extends string = UiComponent,
-	TChild extends UiChildNode<string> = UiChildNode,
-> {
-	component: TComponent;
+export interface UiNode {
+	component: UiComponent;
 	props: Record<string, unknown>;
-	children?: (string | TChild)[];
+	children?: (string | UiChildNode)[];
 }
 
-/** The v1 write-side envelope by default. Generic parameters let the shared
- * read guard represent structurally sound future versions without pretending
- * they use the v1 catalog. */
-export interface UiPayloadEventPayload<
-	TVersion extends number = 1,
-	TNode extends UiNode<string, UiChildNode<string>> = UiNode,
-> {
+/** The validated v1 write-side envelope. */
+export interface UiPayloadEventPayload {
 	[key: string]: unknown;
 	messageId: string;
-	version: TVersion;
-	payload: TNode;
+	version: 1;
+	payload: UiNode;
 }
 
-export type ParsedUiPayloadEventPayload = UiPayloadEventPayload<
-	number,
-	UiNode<string, UiChildNode<string>>
->;
+/** The read-side envelope. Unknown positive versions stay opaque so an older
+ * reader can preserve them for the client's framed fallback. */
+export interface ParsedUiPayloadEventPayload {
+	[key: string]: unknown;
+	messageId: string;
+	version: number;
+	payload: Record<string, unknown>;
+}
 
 /**
  * The nine short public tool names a client may see (ADR-0009). Tool events
@@ -493,24 +487,26 @@ export function isToolCallResultPayload(
 export function isUiPayloadEventPayload(
 	value: unknown,
 ): value is ParsedUiPayloadEventPayload {
-	return (
-		isPlainRecord(value) &&
-		isNonEmptyString(value.messageId) &&
-		Number.isInteger(value.version) &&
-		typeof value.version === "number" &&
-		value.version > 0 &&
-		isUiNode(value.payload)
-	);
+	if (
+		!isPlainRecord(value) ||
+		!isNonEmptyString(value.messageId) ||
+		typeof value.version !== "number" ||
+		!Number.isInteger(value.version) ||
+		value.version <= 0 ||
+		!isPlainRecord(value.payload)
+	) {
+		return false;
+	}
+
+	return value.version !== 1 || isUiNode(value.payload);
 }
 
-export function isUiNode(
-	value: unknown,
-): value is UiNode<string, UiChildNode<string>> {
+function isUiNode(value: unknown): boolean {
 	return (
 		isPlainRecord(value) &&
 		isNonEmptyString(value.component) &&
 		isPlainRecord(value.props) &&
-		(value.children === undefined ||
+		(!("children" in value) ||
 			(value.component === "card" &&
 				Array.isArray(value.children) &&
 				value.children.every(
@@ -519,7 +515,7 @@ export function isUiNode(
 	);
 }
 
-export function isUiChildNode(value: unknown): value is UiChildNode<string> {
+function isUiChildNode(value: unknown): boolean {
 	return (
 		isPlainRecord(value) &&
 		isNonEmptyString(value.component) &&

--- a/packages/agent-db/src/run-events.ts
+++ b/packages/agent-db/src/run-events.ts
@@ -21,6 +21,8 @@ export const RunEventType = {
 	ToolCallArgs: "tool_call_args",
 	ToolCallCompleted: "tool_call_completed",
 	ToolCallResult: "tool_call_result",
+	/** One validated display-only component payload (ADR-0017). */
+	UiPayload: "ui_payload",
 	/** Terminal: the run finished successfully. */
 	Done: "run_done",
 	/** Terminal: the run failed. Payload `{ message }`. */
@@ -37,6 +39,7 @@ export const CANONICAL_MODEL_RUN_EVENT_TYPES = [
 	RunEventType.ToolCallArgs,
 	RunEventType.ToolCallCompleted,
 	RunEventType.ToolCallResult,
+	RunEventType.UiPayload,
 ] as const;
 
 export interface RunStartedPayload {
@@ -57,6 +60,47 @@ export interface AssistantMessageCompletedPayload {
 	messageId: string;
 	text: string;
 }
+
+export type UiComponent =
+	| "chart"
+	| "diagram"
+	| "table"
+	| "citation-card"
+	| "card";
+
+export interface UiChildNode<
+	TComponent extends string = Exclude<UiComponent, "card">,
+> {
+	component: TComponent;
+	props: Record<string, unknown>;
+}
+
+export interface UiNode<
+	TComponent extends string = UiComponent,
+	TChild extends UiChildNode<string> = UiChildNode,
+> {
+	component: TComponent;
+	props: Record<string, unknown>;
+	children?: (string | TChild)[];
+}
+
+/** The v1 write-side envelope by default. Generic parameters let the shared
+ * read guard represent structurally sound future versions without pretending
+ * they use the v1 catalog. */
+export interface UiPayloadEventPayload<
+	TVersion extends number = 1,
+	TNode extends UiNode<string, UiChildNode<string>> = UiNode,
+> {
+	[key: string]: unknown;
+	messageId: string;
+	version: TVersion;
+	payload: TNode;
+}
+
+export type ParsedUiPayloadEventPayload = UiPayloadEventPayload<
+	number,
+	UiNode<string, UiChildNode<string>>
+>;
 
 /**
  * The nine short public tool names a client may see (ADR-0009). Tool events
@@ -184,6 +228,10 @@ export type DurableRunEvent =
 	  }
 	| { type: typeof RunEventType.ToolCallResult; payload: ToolCallResultPayload }
 	| {
+			type: typeof RunEventType.UiPayload;
+			payload: ParsedUiPayloadEventPayload;
+	  }
+	| {
 			type:
 				| typeof RunEventType.Done
 				| typeof RunEventType.Error
@@ -286,6 +334,17 @@ export function validateDurableRunEventSequence(
 				toolResultMessageIds.add(parsed.payload.messageId);
 				toolStates.set(parsed.payload.toolCallId, "result");
 				break;
+			case RunEventType.UiPayload:
+				if (
+					submittedMessageIds.has(parsed.payload.messageId) ||
+					toolResultMessageIds.has(parsed.payload.messageId)
+				) {
+					invalidSequence("duplicate messageId");
+				}
+				if (!completedAssistantMessageIds.has(parsed.payload.messageId)) {
+					invalidSequence("UI payload has no completed Assistant message");
+				}
+				break;
 			case RunEventType.Done:
 			case RunEventType.Error:
 			case RunEventType.Interrupted:
@@ -346,6 +405,9 @@ export function parseDurableRunEvent(
 			break;
 		case RunEventType.ToolCallResult:
 			if (isToolCallResultPayload(payload)) return { type, payload };
+			break;
+		case RunEventType.UiPayload:
+			if (isUiPayloadEventPayload(payload)) return { type, payload };
 			break;
 		case RunEventType.Done:
 			if (isRunOutcomePayload(payload, "done")) return { type, payload };
@@ -425,6 +487,45 @@ export function isToolCallResultPayload(
 		isNonEmptyString(value.toolCallId) &&
 		typeof value.content === "string" &&
 		typeof value.isError === "boolean"
+	);
+}
+
+export function isUiPayloadEventPayload(
+	value: unknown,
+): value is ParsedUiPayloadEventPayload {
+	return (
+		isPlainRecord(value) &&
+		isNonEmptyString(value.messageId) &&
+		Number.isInteger(value.version) &&
+		typeof value.version === "number" &&
+		value.version > 0 &&
+		isUiNode(value.payload)
+	);
+}
+
+export function isUiNode(
+	value: unknown,
+): value is UiNode<string, UiChildNode<string>> {
+	return (
+		isPlainRecord(value) &&
+		isNonEmptyString(value.component) &&
+		isPlainRecord(value.props) &&
+		(value.children === undefined ||
+			(value.component === "card" &&
+				Array.isArray(value.children) &&
+				value.children.every(
+					(child) => typeof child === "string" || isUiChildNode(child),
+				)))
+	);
+}
+
+export function isUiChildNode(value: unknown): value is UiChildNode<string> {
+	return (
+		isPlainRecord(value) &&
+		isNonEmptyString(value.component) &&
+		value.component !== "card" &&
+		isPlainRecord(value.props) &&
+		!("children" in value)
 	);
 }
 

--- a/packages/agent-db/src/run-store.test.ts
+++ b/packages/agent-db/src/run-store.test.ts
@@ -661,6 +661,126 @@ describe("appendRunEventTx", () => {
 		).toEqual(events.map((event, index) => ({ seq: index + 1, ...event })));
 	});
 
+	it("appends a UI payload only after its owning Assistant completes", async () => {
+		await admitQueuedRunTx(tdb.db, {
+			runId: "run-1",
+			userId: "user-1",
+			conversationId: "conv-1",
+			messageId: "user-message-1",
+			text: "Show the results",
+			scope: "general",
+			collectionId: null,
+			summaryId: null,
+		});
+		const claim = await claimConversationTx(tdb.db, {
+			workerId: "worker-1",
+		});
+		if (!claim) throw new Error("test setup claimed no Conversation");
+		const started = await startClaimedRunTx(tdb.db, {
+			owner: claim,
+			runId: "run-1",
+			workerId: "worker-1",
+		});
+		if (started.outcome !== "started") {
+			throw new Error("test setup could not start run-1");
+		}
+		const runOwner = { ...claim, runId: "run-1", workerId: "worker-1" };
+		const appendUiPayload = (messageId: string) =>
+			appendRunEventTx(tdb.db, {
+				owner: runOwner,
+				type: RunEventType.UiPayload,
+				payload: {
+					messageId,
+					version: 1,
+					payload: { component: "chart", props: { spec: {} } },
+				},
+				appendClass: "model",
+			});
+
+		await expect(appendUiPayload("assistant-message-1")).rejects.toBeInstanceOf(
+			InvalidRunEventError,
+		);
+		await expect(appendUiPayload("user-message-1")).rejects.toBeInstanceOf(
+			InvalidRunEventError,
+		);
+		await appendRunEventTx(tdb.db, {
+			owner: runOwner,
+			type: RunEventType.AssistantMessageCompleted,
+			payload: { messageId: "assistant-message-1", text: "Here it is." },
+			appendClass: "model",
+		});
+		expect(await appendUiPayload("assistant-message-1")).toEqual({
+			outcome: "appended",
+			seq: 3,
+		});
+
+		await appendRunEventsTx(tdb.db, {
+			owner: runOwner,
+			appendClass: "model",
+			events: [
+				{
+					type: RunEventType.ToolCallStarted,
+					payload: {
+						toolCallId: "tool-1",
+						toolCallName: "Read",
+						parentMessageId: "assistant-message-1",
+					},
+				},
+				{
+					type: RunEventType.ToolCallArgs,
+					payload: { toolCallId: "tool-1", delta: "{}" },
+				},
+				{
+					type: RunEventType.ToolCallCompleted,
+					payload: { toolCallId: "tool-1" },
+				},
+				{
+					type: RunEventType.ToolCallResult,
+					payload: {
+						messageId: "tool-message-1",
+						toolCallId: "tool-1",
+						content: "Read completed",
+						isError: false,
+					},
+				},
+			],
+		});
+		await expect(appendUiPayload("tool-message-1")).rejects.toBeInstanceOf(
+			InvalidRunEventError,
+		);
+	});
+
+	it("fences UI payload appends by Ownership epoch and running status", async () => {
+		await claimRun("run-1", "conv-1", "worker-1");
+		const input = {
+			type: RunEventType.UiPayload,
+			payload: {
+				messageId: "assistant-message-1",
+				version: 1,
+				payload: { component: "table", props: { columns: [], rows: [] } },
+			},
+			appendClass: "model",
+		} as const;
+
+		expect(
+			await appendRunEventTx(tdb.db, {
+				owner: owner({ epoch: 999, workerId: "worker-2" }),
+				...input,
+			}),
+		).toEqual({ outcome: "rejected", rejected: "lease" });
+		await tdb.db
+			.update(runs)
+			.set({ status: "interrupt_requested" })
+			.where(eq(runs.runId, "run-1"));
+		expect(
+			await appendRunEventTx(tdb.db, { owner: owner(), ...input }),
+		).toEqual({
+			outcome: "rejected",
+			rejected: "status",
+			current: "interrupt_requested",
+		});
+	});
+
 	it("atomically appends one complete Tool invocation lifecycle", async () => {
 		await claimRun("run-1", "conv-1", "worker-1");
 		const events = [
@@ -970,6 +1090,48 @@ describe("appendRunEventTx", () => {
 });
 
 describe("transitionRunTerminalTx", () => {
+	it.each([
+		"done",
+		"interrupted",
+	] as const)("validates and retains UI payloads when a Run becomes %s", async (status) => {
+		await claimRun("run-1", "conv-1", "worker-1");
+		await appendRunEventTx(tdb.db, {
+			owner: owner(),
+			type: RunEventType.AssistantMessageCompleted,
+			payload: { messageId: "assistant-message-1", text: "Results" },
+			appendClass: "model",
+		});
+		await appendRunEventTx(tdb.db, {
+			owner: owner(),
+			type: RunEventType.UiPayload,
+			payload: {
+				messageId: "assistant-message-1",
+				version: 1,
+				payload: { component: "diagram", props: { source: "flowchart LR" } },
+			},
+			appendClass: "model",
+		});
+		if (status === "interrupted") {
+			await requestRunInterruptionTx(tdb.db, {
+				runId: "run-1",
+				userId: "user-1",
+				conversationId: "conv-1",
+			});
+		}
+
+		expect(
+			await transitionRunTerminalTx(tdb.db, {
+				owner: owner(),
+				status,
+			}),
+		).toMatchObject({ outcome: "committed", run: { status } });
+		expect((await readEvents("run-1")).map((event) => event.type)).toEqual([
+			RunEventType.AssistantMessageCompleted,
+			RunEventType.UiPayload,
+			status === "done" ? RunEventType.Done : RunEventType.Interrupted,
+		]);
+	});
+
 	it("rejects a lapsed Ownership epoch without committing an Outcome", async () => {
 		await queueRun("run-1", "conv-1");
 		const claim = await claimConversationTx(tdb.db, {

--- a/packages/agent-db/src/run-store.test.ts
+++ b/packages/agent-db/src/run-store.test.ts
@@ -781,6 +781,37 @@ describe("appendRunEventTx", () => {
 		});
 	});
 
+	it("rejects a UI payload through the cancellation append class", async () => {
+		await claimRun("run-1", "conv-1", "worker-1");
+		await appendRunEventTx(tdb.db, {
+			owner: owner(),
+			type: RunEventType.AssistantMessageCompleted,
+			payload: { messageId: "assistant-message-1", text: "Results" },
+			appendClass: "model",
+		});
+		await requestRunInterruptionTx(tdb.db, {
+			runId: "run-1",
+			userId: "user-1",
+			conversationId: "conv-1",
+		});
+
+		await expect(
+			appendRunEventTx(tdb.db, {
+				owner: owner(),
+				type: RunEventType.UiPayload,
+				payload: {
+					messageId: "assistant-message-1",
+					version: 1,
+					payload: { component: "chart", props: { spec: {} } },
+				},
+				appendClass: "cancellation",
+			}),
+		).rejects.toBeInstanceOf(InvalidRunEventError);
+		expect((await readEvents("run-1")).map((event) => event.type)).toEqual([
+			RunEventType.AssistantMessageCompleted,
+		]);
+	});
+
 	it("atomically appends one complete Tool invocation lifecycle", async () => {
 		await claimRun("run-1", "conv-1", "worker-1");
 		const events = [

--- a/packages/agent-db/src/run-store.ts
+++ b/packages/agent-db/src/run-store.ts
@@ -620,12 +620,12 @@ export async function appendRunEventsTx(
 				event.type,
 			),
 		);
-		if (canonicalEvents.length > 0 && input.appendClass !== "model") {
-			throw new InvalidRunEventError(
-				"canonical model events require the model append class",
-			);
-		}
 		if (canonicalEvents.length > 0) {
+			if (input.appendClass !== "model") {
+				throw new InvalidRunEventError(
+					"canonical model events require the model append class",
+				);
+			}
 			const priorCanonicalEvents = await tx
 				.select({ type: runEvents.type, payload: runEvents.payload })
 				.from(runEvents)

--- a/packages/agent-db/src/run-store.ts
+++ b/packages/agent-db/src/run-store.ts
@@ -620,6 +620,11 @@ export async function appendRunEventsTx(
 				event.type,
 			),
 		);
+		if (canonicalEvents.length > 0 && input.appendClass !== "model") {
+			throw new InvalidRunEventError(
+				"canonical model events require the model append class",
+			);
+		}
 		if (canonicalEvents.length > 0) {
 			const priorCanonicalEvents = await tx
 				.select({ type: runEvents.type, payload: runEvents.payload })


### PR DESCRIPTION
## Summary

- add `ui_payload` to the shared canonical run-event vocabulary
- export the ADR-0017 v1 payload types and forward-compatible read guards
- enforce Assistant-message correlation, message-ID collision rules, and model-only append authorization
- validate terminal sequences and retain committed UI payloads across interruption
- add PGlite coverage for sequencing, fencing, parsing, terminalization, and append-class isolation

## Why

The shared writable-DB layer did not yet understand ADR-0017 UI payloads. Without a canonical event type and shared structural guards, the worker and chat-api could not safely persist or read generative-UI content. Canonical model events also needed explicit append-class enforcement so they could not borrow the cancellation lane after interruption.

## Impact

The worker and chat-api now share one exported, forward-compatible durable contract for UI payloads. Newer versions and component names can pass through older readers structurally intact, while corrupt payloads fail loudly. `PresentUI` is not exposed through the public Tool-name vocabulary.

Closes #418.

## Validation

- `bun run test`
  - 41 root tests
  - 172 agent-db tests (13 expected real-Postgres concurrency tests skipped)
  - 29 live-text tests
  - 499 agent-worker tests
  - 129 chat-api tests
  - 17 worker-scaler tests
- TypeScript checks for agent-db, agent-worker, and chat-api
- Biome checks on all changed files
- independent standards and issue-spec review; no remaining findings
