### PR TITLE
docs(agentcore): define production canary architecture

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -40,6 +40,79 @@ The set of documents a conversation may access — `general`, `collection`, or
 `document`. Resolved once at conversation creation, then only ever re-read.
 _Avoid_: permissions, access level
 
+**Execution lane**:
+The immutable classification of a Conversation that determines which runtime
+may claim and execute its Runs. A Conversation never mixes runtimes.
+_Avoid_: Run target, worker preference, routing hint
+
+**AgentCore canary**:
+An operator-triggered, traffic-free production exercise that runs only
+synthetic Conversations on the AgentCore execution lane while Fargate remains
+the user-traffic runtime.
+_Avoid_: rollout, shadow traffic, production migration
+
+**Canary campaign**:
+One bounded, on-demand AgentCore canary exercise over a fresh synthetic
+Conversation, ending in a recorded Canary verdict and explicit cleanup.
+_Avoid_: scheduled probe, continuous canary, rollout stage
+
+**Canary scenario**:
+One versioned behavior probe within a Canary campaign, represented by one exact
+Run whose identity is stable across control-plane retries.
+_Avoid_: Run retry, test attempt, workflow step
+
+**Canary verdict**:
+The outcome of a Canary campaign: `pass_for_rollout_review`, `fail`, or
+`inconclusive`. An observed requirement violation is a failure; inconclusive
+means the required behavior could not be observed. A verdict informs a separate
+rollout decision and never changes user routing itself.
+_Avoid_: rollout approval, deployment status, Run Outcome
+
+**Canary fixture**:
+The versioned synthetic identity, collection, documents, and expected outputs
+used by every Canary campaign. It contains no real-user data.
+_Avoid_: test user, production sample, general Scope
+
+**AgentCore dispatch**:
+An at-least-once request for AgentCore to acquire one exact Run from an
+AgentCore-canary Conversation. Repeated delivery never creates another Run.
+_Avoid_: Run retry, job, invocation attempt
+
+**Durable acquisition**:
+The committed transition in which one AgentCore invocation obtains live
+Conversation Ownership and starts its exact dispatched Run. Runtime entry or
+an HTTP response alone is not acquisition.
+_Avoid_: container start, invocation acceptance, queue acknowledgement
+
+**Dispatch disposition**:
+The typed result of evaluating an AgentCore dispatch against durable Run and
+Ownership state, determining whether delivery is acknowledged or retried.
+_Avoid_: duplicate-or-missing, HTTP status, Run Outcome
+
+**Acquisition receipt**:
+The versioned, machine-readable proof that an AgentCore dispatch reached one
+specific Dispatch disposition. It is emitted only after the disposition's
+durable facts commit and contains no user or secret content.
+_Avoid_: AG-UI event, HTTP success, log line
+
+**Runtime session**:
+The AgentCore compute-lifecycle identity used to reconnect or stop the compute
+serving a synthetic Conversation. It is not the Claude Agent session and does
+not own Run ordering or continuity.
+_Avoid_: Agent session, Conversation, worker id
+
+**Campaign record**:
+The durable control record for one Canary campaign, including its identity,
+version, synthetic Conversation, lifecycle status, Canary verdict, and evidence
+location.
+_Avoid_: Step Functions execution, workflow run, Run
+
+**Canary report**:
+The signed, bounded evidence artifact derived from a Canary campaign, recording
+every gate, observation, cleanup result, cost estimate, and Canary verdict
+without user content or secret values.
+_Avoid_: log bundle, rollout approval, Conversation history
+
 **Run**:
 One backend execution attempt serving a user message. A Conversation's Runs are
 executed one at a time in submission order, and a Run executes at most once —

--- a/docs/adr/0019-isolate-agentcore-canaries-by-conversation-execution-lane.md
+++ b/docs/adr/0019-isolate-agentcore-canaries-by-conversation-execution-lane.md
@@ -1,0 +1,39 @@
+# Isolate AgentCore canaries by Conversation execution lane
+
+Status: accepted
+
+MyMemo will introduce an immutable execution lane on each Conversation, with
+all existing and public creation paths defaulting to Fargate and only the
+operator canary path able to create an AgentCore-canary Conversation. Claims
+and dispatch are lane-aware, but Postgres Conversation Ownership and its epoch
+fence remain the single execution authority. This prevents Fargate from taking
+synthetic AgentCore work and prevents an AgentCore invocation from draining
+unrelated user work without splitting Run state into a second database or
+weakening the Conversation-scoped ownership model.
+
+## Considered options
+
+- **Target individual Runs.** Rejected because execution ownership, Workspace,
+  Agent session, and artifacts are Conversation-scoped; mixed-runtime Runs
+  would create a second authority boundary inside one Conversation.
+- **Use an advisory routing hint.** Rejected because either runtime could still
+  execute the wrong work when dispatch is duplicated or delayed.
+- **Use a separate canary database.** Rejected because it would not validate
+  production ownership, dispatch, TLS, recovery, and secret wiring.
+
+## Consequences
+
+- Ordinary Run admission never creates AgentCore dispatch work. Only admission
+  against an operator-created AgentCore-canary Conversation does so, atomically
+  with the admitted Run.
+- The AgentCore entrypoint acquires only the specifically dispatched
+  Conversation and Run; it never starts the generic global drain loop.
+- The canary uses production infrastructure with a dedicated synthetic
+  identity and synthetic collection, while real-user routing remains Fargate.
+- Deployment is ordered: add the default-Fargate lane, deploy and verify the
+  lane-aware Fargate claimant on every task, and only then install authority to
+  create an AgentCore-canary Conversation.
+- A lane-unaware Fargate binary cannot be restored while any AgentCore-canary
+  Conversation exists. Incident rollback first disables dispatch, completes
+  canary cleanup, and proves the database contains only Fargate Conversations;
+  the additive lane schema remains in place.

--- a/docs/adr/0020-dispatch-agentcore-through-a-transactional-outbox.md
+++ b/docs/adr/0020-dispatch-agentcore-through-a-transactional-outbox.md
@@ -1,0 +1,43 @@
+# Dispatch AgentCore through a transactional outbox
+
+Status: accepted
+
+Admission of a Run on an AgentCore-canary Conversation will atomically create
+an outbox record, which is published at least once to an encrypted standard SQS
+queue. The consumer invokes AgentCore for that exact Conversation and Run, but
+Postgres Conversation Ownership and Run state remain the ordering,
+duplicate-execution, and recovery authority. SQS delivery order and
+deduplication therefore carry no correctness weight.
+
+The consumer acknowledges delivery only after a typed Dispatch disposition
+proves Durable acquisition, proves the exact Run is already durably acquired,
+or proves it already has an Outcome. Temporary contention and ambiguous
+infrastructure failures retry; malformed or lane-mismatched poison work is
+acknowledged and alarmed. Merely entering the Runtime, receiving HTTP success,
+or finding text resembling `RUN_STARTED` is never sufficient.
+
+The Runtime communicates that proof through a strict, versioned Acquisition
+receipt whose identifiers must match the dispatch envelope. The receipt is
+emitted only after the disposition's durable transaction commits. On new
+acquisition, the Lambda consumer may then close its response stream and
+acknowledge SQS while the Runtime continues the Run detached.
+
+## Considered options
+
+- **Publish after admission without an outbox.** Rejected because a crash
+  between the database commit and SQS publish would strand an admitted Run.
+- **Use SQS FIFO ordering or deduplication as the execution authority.**
+  Rejected because AgentCore does not serialize same-session invocations and
+  publisher ambiguity still permits duplicate delivery.
+- **Acknowledge when Runtime invocation begins.** Rejected because container
+  entry does not prove that the requested Run obtained durable authority.
+
+## Consequences
+
+- The manual launcher makes an immediate bounded publish attempt after
+  admission, while a scheduled invocation of the same publisher repairs
+  pending rows.
+- Publisher row claims expire, making concurrent publishers and retry after an
+  ambiguous SQS result safe.
+- The Runtime adapter needs a specific-acquisition primitive and typed receipt;
+  it cannot reuse the global Fargate drain loop unchanged.

--- a/docs/adr/0021-deploy-the-agentcore-canary-independently-of-fargate.md
+++ b/docs/adr/0021-deploy-the-agentcore-canary-independently-of-fargate.md
@@ -1,0 +1,49 @@
+# Deploy the AgentCore canary independently of Fargate
+
+Status: accepted
+
+The production AgentCore canary will have a dedicated locked Terraform state,
+immutable ARM64 image repository, request-oriented Runtime entrypoint, and
+deployment role. It may reference shared production resources, but applying,
+disabling, or destroying the canary must not update the Fargate service or its
+state. This preserves Fargate as the unchanged user-traffic runtime while the
+drift-prone AgentCore control plane is evaluated.
+
+The canary keeps its private subnets, route tables, and security group between
+campaigns but creates one NAT Gateway and EIP only for an approved campaign
+window. AgentCore Runtime compute has no fixed endpoint fee, while a persistent
+NAT would dominate the cost of an otherwise on-demand exercise. Delayed
+AgentCore-managed ENI release is recorded during cleanup but is not treated as
+an application lifecycle feature.
+
+## Considered options
+
+- **Add the canary to the existing production state and image pipeline.**
+  Rejected because a canary plan or teardown could then alter user-serving
+  Fargate resources, and the existing AMD64 supervisor image does not satisfy
+  AgentCore's ARM64 request-runtime contract.
+- **Keep NAT provisioned between campaigns.** Rejected because the recurring
+  fixed cost is disproportionate to an operator-triggered, traffic-free
+  canary.
+- **Use a separate database and network.** Rejected because that would avoid
+  validating the production ownership, TLS, secret, and recovery wiring the
+  canary exists to test.
+
+## Consequences
+
+- Canary deployment and campaign launch use distinct, GitHub
+  Environment-protected OIDC roles; runtime fault injection has a narrower
+  service role and accepts no operator-supplied resource identifiers.
+- The Runtime reads exact secret ARNs at fresh session boot and requires RDS
+  certificate verification without changing Fargate's current TLS behavior.
+- Every campaign report records the image digest and resolved Runtime version.
+- The control-plane stack remains deployed but disabled between campaigns.
+  Campaign cleanup removes Runtime sessions, NAT/EIP, synthetic durable data,
+  sandboxes, artifacts, and queued work; full stack destruction is a separate
+  decommission operation.
+- Runtime image promotion is manual and environment-approved. Ordinary Fargate
+  releases do not update the dormant AgentCore Runtime.
+- Every deployment parses its Terraform plan and permits mutations only inside
+  the dedicated canary-resource allowlist. Shared production infrastructure is
+  referenced read-only; provider-major changes, replacements, deletions, trust
+  expansion, and full decommission require separate explicit approval paths.

--- a/docs/adr/0022-acquire-an-agentcore-dispatch-atomically.md
+++ b/docs/adr/0022-acquire-an-agentcore-dispatch-atomically.md
@@ -1,0 +1,28 @@
+# Acquire an AgentCore dispatch atomically
+
+Status: accepted
+
+An AgentCore invocation will acquire its exact dispatched Run in one
+transaction that locks the Conversation before the Run, validates its immutable
+AgentCore execution lane, establishes a new Conversation Ownership epoch and
+lease, and transitions that Run from `queued` to `running`. Claim and start are
+not separate operations: a crash between them would leave an owned Conversation
+without the Durable acquisition required to acknowledge SQS.
+
+The transaction returns a typed Dispatch disposition. A live exact acquisition
+and an already-terminal exact Run may be acknowledged; queued contention or an
+expired holder awaiting Reclamation retries; identity, lane, or Runtime-session
+mismatch is poison work and alarms. Existing epoch-fenced renewal, Run-event,
+runtime, transcript, artifact, terminal, release, and Reclamation helpers remain
+the only write and recovery authority.
+
+## Considered options
+
+- **Call the existing global Claim and then start the requested Run.** Rejected
+  because global Claim may select unrelated work and leaves a crash boundary
+  before Run start.
+- **Give AgentCore a Run-scoped lease.** Rejected because it would conflict with
+  the Conversation-scoped authority shared by Workspace, Agent session,
+  artifacts, and every other execution write.
+- **Retry a Run after expired ownership.** Rejected because a MyMemo Run
+  executes at most once; Reclamation establishes its error Outcome instead.

--- a/docs/adr/0023-share-run-serving-without-sharing-runtime-control-loops.md
+++ b/docs/adr/0023-share-run-serving-without-sharing-runtime-control-loops.md
@@ -1,0 +1,35 @@
+# Share Run serving without sharing runtime control loops
+
+Status: accepted
+
+Fargate and AgentCore will share one `serveStartedRun` behavior for lease
+renewal, interruption observation, Live Stream production, SDK and Tool work,
+terminalization, and abort reconciliation. Fargate keeps its global queue
+control loop, snapshot drain, lane-filtered Claim, and release; an AgentCore
+invocation atomically acquires one exact Run, serves it once, and releases. This
+keeps Run semantics identical without starting a global claimant or sweeper per
+HTTP invocation.
+
+The always-on Fargate loop remains the single global Reclamation runner and may
+reclaim expired Ownership from either execution lane. Fargate claimable counts,
+doorbells, and Claims filter to Fargate, while the shared queued backstop uses a
+60-second Fargate timeout and a ten-minute AgentCore-canary timeout. AgentCore
+request handlers never run global expiration or Reclamation.
+
+An AgentCore handler emits its Acquisition receipt after commit but remains
+alive until shared Run serving ends. Response-stream cancellation does not abort
+the Run; only durable interruption, ownership loss, Runtime shutdown, mirror
+failure, or sandbox-renewal failure does. A process-level registry bounds the
+canary to one active execution and keeps `/ping` at `HealthyBusy` until that
+execution actually ends.
+
+## Considered options
+
+- **Run the existing `RunLoop` per invocation.** Rejected because every request
+  would globally claim and sweep work, multiply concurrency limits, and own an
+  independent shutdown lifecycle.
+- **Copy the Run execution path into the AgentCore adapter.** Rejected because
+  interruption, fencing, transcript, artifact, and Live Stream semantics would
+  drift between runtimes.
+- **Add an AgentCore-specific reaper.** Rejected because Reclamation protects
+  shared Conversation Ownership and must remain one durable authority.

--- a/docs/adr/0024-orchestrate-canary-control-without-retrying-runs.md
+++ b/docs/adr/0024-orchestrate-canary-control-without-retrying-runs.md
@@ -1,0 +1,36 @@
+# Orchestrate canary control without retrying Runs
+
+Status: accepted
+
+An environment-approved GitHub workflow starts or reattaches to a Postgres
+Campaign record and an AWS Step Functions Standard execution, then may
+disconnect without affecting the campaign. Postgres owns the monotonic campaign
+lifecycle and final verdict; Step Functions durably coordinates provisioning,
+five sequential scenarios, fault injection, validation, reporting, and cleanup.
+A scheduled watchdog invokes the same idempotent cleanup when campaign
+heartbeats or deadlines lapse.
+
+Each Canary scenario has deterministic Run and message identities. Control
+operations, exact admission, outbox publication, observation, validation, and
+cleanup may retry with those identities, but orchestration never substitutes a
+new Run after an Outcome. A fresh model execution requires a new Campaign
+idempotency key and a fresh synthetic Conversation.
+
+## Considered options
+
+- **Run the campaign inside GitHub Actions.** Rejected because runner
+  cancellation would become an implicit production abort and long waits would
+  have no durable AWS control state.
+- **Use one long-running Lambda.** Rejected because its execution limit and
+  restart behavior do not fit the campaign and cleanup windows.
+- **Retry a failed scenario with a new Run.** Rejected because it would hide a
+  production failure and violate the Run-at-most-once vocabulary.
+
+## Consequences
+
+- The Campaign record separates lifecycle from verdict and permits only one
+  non-terminal campaign at a time.
+- Step Functions observes durable Postgres state, not the temporary Live Stream,
+  before interruption, Runtime death, or scenario validation.
+- Operator abort is an explicit durable control action; killing the workflow
+  process is not cancellation.


### PR DESCRIPTION
## Summary

- add the AgentCore production-canary vocabulary to the domain glossary
- record six accepted architectural decisions covering execution lanes, transactional dispatch, independent deployment, atomic acquisition, shared Run serving, and durable campaign orchestration
- reserve ADR-0018 for the existing scripted-HTML design tracked in #437, numbering these decisions ADR-0019 through ADR-0024

## Why

The Stage 4 AgentCore parity prototype supports a production canary review, but the production boundary needed explicit, durable decisions before implementation. This documentation captures the shared design behind spec #445 and implementation tickets #447–#454.

## Impact

Documentation only. This PR changes no runtime behavior, infrastructure, routing, database schema, or production configuration. It establishes the canonical vocabulary and constraints agents should follow while implementing the canary tickets.

## Validation

- `git diff --check origin/main...HEAD`
- verified the worktree is clean after commit
- verified ADR numbering does not collide with the ADR-0018 reservation in #437
- reviewed the complete seven-file diff

Tests were not run because this PR changes documentation only.
