### PR TITLE
Harden AgentCore Runtime image

### DIFF
--- a/apps/agentcore-canary-runtime/Dockerfile
+++ b/apps/agentcore-canary-runtime/Dockerfile
@@ -1,6 +1,11 @@
 # syntax=docker/dockerfile:1.7
 
-FROM oven/bun:1 AS base
+ARG BUN_VERSION=1.3.14
+
+FROM oven/bun:${BUN_VERSION} AS base
+RUN apt-get update \
+ && apt-get upgrade -y --no-install-recommends \
+ && rm -rf /var/lib/apt/lists/*
 WORKDIR /usr/src/app
 
 FROM base AS manifests
@@ -14,8 +19,18 @@ FROM base AS install
 COPY --from=manifests /usr/src/app /temp/prod
 RUN cd /temp/prod && bun install --frozen-lockfile --production
 
-FROM base AS release
+FROM base AS runtime-files
+
+# Current AWS RDS global trust bundle, digest-pinned at image build. Both agent
+# and KB PostgreSQL URLs are separately required to use sslmode=verify-full.
+ADD --checksum=sha256:e5bb2084ccf45087bda1c9bffdea0eb15ee67f0b91646106e466714f9de3c7e3 https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /etc/ssl/certs/rds-global-bundle.pem
+RUN chmod 0444 /etc/ssl/certs/rds-global-bundle.pem \
+ && mkdir -p /workspace/conversations \
+ && chown -R 65532:65532 /workspace
+
+FROM oven/bun:${BUN_VERSION}-distroless AS release
 LABEL com.mymemo.agentcore-runtime.request-oriented="true"
+WORKDIR /usr/src/app
 COPY --from=install /temp/prod/node_modules node_modules
 COPY apps/agentcore-canary-runtime apps/agentcore-canary-runtime
 COPY apps/agentcore-canary-dispatch apps/agentcore-canary-dispatch
@@ -25,17 +40,12 @@ COPY packages/agentcore-dispatch packages/agentcore-dispatch
 COPY packages/live-text packages/live-text
 COPY package.json .
 
-# Current AWS RDS global trust bundle, digest-pinned at image build. Both agent
-# and KB PostgreSQL URLs are separately required to use sslmode=verify-full.
-ADD --checksum=sha256:e5bb2084ccf45087bda1c9bffdea0eb15ee67f0b91646106e466714f9de3c7e3 https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /etc/ssl/certs/rds-global-bundle.pem
+COPY --from=runtime-files --chmod=0444 /etc/ssl/certs/rds-global-bundle.pem /etc/ssl/certs/rds-global-bundle.pem
+COPY --from=runtime-files --chown=65532:65532 /workspace /workspace
 ENV RDS_CA_BUNDLE_PATH=/etc/ssl/certs/rds-global-bundle.pem
 ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/rds-global-bundle.pem
 
-RUN chmod 0444 /etc/ssl/certs/rds-global-bundle.pem \
- && mkdir -p /workspace/conversations \
- && chown -R bun:bun /workspace
-
 WORKDIR /usr/src/app/apps/agentcore-canary-runtime
-USER bun
+USER 65532:65532
 EXPOSE 8080/tcp
 ENTRYPOINT [ "bun", "run", "src/index.ts" ]

--- a/apps/agentcore-canary-runtime/src/image-cli-contract.ts
+++ b/apps/agentcore-canary-runtime/src/image-cli-contract.ts
@@ -1,9 +1,11 @@
+import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { resolveAndVerifyClaudeCodeExecutable } from "agent-worker/claude-code-executable";
 
 const MIN_RDS_CA_BUNDLE_BYTES = 100_000;
 const ELF_MACHINE_OFFSET = 18;
 const AARCH64_ELF_MACHINE = 183;
+const EMULATED_CLI_TIMEOUT_MS = 15_000;
 
 const caPath = process.env.RDS_CA_BUNDLE_PATH;
 if (!caPath) throw new Error("RDS CA bundle path missing");
@@ -12,18 +14,34 @@ if (!(await ca.exists()) || ca.size < MIN_RDS_CA_BUNDLE_BYTES) {
 	throw new Error("RDS CA bundle missing");
 }
 
+const cpuInfo = readFileSync("/proc/cpuinfo", "utf8");
+const x64HostEmulation =
+	process.arch === "arm64" &&
+	/vendor_id\s*:\s*(?:GenuineIntel|AuthenticAMD)/.test(cpuInfo);
+
 try {
-	console.log(resolveAndVerifyClaudeCodeExecutable());
+	console.log(
+		resolveAndVerifyClaudeCodeExecutable({
+			execFile(executable, args) {
+				execFileSync(executable, [...args], {
+					stdio: "ignore",
+					...(x64HostEmulation
+						? { timeout: EMULATED_CLI_TIMEOUT_MS, killSignal: "SIGKILL" }
+						: {}),
+				});
+			},
+		}),
+	);
 } catch (error) {
 	const cause =
 		error instanceof Error && error.cause && typeof error.cause === "object"
 			? error.cause
 			: undefined;
 	const signal = cause && "signal" in cause ? cause.signal : undefined;
-	const cpuInfo = readFileSync("/proc/cpuinfo", "utf8");
+	const code = cause && "code" in cause ? cause.code : undefined;
 	if (
-		signal !== "SIGSEGV" ||
-		!/vendor_id\s*:\s*(?:GenuineIntel|AuthenticAMD)/.test(cpuInfo)
+		!x64HostEmulation ||
+		(code !== "ETIMEDOUT" && signal !== "SIGSEGV" && signal !== "SIGABRT")
 	) {
 		throw error;
 	}
@@ -44,7 +62,7 @@ try {
 		},
 	});
 	console.warn(
-		"ARM64 CLI execution unavailable after SIGSEGV under x64 host emulation; verified executable contract and ELF instead",
+		"ARM64 CLI execution unavailable under x64 host emulation; verified executable contract and ELF instead",
 	);
 	console.log(executable);
 }

--- a/scripts/agentcore-infra.test.ts
+++ b/scripts/agentcore-infra.test.ts
@@ -21,6 +21,27 @@ function terraformSource(): string {
 }
 
 describe("production AgentCore dispatch infrastructure", () => {
+	it("builds the Runtime on updated packages and ships a non-root distroless release", () => {
+		const dockerfile = readFileSync(
+			join(root, "apps", "agentcore-canary-runtime", "Dockerfile"),
+			"utf8",
+		);
+
+		expect(dockerfile).toContain("apt-get update");
+		expect(dockerfile).toContain("apt-get upgrade -y --no-install-recommends");
+		expect(dockerfile).toContain("rm -rf /var/lib/apt/lists/*");
+		expect(dockerfile).toContain(
+			`FROM oven/bun:\${BUN_VERSION}-distroless AS release`,
+		);
+		expect(dockerfile).toContain(
+			'AS release\nLABEL com.mymemo.agentcore-runtime.request-oriented="true"\nWORKDIR /usr/src/app',
+		);
+		expect(dockerfile).toContain("USER 65532:65532");
+		expect(dockerfile.indexOf("apt-get update")).toBeLessThan(
+			dockerfile.indexOf("AS release"),
+		);
+	});
+
 	it("keeps the existing isolated state while exposing a production Terraform root", () => {
 		const versions = readFileSync(join(terraformDir, "versions.tf"), "utf8");
 		const readme = readFileSync(join(terraformDir, "README.md"), "utf8");

--- a/scripts/smoke/agentcore-canary-runtime-image-check.sh
+++ b/scripts/smoke/agentcore-canary-runtime-image-check.sh
@@ -32,8 +32,8 @@ fi
 
 # Verify the pinned SDK-owned ARM64 CLI and the baked CA with all networking
 # disabled. Execute the same --version boot check used in production. Old x64
-# Docker/QEMU combinations can SIGSEGV a valid ARM64 binary; only on that
-# identifiable host-emulation path, fall back to checking the resolved ELF.
+# Docker/QEMU combinations can crash or hang a valid ARM64 binary; only on that
+# bounded, identifiable host-emulation path, fall back to the resolved ELF.
 docker run --rm \
   --platform linux/arm64 \
   --network none \


### PR DESCRIPTION
## What changed

- build the production Runtime on refreshed Debian packages
- ship the final Runtime on Bun's official distroless image as a non-root user
- preserve the RDS CA bundle and writable conversation workspace without final-stage shell utilities
- bound the ARM CLI check under positively identified x86/QEMU emulation

## Why

The Release deployment exposed vulnerabilities in the Debian-based Runtime image. Updating installed packages reduced the AWS ECR scan from 5 critical / 19 high findings to 4 critical / 8 high, but the remaining packages had no stable Debian fix. Removing unused operating-system packages from the final image eliminates the vulnerable Perl and SQLite surface while keeping native ARM CLI verification strict.

## Validation

- `bun test apps/agent-worker/src/sdk/claude-code-executable.test.ts scripts/agentcore-infra.test.ts` — 16 passed
- `bunx biome check apps/agentcore-canary-runtime/src/image-cli-contract.ts scripts/agentcore-infra.test.ts`
- full offline Runtime image contract — passed
- AWS ECR scan for `sha256:9e70d3bb19d9eea45edd87849d48e919c09633da99da741d1ba148e4c628b632` — 0 findings