### PR TITLE
refactor(agent-worker): drop the partial/complete assistant text compare

### DIFF
--- a/apps/agent-worker/src/sdk/agent-stream.test.ts
+++ b/apps/agent-worker/src/sdk/agent-stream.test.ts
@@ -677,7 +677,6 @@ describe("consumeAgentStream", () => {
 	it("fails closed when message_stop arrives before the envelope is complete", async () => {
 		const envelope = textEnvelope({
 			completeText: "uncommitted",
-			partialText: "preview",
 		});
 		const query = fakeQuery([
 			...envelope.slice(0, 3).map((message) => ({ message })),

--- a/apps/agent-worker/src/sdk/agent-stream.ts
+++ b/apps/agent-worker/src/sdk/agent-stream.ts
@@ -16,7 +16,6 @@ import {
 } from "../ui-payload-validator";
 import { AgUiTextStream } from "./ag-ui-text-stream";
 import {
-	AssistantEnvelopeProtocolError,
 	AssistantMessageAssembler,
 	type EnvelopeCommit,
 } from "./assistant-message-assembler";
@@ -175,16 +174,10 @@ export async function consumeAgentStream(
 		disposition: "completed",
 		mirrorErrorObserved: false,
 	};
-	let liveMessageMatchesCompletion = true;
-	const assembler = new AssistantMessageAssembler({
-		onPartialCompleteMismatch: () => {
-			liveMessageMatchesCompletion = false;
-		},
-	});
+	const assembler = new AssistantMessageAssembler();
 	const abandonOpenMessage = async (): Promise<void> => {
 		assembler.abandon();
 		await agUiText.abandon();
-		liveMessageMatchesCompletion = true;
 	};
 	const appendLiveEvent = async (event: AGUIEvent): Promise<void> => {
 		await params.appendLiveEvent?.(event);
@@ -562,24 +555,17 @@ export async function consumeAgentStream(
 						assembled.commit.text.text,
 					);
 				}
-				if (!liveMessageMatchesCompletion) {
-					throw new AssistantEnvelopeProtocolError(
-						"Assistant partial text did not match its completed response",
-					);
-				}
 				const liveMessageId = await agUiText.flushMessage();
 				await commitEnvelope(assembled.commit);
 				if (
 					assembled.commit.text !== null &&
-					liveMessageId === assembled.commit.text.messageId &&
-					liveMessageMatchesCompletion
+					liveMessageId === assembled.commit.text.messageId
 				) {
 					await appendLiveEvent({
 						type: EventType.TEXT_MESSAGE_END,
 						messageId: liveMessageId,
 					});
 				}
-				liveMessageMatchesCompletion = true;
 			}
 		}
 		if (stopRequested) return settleStopped();

--- a/apps/agent-worker/src/sdk/assistant-message-assembler.ts
+++ b/apps/agent-worker/src/sdk/assistant-message-assembler.ts
@@ -19,7 +19,6 @@ interface ActiveEnvelope {
 	activeBlock: ActiveBlock | null;
 	nextBlockIndex: number;
 	messageDeltaSeen: boolean;
-	partialText: string;
 	completedText: string;
 	toolUses: CompletedToolUse[];
 }
@@ -30,7 +29,6 @@ export class AssistantEnvelopeProtocolError extends Error {
 
 export interface AssistantMessageAssemblerOptions {
 	createMessageId?: () => string;
-	onPartialCompleteMismatch?: () => void;
 }
 
 /**
@@ -102,19 +100,11 @@ const KNOWN_BLOCK_DELTA_TYPES: ReadonlyMap<string, readonly string[]> = new Map<
  */
 export class AssistantMessageAssembler {
 	readonly #createMessageId: () => string;
-	readonly #onPartialCompleteMismatch: () => void;
 	readonly #issuedMessageIds = new Set<string>();
 	#active: ActiveEnvelope | null = null;
-	#livePreviewEnabled = true;
 
 	constructor(options: AssistantMessageAssemblerOptions = {}) {
 		this.#createMessageId = options.createMessageId ?? randomUUID;
-		this.#onPartialCompleteMismatch =
-			options.onPartialCompleteMismatch ?? (() => {});
-	}
-
-	get livePreviewEnabled(): boolean {
-		return this.#livePreviewEnabled;
 	}
 
 	accept(message: SDKMessage): AssistantAssembly | null {
@@ -188,7 +178,6 @@ export class AssistantMessageAssembler {
 			activeBlock: null,
 			nextBlockIndex: 0,
 			messageDeltaSeen: false,
-			partialText: "",
 			completedText: "",
 			toolUses: [],
 		};
@@ -225,7 +214,6 @@ export class AssistantMessageAssembler {
 			}
 			const active = this.#active;
 			if (active === null) return null;
-			active.partialText += delta.text;
 			return {
 				type: "partial_text",
 				messageId: active.messageId,
@@ -302,10 +290,6 @@ export class AssistantMessageAssembler {
 		const active = this.#requireEnvelope("message_stop");
 		if (active.activeBlock !== null) {
 			this.#violation("message_stop arrived before content_block_stop");
-		}
-		if (active.partialText !== active.completedText) {
-			this.#livePreviewEnabled = false;
-			this.#onPartialCompleteMismatch();
 		}
 		this.#active = null;
 		return {

--- a/apps/agent-worker/src/sdk/run-processor.test.ts
+++ b/apps/agent-worker/src/sdk/run-processor.test.ts
@@ -85,7 +85,6 @@ afterEach(async () => {
 interface EnvelopeBlock {
 	type: "text" | "tool_use" | "other";
 	completeText?: string;
-	partialText?: string;
 }
 
 function providerEnvelope(
@@ -126,7 +125,7 @@ function providerEnvelope(
 					index,
 					delta: {
 						type: "text_delta",
-						text: block.partialText ?? block.completeText ?? "",
+						text: block.completeText ?? "",
 					},
 				}),
 				assistantBlock(providerMessageId, {
@@ -841,35 +840,6 @@ describe("createSdkRunProcessor — through the run loop", () => {
 			});
 		});
 	}
-
-	it("fails a Run whose streamed text disagrees with provider completion", async () => {
-		const worker = buildWorker();
-		const loop = buildLoop(worker, async () =>
-			messageQuery([
-				...textEnvelope({
-					completeText: "COMMIT",
-					providerMessageId: "provider-1",
-					partialText: "PREVIEW",
-				}),
-				...textEnvelope({
-					completeText: "NEXT",
-					providerMessageId: "provider-2",
-				}),
-			]),
-		);
-		await seedQueuedRun(tdb.db, {
-			runId: "run-1",
-			userId: "user-1",
-			conversationId: "conv-1",
-		});
-
-		await loop.tick();
-		await worker.drain();
-
-		expect((await readRun("run-1"))?.status).toBe("error");
-		const events = await readEvents("run-1");
-		expect(events.map((event) => event.type)).toEqual(["run_error"]);
-	});
 
 	it("passes the claimed run, abort signal, and Ownership epoch to startRunQuery", async () => {
 		const worker = buildWorker();

--- a/docs/adr/0008-token-streaming-redis-live-lane.md
+++ b/docs/adr/0008-token-streaming-redis-live-lane.md
@@ -49,11 +49,18 @@ provisional Live preview from authoritative Assistant-message storage.
   visible text in content-block order and appends that complete text as one
   `assistant_text` run event. Partial `stream_event` text is preview-only, and
   the terminal `result.result` echo remains ignored.
-- At `message_stop`, the worker also compares the locally accumulated partial
-  text with the completed-block aggregate exactly. A mismatch does not fail the
-  run: the completed-block aggregate still commits and replaces the inaccurate
-  preview, the worker records a payload-free mismatch metric, and live preview
-  stays disabled for the rest of that run.
+- ~~At `message_stop`, the worker also compares the locally accumulated partial
+  text with the completed-block aggregate exactly.~~ **Withdrawn (2026-08-14).**
+  The worker no longer accumulates partial text and performs no such comparison.
+  The two texts were never independent: the provider's streaming protocol sends
+  no finished block text, so the completed block the SDK hands us is itself a
+  reconstruction of the same deltas we saw. The check therefore compared our
+  accumulation against the SDK's accumulation of identical input, and the
+  accumulated copy existed for no other purpose — no live or durable path ever
+  read it. Envelope-structure violations already fail closed and are what a
+  changed SDK stream shape actually trips; a content-level check on top of them
+  did not earn its machinery. Partial text remains preview-only and undurable,
+  which is unchanged.
 - `message_stop` is the only event that may commit an envelope. Run interruption,
   ownership loss, shutdown, an SDK error result, or iterator rejection abandons
   the open assembler and ignores its late events; no accumulated partial or
@@ -201,8 +208,9 @@ synthetic valid or malformed fixtures. It verified that the design can:
 - commit exactly once and only at `message_stop`, concatenating completed
   visible blocks in content-block order;
 - abandon incomplete envelopes without a durable text append; and
-- prove that partial/complete mismatch preserves the completed-block commit,
-  disables further preview for the run, and reports only payload-free telemetry.
+- ~~prove that partial/complete mismatch preserves the completed-block commit,
+  disables further preview for the run, and reports only payload-free
+  telemetry.~~ Withdrawn with the comparison itself (see the Decision above).
 
 The prototype also verified that the terminal result echo is ignored and that
 an SDK error result followed by iterator rejection yields only one outcome. Its


### PR DESCRIPTION
## What

Removes the partial-vs-completed Assistant text comparison from the worker's SDK envelope assembler, along with the shadow accumulation that fed it, and amends ADR-0008 to match.

Deleted:
- `ActiveEnvelope.partialText` (field, init, per-delta concat) and the `message_stop` equality check — `assistant-message-assembler.ts`
- `#livePreviewEnabled` and its unread getter, plus the `onPartialCompleteMismatch` option/field/constructor wiring — same file
- `liveMessageMatchesCompletion` and all five of its sites, including the `AssistantEnvelopeProtocolError` throw and the now-orphaned import — `agent-stream.ts`
- The test asserting the removed behaviour, and two now-vestigial test fixture values

Kept: text deltas still flow to the Live Stream exactly as before. Only the shadow copy and its self-check are gone.

## Why

Discovered while inventorying `agent-stream.ts` for #464: the code's behaviour diverged from ADR-0008, which is unambiguous that a mismatch **must not** fail the Run —

> A mismatch does not fail the run: the completed-block aggregate still commits and replaces the inaccurate preview, the worker records a payload-free mismatch metric, and live preview stays disabled for the rest of that run.

The code instead threw *before* `commitEnvelope`, so a mismatch discarded a completed Assistant message and terminalized the Run `error`. The "disable preview for the rest of the Run" half was never implemented at all — `#livePreviewEnabled` was written but never read, and `agent-stream.ts` reset its flag per message rather than per Run.

So the divergence was real and unratified (ADR-0012 supersedes ADR-0008's *message-reconciliation policy*, but that clause scopes to chat-api's two-transport merge, not the worker's own compare). That left a choice: restore the ADR's behaviour, or remove the check. Removal won, for three reasons:

1. **The accumulation had no consumer but its own assertion.** `partialText` was written per delta and read only at the equality check. Nothing live or durable touched it — `#acceptDelta` returns the *individual* delta for the Live Stream, and `AgUiTextStream` keeps its own 50 ms coalescing buffer.
2. **The two texts were never independent.** The provider's streaming protocol sends no finished block text; the completed block the SDK hands us is itself a reconstruction of the same deltas we saw. The check compared our accumulation against the SDK's accumulation of identical input.
3. **The failure mode was disproportionate and non-degrading.** A stream-shape change wouldn't fire this occasionally — it would fire on every message of every Run, turning a preview-fidelity concern into a total outage where every Conversation gets Outcome `error`.

Envelope-*structure* violations still fail closed (overlapping envelopes, non-contiguous block indices, wrong delta subtypes, `content.length !== 1`, `message_stop` before `content_block_stop`, stream-end with an open envelope). Those are what a changed SDK stream shape actually trips; a content-level check layered on top did not earn its machinery.

## Reviewer notes

**SDK behaviour re-verified.** ADR-0008's envelope model came from a spike against SDK `0.2.117`; the repo now pins `0.3.218`. I re-ran the spike against the pinned version (resolved package and CLI both confirmed `0.3.218` / `claude 2.1.218`, not assumed). The model holds: `assistant` messages are content-block-granular (`content.length === 1` in every case) and arrive *before* `message_stop`. Even a trivial one-sentence prompt produced two blocks (thinking, then text), so there is no case where "just take the complete message" would work.

Note this contradicts the published [streaming-output docs](https://code.claude.com/docs/en/agent-sdk/streaming-output), which describe one `AssistantMessage` arriving *after* `message_stop` "with all content". Our assembler is correct and the docs are idealised — worth knowing before anyone "fixes" the assembler to match them.

**One fixture value kept deliberately.** `textEnvelope({ partialText })` survives in `sdk-message-fixtures.ts` (test-only; imported by two `.test.ts` files, never shipped). It's load-bearing for the coalescing test — verified by removing it and watching the test fail (`"hello"` → `"hellolo"`), since it's what makes the first delta a prefix so a spliced second delta completes it. That test is currently the *only* coverage of ADR-0008's coalescing decision; `ag-ui-text-stream.ts` has no test file of its own.

**Pre-existing lint failure, unrelated to this PR.** `src/e2b/command-client.test.ts` fails `biome check` with a formatting diff. Confirmed it fails at `HEAD` too (verified via `git stash`). Untouched here, but CI lint will likely trip on it.

## Testing

- `bunx tsc --noEmit` — clean
- `bun test` (agent-worker) — **573 pass / 0 fail** across 43 files
- `biome check` on all four changed source files — clean

## Follow-ups (not in this PR)

- ADR-0008's Validation section still cites the `0.2.117` spike as provenance; it could record the `0.3.218` re-verification.
- ADR-0008's Consequences require retaining the live partial-message spike as a conformance test. That obligation is still unmet — the spike I ran was throwaway. It could be checked in gated on `OPENROUTER_API_KEY`, the way the Postgres tests gate on `AGENT_DATABASE_URL`.
- `ag-ui-text-stream.ts` has no unit tests: the 50 ms timer flush, the 16 KiB `MAX_PENDING_TEXT_LENGTH` drain, and the failure path are all uncovered.
- The surviving fixture parameter is still named `partialText`, after the concept this PR deletes; `deltaText` would describe what it actually does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
