### PR TITLE
chore: untrack .codex/config.toml (contained a live Context7 API key)

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,5 +1,0 @@
-[mcp_servers.context7]
-url = "https://mcp.context7.com/mcp"
-
-[mcp_servers.context7.http_headers]
-CONTEXT7_API_KEY = "ctx7sk-a52a4884-aeff-4db1-a1fe-7b359384c16d"

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ worker-local
 
 # worktrees
 worktrees
+
+# codex local config (contains API keys)
+.codex/config.toml


### PR DESCRIPTION
## What

Untracks `.codex/config.toml` and adds it to `.gitignore`. The local file is left
in place, so nothing changes for anyone's local codex setup.

## Why

The file was committed in `c5cdf8a` (2026-07-04) with a live Context7 API key
(`ctx7sk-a52a…`) in `http_headers`. `X-GPT/mymemo-agent` was **public** on that
date, went private 2026-07-18, and has been public again since 2026-07-29 — so the
value has been world-readable for roughly a month in total.

The key is being rotated at Context7 separately; **that rotation is the actual
remediation.** This PR only prevents the file from being committed again.

## For reviewers

- The leaked value appears exactly once in history — one file, one commit. Verified
  with `git grep` over `HEAD` and `git log --all -S`.
- **No history rewrite.** The blob stays reachable via `c5cdf8a` and in any clone or
  fork taken during the public windows. Once the key is dead a rewrite buys nothing,
  and until it's dead a rewrite wouldn't help either.
- Merging this does **not** close the exposure. Confirm the Context7 key has been
  revoked and reissued before considering the incident resolved.
- Nothing else with real credential material has ever been committed — only
  `.example` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
