### PR TITLE
fix(alarms): route chat-api and agent-worker infra alarms to SNS

### DIFF
--- a/infra/terraform/cloudwatch.tf
+++ b/infra/terraform/cloudwatch.tf
@@ -206,6 +206,8 @@ resource "aws_cloudwatch_metric_alarm" "chat_api_unhealthy" {
   evaluation_periods  = 3
   threshold           = 0
   comparison_operator = "GreaterThanThreshold"
+  alarm_actions       = var.alarm_action_arns
+  ok_actions          = var.alarm_action_arns
 
   dimensions = {
     LoadBalancer = aws_lb.agent.arn_suffix
@@ -223,6 +225,8 @@ resource "aws_cloudwatch_metric_alarm" "chat_api_cpu_high" {
   evaluation_periods  = 5
   threshold           = 80
   comparison_operator = "GreaterThanThreshold"
+  alarm_actions       = var.alarm_action_arns
+  ok_actions          = var.alarm_action_arns
 
   dimensions = {
     ClusterName = local.shared_ecs_cluster_name
@@ -240,6 +244,8 @@ resource "aws_cloudwatch_metric_alarm" "agent_worker_cpu_high" {
   evaluation_periods  = 5
   threshold           = 80
   comparison_operator = "GreaterThanThreshold"
+  alarm_actions       = var.alarm_action_arns
+  ok_actions          = var.alarm_action_arns
 
   dimensions = {
     ClusterName = local.shared_ecs_cluster_name

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -127,7 +127,7 @@ variable "live_redis_engine_version" {
 }
 
 variable "alarm_action_arns" {
-  description = "Optional SNS topic ARNs notified by Live Stream relay CloudWatch alarms."
+  description = "Optional SNS topic ARNs notified by this stack's CloudWatch alarms."
   type        = list(string)
   default     = []
 }


### PR DESCRIPTION
## What

Adds `alarm_actions` / `ok_actions` to the three infra alarms in `infra/terraform/cloudwatch.tf` that were created without them:

- `chat_api_unhealthy` (`${local.chat_api_name}-unhealthy-hosts`)
- `chat_api_cpu_high`
- `agent_worker_cpu_high`

Six lines, reusing `var.alarm_action_arns` — the same variable the three Live Stream alarms above them already use.

## Why

Verified against production on 2026-08-16:

| Alarm | `AlarmActions` |
|---|---|
| `mymemo-agent-prod-chat-api-live-stream-recovery-rate` | `mymemo-staging-alarms` |
| `mymemo-agent-prod-agent-worker-live-stream-capacity-bound` | `mymemo-staging-alarms` |
| `mymemo-agent-prod-chat-api-unhealthy-hosts` | **`[]`** |
| `mymemo-agent-prod-chat-api-cpu-high` | **`[]`** |
| `mymemo-agent-prod-worker-cpu-high` | **`[]`** |

So the variable is demonstrably wired in prod and these three simply never asked for it. They have never notified anyone since they were created.

`chat_api_unhealthy` is the one that matters: it is the alarm that should have caught the 2026-08-03 upstream relay outage, which ran 2.5h before anyone noticed. The postmortem found two blind spots (`/status` does not cover agent; the heartbeat does not count 5xx) — this was a third one nobody checked, because the usual audit asks "does this SNS topic have a subscriber" and never notices an alarm that points at no topic at all.

Found by:

```bash
aws cloudwatch describe-alarms --region us-west-2 \
  --query 'MetricAlarms[?length(AlarmActions)==`0`].AlarmName' --output text
```

## Risk

None beyond the alarms starting to fire. No resource is replaced; `terraform plan` should show three in-place updates and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)