### PR TITLE
fix(ci): format generated Terraform variable overlay

### DIFF
--- a/scripts/deploy-config.test.ts
+++ b/scripts/deploy-config.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "bun:test";
-import { existsSync, readdirSync, readFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { loadWorkerConfigFromEnv } from "../apps/agent-worker/src/config/env";
 import { loadApiConfigFromEnv } from "../apps/chat-api/src/config/env";
@@ -721,6 +728,53 @@ describe("agent deployment config", () => {
 		expect(releaseDeployWorkflow).not.toContain(
 			"CONFIRM_AGENT_PROD_APPLY: apply-mymemo-agent-prod",
 		);
+	});
+
+	it("writes a Terraform-formatted generated image overlay", () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "mymemo-deploy-tfvars-"));
+		const generatedTfvars = join(tempDir, "generated.auto.tfvars");
+
+		try {
+			const result = Bun.spawnSync({
+				cmd: [
+					join(root, "scripts", "deploy", "ci_prepare_tfvars.sh"),
+					generatedTfvars,
+				],
+				cwd: root,
+				env: {
+					...process.env,
+					AWS_REGION: "us-west-2",
+					DEPLOY_ENVIRONMENT: "prod",
+					CHAT_API_IMAGE: "example.test/chat-api:release-test",
+					AGENT_WORKER_IMAGE: "example.test/agent-worker:release-test",
+					AGENTCORE_DISPATCH_PUBLISHER_IMAGE:
+						"example.test/agentcore-dispatch-publisher:release-test",
+				},
+			});
+
+			expect(result.exitCode).toBe(0);
+
+			const lines = readFileSync(generatedTfvars, "utf8").trimEnd().split("\n");
+			const assignments = lines.map((line) => {
+				const equalsColumn = line.indexOf("=");
+				return {
+					equalsColumn,
+					key: line.slice(0, equalsColumn).trimEnd(),
+				};
+			});
+			const maxKeyLength = Math.max(
+				...assignments.map(({ key }) => key.length),
+			);
+
+			expect(assignments).toHaveLength(4);
+			expect(
+				assignments.every(
+					({ equalsColumn }) => equalsColumn === maxKeyLength + 1,
+				),
+			).toBe(true);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
 	});
 
 	it("bootstrap IAM owns the agent-specific GitHub Actions deploy role", () => {

--- a/scripts/deploy/ci_prepare_tfvars.sh
+++ b/scripts/deploy/ci_prepare_tfvars.sh
@@ -52,10 +52,10 @@ fi
 mkdir -p "$(dirname "$out")"
 
 cat >"$out" <<TFVARS
-aws_region                            = "${AWS_REGION}"
-chat_api_image                        = "${chat_api_image}"
-agent_worker_image                    = "${agent_worker_image}"
-agentcore_dispatch_publisher_image    = "${agentcore_dispatch_publisher_image}"
+aws_region                         = "${AWS_REGION}"
+chat_api_image                     = "${chat_api_image}"
+agent_worker_image                 = "${agent_worker_image}"
+agentcore_dispatch_publisher_image = "${agentcore_dispatch_publisher_image}"
 TFVARS
 
 echo "Wrote $out"


### PR DESCRIPTION
## Summary

- format the generated Terraform image-variable overlay using Terraform's canonical assignment alignment
- add a regression test that executes the generator and verifies canonical alignment

## Root cause

Adding `agentcore_dispatch_publisher_image` left extra padding before the assignment operator in `generated.auto.tfvars`. The release workflow's `terraform fmt -check` rejected the generated file with exit code 3 before `terraform plan` ran.

## Impact

Release deploys can proceed past the formatting gate, and future additions to the generated overlay are covered by an executable regression test.

## Validation

- `terraform fmt -check -diff /tmp/mymemo-release-generated.auto.tfvars`
- `bun test scripts/deploy-config.test.ts`
- `bun run test`
- `bash -n scripts/deploy/ci_prepare_tfvars.sh`
- `git diff --check`