### PR TITLE
Document dedicated AgentCore Dispatch publisher service

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -59,6 +59,12 @@ It states nothing about whether the Run was acquired or executed; Run state
 answers that.
 _Avoid_: delivery, dispatch sent, Run started
 
+**Dispatch publisher**:
+The trusted control-plane actor that turns pending AgentCore dispatch outbox
+records into queue envelopes. It never acquires Conversation Ownership or
+executes Runs.
+_Avoid_: dispatch worker, Run executor, execution runtime
+
 **Durable acquisition**:
 The committed transition in which one AgentCore invocation obtains live
 Conversation Ownership and starts its exact dispatched Run. Runtime entry or

--- a/docs/adr/0025-select-the-execution-runtime-at-conversation-creation.md
+++ b/docs/adr/0025-select-the-execution-runtime-at-conversation-creation.md
@@ -1,6 +1,8 @@
 # Select the execution runtime at Conversation creation
 
 Status: accepted (2026-08-16). Supersedes ADR-0019, ADR-0021, and ADR-0024.
+Amended (2026-08-17) by
+[ADR-0027](./0027-deploy-the-agentcore-dispatch-publisher-as-a-dedicated-service.md).
 
 Every Conversation carries an immutable execution runtime — `fargate` or
 `agentcore` — selected exactly once at creation by a server-side Statsig gate
@@ -27,16 +29,17 @@ ADR-0020 records.
 
 This decision covers coexistence, not replacement. Fargate remains the default
 runtime and the single global expiration and Reclamation runner; retiring
-Fargate — re-homing Reclamation, the pull loop, and the publisher's
-post-Fargate home — is explicitly out of scope and undecided. The fail-closed
-SSM dispatch parameter survives, renamed, as the dispatch-layer kill switch:
-the gate stops new `agentcore` Conversations, while the parameter stops
-delivery for existing ones, whose queued Runs then error at the queued backstop
-timeout. Runtime immutability has one documented break-glass exception: with
-dispatch disabled, zero Active Runs, and no pending dispatch rows, an operator
-runbook step may reassign stranded `agentcore` Conversations to `fargate` —
-safe because every durable resource (transcript, Workspace, artifacts) is
-runtime-agnostic by construction.
+Fargate — re-homing Reclamation and the pull loop — is explicitly out of scope
+and undecided. The Dispatch publisher is independently homed by ADR-0027, so
+Fargate retirement does not move it. The fail-closed SSM dispatch parameter
+survives, renamed, as the dispatch-layer kill switch: the gate stops new
+`agentcore` Conversations, while the parameter stops delivery for existing
+ones, whose queued Runs then error at the queued backstop timeout. Runtime
+immutability has one documented break-glass exception: with dispatch disabled,
+zero Active Runs, and no pending dispatch rows, an operator runbook step may
+reassign stranded `agentcore` Conversations to `fargate` — safe because every
+durable resource (transcript, Workspace, artifacts) is runtime-agnostic by
+construction.
 
 ## Considered options
 
@@ -72,10 +75,13 @@ runtime-agnostic by construction.
 - Re-homed from ADR-0021 as production posture: the digest-pinned ARM64
   request-oriented Runtime image, exact secret ARNs resolved at fresh session
   boot with verified RDS TLS, and per-workload least-privilege roles for
-  Runtime, publisher, and consumer. The Runtime writes Downloadable artifacts
-  in the standard production namespace with worker-equivalent upload access;
-  the canary prefix dies, because both runtimes serve the same Conversations
-  and their artifact keys must be indistinguishable to chat-api's signer.
+  Runtime, Dispatch publisher, and consumer. ADR-0027 realizes the publisher's
+  process, dependency, and AWS-capability boundary as a dedicated service while
+  deliberately retaining the shared writable database trust and coordinated
+  release train. The Runtime writes Downloadable artifacts in the standard
+  production namespace with worker-equivalent upload access; the canary prefix
+  dies, because both runtimes serve the same Conversations and their artifact
+  keys must be indistinguishable to chat-api's signer.
 - The canary-only surfaces are deleted: the control Lambda and preflight, the
   Campaign table, the campaign columns and constraints on the outbox, the
   `agentcore_canary` value, and the campaign-semantic alarms. Canary
@@ -85,7 +91,8 @@ runtime-agnostic by construction.
 - The dispatch contract amendments — envelope version 2, dropped campaign,
   scenario, and lane fields, run identity as dispatch identity, and the
   consumer's pre-invocation Run-status check — are recorded on ADR-0020. The
-  publisher's behavioral contract is ADR-0026.
+  publisher's behavioral contract is ADR-0026 and its deployment boundary is
+  ADR-0027.
 - Cutover is a coordinated rename rather than expand-contract, defensible only
   while there is no real user traffic. The runbook asserts its preconditions
   instead of assuming them: zero `agentcore_canary` Conversations, zero

--- a/docs/adr/0026-publish-agentcore-dispatch-through-one-advisory-locked-loop.md
+++ b/docs/adr/0026-publish-agentcore-dispatch-through-one-advisory-locked-loop.md
@@ -2,6 +2,10 @@
 
 Status: accepted (2026-08-16). Amends ADR-0020's publisher consequences.
 
+Amended (2026-08-17) by
+[ADR-0027](./0027-deploy-the-agentcore-dispatch-publisher-as-a-dedicated-service.md),
+which supersedes only this ADR's initial compute-home consequence.
+
 One publisher: a continuously running loop, single-flighted by a session-scoped
 Postgres advisory lock taken and released around each tick. Each tick selects
 unpublished outbox rows, sends them to the queue, and marks them published.
@@ -44,12 +48,13 @@ re-insertion, to shrink a table that stays at pending size anyway.
 
 ## Consequences
 
-- The compute home is constrained only to a long-lived process. The
-  agent-worker process, which outlives the rollout and already runs
-  advisory-locked maintenance loops, is the natural first home; moving the
-  loop later does not change this contract.
+- This decision originally selected agent-worker as the natural first home
+  because it is long-lived and already runs advisory-locked maintenance loops.
+  ADR-0027 supersedes that placement with a dedicated service; the publisher
+  loop and every behavioral guarantee above remain unchanged.
 - The EventBridge repair rule and the control-Lambda immediate publish retire
   with the canary.
-- The loop emits its lost-lock outcome and a pending-age metric; publisher
+- The loop emits an informational lock-not-acquired outcome, publisher errors,
+  and pending age. Pending age is the primary paging symptom; publisher
   observability replaces the Campaign's overdue marking as the way stuck
   dispatch is seen.

--- a/docs/adr/0027-deploy-the-agentcore-dispatch-publisher-as-a-dedicated-service.md
+++ b/docs/adr/0027-deploy-the-agentcore-dispatch-publisher-as-a-dedicated-service.md
@@ -1,0 +1,75 @@
+# Deploy the AgentCore Dispatch publisher as a dedicated service
+
+Status: accepted (2026-08-17). Amends ADR-0025 and supersedes ADR-0026's
+initial compute-home consequence.
+
+AgentCore Dispatch publication runs in one dedicated long-lived ECS service,
+not in the Conversation-serving agent-worker process. The service has its own
+app, filtered image, process lifecycle, task and execution roles, security
+group, logs, and task definition; it owns the fail-closed SSM gate, bounded
+Postgres outbox publication, and SQS send authority, but never acquires
+Conversation Ownership or executes Runs. This isolates publisher failures and
+AWS capabilities from Conversation execution without changing ADR-0026's
+single advisory-locked loop, at-least-once delivery, or seconds-scale healthy
+publication latency.
+
+The deployment has one ECS service with desired count one in steady state.
+Operators may deliberately set it to zero, and old and new tasks may overlap
+during a rolling deploy; the tick-scoped advisory lock, rather than task count,
+ensures that only one publishing critical section runs. Fargate agent-worker
+remains the single global expiration and Reclamation runner during coexistence,
+as ADR-0023 and ADR-0025 require.
+
+This is a process, dependency, and AWS-capability boundary, not a complete
+trust or release boundary. The publisher initially retains the shared writable
+agent database credential, unrestricted outbound egress, and the coordinated
+release train. Its image and task definition are independently deployable and
+rollbackable, but ordinary releases remain coordinated so schema, envelope,
+publisher, and consumer compatibility move together.
+
+On termination the publisher stops beginning ticks and batches, bounds SSM and
+SQS operations below the ECS stop timeout, and lets the current send/confirm
+unit settle. Forced termination still releases the connection-scoped advisory
+lock, and an interrupted send remains safe through at-least-once delivery and
+Durable acquisition. Invalid bootstrap configuration ends the process;
+transient tick failures keep the loop alive, emit publisher-error telemetry,
+and rely on pending age as the primary paging symptom. A task that does not
+acquire the advisory lock emits informational `lock_not_acquired` telemetry;
+it did not lose a lock it previously held.
+
+## Considered options
+
+- **Run the publisher inside agent-worker.** Rejected because it grants the
+  Conversation executor unrelated SSM, SQS, and KMS authority and couples
+  publisher dependencies, bootstrap, failure, and shutdown to execution.
+- **Run a publisher sidecar in the agent-worker task.** Rejected because an ECS
+  task shares one task role and lifecycle, so the sidecar does not establish
+  the selected authority or failure boundary.
+- **Run a scheduled Lambda publisher.** Rejected by ADR-0026 because the
+  scheduling floor cannot provide seconds-scale publication without restoring
+  a second immediate-publish path.
+- **Run two steady-state publisher tasks.** Rejected for now because durable
+  backlog and ECS replacement already preserve correctness, while a permanent
+  standby adds cost and continuous expected lock contention. Revisit if
+  seconds-scale latency becomes a fault-state objective.
+- **Release the publisher autonomously.** Rejected for now because independent
+  cadence creates a compatibility matrix across the database schema, envelope,
+  publisher, and consumer without improving the selected runtime boundary.
+- **Create a general AgentCore control-plane service.** Rejected during
+  coexistence because global expiration and Reclamation deliberately remain in
+  Fargate; extracting them belongs to a later Fargate-retirement decision.
+
+## Consequences
+
+- agent-worker holds no Dispatch publication code, configuration, queue
+  authority, or responsibility, but it continues global expiration and
+  Reclamation for both execution runtimes.
+- Publication latency is on the order of seconds while the service is healthy;
+  task replacement may pause publication, with pending age and the queued-Run
+  timeout exposing and bounding the degradation.
+- A publisher-specific Postgres role, destination-restricted egress, and an
+  autonomous release cadence are possible later hardening steps, not claims of
+  this decision.
+- Publisher metric emission belongs to the publisher delivery slice; production
+  pending-age and sustained-error alarms belong to the shared dispatch
+  infrastructure slice. `lock_not_acquired` remains informational.


### PR DESCRIPTION
## Summary

- add ADR-0027 to place the AgentCore Dispatch publisher in a dedicated ECS service
- amend ADR-0025 and ADR-0026 without erasing the original worker-first decision
- add `Dispatch publisher` to the project glossary
- document the deliberately limited process, dependency, and AWS-capability boundary

## Decision

The publisher is independently deployable and rollbackable but remains on the coordinated release train. `agent-worker` retains global expiration and Reclamation while holding no Dispatch publication code or AWS authority. Shared database trust and unrestricted outbound egress remain explicit non-goals of this decision.

## Verification

- `git diff --check`
- CI: `test`
- CI: `integration`
- CI: `agentcore-infrastructure`

## Related

- #476
- #481
- #483
- #484
