### PR TITLE
Fix AgentCore queue encryption

### DIFF
--- a/infra/agentcore/queue.tf
+++ b/infra/agentcore/queue.tf
@@ -14,7 +14,6 @@ resource "aws_sqs_queue" "dead_letter" {
   message_retention_seconds  = 86400
   visibility_timeout_seconds = 300
   kms_master_key_id          = aws_kms_key.dispatch.arn
-  sqs_managed_sse_enabled    = false
 }
 
 resource "aws_sqs_queue" "dispatch" {
@@ -23,7 +22,6 @@ resource "aws_sqs_queue" "dispatch" {
   visibility_timeout_seconds = 180
   receive_wait_time_seconds  = 20
   kms_master_key_id          = aws_kms_key.dispatch.arn
-  sqs_managed_sse_enabled    = false
 
   redrive_policy = jsonencode({
     deadLetterTargetArn = aws_sqs_queue.dead_letter.arn

--- a/scripts/agentcore-infra.test.ts
+++ b/scripts/agentcore-infra.test.ts
@@ -134,6 +134,7 @@ describe("production AgentCore dispatch infrastructure", () => {
 				`resource\\s+"aws_sqs_queue"\\s+"dispatch"[\\s\\S]*?message_retention_seconds\\s*=\\s*${queue.retentionSeconds}[\\s\\S]*?visibility_timeout_seconds\\s*=\\s*${queue.visibilityTimeoutSeconds}[\\s\\S]*?kms_master_key_id\\s*=\\s*aws_kms_key\\.dispatch\\.arn`,
 			),
 		);
+		expect(source).not.toContain("sqs_managed_sse_enabled");
 		expect(source).toMatch(
 			new RegExp(`maxReceiveCount\\s*=\\s*${queue.maxReceiveCount}`),
 		);


### PR DESCRIPTION
## What changed

- remove `sqs_managed_sse_enabled = false` from both AgentCore SQS queues
- retain the customer-managed KMS key on both queues
- add a regression assertion that the mutually exclusive SQS option is absent

## Why

The first idle production apply stopped when the AWS provider rejected `kms_master_key_id` together with `sqs_managed_sse_enabled`. The customer-managed KMS key is the intended encryption mode, so the explicit AWS-managed SSE flag is redundant and conflicting.

Terraform recorded all resources created before the queue error, and Dispatch remains disabled. A subsequent apply will resume from that state.

## Validation

- `bun test scripts/agentcore-infra.test.ts` — 12 passed
- `bunx biome check scripts/agentcore-infra.test.ts`
- `terraform -chdir=infra/agentcore fmt -check`
- `terraform -chdir=infra/agentcore validate`