### PR TITLE
fix(ci): keep AgentCore Dispatch publisher dormant

### DIFF
--- a/infra/terraform/iam.tf
+++ b/infra/terraform/iam.tf
@@ -100,12 +100,16 @@ data "aws_iam_policy_document" "agentcore_dispatch_publisher" {
     resources = [local.agentcore_dispatch_queue_arn]
   }
 
-  statement {
-    actions = [
-      "kms:Decrypt",
-      "kms:GenerateDataKey",
-    ]
-    resources = [data.aws_kms_alias.agentcore_dispatch_queue.target_key_arn]
+  dynamic "statement" {
+    for_each = var.agentcore_dispatch_publisher_desired_count == 1 ? [1] : []
+
+    content {
+      actions = [
+        "kms:Decrypt",
+        "kms:GenerateDataKey",
+      ]
+      resources = [data.aws_kms_alias.agentcore_dispatch_queue[0].target_key_arn]
+    }
   }
 }
 

--- a/infra/terraform/prod.tfvars
+++ b/infra/terraform/prod.tfvars
@@ -21,9 +21,11 @@ kb_database_security_group_id = "sg-0c7084b87f3e109d7"
 # inherited network constraint, not the preferred production pattern.
 assign_public_ip = true
 
-chat_api_desired_count                     = 1
-agent_worker_desired_count                 = 1
-agentcore_dispatch_publisher_desired_count = 1
+chat_api_desired_count     = 1
+agent_worker_desired_count = 1
+# The shared AgentCore queue, SSM control, and KMS key are not deployed yet.
+# Keep the Dispatch publisher dormant until that infrastructure exists.
+agentcore_dispatch_publisher_desired_count = 0
 
 e2b_template                        = "sandbox-template-prod"
 worker_e2b_template                 = "mymemo-agent-sandbox"

--- a/infra/terraform/shared_state.tf
+++ b/infra/terraform/shared_state.tf
@@ -31,5 +31,7 @@ data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 
 data "aws_kms_alias" "agentcore_dispatch_queue" {
+  count = var.agentcore_dispatch_publisher_desired_count == 1 ? 1 : 0
+
   name = local.agentcore_dispatch_queue_kms_alias_name
 }

--- a/scripts/deploy-config.test.ts
+++ b/scripts/deploy-config.test.ts
@@ -456,6 +456,28 @@ describe("agent deployment config", () => {
 		expect(prodTfvars).not.toContain("_SECRET_ARN");
 	});
 
+	it("keeps the Dispatch publisher dormant until shared infrastructure exists", () => {
+		const iamConfig = readFileSync(join(terraformDir, "iam.tf"), "utf8");
+		const sharedState = readFileSync(
+			join(terraformDir, "shared_state.tf"),
+			"utf8",
+		);
+
+		expect(prodTfvars).toContain(
+			"agentcore_dispatch_publisher_desired_count = 0",
+		);
+		expect(sharedState).toContain(
+			"count = var.agentcore_dispatch_publisher_desired_count == 1 ? 1 : 0",
+		);
+		expect(iamConfig).toContain('dynamic "statement"');
+		expect(iamConfig).toContain(
+			"for_each = var.agentcore_dispatch_publisher_desired_count == 1 ? [1] : []",
+		);
+		expect(iamConfig).toContain(
+			"data.aws_kms_alias.agentcore_dispatch_queue[0].target_key_arn",
+		);
+	});
+
 	it("checked-in prod deploy env is limited to CI and smoke inputs", () => {
 		for (const required of [
 			"AWS_REGION=us-west-2",


### PR DESCRIPTION
## Summary

- Keep the production AgentCore Dispatch publisher at zero tasks until the shared queue, SSM control, and KMS infrastructure exists.
- Read the queue KMS alias and add its IAM permissions only when the publisher is active.
- Add regression coverage for the dormant production configuration.

## Root cause

Release deploy always queried the transitional AgentCore queue KMS alias. The shared AgentCore infrastructure has not been deployed, so Terraform stopped before it could classify or apply the plan.

## Impact

Fargate releases can continue while the AgentCore deployment remains dormant. No Dispatch publisher task starts, and no Dispatch publication can occur before the shared infrastructure is ready.

## Validation

- `bun test scripts/deploy-config.test.ts`
- `bun test scripts/smoke/agent-conversation-smoke.test.ts`
- `bun run scripts/test-workspaces.ts`
- `terraform -chdir=infra/terraform fmt -check`
- `terraform -chdir=infra/terraform validate`
- Read-only full-refresh production Terraform plan

No AWS changes were applied during validation.