### PR TITLE
feat(agentcore): gate runtime and dispatch admission

### DIFF
--- a/apps/chat-api/src/config/env.test.ts
+++ b/apps/chat-api/src/config/env.test.ts
@@ -92,6 +92,17 @@ describe("loadApiConfigFromEnv — worker-secret boundary", () => {
 			"kbDatabaseUrl",
 		);
 	});
+
+	it("ignores AgentCore queue and SSM dispatch configuration", () => {
+		const env = baseEnv();
+		env.AGENTCORE_DISPATCH_QUEUE_URL =
+			"https://sqs.us-west-2.amazonaws.com/123/dispatch";
+		env.AGENTCORE_DISPATCH_ENABLED_PARAMETER_NAME = "/mymemo/dispatch/enabled";
+
+		const serialized = JSON.stringify(loadApiConfigFromEnv(env));
+		expect(serialized).not.toContain("sqs.us-west-2.amazonaws.com");
+		expect(serialized).not.toContain("/mymemo/dispatch/enabled");
+	});
 });
 
 describe("loadApiConfigFromEnv — Statsig exposure config", () => {

--- a/apps/chat-api/src/config/env.ts
+++ b/apps/chat-api/src/config/env.ts
@@ -43,16 +43,16 @@ export interface ApiConfig {
 	 */
 	databaseUrl: string;
 	/**
-	 * Statsig server secret backing the production agent exposure gate (MYM-46).
+	 * Statsig server secret backing the production exposure and runtime gates.
 	 * Required unless operator break-glass is on; undefined only in that case.
 	 * Never sent to the sandbox or logged.
 	 */
 	statsigServerSecret: string | undefined;
 	/**
-	 * Operator break-glass for the agent exposure gate. When true, new agent work
-	 * is allowed without Statsig (local dev, or an incident where Statsig is
-	 * unavailable). When false (production default), the gate fails closed and a
-	 * Statsig secret is required. Identity-independent and explicit.
+	 * Operator break-glass for Statsig gating. When true, new agent work is allowed
+	 * without Statsig and every new Conversation selects Fargate (local dev, or an
+	 * incident where Statsig is unavailable). When false (production default), the
+	 * exposure gate fails closed and a Statsig secret is required.
 	 */
 	agentExposureBreakGlass: boolean;
 	/** Required authenticated TLS Redis secret for the Live Stream relay. */
@@ -125,9 +125,9 @@ export function loadApiConfigFromEnv(env: Env): ApiConfig {
 	const artifactRegion = env.AWS_REGION?.trim();
 	assert(artifactRegion, "AWS_REGION is required");
 
-	// Agent exposure (MYM-46) fails closed in production: a Statsig secret is
-	// required unless an operator explicitly enables break-glass (local dev, or an
-	// incident where Statsig is unavailable). The worker-only secrets (OpenRouter,
+	// Statsig exposure fails closed and runtime selection fails safe to Fargate: a
+	// Statsig secret is required unless an operator explicitly enables break-glass
+	// (local dev, or an incident where Statsig is unavailable). Worker-only secrets (OpenRouter,
 	// KB) are intentionally NOT read here — chat-api must not hold them.
 	const agentExposureBreakGlass = env.AGENT_EXPOSURE_BREAK_GLASS === "true";
 	if (!agentExposureBreakGlass) {

--- a/apps/chat-api/src/deps.ts
+++ b/apps/chat-api/src/deps.ts
@@ -28,6 +28,7 @@ import {
 	type ExposureGate,
 } from "./features/exposure-gate";
 import { PostgresRunStore, type RunStore } from "./features/run-store";
+import { createRuntimeGate, type RuntimeGate } from "./features/runtime-gate";
 
 /**
  * Application dependencies, built once from a validated `ApiConfig` at the
@@ -59,6 +60,8 @@ export interface AppDeps {
 	 * parsed and before any write. Fails closed.
 	 */
 	exposureGate: ExposureGate;
+	/** Selects and freezes one execution runtime at Conversation creation. */
+	runtimeGate: RuntimeGate;
 }
 
 /** Hono environment: pino logger vars plus the injected `AppDeps`. */
@@ -100,5 +103,6 @@ export function createDeps(
 		liveStreamTelemetry,
 		closeLiveResources: () => liveStreamRelay.close(),
 		exposureGate: createExposureGate(config),
+		runtimeGate: createRuntimeGate(config),
 	};
 }

--- a/apps/chat-api/src/features/artifacts/artifact-delivery.acceptance.test.ts
+++ b/apps/chat-api/src/features/artifacts/artifact-delivery.acceptance.test.ts
@@ -242,6 +242,7 @@ describe("Downloadable artifact delivery acceptance", () => {
 			await http.conversationStore.create({
 				userId: "member-1",
 				conversationId: "conversation-1",
+				executionRuntime: "fargate",
 				scope: "general",
 				collectionId: null,
 				summaryId: null,
@@ -402,6 +403,7 @@ describe("Downloadable artifact delivery acceptance", () => {
 			await http.conversationStore.create({
 				userId: "member-1",
 				conversationId: "conversation-1",
+				executionRuntime: "fargate",
 				scope: "general",
 				collectionId: null,
 				summaryId: null,

--- a/apps/chat-api/src/features/conversation-history/postgres-conversation-history-store.test.ts
+++ b/apps/chat-api/src/features/conversation-history/postgres-conversation-history-store.test.ts
@@ -917,6 +917,7 @@ describe("PostgresConversationHistoryStore", () => {
 		await conversationStore.create({
 			userId: "member-1",
 			conversationId: "conversation-1",
+			executionRuntime: "fargate",
 			scope: "general",
 			collectionId: null,
 			summaryId: null,

--- a/apps/chat-api/src/features/conversation-store/conversation-store.ts
+++ b/apps/chat-api/src/features/conversation-store/conversation-store.ts
@@ -1,10 +1,12 @@
+import type { ConversationExecutionRuntime } from "@mymemo/agent-db/execution-runtime";
 import type { ChatMessagesScope } from "@/config/env";
 
 /**
  * Durable conversation registry. A conversation record is the source of truth
- * for a conversation's immutable document scope — created once and never
- * re-scoped, so a turn re-derives the same signed scope every time instead of
- * trusting per-request ids. It lives in chat-api's writable `mymemo_agent` DB,
+ * for a conversation's immutable document scope and execution runtime — both
+ * are created once and never changed, so a turn re-derives the same signed
+ * scope every time instead of trusting per-request ids. It lives in chat-api's
+ * writable `mymemo_agent` DB,
  * keyed by `{userId, conversationId}` like the sandbox lease, but is kept in a
  * separate table on purpose: the lease is a disposable optimization the reaper
  * may delete, whereas scope is a correctness/security boundary that must
@@ -25,11 +27,12 @@ export interface ConversationRef {
 }
 
 /** Input used to create a Conversation before database-owned lifecycle metadata
- * has been established. `collectionId`/`summaryId` are non-null only for the
- * matching frozen Scope. */
+ * has been established. The execution runtime and Scope are frozen here;
+ * `collectionId`/`summaryId` are non-null only for the matching Scope. */
 export interface ConversationCreateInput {
 	userId: string;
 	conversationId: string;
+	executionRuntime: ConversationExecutionRuntime;
 	scope: ConversationScope;
 	collectionId: string | null;
 	summaryId: string | null;

--- a/apps/chat-api/src/features/conversation-store/postgres-conversation-store.test.ts
+++ b/apps/chat-api/src/features/conversation-store/postgres-conversation-store.test.ts
@@ -16,6 +16,7 @@ import { PostgresConversationStore } from "./postgres-conversation-store";
 const collectionConversation: ConversationCreateInput = {
 	userId: "user-1",
 	conversationId: "conv-1",
+	executionRuntime: "fargate",
 	scope: "collection",
 	collectionId: "col-1",
 	summaryId: null,
@@ -69,10 +70,26 @@ describe("PostgresConversationStore", () => {
 		expect(row?.executionRuntime).toBe("fargate");
 	});
 
+	it("persists the selected AgentCore runtime without exposing an update path", async () => {
+		await store.create({
+			...collectionConversation,
+			conversationId: "agentcore-conversation",
+			executionRuntime: "agentcore",
+		});
+
+		await expect(
+			store.get({
+				userId: "user-1",
+				conversationId: "agentcore-conversation",
+			}),
+		).resolves.toMatchObject({ executionRuntime: "agentcore" });
+	});
+
 	it("round-trips general and document scopes with null id columns", async () => {
 		await store.create({
 			userId: "u",
 			conversationId: "general",
+			executionRuntime: "fargate",
 			scope: "general",
 			collectionId: null,
 			summaryId: null,
@@ -80,6 +97,7 @@ describe("PostgresConversationStore", () => {
 		await store.create({
 			userId: "u",
 			conversationId: "doc",
+			executionRuntime: "fargate",
 			scope: "document",
 			collectionId: null,
 			summaryId: "sum-9",

--- a/apps/chat-api/src/features/conversation-store/postgres-conversation-store.ts
+++ b/apps/chat-api/src/features/conversation-store/postgres-conversation-store.ts
@@ -66,6 +66,7 @@ export class PostgresConversationStore implements ConversationStore {
 			.values({
 				userId: record.userId,
 				conversationId: record.conversationId,
+				executionRuntime: record.executionRuntime,
 				scope: record.scope,
 				collectionId: record.collectionId,
 				summaryId: record.summaryId,

--- a/apps/chat-api/src/features/conversations/conversations.controller.test.ts
+++ b/apps/chat-api/src/features/conversations/conversations.controller.test.ts
@@ -42,6 +42,7 @@ function fakeStore() {
 const conversation: ConversationRecord = {
 	userId: "member-1",
 	conversationId: "conv-1",
+	executionRuntime: "fargate",
 	scope: "general",
 	collectionId: null,
 	summaryId: null,
@@ -58,6 +59,7 @@ describe("createConversation", () => {
 			store,
 			{ memberCode: "member-1", partnerCode: "partner-1" },
 			{},
+			"fargate",
 		);
 
 		expect(result.scope).toBe("general");
@@ -76,6 +78,7 @@ describe("createConversation", () => {
 			store,
 			{ memberCode: "member-1", partnerCode: "partner-1" },
 			{ collectionId: " col-9 " },
+			"fargate",
 		);
 
 		expect(result.scope).toBe("collection");
@@ -91,6 +94,7 @@ describe("createConversation", () => {
 			store,
 			{ memberCode: "member-1", partnerCode: "partner-1" },
 			{ collectionId: "col-9", summaryId: "sum-3" },
+			"fargate",
 		);
 
 		expect(result.scope).toBe("document");

--- a/apps/chat-api/src/features/conversations/conversations.controller.ts
+++ b/apps/chat-api/src/features/conversations/conversations.controller.ts
@@ -1,3 +1,4 @@
+import type { ConversationExecutionRuntime } from "@mymemo/agent-db/execution-runtime";
 import type { AppDeps } from "@/deps";
 import type {
 	ConversationRecord,
@@ -42,6 +43,7 @@ export async function createConversation(
 	store: ConversationStore,
 	identity: InternalIdentity,
 	body: { collectionId?: string | null; summaryId?: string | null },
+	executionRuntime: ConversationExecutionRuntime,
 ): Promise<ConversationSummary> {
 	const conversationId = crypto.randomUUID();
 	const collectionId = body.collectionId?.trim() || null;
@@ -57,6 +59,7 @@ export async function createConversation(
 	const conversation = await store.create({
 		userId: identity.memberCode,
 		conversationId,
+		executionRuntime,
 		scope,
 		collectionId,
 		summaryId,

--- a/apps/chat-api/src/features/conversations/conversations.route.test.ts
+++ b/apps/chat-api/src/features/conversations/conversations.route.test.ts
@@ -218,7 +218,7 @@ function fakeRunStore() {
 }
 
 function transactionalAdmissionFake(
-	executionRuntime: ConversationExecutionRuntime,
+	conversationStore: ConversationStore,
 	failure?: "run" | "dispatch",
 ) {
 	const admittedRuns = new Map<string, RunRecord>();
@@ -234,6 +234,8 @@ function transactionalAdmissionFake(
 			const existing = admittedRuns.get(input.runId);
 			if (existing) return { outcome: "existing", run: existing };
 			if (failure === "run") throw new Error("Run admission failed");
+			const conversation = await conversationStore.get(input.conversation);
+			if (!conversation) throw new Error("Conversation not found");
 
 			const run = runRecord({
 				runId: input.runId,
@@ -241,7 +243,7 @@ function transactionalAdmissionFake(
 				conversationId: input.conversation.conversationId,
 				status: "done",
 			});
-			const recordsDispatch = executionRuntime === "agentcore";
+			const recordsDispatch = conversation.executionRuntime === "agentcore";
 			if (recordsDispatch && failure === "dispatch") {
 				throw new Error("dispatch recording failed");
 			}
@@ -1407,7 +1409,7 @@ describe("POST /v1/conversations/:id/runs", () => {
 describe("Run dispatch admission through HTTP", () => {
 	it("records one AgentCore dispatch and reattaches an exact retry", async () => {
 		const { store } = fakeStore([persistedConversation("agentcore")]);
-		const admission = transactionalAdmissionFake("agentcore");
+		const admission = transactionalAdmissionFake(store);
 		const exposure = recordingGate(true);
 		const app = buildApp(store, exposure.gate, {
 			...fakeRunStore(),
@@ -1434,7 +1436,7 @@ describe("Run dispatch admission through HTTP", () => {
 
 	it("admits a Fargate Run without a dispatch", async () => {
 		const { store } = fakeStore([persistedConversation("fargate")]);
-		const admission = transactionalAdmissionFake("fargate");
+		const admission = transactionalAdmissionFake(store);
 		const app = buildApp(store, recordingGate(true).gate, {
 			...fakeRunStore(),
 			runStore: admission.runStore,
@@ -1456,7 +1458,7 @@ describe("Run dispatch admission through HTTP", () => {
 		"dispatch",
 	] as const)("leaves neither an AgentCore Run nor dispatch when %s recording fails", async (failure) => {
 		const { store } = fakeStore([persistedConversation("agentcore")]);
-		const admission = transactionalAdmissionFake("agentcore", failure);
+		const admission = transactionalAdmissionFake(store, failure);
 		const app = buildApp(store, recordingGate(true).gate, {
 			...fakeRunStore(),
 			runStore: admission.runStore,

--- a/apps/chat-api/src/features/conversations/conversations.route.test.ts
+++ b/apps/chat-api/src/features/conversations/conversations.route.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { EventType } from "@ag-ui/core";
+import type { ConversationExecutionRuntime } from "@mymemo/agent-db/execution-runtime";
 import {
 	createInMemoryLiveStreamRelay,
 	createLiveStreamTelemetry,
@@ -25,6 +26,12 @@ import {
 	type RunRecord,
 	type RunStore,
 } from "@/features/run-store";
+import {
+	BreakGlassRuntimeGate,
+	type RuntimeGate,
+	type StatsigClientLike as RuntimeStatsigClientLike,
+	StatsigRuntimeGate,
+} from "@/features/runtime-gate";
 import type { InternalIdentity } from "./conversations.schema";
 
 const { createApp } = await import("@/app");
@@ -89,17 +96,30 @@ function gateThatFailsIfConsulted(): ExposureGate {
 	};
 }
 
+function recordingRuntimeGate(executionRuntime: ConversationExecutionRuntime) {
+	const seen: InternalIdentity[] = [];
+	const gate: RuntimeGate = {
+		async selectRuntime(identity) {
+			seen.push(identity);
+			return executionRuntime;
+		},
+	};
+	return { gate, seen };
+}
+
 function buildApp(
 	conversationStore: ConversationStore,
 	exposureGate: ExposureGate = recordingGate(true).gate,
 	fakeRuns = fakeRunStore(),
 	liveStreamRelay: LiveStreamRelay = createInMemoryLiveStreamRelay(),
 	liveStreamTelemetry: LiveStreamTelemetry = silentLiveStreamTelemetry,
+	runtimeGate: RuntimeGate = recordingRuntimeGate("fargate").gate,
 ) {
 	const deps = {
 		config: {},
 		conversationStore,
 		exposureGate,
+		runtimeGate,
 		runStore: fakeRuns.runStore,
 		liveStreamRelay,
 		liveStreamTelemetry,
@@ -194,6 +214,72 @@ function fakeRunStore() {
 		runStore,
 		runOwners,
 		interruptions,
+	};
+}
+
+function transactionalAdmissionFake(
+	executionRuntime: ConversationExecutionRuntime,
+	failure?: "run" | "dispatch",
+) {
+	const admittedRuns = new Map<string, RunRecord>();
+	const dispatchRunIds = new Set<string>();
+	const runStore: RunStore = {
+		async getRun({ userId, conversationId, runId }) {
+			const run = admittedRuns.get(runId);
+			return run?.userId === userId && run.conversationId === conversationId
+				? run
+				: null;
+		},
+		async admitRun(input) {
+			const existing = admittedRuns.get(input.runId);
+			if (existing) return { outcome: "existing", run: existing };
+			if (failure === "run") throw new Error("Run admission failed");
+
+			const run = runRecord({
+				runId: input.runId,
+				userId: input.conversation.userId,
+				conversationId: input.conversation.conversationId,
+				status: "done",
+			});
+			const recordsDispatch = executionRuntime === "agentcore";
+			if (recordsDispatch && failure === "dispatch") {
+				throw new Error("dispatch recording failed");
+			}
+
+			admittedRuns.set(input.runId, run);
+			if (recordsDispatch) dispatchRunIds.add(input.runId);
+			return { outcome: "created", run };
+		},
+		async requestInterruption() {
+			return { outcome: "not_found" };
+		},
+	};
+	return {
+		runStore,
+		get runIds() {
+			return [...admittedRuns.keys()];
+		},
+		get dispatchRunIds() {
+			return [...dispatchRunIds];
+		},
+	};
+}
+
+function persistedConversation(
+	executionRuntime: ConversationExecutionRuntime,
+): ConversationRecord {
+	const createdAt = new Date("2026-01-01T00:00:00.000Z");
+	return {
+		userId: "member-1",
+		conversationId: "conv-1",
+		executionRuntime,
+		scope: "general",
+		collectionId: null,
+		summaryId: null,
+		title: null,
+		createdAt,
+		lastActivityAt: createdAt,
+		archivedAt: null,
 	};
 }
 
@@ -570,6 +656,7 @@ describe("PATCH /v1/conversations/:id", () => {
 			await store.create({
 				userId: "member-1",
 				conversationId: "conv-lifecycle",
+				executionRuntime: "fargate",
 				scope: "general",
 				collectionId: null,
 				summaryId: null,
@@ -652,6 +739,7 @@ describe("PATCH /v1/conversations/:id", () => {
 			await store.create({
 				userId: "member-1",
 				conversationId: "conv-archive-race",
+				executionRuntime: "fargate",
 				scope: "general",
 				collectionId: null,
 				summaryId: null,
@@ -659,6 +747,7 @@ describe("PATCH /v1/conversations/:id", () => {
 			await store.create({
 				userId: "member-1",
 				conversationId: "conv-unarchive-race",
+				executionRuntime: "fargate",
 				scope: "general",
 				collectionId: null,
 				summaryId: null,
@@ -751,6 +840,7 @@ describe("PATCH /v1/conversations/:id", () => {
 			await store.create({
 				userId: "other-member",
 				conversationId: "foreign-conversation",
+				executionRuntime: "fargate",
 				scope: "general",
 				collectionId: null,
 				summaryId: null,
@@ -868,6 +958,7 @@ describe("DELETE /v1/conversations/:id", () => {
 			await store.create({
 				userId: "member-1",
 				conversationId: "conv-delete",
+				executionRuntime: "fargate",
 				scope: "general",
 				collectionId: null,
 				summaryId: null,
@@ -937,6 +1028,7 @@ describe("DELETE /v1/conversations/:id", () => {
 			await store.create({
 				userId: "member-1",
 				conversationId: "conv-delete-race",
+				executionRuntime: "fargate",
 				scope: "general",
 				collectionId: null,
 				summaryId: null,
@@ -986,6 +1078,7 @@ describe("POST /v1/conversations/:id/runs", () => {
 	const existing: ConversationRecord = {
 		userId: "member-1",
 		conversationId: "conv-1",
+		executionRuntime: "fargate",
 		scope: "general",
 		collectionId: null,
 		summaryId: null,
@@ -1311,10 +1404,81 @@ describe("POST /v1/conversations/:id/runs", () => {
 	});
 });
 
+describe("Run dispatch admission through HTTP", () => {
+	it("records one AgentCore dispatch and reattaches an exact retry", async () => {
+		const { store } = fakeStore([persistedConversation("agentcore")]);
+		const admission = transactionalAdmissionFake("agentcore");
+		const exposure = recordingGate(true);
+		const app = buildApp(store, exposure.gate, {
+			...fakeRunStore(),
+			runStore: admission.runStore,
+		});
+
+		const first = await app.request("/v1/conversations/conv-1/runs", {
+			method: "POST",
+			headers: identityHeaders,
+			body: JSON.stringify(agUiRunInput()),
+		});
+		const retry = await app.request("/v1/conversations/conv-1/runs", {
+			method: "POST",
+			headers: identityHeaders,
+			body: JSON.stringify(agUiRunInput()),
+		});
+
+		expect(first.status).toBe(410);
+		expect(retry.status).toBe(410);
+		expect(admission.runIds).toEqual(["client-run-1"]);
+		expect(admission.dispatchRunIds).toEqual(["client-run-1"]);
+		expect(exposure.seen).toHaveLength(1);
+	});
+
+	it("admits a Fargate Run without a dispatch", async () => {
+		const { store } = fakeStore([persistedConversation("fargate")]);
+		const admission = transactionalAdmissionFake("fargate");
+		const app = buildApp(store, recordingGate(true).gate, {
+			...fakeRunStore(),
+			runStore: admission.runStore,
+		});
+
+		const response = await app.request("/v1/conversations/conv-1/runs", {
+			method: "POST",
+			headers: identityHeaders,
+			body: JSON.stringify(agUiRunInput()),
+		});
+
+		expect(response.status).toBe(410);
+		expect(admission.runIds).toEqual(["client-run-1"]);
+		expect(admission.dispatchRunIds).toEqual([]);
+	});
+
+	it.each([
+		"run",
+		"dispatch",
+	] as const)("leaves neither an AgentCore Run nor dispatch when %s recording fails", async (failure) => {
+		const { store } = fakeStore([persistedConversation("agentcore")]);
+		const admission = transactionalAdmissionFake("agentcore", failure);
+		const app = buildApp(store, recordingGate(true).gate, {
+			...fakeRunStore(),
+			runStore: admission.runStore,
+		});
+
+		const response = await app.request("/v1/conversations/conv-1/runs", {
+			method: "POST",
+			headers: identityHeaders,
+			body: JSON.stringify(agUiRunInput()),
+		});
+
+		expect(response.status).toBe(500);
+		expect(admission.runIds).toEqual([]);
+		expect(admission.dispatchRunIds).toEqual([]);
+	});
+});
+
 describe("POST /v1/conversations/:id/runs/:runId/interrupt", () => {
 	const existing: ConversationRecord = {
 		userId: "member-1",
 		conversationId: "conv-1",
+		executionRuntime: "fargate",
 		scope: "general",
 		collectionId: null,
 		summaryId: null,
@@ -1458,6 +1622,7 @@ describe("GET /v1/conversations/:id/runs/:runId/events", () => {
 	const existing: ConversationRecord = {
 		userId: "member-1",
 		conversationId: "conv-1",
+		executionRuntime: "fargate",
 		scope: "general",
 		collectionId: null,
 		summaryId: null,
@@ -1962,5 +2127,131 @@ describe("exposure gate (MYM-46)", () => {
 		});
 		expect(res.status).toBe(401);
 		expect(seen).toHaveLength(0);
+	});
+});
+
+describe("Conversation execution runtime gate", () => {
+	it.each([
+		["gate on", recordingRuntimeGate("agentcore").gate, "agentcore"],
+		["gate off", recordingRuntimeGate("fargate").gate, "fargate"],
+		[
+			"Statsig error",
+			new StatsigRuntimeGate({
+				initialize: async () => {
+					throw new Error("Statsig unavailable");
+				},
+				checkGate: () => true,
+			} satisfies RuntimeStatsigClientLike),
+			"fargate",
+		],
+		["break-glass", new BreakGlassRuntimeGate(), "fargate"],
+	] as const)("stamps %s selection exactly once at Conversation creation", async (_condition, runtimeGate, expectedRuntime) => {
+		const { store, created } = fakeStore();
+		const res = await buildApp(
+			store,
+			recordingGate(true).gate,
+			fakeRunStore(),
+			createInMemoryLiveStreamRelay(),
+			silentLiveStreamTelemetry,
+			runtimeGate,
+		).request("/v1/conversations", {
+			method: "POST",
+			headers: identityHeaders,
+			body: JSON.stringify({}),
+		});
+
+		expect(res.status).toBe(201);
+		expect(created).toHaveLength(1);
+		expect(created[0]?.executionRuntime).toBe(expectedRuntime);
+	});
+
+	it("evaluates runtime selection after exposure allows", async () => {
+		const order: string[] = [];
+		const { store } = fakeStore();
+		const exposureGate: ExposureGate = {
+			async isAgentEnabled() {
+				order.push("exposure");
+				return true;
+			},
+		};
+		const runtimeGate: RuntimeGate = {
+			async selectRuntime() {
+				order.push("runtime");
+				return "agentcore";
+			},
+		};
+
+		const res = await buildApp(
+			store,
+			exposureGate,
+			fakeRunStore(),
+			createInMemoryLiveStreamRelay(),
+			silentLiveStreamTelemetry,
+			runtimeGate,
+		).request("/v1/conversations", {
+			method: "POST",
+			headers: identityHeaders,
+			body: JSON.stringify({}),
+		});
+
+		expect(res.status).toBe(201);
+		expect(order).toEqual(["exposure", "runtime"]);
+	});
+
+	it("never re-evaluates the frozen runtime during later Run admission", async () => {
+		const { store } = fakeStore();
+		let runtimeGateCalls = 0;
+		const runtimeGate: RuntimeGate = {
+			async selectRuntime() {
+				runtimeGateCalls++;
+				if (runtimeGateCalls > 1) {
+					throw new Error(
+						"runtime gate must only run at Conversation creation",
+					);
+				}
+				return "agentcore";
+			},
+		};
+		const fakeRuns = fakeRunStore();
+		fakeRuns.runStore.admitRun = async (input) => {
+			return {
+				outcome: "created",
+				run: runRecord({
+					runId: input.runId,
+					userId: input.conversation.userId,
+					conversationId: input.conversation.conversationId,
+					status: "done",
+				}),
+			};
+		};
+		const app = buildApp(
+			store,
+			recordingGate(true).gate,
+			fakeRuns,
+			createInMemoryLiveStreamRelay(),
+			silentLiveStreamTelemetry,
+			runtimeGate,
+		);
+
+		const created = await app.request("/v1/conversations", {
+			method: "POST",
+			headers: identityHeaders,
+			body: JSON.stringify({}),
+		});
+		const { conversationId } = (await created.json()) as {
+			conversationId: string;
+		};
+		const admitted = await app.request(
+			`/v1/conversations/${conversationId}/runs`,
+			{
+				method: "POST",
+				headers: identityHeaders,
+				body: JSON.stringify(agUiRunInput({ threadId: conversationId })),
+			},
+		);
+
+		expect(created.status).toBe(201);
+		expect(admitted.status).toBe(410);
+		expect(runtimeGateCalls).toBe(1);
 	});
 });

--- a/apps/chat-api/src/features/conversations/conversations.route.ts
+++ b/apps/chat-api/src/features/conversations/conversations.route.ts
@@ -545,11 +545,15 @@ app.post(
 		if (!(await c.var.deps.exposureGate.isAgentEnabled(identity.data))) {
 			return c.json({ error: "Agent is not enabled" }, 403);
 		}
+		const executionRuntime = await c.var.deps.runtimeGate.selectRuntime(
+			identity.data,
+		);
 
 		const result = await createConversation(
 			c.var.deps.conversationStore,
 			identity.data,
 			c.req.valid("json"),
+			executionRuntime,
 		);
 		return c.json(result, 201);
 	},

--- a/apps/chat-api/src/features/exposure-gate/exposure-gate.ts
+++ b/apps/chat-api/src/features/exposure-gate/exposure-gate.ts
@@ -1,5 +1,12 @@
-import { Statsig, StatsigUser } from "@statsig/statsig-node-core";
 import type { InternalIdentity } from "@/features/conversations/conversations.schema";
+import {
+	createStatsigClient,
+	type GateLogger,
+	StatsigBooleanGate,
+	type StatsigClientLike,
+} from "@/features/statsig-gate";
+
+export type { StatsigClientLike } from "@/features/statsig-gate";
 
 /** The server-side gate name that controls split-runtime agent exposure. */
 export const AGENT_EXPOSURE_GATE = "mymemo_agent_split_runtime_enabled";
@@ -28,20 +35,6 @@ export class BreakGlassExposureGate implements ExposureGate {
 }
 
 /**
- * The narrow slice of the Statsig client the gate depends on. Lets tests inject
- * a fake for fail-closed paths while production passes the real `Statsig`.
- */
-export interface StatsigClientLike {
-	initialize(): Promise<unknown>;
-	checkGate(user: StatsigUser, gateName: string): boolean;
-}
-
-/** Minimal logger seam; the route logger satisfies it. */
-interface GateLogger {
-	error(obj: Record<string, unknown>): void;
-}
-
-/**
  * Statsig-backed production gate. Fails CLOSED: if initialization fails or an
  * evaluation throws, new work is denied. The Statsig secret is never logged.
  *
@@ -53,54 +46,23 @@ interface GateLogger {
  * I/O fires at import.
  */
 export class StatsigExposureGate implements ExposureGate {
-	/** Resolves true once Statsig is initialized; false if init failed. */
-	private readonly ready: Promise<boolean>;
+	private readonly gate: StatsigBooleanGate;
 
-	constructor(
-		private readonly client: StatsigClientLike,
-		private readonly logger?: GateLogger,
-	) {
-		this.ready = client
-			.initialize()
-			.then(() => true)
-			.catch((error) => {
-				this.logger?.error({
-					message: "Statsig initialization failed; failing closed",
-					error: error instanceof Error ? error.message : String(error),
-				});
-				return false;
-			});
+	constructor(client: StatsigClientLike, logger?: GateLogger) {
+		this.gate = new StatsigBooleanGate(
+			client,
+			AGENT_EXPOSURE_GATE,
+			{
+				initialization: "Statsig initialization failed; failing closed",
+				evaluation: "Statsig gate evaluation failed; failing closed",
+			},
+			logger,
+		);
 	}
 
 	async isAgentEnabled(identity: InternalIdentity): Promise<boolean> {
-		if (!(await this.ready)) return false;
-		try {
-			const user = buildStatsigUser(identity);
-			return this.client.checkGate(user, AGENT_EXPOSURE_GATE);
-		} catch (error) {
-			this.logger?.error({
-				message: "Statsig gate evaluation failed; failing closed",
-				error: error instanceof Error ? error.message : String(error),
-			});
-			return false;
-		}
+		return this.gate.isEnabled(identity);
 	}
-}
-
-/**
- * Build the Statsig user from trusted identity headers only. `memberCode` is the
- * stable user id; partner/team ride along as targeting attributes. Body fields
- * never reach here — the route derives identity from headers.
- */
-function buildStatsigUser(identity: InternalIdentity): StatsigUser {
-	return new StatsigUser({
-		userID: identity.memberCode,
-		customIDs: { partnerCode: identity.partnerCode },
-		custom: {
-			partnerCode: identity.partnerCode,
-			...(identity.teamCode ? { teamCode: identity.teamCode } : {}),
-		},
-	});
 }
 
 /**
@@ -113,12 +75,8 @@ export function createStatsigExposureGate(
 	options: { environment?: string } = {},
 	logger?: GateLogger,
 ): StatsigExposureGate {
-	const statsig = new Statsig(serverSecret, {
-		environment: options.environment,
-		outputLogLevel: "warn",
-	});
 	return new StatsigExposureGate(
-		statsig as unknown as StatsigClientLike,
+		createStatsigClient(serverSecret, options),
 		logger,
 	);
 }

--- a/apps/chat-api/src/features/run-store/postgres-run-store.test.ts
+++ b/apps/chat-api/src/features/run-store/postgres-run-store.test.ts
@@ -1,7 +1,12 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
 import { loadRunStartedTx } from "@mymemo/agent-db/run-store";
 import { eq } from "drizzle-orm";
-import { conversations, runEvents, runs } from "@/db/schema";
+import {
+	agentCoreDispatchOutbox,
+	conversations,
+	runEvents,
+	runs,
+} from "@/db/schema";
 import { createTestDatabase, type TestDb } from "@/db/testing";
 import {
 	type ConversationRecord,
@@ -19,6 +24,7 @@ const initialActivity = new Date("2026-01-01T00:00:00.000Z");
 const conversation: ConversationRecord = {
 	userId: "user-1",
 	conversationId: "conv-1",
+	executionRuntime: "fargate",
 	scope: "collection",
 	collectionId: "col-1",
 	summaryId: null,
@@ -55,6 +61,7 @@ describe("PostgresRunStore", () => {
 	afterAll(() => tdb.close());
 
 	afterEach(async () => {
+		await tdb.db.delete(agentCoreDispatchOutbox);
 		await tdb.db.delete(runs); // cascades run_events
 		await tdb.db
 			.insert(conversations)
@@ -62,6 +69,7 @@ describe("PostgresRunStore", () => {
 			.onConflictDoUpdate({
 				target: [conversations.userId, conversations.conversationId],
 				set: {
+					executionRuntime: "fargate",
 					title: null,
 					lastActivityAt: initialActivity,
 					archivedAt: null,
@@ -106,6 +114,99 @@ describe("PostgresRunStore", () => {
 			collectionId: "col-1",
 			summaryId: null,
 		});
+	});
+
+	it("records one dispatch with a newly admitted AgentCore Run", async () => {
+		await tdb.db
+			.update(conversations)
+			.set({ executionRuntime: "agentcore" })
+			.where(eq(conversations.conversationId, "conv-1"));
+
+		await expect(
+			store.admitRun(runInput("run-agentcore", "hello AgentCore")),
+		).resolves.toMatchObject({ outcome: "created" });
+
+		expect(await tdb.db.select().from(runs)).toMatchObject([
+			{ runId: "run-agentcore", status: "queued" },
+		]);
+		expect(await tdb.db.select().from(agentCoreDispatchOutbox)).toMatchObject([
+			{
+				runId: "run-agentcore",
+				userId: "user-1",
+				conversationId: "conv-1",
+			},
+		]);
+	});
+
+	it("reattaches an exact AgentCore retry without a second dispatch", async () => {
+		await tdb.db
+			.update(conversations)
+			.set({ executionRuntime: "agentcore" })
+			.where(eq(conversations.conversationId, "conv-1"));
+		const input = runInput("run-agentcore-retry", "retry-safe work");
+
+		await expect(store.admitRun(input)).resolves.toMatchObject({
+			outcome: "created",
+		});
+		await expect(store.admitRun(input)).resolves.toMatchObject({
+			outcome: "existing",
+		});
+
+		expect(await tdb.db.select().from(agentCoreDispatchOutbox)).toHaveLength(1);
+	});
+
+	it("does not record a dispatch for a Fargate Run", async () => {
+		await expect(
+			store.admitRun(runInput("run-fargate", "stay on Fargate")),
+		).resolves.toMatchObject({ outcome: "created" });
+
+		expect(await tdb.db.select().from(agentCoreDispatchOutbox)).toEqual([]);
+	});
+
+	it("rolls back an AgentCore Run when dispatch recording fails", async () => {
+		await tdb.db
+			.update(conversations)
+			.set({ executionRuntime: "agentcore" })
+			.where(eq(conversations.conversationId, "conv-1"));
+		await tdb.db.insert(agentCoreDispatchOutbox).values({
+			runId: "run-dispatch-conflict",
+			userId: "preexisting-user",
+			conversationId: "preexisting-conversation",
+		});
+
+		await expect(
+			store.admitRun(
+				runInput("run-dispatch-conflict", "must roll back with dispatch"),
+			),
+		).rejects.toThrow();
+
+		expect(await tdb.db.select().from(runs)).toEqual([]);
+		expect(await tdb.db.select().from(runEvents)).toEqual([]);
+		expect(await tdb.db.select().from(agentCoreDispatchOutbox)).toMatchObject([
+			{
+				runId: "run-dispatch-conflict",
+				userId: "preexisting-user",
+			},
+		]);
+	});
+
+	it("does not record a dispatch when AgentCore Run admission rolls back", async () => {
+		await tdb.db
+			.update(conversations)
+			.set({ executionRuntime: "agentcore" })
+			.where(eq(conversations.conversationId, "conv-1"));
+		await store.admitRun(runInput("run-active", "first"));
+
+		await expect(
+			store.admitRun(runInput("run-rejected", "must not dispatch")),
+		).rejects.toBeInstanceOf(ActiveRunExistsError);
+
+		expect(
+			await tdb.db
+				.select()
+				.from(agentCoreDispatchOutbox)
+				.where(eq(agentCoreDispatchOutbox.runId, "run-rejected")),
+		).toEqual([]);
 	});
 
 	it("idempotently admits one canonical AG-UI Run input", async () => {

--- a/apps/chat-api/src/features/run-store/run-store.ts
+++ b/apps/chat-api/src/features/run-store/run-store.ts
@@ -1,3 +1,5 @@
+import { recordAgentCoreDispatchInTx } from "@mymemo/agent-db/agentcore-dispatch";
+import { AGENTCORE_EXECUTION_RUNTIME } from "@mymemo/agent-db/execution-runtime";
 import {
 	ActiveRunConflictError,
 	admitQueuedRunInTx,
@@ -136,6 +138,13 @@ export async function admitRunTx(
 				summaryId: conversation.summaryId,
 			});
 			if (admission.outcome === "created") {
+				if (conversation.executionRuntime === AGENTCORE_EXECUTION_RUNTIME) {
+					await recordAgentCoreDispatchInTx(tx, {
+						userId: conversation.userId,
+						conversationId: conversation.conversationId,
+						runId: admission.run.runId,
+					});
+				}
 				await tx
 					.update(conversations)
 					.set({

--- a/apps/chat-api/src/features/runtime-gate/index.ts
+++ b/apps/chat-api/src/features/runtime-gate/index.ts
@@ -1,0 +1,32 @@
+import type { ApiConfig } from "@/config/env";
+import {
+	BreakGlassRuntimeGate,
+	createStatsigRuntimeGate,
+	type RuntimeGate,
+} from "./runtime-gate";
+
+export {
+	AGENTCORE_RUNTIME_GATE,
+	BreakGlassRuntimeGate,
+	type RuntimeGate,
+	type StatsigClientLike,
+	StatsigRuntimeGate,
+} from "./runtime-gate";
+
+interface GateLogger {
+	error(obj: Record<string, unknown>): void;
+}
+
+export function createRuntimeGate(
+	config: ApiConfig,
+	logger?: GateLogger,
+): RuntimeGate {
+	if (config.agentExposureBreakGlass) {
+		return new BreakGlassRuntimeGate();
+	}
+	return createStatsigRuntimeGate(
+		config.statsigServerSecret as string,
+		{},
+		logger,
+	);
+}

--- a/apps/chat-api/src/features/runtime-gate/runtime-gate.test.ts
+++ b/apps/chat-api/src/features/runtime-gate/runtime-gate.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "bun:test";
+import type { ApiConfig } from "@/config/env";
+import type { InternalIdentity } from "@/features/conversations/conversations.schema";
+import { createRuntimeGate } from "./index";
+import {
+	AGENTCORE_RUNTIME_GATE,
+	BreakGlassRuntimeGate,
+	type StatsigClientLike,
+	StatsigRuntimeGate,
+} from "./runtime-gate";
+
+const identity: InternalIdentity = {
+	memberCode: "member-1",
+	partnerCode: "partner-1",
+	teamCode: "team-1",
+};
+
+describe("StatsigRuntimeGate", () => {
+	it.each([
+		[true, "agentcore"],
+		[false, "fargate"],
+	] as const)("selects the frozen execution runtime from a %s gate decision", async (decision, expectedRuntime) => {
+		const seen: Array<{ userID: string | null; gate: string }> = [];
+		const client: StatsigClientLike = {
+			initialize: async () => {},
+			checkGate: (user, gate) => {
+				seen.push({ userID: user.userID, gate });
+				return decision;
+			},
+		};
+
+		const gate = new StatsigRuntimeGate(client);
+
+		await expect(gate.selectRuntime(identity)).resolves.toBe(expectedRuntime);
+		expect(seen).toEqual([
+			{ userID: "member-1", gate: AGENTCORE_RUNTIME_GATE },
+		]);
+	});
+
+	it.each([
+		[
+			"initialization failure",
+			{
+				initialize: async () => {
+					throw new Error("Statsig unavailable");
+				},
+				checkGate: () => true,
+			} satisfies StatsigClientLike,
+		],
+		[
+			"evaluation failure",
+			{
+				initialize: async () => {},
+				checkGate: () => {
+					throw new Error("evaluation failed");
+				},
+			} satisfies StatsigClientLike,
+		],
+	] as const)("fails safe to Fargate on %s", async (_name, client) => {
+		const gate = new StatsigRuntimeGate(client);
+
+		await expect(gate.selectRuntime(identity)).resolves.toBe("fargate");
+	});
+});
+
+describe("BreakGlassRuntimeGate", () => {
+	it("always selects Fargate without consulting Statsig", async () => {
+		const gate = new BreakGlassRuntimeGate();
+
+		await expect(gate.selectRuntime(identity)).resolves.toBe("fargate");
+	});
+
+	it("is selected by break-glass configuration without a Statsig secret", async () => {
+		const gate = createRuntimeGate({
+			agentExposureBreakGlass: true,
+			statsigServerSecret: undefined,
+		} as ApiConfig);
+
+		await expect(gate.selectRuntime(identity)).resolves.toBe("fargate");
+	});
+});

--- a/apps/chat-api/src/features/runtime-gate/runtime-gate.ts
+++ b/apps/chat-api/src/features/runtime-gate/runtime-gate.ts
@@ -1,0 +1,68 @@
+import {
+	AGENTCORE_EXECUTION_RUNTIME,
+	type ConversationExecutionRuntime,
+	FARGATE_EXECUTION_RUNTIME,
+} from "@mymemo/agent-db/execution-runtime";
+import type { InternalIdentity } from "@/features/conversations/conversations.schema";
+import {
+	createStatsigClient,
+	type GateLogger,
+	StatsigBooleanGate,
+	type StatsigClientLike,
+} from "@/features/statsig-gate";
+
+export type { StatsigClientLike } from "@/features/statsig-gate";
+
+/** Dedicated server-side gate for immutable Conversation runtime selection. */
+export const AGENTCORE_RUNTIME_GATE = "mymemo_agent_agentcore_runtime_enabled";
+
+export interface RuntimeGate {
+	selectRuntime(
+		identity: InternalIdentity,
+	): Promise<ConversationExecutionRuntime>;
+}
+
+/** Operator break-glass keeps new Conversations on the proven Fargate path. */
+export class BreakGlassRuntimeGate implements RuntimeGate {
+	async selectRuntime(
+		_identity: InternalIdentity,
+	): Promise<ConversationExecutionRuntime> {
+		return FARGATE_EXECUTION_RUNTIME;
+	}
+}
+
+export class StatsigRuntimeGate implements RuntimeGate {
+	private readonly gate: StatsigBooleanGate;
+
+	constructor(client: StatsigClientLike, logger?: GateLogger) {
+		this.gate = new StatsigBooleanGate(
+			client,
+			AGENTCORE_RUNTIME_GATE,
+			{
+				initialization:
+					"Statsig runtime gate initialization failed; selecting Fargate",
+				evaluation: "Statsig runtime gate evaluation failed; selecting Fargate",
+			},
+			logger,
+		);
+	}
+
+	async selectRuntime(
+		identity: InternalIdentity,
+	): Promise<ConversationExecutionRuntime> {
+		return (await this.gate.isEnabled(identity))
+			? AGENTCORE_EXECUTION_RUNTIME
+			: FARGATE_EXECUTION_RUNTIME;
+	}
+}
+
+export function createStatsigRuntimeGate(
+	serverSecret: string,
+	options: { environment?: string } = {},
+	logger?: GateLogger,
+): StatsigRuntimeGate {
+	return new StatsigRuntimeGate(
+		createStatsigClient(serverSecret, options),
+		logger,
+	);
+}

--- a/apps/chat-api/src/features/statsig-gate.ts
+++ b/apps/chat-api/src/features/statsig-gate.ts
@@ -1,0 +1,78 @@
+import { Statsig, StatsigUser } from "@statsig/statsig-node-core";
+import type { InternalIdentity } from "@/features/conversations/conversations.schema";
+
+/** The narrow Statsig client surface used by server-side gates. */
+export interface StatsigClientLike {
+	initialize(): Promise<unknown>;
+	checkGate(user: StatsigUser, gateName: string): boolean;
+}
+
+export interface GateLogger {
+	error(obj: Record<string, unknown>): void;
+}
+
+interface StatsigGateErrorMessages {
+	initialization: string;
+	evaluation: string;
+}
+
+/**
+ * Shared Statsig adapter for boolean gates. Initialization overlaps boot, and
+ * every SDK failure resolves false so each owning feature can apply its own
+ * fail-closed or fail-safe policy without duplicating client mechanics.
+ */
+export class StatsigBooleanGate {
+	private readonly ready: Promise<boolean>;
+
+	constructor(
+		private readonly client: StatsigClientLike,
+		private readonly gateName: string,
+		private readonly messages: StatsigGateErrorMessages,
+		private readonly logger?: GateLogger,
+	) {
+		this.ready = client
+			.initialize()
+			.then(() => true)
+			.catch((error) => {
+				this.logger?.error({
+					message: messages.initialization,
+					error: error instanceof Error ? error.message : String(error),
+				});
+				return false;
+			});
+	}
+
+	async isEnabled(identity: InternalIdentity): Promise<boolean> {
+		if (!(await this.ready)) return false;
+		try {
+			return this.client.checkGate(buildStatsigUser(identity), this.gateName);
+		} catch (error) {
+			this.logger?.error({
+				message: this.messages.evaluation,
+				error: error instanceof Error ? error.message : String(error),
+			});
+			return false;
+		}
+	}
+}
+
+function buildStatsigUser(identity: InternalIdentity): StatsigUser {
+	return new StatsigUser({
+		userID: identity.memberCode,
+		customIDs: { partnerCode: identity.partnerCode },
+		custom: {
+			partnerCode: identity.partnerCode,
+			...(identity.teamCode ? { teamCode: identity.teamCode } : {}),
+		},
+	});
+}
+
+export function createStatsigClient(
+	serverSecret: string,
+	options: { environment?: string } = {},
+): StatsigClientLike {
+	return new Statsig(serverSecret, {
+		environment: options.environment,
+		outputLogLevel: "warn",
+	}) as unknown as StatsigClientLike;
+}

--- a/apps/chat-api/src/test-setup.ts
+++ b/apps/chat-api/src/test-setup.ts
@@ -11,8 +11,8 @@ Bun.env.AWS_REGION = Bun.env.AWS_REGION ?? "us-west-2";
 // Run tests with the exposure gate in break-glass mode. This lets config load
 // without a Statsig secret AND, crucially, makes the entrypoint's default export
 // (`createApp(loadApiConfigFromEnv(Bun.env))`, evaluated whenever a test imports
-// `@/index`) build a BreakGlassExposureGate — so no real Statsig client is
-// constructed and no network I/O fires at import time. Gate-specific tests
-// construct StatsigExposureGate directly with a fake/offline client.
+// `@/index`) build break-glass exposure and runtime gates — so no real Statsig
+// client is constructed and no network I/O fires at import time. Gate-specific
+// tests construct Statsig-backed gates directly with fake/offline clients.
 Bun.env.AGENT_EXPOSURE_BREAK_GLASS =
 	Bun.env.AGENT_EXPOSURE_BREAK_GLASS ?? "true";

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -38,6 +38,7 @@ Workspace persistence, Agent session continuity, Searchable document loading, an
 | `apps/chat-api/src/features/artifacts/` | Current-artifact listing and five-minute S3 download signing |
 | `apps/chat-api/src/features/conversation-store/` | Durable Conversation registry and frozen Scope |
 | `apps/chat-api/src/features/exposure-gate/` | Statsig and break-glass implementations of the new-work gate |
+| `apps/chat-api/src/features/runtime-gate/` | Fail-safe Statsig selection of the immutable Conversation execution runtime |
 | `apps/chat-api/src/features/run-store/` | Run admission, owner-scoped Run reads, and durable interruption |
 | `apps/chat-api/src/features/conversation-runtime-store/` | Thin re-export of shared fenced Workspace, taint, and Agent session runtime persistence |
 | `apps/chat-api/src/db/` | Thin bindings to `@mymemo/agent-db` and the shared migration runner |

--- a/docs/agents/chat-api.md
+++ b/docs/agents/chat-api.md
@@ -8,7 +8,7 @@ A Conversation is the durable container, a Run serves one submitted message, and
 
 ### Create a Conversation
 
-`POST /v1/conversations` accepts the strict `CreateConversationBody` (`.strict()`) with optional `collectionId` and `summaryId`. It resolves the Scope once and freezes it on the Conversation.
+`POST /v1/conversations` accepts the strict `CreateConversationBody` (`.strict()`) with optional `collectionId` and `summaryId`. It resolves the Scope once and freezes it on the Conversation. After the exposure gate allows, the runtime gate is evaluated once on trusted identity and the result is frozen as the Conversation's execution runtime; later surfaces never re-evaluate it.
 
 `InternalIdentity` comes from `X-Member-Code` and `X-Partner-Code`; `X-Team-Code`, `X-Member-Name`, and `X-Partner-Name` are optional. `memberCode` becomes the owner (`user_id`). The server generates the Conversation UUID.
 
@@ -24,7 +24,7 @@ All operations are owner-scoped. Missing and foreign Conversations both return `
 
 `POST /v1/conversations/:conversationId/runs` strictly validates one standard `RunAgentInput` and requires `threadId` to equal the owned Conversation id. Reject client Tools, state, and forwarded authority.
 
-`admitAgUiRun` is the only admission path. It atomically writes the client-supplied `runId`, the final plain-text User message, and `run_started` under the Conversation lifecycle lock. Exact retries reattach to the same logical Run; mismatched reuse returns `409`. Admission commits before Redis access. Backpressure uses the explicit Active Run count under the same Conversation row lock.
+`admitAgUiRun` is the only admission path. It atomically writes the client-supplied `runId`, the final plain-text User message, and `run_started` under the Conversation lifecycle lock. The transaction reads the frozen execution runtime from that locked row and, for `agentcore`, also inserts the Run-keyed dispatch outbox row. Exact retries reattach to the same logical Run without another dispatch; mismatched reuse returns `409`. Admission commits before Redis access. Backpressure uses the explicit Active Run count under the same Conversation row lock.
 
 Do not reintroduce the removed `runs_one_active_per_conversation` partial unique index as an implicit backpressure mechanism.
 

--- a/docs/agents/configuration.md
+++ b/docs/agents/configuration.md
@@ -42,7 +42,7 @@ Runtime shutdown grace is fixed at 30 seconds and concurrency is fixed at one ex
 Required:
 
 - `AGENT_DATABASE_URL`: writable `mymemo_agent` database. It is deliberately not named `DATABASE_URL`, which denotes the read-only KB credential elsewhere. It is separate from the worker's read-only `mymemo_kb` credential. The process fails at startup when it is absent. `bun run db:migrate` in `apps/chat-api` applies migrations owned by `packages/agent-db` through its exported `MIGRATIONS_DIR`.
-- `STATSIG_SERVER_SECRET`: production exposure-gate secret; required unless `AGENT_EXPOSURE_BREAK_GLASS=true`
+- `STATSIG_SERVER_SECRET`: production exposure- and runtime-gate secret; required unless `AGENT_EXPOSURE_BREAK_GLASS=true`
 - `ARTIFACT_BUCKET`: private artifact bucket; chat-api receives read-only object access
 - `AWS_REGION`: artifact S3 region
 - `REDIS_URL`: authenticated `rediss://` URL. Missing, malformed, unauthenticated, or non-TLS values fail startup. Never log it.
@@ -51,7 +51,9 @@ Optional:
 
 - `LOG_LEVEL` (default `info`)
 - `PORT` (default `3000`)
-- `AGENT_EXPOSURE_BREAK_GLASS` (default off): when exactly `true`, allow new work without Statsig; keep it off by default in production
+- `AGENT_EXPOSURE_BREAK_GLASS` (default off): when exactly `true`, allow new work without Statsig and select `fargate` for every new Conversation; keep it off by default in production
+
+chat-api has no AgentCore dispatch queue or SSM parameter configuration. Admission ends after the transactional Postgres outbox write; publisher and consumer processes own queue delivery and the dispatch kill switch.
 - `DB_PASSWORD`: splice into a passwordless `AGENT_DATABASE_URL`
 - `DB_SSL` (default on; `disable` only for local non-TLS Postgres)
 - `LIVE_STREAM_ALLOW_INSECURE_LOCAL_REDIS` (default off): when exactly `true`, allow unauthenticated `redis://` only for `localhost`, `127.0.0.1`, or `[::1]` in integration tests

--- a/docs/agents/database.md
+++ b/docs/agents/database.md
@@ -19,7 +19,7 @@ The package exposes concurrency-critical operations including `startClaimedRunTx
 - `src/artifact-store.ts`: pre-upload object ledger and fence-first atomic artifact-pointer/current-metadata/`run_done` commit
 - `src/testing.ts`: PGlite harness and shared seed helpers
 
-chat-api's `PostgresRunStore` composes shared admission inside the Conversation lifecycle lock. Run-store operations compose runtime pointer publication into qualifying terminal transactions through the same live Ownership fence.
+chat-api's `PostgresRunStore` composes shared admission inside the Conversation lifecycle lock. For an `agentcore` Conversation, the new Run, its `run_started` event, and its Run-keyed dispatch outbox row share that transaction; exact retries insert nothing. Run-store operations compose runtime pointer publication into qualifying terminal transactions through the same live Ownership fence.
 
 ## Concurrency tests
 

--- a/docs/agents/security.md
+++ b/docs/agents/security.md
@@ -15,7 +15,9 @@ New agent work is gated by the server-side Statsig gate `mymemo_agent_split_runt
 
 `createExposureGate(config)` selects the fail-closed `StatsigExposureGate` or the explicitly configured always-allow `BreakGlassExposureGate`.
 
-Reconnect, interruption, history, artifact access, and Conversation management for existing owned resources do not consult the new-work gate.
+After exposure allows Conversation creation, the separate Statsig gate `mymemo_agent_agentcore_runtime_enabled` selects the immutable execution runtime. Only ON selects `agentcore`; OFF, initialization or evaluation errors, and operator break-glass select `fargate`. Run admission and every other later surface read the persisted selection and never consult this gate. chat-api records AgentCore dispatch only in Postgres and holds no SQS or SSM authority.
+
+Reconnect, interruption, history, artifact access, and Conversation management for existing owned resources do not consult either gate.
 
 ## Runtime trust boundary
 

--- a/packages/agent-db/package.json
+++ b/packages/agent-db/package.json
@@ -5,6 +5,7 @@
 	"exports": {
 		".": "./src/index.ts",
 		"./schema": "./src/schema.ts",
+		"./agentcore-dispatch": "./src/canary-dispatch.ts",
 		"./artifact-store": "./src/artifact-store.ts",
 		"./canary-dispatch": "./src/canary-dispatch.ts",
 		"./client": "./src/client.ts",

--- a/packages/agent-db/src/schema.ts
+++ b/packages/agent-db/src/schema.ts
@@ -112,7 +112,7 @@ export const conversations = pgTable(
 		conversationId: text("conversation_id").notNull(),
 		/** 'general' | 'collection' | 'document' — frozen at creation. */
 		scope: text("scope").notNull(),
-		/** Immutable runtime classification; public creation always takes default. */
+		/** Immutable runtime classification, selected once at Conversation creation. */
 		executionRuntime: text("execution_runtime", {
 			enum: CONVERSATION_EXECUTION_RUNTIMES,
 		})


### PR DESCRIPTION
## Summary

- Add a dedicated server-side Statsig gate that selects and freezes `fargate | agentcore` once at Conversation creation.
- Fail safely to Fargate when the gate is off, Statsig fails, or operator break-glass is active.
- Read the persisted runtime under the Conversation lock and atomically record AgentCore Run admission with its dispatch outbox row.
- Keep exact retries idempotent, omit dispatch for Fargate, and preserve the chat-api boundary without SQS or SSM authority.

## Acceptance criteria

- [x] Creation covers gate on, gate off, Statsig failure, and break-glass; only gate-on selects AgentCore, and later surfaces do not re-evaluate it.
- [x] AgentCore admission commits the Run, `run_started`, and dispatch outbox row atomically; either failure rolls the transaction back.
- [x] Exact retries reattach without a second outbox row; Fargate admission writes no outbox row.
- [x] Injected route fakes cover runtime selection and admission behavior; chat-api has no queue or SSM client configuration.

## Validation

- `bun test` — 1,077 passed, 43 skipped, 0 failed.
- `bun test apps/chat-api/src/features/conversations/conversations.route.test.ts` — 53 passed.
- `bun test apps/chat-api/src/features/run-store/postgres-run-store.test.ts` — 17 passed.
- `bunx tsc --noEmit -p apps/chat-api/tsconfig.json` — passed.
- `bunx biome check apps/chat-api/src/features/conversations/conversations.route.test.ts` — passed.
- Required GitHub Actions checks passed: `test`, `integration`, `agentcore-infrastructure`, `worker-image`, and `image-contract`.

Closes #480