### PR TITLE
Handle empty Lambda concurrency response

### DIFF
--- a/scripts/deploy/agentcore_aws_checks.sh
+++ b/scripts/deploy/agentcore_aws_checks.sh
@@ -197,6 +197,9 @@ verify_agentcore_idle_dispatch() {
   consumer_concurrency="$(aws --profile mymemo lambda get-function-concurrency \
     --region "${region}" \
     --function-name "${expected_consumer_function_arn}")"
+  if [[ -z "${consumer_concurrency}" ]]; then
+    consumer_concurrency="{}"
+  fi
   jq -e '(.ReservedConcurrentExecutions // null) == null' \
     <<<"${consumer_concurrency}" >/dev/null
   [[ "$(aws --profile mymemo ssm get-parameter --region "${region}" --name "${enabled_parameter}" --query Parameter.Value --output text)" == "disabled" ]]

--- a/scripts/deploy/agentcore_aws_checks.test.ts
+++ b/scripts/deploy/agentcore_aws_checks.test.ts
@@ -83,7 +83,10 @@ function expectedWiring(): LiveWiring {
 	};
 }
 
-function verify(wiring: LiveWiring) {
+function verify(
+	wiring: LiveWiring,
+	options: { emptyConcurrencyResponse?: boolean } = {},
+) {
 	const script = `
 set -euo pipefail
 source "${checksPath}"
@@ -91,7 +94,11 @@ aws() {
   case "$*" in
     *"lambda get-event-source-mapping"*) printf '%s\n' "$MAPPING" ;;
     *"lambda get-function-configuration"*) printf '%s\n' "$CONSUMER" ;;
-    *"lambda get-function-concurrency"*) printf '%s\n' "$CONCURRENCY" ;;
+    *"lambda get-function-concurrency"*)
+      if [[ "$EMPTY_CONCURRENCY_RESPONSE" != "true" ]]; then
+        printf '%s\n' "$CONCURRENCY"
+      fi
+      ;;
     *"ssm get-parameter"*) printf '%s\n' "disabled" ;;
     *) exit 97 ;;
   esac
@@ -106,6 +113,9 @@ verify_agentcore_idle_dispatch us-west-2 "$TF_OUTPUT"
 			MAPPING: JSON.stringify(wiring.mapping),
 			CONSUMER: JSON.stringify(wiring.consumer),
 			CONCURRENCY: JSON.stringify(wiring.concurrency),
+			EMPTY_CONCURRENCY_RESPONSE: String(
+				options.emptyConcurrencyResponse ?? false,
+			),
 		},
 	});
 }
@@ -273,6 +283,11 @@ assert_agentcore_legacy_queues_empty us-west-2
 describe("production AgentCore idle dispatch wiring", () => {
 	it("accepts the enabled consumer and fail-closed SSM graph", () => {
 		const result = verify(expectedWiring());
+		expect(result.status, result.stderr).toBe(0);
+	});
+
+	it("accepts AWS's empty response for unreserved consumer concurrency", () => {
+		const result = verify(expectedWiring(), { emptyConcurrencyResponse: true });
 		expect(result.status, result.stderr).toBe(0);
 	});
 


### PR DESCRIPTION
## What changed

- normalize an empty `get-function-concurrency` response to `{}` before checking for reserved concurrency
- add a regression test matching AWS's real response when no reserved concurrency is configured

## Why

The idle production stack deployed successfully, but the final inspection exited with jq code 4. AWS returns an empty body—not JSON—when a Lambda has no reserved concurrency. No reserved concurrency is the intended production configuration, so the verifier must accept that response while continuing to reject any positive reservation.

## Validation

- `bash -n scripts/deploy/agentcore_aws_checks.sh`
- `bun test scripts/deploy/agentcore_aws_checks.test.ts scripts/agentcore-infra.test.ts` — 32 passed
- `bunx biome check scripts/deploy/agentcore_aws_checks.test.ts`
- patched idle-dispatch assertion against the live production stack — passed