### PR TITLE
feat(chat-api): project generative UI in history

### DIFF
--- a/apps/chat-api/src/features/conversation-history/conversation-history-store.ts
+++ b/apps/chat-api/src/features/conversation-history/conversation-history-store.ts
@@ -1,4 +1,10 @@
-import type { Message, RunErrorEvent, RunFinishedEvent } from "@ag-ui/core";
+import type {
+	AssistantMessage,
+	Message,
+	RunErrorEvent,
+	RunFinishedEvent,
+} from "@ag-ui/core";
+import type { ParsedUiPayloadEventPayload } from "@mymemo/agent-db/run-events";
 import type { RunInterruptedEvent } from "@mymemo/live-text";
 import type { ConversationScope } from "@/features/conversation-store";
 
@@ -20,9 +26,21 @@ export type RunTerminalEvent =
 	| RunErrorEvent
 	| RunInterruptedEvent;
 
+export interface GenerativeUiPart extends ParsedUiPayloadEventPayload {
+	eventId: string;
+}
+
+export type ConversationHistoryAssistantMessage = AssistantMessage & {
+	generativeUi?: GenerativeUiPart[];
+};
+
+export type ConversationHistoryMessage =
+	| Exclude<Message, AssistantMessage>
+	| ConversationHistoryAssistantMessage;
+
 export interface ConversationHistoryRun {
 	runId: string;
-	messages: Message[];
+	messages: ConversationHistoryMessage[];
 	terminalEvent: RunTerminalEvent | null;
 }
 

--- a/apps/chat-api/src/features/conversation-history/conversation-history.route.test.ts
+++ b/apps/chat-api/src/features/conversation-history/conversation-history.route.test.ts
@@ -53,21 +53,9 @@ describe("GET /v1/conversations/:conversationId/history", () => {
 		);
 
 		expect(response.status).toBe(200);
-		expect(await response.json()).toEqual({
-			conversation: {
-				conversationId: "conversation-1",
-				title: "Quarterly plan",
-				scope: "general",
-				collectionId: null,
-				summaryId: null,
-				createdAt: "2026-07-20T01:00:00.000Z",
-				lastActivityAt: "2026-07-20T02:00:00.000Z",
-				archivedAt: null,
-			},
-			runs: [],
-			nextCursor: null,
-			activeRun: { runId: "run-active", status: "running" },
-		});
+		expect(await response.text()).toBe(
+			'{"conversation":{"conversationId":"conversation-1","title":"Quarterly plan","scope":"general","collectionId":null,"summaryId":null,"createdAt":"2026-07-20T01:00:00.000Z","lastActivityAt":"2026-07-20T02:00:00.000Z","archivedAt":null},"runs":[],"nextCursor":null,"activeRun":{"runId":"run-active","status":"running"}}',
+		);
 		expect(calls).toEqual([
 			{
 				userId: "member-1",
@@ -76,6 +64,75 @@ describe("GET /v1/conversations/:conversationId/history", () => {
 				cursor: null,
 			},
 		]);
+	});
+
+	it("serializes generative UI additively and omits it from messages without payloads", async () => {
+		const historyStore: ConversationHistoryStore = {
+			async getPage() {
+				return {
+					conversation: {
+						conversationId: "conversation-1",
+						title: null,
+						scope: "general",
+						collectionId: null,
+						summaryId: null,
+						createdAt: new Date("2026-07-20T01:00:00.000Z"),
+						lastActivityAt: new Date("2026-07-20T02:00:00.000Z"),
+						archivedAt: null,
+					},
+					runs: [
+						{
+							runId: "run-1",
+							messages: [
+								{
+									id: "assistant-ui",
+									role: "assistant",
+									content: "Visual answer",
+									generativeUi: [
+										{
+											eventId: "run-1:3",
+											messageId: "assistant-ui",
+											version: 1,
+											payload: {
+												component: "diagram",
+												props: { source: "flowchart LR\nA --> B" },
+											},
+										},
+									],
+								},
+								{
+									id: "assistant-text",
+									role: "assistant",
+									content: "Text-only answer",
+								},
+							],
+							terminalEvent: null,
+						},
+					],
+					nextCursor: null,
+					activeRun: null,
+				};
+			},
+		};
+		const deps = {
+			conversationHistoryStore: historyStore,
+		} as unknown as AppDeps;
+		const app = createApp({ logLevel: "silent" } as ApiConfig, deps);
+
+		const response = await app.request(
+			"/v1/conversations/conversation-1/history",
+			{ headers: identityHeaders },
+		);
+
+		expect(response.status).toBe(200);
+		const body = await response.text();
+		expect(body).toContain(
+			'"generativeUi":[{"eventId":"run-1:3","messageId":"assistant-ui","version":1',
+		);
+		expect(body).toContain(
+			'{"id":"assistant-text","role":"assistant","content":"Text-only answer"}',
+		);
+		expect(body).not.toContain('"id":"assistant-text","generativeUi"');
 	});
 
 	it("rejects invalid cursors and hides durable-history corruption", async () => {

--- a/apps/chat-api/src/features/conversation-history/index.ts
+++ b/apps/chat-api/src/features/conversation-history/index.ts
@@ -1,11 +1,14 @@
 export { default as conversationHistoryRoutes } from "./conversation-history.route";
 export type {
 	ActiveRunSummary,
+	ConversationHistoryAssistantMessage,
+	ConversationHistoryMessage,
 	ConversationHistoryPage,
 	ConversationHistoryPageInput,
 	ConversationHistoryRun,
 	ConversationHistoryStore,
 	ConversationSummary,
+	GenerativeUiPart,
 	RunInterruptedEvent,
 	RunTerminalEvent,
 } from "./conversation-history-store";

--- a/apps/chat-api/src/features/conversation-history/postgres-conversation-history-store.test.ts
+++ b/apps/chat-api/src/features/conversation-history/postgres-conversation-history-store.test.ts
@@ -551,6 +551,7 @@ describe("PostgresConversationHistoryStore", () => {
 				payload: {
 					messageId: "assistant-2",
 					version: 7,
+					futureEnvelopeField: { nested: true },
 					payload: {
 						component: "future-component",
 						props: { future: true },
@@ -634,6 +635,7 @@ describe("PostgresConversationHistoryStore", () => {
 						eventId: "run-ui:9",
 						messageId: "assistant-2",
 						version: 7,
+						futureEnvelopeField: { nested: true },
 						payload: {
 							component: "future-component",
 							props: { future: true },
@@ -819,7 +821,7 @@ describe("PostgresConversationHistoryStore", () => {
 		});
 	});
 
-	it("skips unknown events but rejects a malformed known event as corruption", async () => {
+	it("skips unknown events but rejects malformed known events as corruption", async () => {
 		await tdb.db.insert(conversations).values({
 			userId: "member-1",
 			conversationId: "conversation-1",
@@ -882,6 +884,22 @@ describe("PostgresConversationHistoryStore", () => {
 					version: 1,
 					payload: "not an object",
 				},
+			})
+			.where(and(eq(runEvents.runId, "run-1"), eq(runEvents.seq, 2)));
+		await expect(
+			store.getPage({
+				userId: "member-1",
+				conversationId: "conversation-1",
+				limit: 20,
+				cursor: null,
+			}),
+		).rejects.toThrow("invalid payload for durable event");
+
+		await tdb.db
+			.update(runEvents)
+			.set({
+				type: RunEventType.AssistantMessageCompleted,
+				payload: { text: "missing messageId" },
 			})
 			.where(and(eq(runEvents.runId, "run-1"), eq(runEvents.seq, 2)));
 		await expect(

--- a/apps/chat-api/src/features/conversation-history/postgres-conversation-history-store.test.ts
+++ b/apps/chat-api/src/features/conversation-history/postgres-conversation-history-store.test.ts
@@ -457,6 +457,193 @@ describe("PostgresConversationHistoryStore", () => {
 		]);
 	});
 
+	it("projects durable generative UI into its owning Assistant messages", async () => {
+		await tdb.db.insert(conversations).values({
+			userId: "member-1",
+			conversationId: "conversation-1",
+			scope: "general",
+		});
+		await tdb.db.insert(runs).values({
+			runId: "run-ui",
+			userId: "member-1",
+			conversationId: "conversation-1",
+			status: "done",
+			terminalAt: new Date("2026-07-20T01:00:05.000Z"),
+			nextEventSeq: 12,
+		});
+		await tdb.db.insert(runEvents).values([
+			{
+				runId: "run-ui",
+				seq: 1,
+				type: RunEventType.Started,
+				payload: {
+					runId: "run-ui",
+					conversationId: "conversation-1",
+					messageId: "user-ui",
+					message: "Show the comparison",
+					scope: "general",
+					collectionId: null,
+					summaryId: null,
+				},
+			},
+			{
+				runId: "run-ui",
+				seq: 2,
+				type: RunEventType.ToolCallStarted,
+				payload: {
+					toolCallId: "tool-call-ui",
+					toolCallName: "Read",
+					parentMessageId: "assistant-1",
+				},
+			},
+			{
+				runId: "run-ui",
+				seq: 3,
+				type: RunEventType.ToolCallArgs,
+				payload: { toolCallId: "tool-call-ui", delta: "{}" },
+			},
+			{
+				runId: "run-ui",
+				seq: 4,
+				type: RunEventType.ToolCallCompleted,
+				payload: { toolCallId: "tool-call-ui" },
+			},
+			{
+				runId: "run-ui",
+				seq: 5,
+				type: RunEventType.AssistantMessageCompleted,
+				payload: { messageId: "assistant-1", text: "First answer" },
+			},
+			{
+				runId: "run-ui",
+				seq: 6,
+				type: RunEventType.UiPayload,
+				payload: {
+					messageId: "assistant-1",
+					version: 1,
+					payload: {
+						component: "diagram",
+						props: { source: "flowchart LR\nA --> B" },
+					},
+				},
+			},
+			{
+				runId: "run-ui",
+				seq: 7,
+				type: RunEventType.ToolCallResult,
+				payload: {
+					messageId: "tool-message-ui",
+					toolCallId: "tool-call-ui",
+					content: "Read complete",
+					isError: false,
+				},
+			},
+			{
+				runId: "run-ui",
+				seq: 8,
+				type: RunEventType.AssistantMessageCompleted,
+				payload: { messageId: "assistant-2", text: "Second answer" },
+			},
+			{
+				runId: "run-ui",
+				seq: 9,
+				type: RunEventType.UiPayload,
+				payload: {
+					messageId: "assistant-2",
+					version: 7,
+					payload: {
+						component: "future-component",
+						props: { future: true },
+					},
+				},
+			},
+			{
+				runId: "run-ui",
+				seq: 10,
+				type: RunEventType.UiPayload,
+				payload: {
+					messageId: "assistant-1",
+					version: 1,
+					payload: {
+						component: "table",
+						props: { columns: [], rows: [] },
+					},
+				},
+			},
+			{
+				runId: "run-ui",
+				seq: 11,
+				type: RunEventType.Done,
+				payload: { outcome: "done" },
+			},
+		]);
+
+		const page = await new PostgresConversationHistoryStore(tdb.db).getPage({
+			userId: "member-1",
+			conversationId: "conversation-1",
+			limit: 20,
+			cursor: null,
+		});
+
+		expect(page?.runs[0]?.messages).toEqual([
+			{ id: "user-ui", role: "user", content: "Show the comparison" },
+			{
+				id: "assistant-1",
+				role: "assistant",
+				content: "First answer",
+				toolCalls: [
+					{
+						id: "tool-call-ui",
+						type: "function",
+						function: { name: "Read", arguments: "{}" },
+					},
+				],
+				generativeUi: [
+					{
+						eventId: "run-ui:6",
+						messageId: "assistant-1",
+						version: 1,
+						payload: {
+							component: "diagram",
+							props: { source: "flowchart LR\nA --> B" },
+						},
+					},
+					{
+						eventId: "run-ui:10",
+						messageId: "assistant-1",
+						version: 1,
+						payload: {
+							component: "table",
+							props: { columns: [], rows: [] },
+						},
+					},
+				],
+			},
+			{
+				id: "tool-message-ui",
+				role: "tool",
+				toolCallId: "tool-call-ui",
+				content: "Read complete",
+			},
+			{
+				id: "assistant-2",
+				role: "assistant",
+				content: "Second answer",
+				generativeUi: [
+					{
+						eventId: "run-ui:9",
+						messageId: "assistant-2",
+						version: 7,
+						payload: {
+							component: "future-component",
+							props: { future: true },
+						},
+					},
+				],
+			},
+		]);
+	});
+
 	it("keeps error and interruption Outcomes only in terminal events", async () => {
 		await tdb.db.insert(conversations).values({
 			userId: "member-1",
@@ -536,6 +723,102 @@ describe("PostgresConversationHistoryStore", () => {
 		]);
 	});
 
+	it("retains committed generative UI when a Run is interrupted", async () => {
+		await tdb.db.insert(conversations).values({
+			userId: "member-1",
+			conversationId: "conversation-1",
+			scope: "general",
+		});
+		await tdb.db.insert(runs).values({
+			runId: "run-interrupted-ui",
+			userId: "member-1",
+			conversationId: "conversation-1",
+			status: "interrupted",
+			terminalAt: new Date("2026-07-20T01:00:05.000Z"),
+			nextEventSeq: 5,
+		});
+		await tdb.db.insert(runEvents).values([
+			{
+				runId: "run-interrupted-ui",
+				seq: 1,
+				type: RunEventType.Started,
+				payload: {
+					runId: "run-interrupted-ui",
+					conversationId: "conversation-1",
+					messageId: "user-interrupted-ui",
+					message: "Show progress",
+					scope: "general",
+					collectionId: null,
+					summaryId: null,
+				},
+			},
+			{
+				runId: "run-interrupted-ui",
+				seq: 2,
+				type: RunEventType.AssistantMessageCompleted,
+				payload: { messageId: "assistant-interrupted-ui", text: "Progress" },
+			},
+			{
+				runId: "run-interrupted-ui",
+				seq: 3,
+				type: RunEventType.UiPayload,
+				payload: {
+					messageId: "assistant-interrupted-ui",
+					version: 1,
+					payload: {
+						component: "card",
+						props: { title: "Committed" },
+					},
+				},
+			},
+			{
+				runId: "run-interrupted-ui",
+				seq: 4,
+				type: RunEventType.Interrupted,
+				payload: { outcome: "interrupted" },
+			},
+		]);
+
+		const page = await new PostgresConversationHistoryStore(tdb.db).getPage({
+			userId: "member-1",
+			conversationId: "conversation-1",
+			limit: 20,
+			cursor: null,
+		});
+
+		expect(page?.runs[0]).toEqual({
+			runId: "run-interrupted-ui",
+			messages: [
+				{
+					id: "user-interrupted-ui",
+					role: "user",
+					content: "Show progress",
+				},
+				{
+					id: "assistant-interrupted-ui",
+					role: "assistant",
+					content: "Progress",
+					generativeUi: [
+						{
+							eventId: "run-interrupted-ui:3",
+							messageId: "assistant-interrupted-ui",
+							version: 1,
+							payload: {
+								component: "card",
+								props: { title: "Committed" },
+							},
+						},
+					],
+				},
+			],
+			terminalEvent: {
+				type: "RUN_INTERRUPTED",
+				threadId: "conversation-1",
+				runId: "run-interrupted-ui",
+			},
+		});
+	});
+
 	it("skips unknown events but rejects a malformed known event as corruption", async () => {
 		await tdb.db.insert(conversations).values({
 			userId: "member-1",
@@ -593,8 +876,12 @@ describe("PostgresConversationHistoryStore", () => {
 		await tdb.db
 			.update(runEvents)
 			.set({
-				type: RunEventType.AssistantMessageCompleted,
-				payload: { text: "missing messageId" },
+				type: RunEventType.UiPayload,
+				payload: {
+					messageId: "assistant-1",
+					version: 1,
+					payload: "not an object",
+				},
 			})
 			.where(and(eq(runEvents.runId, "run-1"), eq(runEvents.seq, 2)));
 		await expect(

--- a/apps/chat-api/src/features/conversation-history/postgres-conversation-history-store.ts
+++ b/apps/chat-api/src/features/conversation-history/postgres-conversation-history-store.ts
@@ -1,10 +1,5 @@
 import { Buffer } from "node:buffer";
-import {
-	type AssistantMessage,
-	EventType,
-	type Message,
-	type ToolCall,
-} from "@ag-ui/core";
+import { EventType, type ToolCall } from "@ag-ui/core";
 import {
 	InvalidRunEventError,
 	parseDurableRunEvent,
@@ -23,6 +18,8 @@ import {
 import type { ConversationScope } from "@/features/conversation-store";
 import type {
 	ActiveRunSummary,
+	ConversationHistoryAssistantMessage,
+	ConversationHistoryMessage,
 	ConversationHistoryPage,
 	ConversationHistoryPageInput,
 	ConversationHistoryRun,
@@ -252,11 +249,11 @@ function projectCompleteRun(
 	events: RunEventRow[],
 ): ConversationHistoryRun {
 	validateDurableRunEventSequence(events);
-	const parsed = events.flatMap((event) => {
-		const value = parseDurableRunEvent(event.type, event.payload);
-		return value ? [value] : [];
+	const parsed = events.flatMap((row) => {
+		const event = parseDurableRunEvent(row.type, row.payload);
+		return event ? [{ event, seq: row.seq }] : [];
 	});
-	const started = parsed[0];
+	const started = parsed[0]?.event;
 	if (
 		started?.type !== RunEventType.Started ||
 		started.payload.runId !== run.runId ||
@@ -265,26 +262,32 @@ function projectCompleteRun(
 		throw new InvalidRunEventError("invalid durable Run start");
 	}
 
-	const messages: Message[] = [
+	const messages: ConversationHistoryMessage[] = [
 		{
 			id: started.payload.messageId,
 			role: "user",
 			content: started.payload.message,
 		},
 	];
-	const assistantMessages = new Map<string, AssistantMessage>();
+	const assistantMessages = new Map<
+		string,
+		ConversationHistoryAssistantMessage
+	>();
 	const toolCalls = new Map<string, ToolCall>();
 	const ensureAssistantMessage = (messageId: string) => {
 		const existing = assistantMessages.get(messageId);
 		if (existing) return existing;
-		const message: AssistantMessage = { id: messageId, role: "assistant" };
+		const message: ConversationHistoryAssistantMessage = {
+			id: messageId,
+			role: "assistant",
+		};
 		assistantMessages.set(messageId, message);
 		messages.push(message);
 		return message;
 	};
 	let terminalEvent: RunTerminalEvent | null = null;
 	let terminalStatus: "done" | "error" | "interrupted" | null = null;
-	for (const event of parsed.slice(1)) {
+	for (const { event, seq } of parsed.slice(1)) {
 		switch (event.type) {
 			case RunEventType.AssistantMessageCompleted:
 				if (event.payload.text) {
@@ -322,6 +325,19 @@ function projectCompleteRun(
 					...(event.payload.isError ? { error: event.payload.content } : {}),
 				});
 				break;
+			case RunEventType.UiPayload: {
+				const assistant = ensureAssistantMessage(event.payload.messageId);
+				assistant.generativeUi = [
+					...(assistant.generativeUi ?? []),
+					{
+						eventId: `${run.runId}:${seq}`,
+						messageId: event.payload.messageId,
+						version: event.payload.version,
+						payload: event.payload.payload,
+					},
+				];
+				break;
+			}
 			case RunEventType.Done:
 				terminalStatus = "done";
 				terminalEvent = {

--- a/apps/chat-api/src/features/conversation-history/postgres-conversation-history-store.ts
+++ b/apps/chat-api/src/features/conversation-history/postgres-conversation-history-store.ts
@@ -327,15 +327,11 @@ function projectCompleteRun(
 				break;
 			case RunEventType.UiPayload: {
 				const assistant = ensureAssistantMessage(event.payload.messageId);
-				assistant.generativeUi = [
-					...(assistant.generativeUi ?? []),
-					{
-						eventId: `${run.runId}:${seq}`,
-						messageId: event.payload.messageId,
-						version: event.payload.version,
-						payload: event.payload.payload,
-					},
-				];
+				assistant.generativeUi ??= [];
+				assistant.generativeUi.push({
+					...event.payload,
+					eventId: `${run.runId}:${seq}`,
+				});
 				break;
 			}
 			case RunEventType.Done:


### PR DESCRIPTION
## Summary

- project each durable `ui_payload` event into the optional `generativeUi` array on its owning Assistant message
- preserve durable event order and stable `<runId>:<seq>` identities across live delivery, reconnect replay, and Conversation history
- retain committed payloads through interruption, pass future versions, components, and envelope fields through unchanged, and fail loudly on corrupt known payloads
- serialize the field additively while keeping payload-free history responses byte-identical

## Why

Issue #422 completes the permanent-history slice of ADR-0017. Clients need the same generative UI object shape and identity whether content arrives live, through replay, or from durable Conversation history.

## Impact

Clients can use one mapper for `mymemo.generative_ui` content across delivery modes. Existing clients remain compatible because Assistant messages without UI payloads are unchanged, while interrupted Runs retain every payload committed before their Outcome.

## Validation

- chat-api suite — 132 passed, 0 failed
- focused history suites — 14 passed, 0 failed
- `bunx tsc --noEmit -p apps/chat-api/tsconfig.json`
- focused Biome checks passed for all changed files
- actionable Standards and Spec review feedback addressed

Closes #422