### PR TITLE
Fix AgentCore live inspection

### DIFF
--- a/scripts/deploy/agentcore_aws_checks.sh
+++ b/scripts/deploy/agentcore_aws_checks.sh
@@ -98,7 +98,7 @@ verify_agentcore_alarms() {
           statistic: .Statistic,
           period: .Period,
           evaluation_periods: .EvaluationPeriods,
-          datapoints_to_alarm: .DatapointsToAlarm,
+          datapoints_to_alarm: (.DatapointsToAlarm // 0),
           comparison_operator: .ComparisonOperator,
           threshold: .Threshold,
           treat_missing_data: .TreatMissingData,
@@ -261,5 +261,15 @@ verify_agentcore_consumer_runtime_authority() {
     --policy-source-arn "${consumer_role_arn}" \
     --action-names bedrock-agentcore:InvokeAgentRuntime \
     --resource-arns "${runtime_arn}" "${endpoint_arn}")"
-  jq -e '[.EvaluationResults[].EvalDecision] | length == 2 and all(. == "allowed")' <<<"${simulation}" >/dev/null
+  jq -e \
+    --arg runtimeArn "${runtime_arn}" \
+    --arg endpointArn "${endpoint_arn}" \
+    '(.EvaluationResults | length == 1)
+      and (.EvaluationResults[0].EvalDecision == "allowed")
+      and ([.EvaluationResults[0].ResourceSpecificResults[]
+        | select(.EvalResourceName == $runtimeArn or .EvalResourceName == $endpointArn)] as $resources
+        | ($resources | length == 2)
+          and ($resources | map(.EvalResourceName) | unique | length == 2)
+          and ($resources | all(.EvalResourceDecision == "allowed")))' \
+    <<<"${simulation}" >/dev/null
 }

--- a/scripts/deploy/agentcore_aws_checks.test.ts
+++ b/scripts/deploy/agentcore_aws_checks.test.ts
@@ -7,6 +7,11 @@ const queueArn =
 	"arn:aws:sqs:us-west-2:637423444544:mymemo-agent-agentcore-prod-dispatch";
 const consumerArn =
 	"arn:aws:lambda:us-west-2:637423444544:function:mymemo-agent-agentcore-prod-consumer";
+const runtimeArn =
+	"arn:aws:bedrock-agentcore:us-west-2:637423444544:runtime/mymemo_agentcore_prod-runtime";
+const endpointArn = `${runtimeArn}/runtime-endpoint/DEFAULT`;
+const consumerRoleArn =
+	"arn:aws:iam::637423444544:role/mymemo-agent-agentcore-prod-consumer";
 
 const terraformOutput = JSON.stringify({
 	consumer_event_source_mapping_uuid: { value: "mapping-1" },
@@ -40,7 +45,7 @@ const alarmConfigurations: Record<string, AlarmConfiguration> = {
 		statistic: "Maximum",
 		period: 60,
 		evaluation_periods: 1,
-		datapoints_to_alarm: 1,
+		datapoints_to_alarm: 0,
 		comparison_operator: "GreaterThanOrEqualToThreshold",
 		threshold: 60000,
 		treat_missing_data: "breaching",
@@ -120,6 +125,31 @@ verify_agentcore_idle_dispatch us-west-2 "$TF_OUTPUT"
 	});
 }
 
+function verifyConsumerRuntimeAuthority(simulation: Record<string, unknown>) {
+	const script = `
+set -euo pipefail
+source "${checksPath}"
+aws() {
+  case "$*" in
+    *"iam simulate-principal-policy"*) printf '%s\n' "$SIMULATION" ;;
+    *) exit 97 ;;
+  esac
+}
+verify_agentcore_consumer_runtime_authority us-west-2 "$TF_OUTPUT"
+`;
+	return spawnSync("bash", ["-c", script], {
+		encoding: "utf8",
+		env: {
+			...process.env,
+			TF_OUTPUT: JSON.stringify({
+				agent_runtime_arn: { value: runtimeArn },
+				consumer_role_arn: { value: consumerRoleArn },
+			}),
+			SIMULATION: JSON.stringify(simulation),
+		},
+	});
+}
+
 function verifyAlarms(liveConfigurations: Record<string, AlarmConfiguration>) {
 	const alarms = Object.entries(liveConfigurations).map(
 		([AlarmName, configuration]) => ({
@@ -132,7 +162,9 @@ function verifyAlarms(liveConfigurations: Record<string, AlarmConfiguration>) {
 			Statistic: configuration.statistic,
 			Period: configuration.period,
 			EvaluationPeriods: configuration.evaluation_periods,
-			DatapointsToAlarm: configuration.datapoints_to_alarm,
+			...(configuration.datapoints_to_alarm > 0
+				? { DatapointsToAlarm: configuration.datapoints_to_alarm }
+				: {}),
 			ComparisonOperator: configuration.comparison_operator,
 			Threshold: configuration.threshold,
 			TreatMissingData: configuration.treat_missing_data,
@@ -317,8 +349,43 @@ describe("production AgentCore idle dispatch wiring", () => {
 	});
 });
 
+describe("production AgentCore consumer Runtime authority", () => {
+	function allowedSimulation() {
+		return {
+			EvaluationResults: [
+				{
+					EvalActionName: "bedrock-agentcore:InvokeAgentRuntime",
+					EvalDecision: "allowed",
+					ResourceSpecificResults: [
+						{
+							EvalResourceName: runtimeArn,
+							EvalResourceDecision: "allowed",
+						},
+						{
+							EvalResourceName: endpointArn,
+							EvalResourceDecision: "allowed",
+						},
+					],
+				},
+			],
+		};
+	}
+
+	it("accepts the IAM simulator's resource-specific allow results", () => {
+		const result = verifyConsumerRuntimeAuthority(allowedSimulation());
+		expect(result.status, result.stderr).toBe(0);
+	});
+
+	it("rejects a denied Runtime resource", () => {
+		const simulation = allowedSimulation();
+		simulation.EvaluationResults[0].ResourceSpecificResults[0].EvalResourceDecision =
+			"implicitDeny";
+		expect(verifyConsumerRuntimeAuthority(simulation).status).not.toBe(0);
+	});
+});
+
 describe("production AgentCore alarm configuration", () => {
-	it("accepts the complete Terraform-owned paging invariant", () => {
+	it("accepts the complete Terraform-owned paging invariant, including an omitted AWS datapoints default", () => {
 		const result = verifyAlarms(alarmConfigurations);
 		expect(result.status, result.stderr).toBe(0);
 	});


### PR DESCRIPTION
Fix the final production AgentCore inspection so it matches the response shapes returned by live AWS APIs.\n\n- validate both Runtime resources in IAM resource-specific results\n- normalize CloudWatch's omitted datapoints default\n- cover both live shapes with regression tests\n\nVerification:\n- 34 focused tests pass\n- shell syntax, Biome, and diff checks pass\n- full read-only inspection of the idle production stack passes