### PR TITLE
feat(smoke): verify AgentCore execution runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,9 +153,11 @@ bun run smoke:local
 
 For production, run `scripts/deploy/prod_smoke.sh` from inside the VPC with
 `AGENT_SMOKE_BASE_URL` configured and the checked-in `codex-smoke` identity
-allowlisted in Statsig. OpenRouter and E2B credentials stay in the deployed
-worker; the smoke caller receives none of them. To check only the default-closed
-gate, set `AGENT_SMOKE_EXPECT_GATE_CLOSED=true`.
+targeted in both the exposure and AgentCore runtime Statsig gates. The wrapper
+requires the public creation response to report `agentcore` before admitting a
+Run. OpenRouter and E2B credentials stay in the deployed worker; the smoke caller
+receives none of them. To check only the default-closed gate, set
+`AGENT_SMOKE_EXPECT_GATE_CLOSED=true`.
 
 `AGENT_SMOKE_SUITE` defaults to `core`; `full` is the local superset used by
 `smoke:local`. See [the two-target smoke verification guide](./docs/verification/e2e-smoke.md)

--- a/apps/chat-api/src/features/conversations/conversations.controller.ts
+++ b/apps/chat-api/src/features/conversations/conversations.controller.ts
@@ -15,6 +15,7 @@ import {
 export interface ConversationSummary {
 	conversationId: string;
 	title: string | null;
+	executionRuntime: ConversationExecutionRuntime;
 	scope: ConversationScope;
 	createdAt: string;
 	lastActivityAt: string;
@@ -27,6 +28,7 @@ export function toConversationSummary(
 	return {
 		conversationId: conversation.conversationId,
 		title: conversation.title,
+		executionRuntime: conversation.executionRuntime,
 		scope: conversation.scope,
 		createdAt: conversation.createdAt.toISOString(),
 		lastActivityAt: conversation.lastActivityAt.toISOString(),

--- a/apps/chat-api/src/features/conversations/conversations.route.test.ts
+++ b/apps/chat-api/src/features/conversations/conversations.route.test.ts
@@ -383,6 +383,7 @@ describe("POST /v1/conversations", () => {
 			const body = (await res.json()) as {
 				conversationId: string;
 				title: string | null;
+				executionRuntime: ConversationExecutionRuntime;
 				scope: string;
 				createdAt: string;
 				lastActivityAt: string;
@@ -391,6 +392,7 @@ describe("POST /v1/conversations", () => {
 			expect(body).toEqual({
 				conversationId: body.conversationId,
 				title: null,
+				executionRuntime: "fargate",
 				scope: "collection",
 				createdAt: body.createdAt,
 				lastActivityAt: body.createdAt,
@@ -494,6 +496,7 @@ describe("GET /v1/conversations", () => {
 				conversations: Array<{
 					conversationId: string;
 					title: string | null;
+					executionRuntime: ConversationExecutionRuntime;
 					scope: string;
 					createdAt: string;
 					lastActivityAt: string;
@@ -509,6 +512,7 @@ describe("GET /v1/conversations", () => {
 			expect(firstBody.conversations[0]).toEqual({
 				conversationId: "conv-c",
 				title: "Recent regular C",
+				executionRuntime: "fargate",
 				scope: "collection",
 				createdAt: "2026-01-03T00:00:00.000Z",
 				lastActivityAt: "2026-01-03T00:00:00.000Z",
@@ -2163,6 +2167,9 @@ describe("Conversation execution runtime gate", () => {
 		});
 
 		expect(res.status).toBe(201);
+		expect(await res.json()).toMatchObject({
+			executionRuntime: expectedRuntime,
+		});
 		expect(created).toHaveLength(1);
 		expect(created[0]?.executionRuntime).toBe(expectedRuntime);
 	});

--- a/docs/agents/chat-api.md
+++ b/docs/agents/chat-api.md
@@ -12,7 +12,7 @@ A Conversation is the durable container, a Run serves one submitted message, and
 
 `InternalIdentity` comes from `X-Member-Code` and `X-Partner-Code`; `X-Team-Code`, `X-Member-Name`, and `X-Partner-Name` are optional. `memberCode` becomes the owner (`user_id`). The server generates the Conversation UUID.
 
-Return `201 { conversationId, title, scope, createdAt, lastActivityAt, archivedAt }`. A new empty draft has `title: null` and `archivedAt: null`.
+Return `201 { conversationId, title, executionRuntime, scope, createdAt, lastActivityAt, archivedAt }`. The immutable `executionRuntime` is also present in the shared Conversation summaries returned by list and lifecycle routes. A new empty draft has `title: null` and `archivedAt: null`.
 
 ### Manage Conversations
 

--- a/docs/runbooks/agentcore-rollout.md
+++ b/docs/runbooks/agentcore-rollout.md
@@ -151,17 +151,22 @@ publisher, consumer, or Runtime versions independently releasable.
    mapping remains enabled.
 5. In Statsig, target only the synthetic smoke identity in both the exposure
    gate and `mymemo_agent_agentcore_runtime_enabled`. Leave the runtime gate's
-   default OFF, then run the ordinary public-contract smoke from the
-   VPC-reachable environment:
+   default OFF. From the VPC-reachable environment, run the ordinary
+   public-contract smoke through its deployed wrapper, which pins
+   `AGENT_SMOKE_EXPECT_EXECUTION_RUNTIME=agentcore`:
 
    ```sh
    AGENT_SMOKE_SUITE=core scripts/deploy/prod_smoke.sh
    ```
 
-   Use the printed Conversation id to confirm `execution_runtime = 'agentcore'`,
-   a terminal Outcome, durable history, and a healthy Runtime invocation. This
-   is an ordinary Conversation through chat-api, not an operator-only creation
-   path.
+   The smoke exits nonzero before Run admission unless the public Conversation
+   creation response reports `executionRuntime: "agentcore"`. A pass then proves
+   done Outcomes, durable history, and Downloadable-artifact listing and
+   download for that ordinary Conversation through chat-api; it uses no database
+   or queue access. Retain the printed Conversation and Run ids for correlation
+   with Runtime telemetry. This pass licenses step 6's staged runtime-gate
+   rollout, but does not license setting the default ON or skipping the telemetry
+   checks at each stage.
 6. Roll out `mymemo_agent_agentcore_runtime_enabled` in deliberate Statsig
    stages. At every stage observe pending age, sustained publisher errors,
    queue/DLQ depth, AgentCore Outcomes, and Fargate health before increasing the

--- a/docs/verification/e2e-smoke.md
+++ b/docs/verification/e2e-smoke.md
@@ -42,8 +42,8 @@ value fails before the first HTTP request.
 
 | Target | Suite | Invocation | Credentials and network |
 | --- | --- | --- | --- |
-| Local compose | `full` | `bun run smoke:local` | The running trusted services hold the developer's OpenRouter, E2B, and AWS credentials. The smoke process needs only localhost access. |
-| Deployed internal ALB | `core` | `AGENT_SMOKE_SUITE=core scripts/deploy/prod_smoke.sh` | Run inside the VPC under the allowlisted smoke identity. The caller receives no provider, sandbox, AWS, or database secrets. |
+| Local compose | `full` | `bun run smoke:local` | The entrypoint expects `fargate`, matching local break-glass runtime selection. The running trusted services hold the developer's OpenRouter, E2B, and AWS credentials. The smoke process needs only localhost access. |
+| Deployed internal ALB | `core` | `AGENT_SMOKE_SUITE=core scripts/deploy/prod_smoke.sh` | The wrapper expects `agentcore`. Run inside the VPC under the synthetic identity targeted in both Statsig gates. The caller receives no provider, sandbox, AWS, or database secrets. |
 
 There is no staging target. Local-real is the pre-merge bar; the deployed core
 suite is the post-deploy bar. The smoke identity must be allowlisted in the
@@ -63,9 +63,16 @@ bun run smoke:local
 ```
 
 The command fixes the local base URL, gate-open expectation, seeded fixture
-member, and `full` suite. A pass prints the Conversation id and all Run ids so
-the evidence can be correlated with service logs. A failure exits non-zero with
-the assertion that failed.
+member, expected `fargate` runtime, and `full` suite. A pass prints the
+Conversation id and all Run ids so the evidence can be correlated with service
+logs. A failure exits non-zero with the assertion that failed.
+
+The deployed wrapper fixes the expected runtime to `agentcore`. After the
+synthetic identity is targeted in both gates, the public creation response must
+report that runtime before the client admits its first Run. A deployed pass is
+the gate for beginning the staged runtime rollout described in the
+[AgentCore rollout runbook](../runbooks/agentcore-rollout.md#deploy-order); it is
+not evidence for widening past the next observed stage.
 
 ## Deterministic verification of the verifier
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "mymemo-agent",
 	"module": "index.ts",
 	"scripts": {
-		"smoke:local": "AGENT_SMOKE_BASE_URL=http://localhost:3000 AGENT_SMOKE_EXPECT_GATE_CLOSED=false AGENT_SMOKE_MEMBER_CODE=demo-member AGENT_SMOKE_SUITE=full bun run scripts/smoke/agent-conversation-smoke.ts",
+		"smoke:local": "AGENT_SMOKE_BASE_URL=http://localhost:3000 AGENT_SMOKE_EXPECT_GATE_CLOSED=false AGENT_SMOKE_EXPECT_EXECUTION_RUNTIME=fargate AGENT_SMOKE_MEMBER_CODE=demo-member AGENT_SMOKE_SUITE=full bun run scripts/smoke/agent-conversation-smoke.ts",
 		"test": "bun test scripts/deploy-config.test.ts scripts/agentcore-infra.test.ts scripts/deploy/agentcore_aws_checks.test.ts scripts/deploy/agentcore_plan.test.ts scripts/smoke/client-contract.test.ts scripts/smoke/agent-conversation-smoke.test.ts && bun run scripts/test-workspaces.ts",
 		"terraform:fmt": "terraform -chdir=infra/bootstrap-iam fmt && terraform -chdir=infra/terraform fmt && terraform -chdir=infra/ecr fmt && terraform -chdir=infra/dev fmt && terraform -chdir=infra/agentcore fmt",
 		"terraform:validate": "terraform -chdir=infra/bootstrap-iam validate && terraform -chdir=infra/terraform validate && terraform -chdir=infra/ecr validate && terraform -chdir=infra/dev validate && terraform -chdir=infra/agentcore validate"

--- a/scripts/deploy/prod_smoke.sh
+++ b/scripts/deploy/prod_smoke.sh
@@ -13,4 +13,5 @@ if [[ "$AGENT_SMOKE_BASE_URL" == REPLACE_ME* ]]; then
   exit 1
 fi
 
+export AGENT_SMOKE_EXPECT_EXECUTION_RUNTIME=agentcore
 bun run scripts/smoke/agent-conversation-smoke.ts

--- a/scripts/smoke/agent-conversation-smoke.test.ts
+++ b/scripts/smoke/agent-conversation-smoke.test.ts
@@ -96,6 +96,39 @@ describe("agent conversation smoke", () => {
 		expect(result.stdout).toContain("Statsig gate is closed by default");
 	});
 
+	it("refuses to admit a Run when the created Conversation is not agentcore", async () => {
+		const paths: string[] = [];
+		const server = Bun.serve({
+			port: 0,
+			fetch(request) {
+				const url = new URL(request.url);
+				paths.push(`${request.method} ${url.pathname}`);
+				if (request.method === "POST" && url.pathname === "/v1/conversations") {
+					return Response.json(
+						{
+							conversationId: "fargate-conversation",
+							executionRuntime: "fargate",
+						},
+						{ status: 201 },
+					);
+				}
+				return new Response("unexpected request", { status: 500 });
+			},
+		});
+		servers.push(server);
+
+		const result = await runSmoke(`http://127.0.0.1:${server.port}`, {
+			AGENT_SMOKE_EXPECT_GATE_CLOSED: "false",
+			AGENT_SMOKE_EXPECT_EXECUTION_RUNTIME: "agentcore",
+		});
+
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr).toContain(
+			"conversation create selected fargate, expected agentcore",
+		);
+		expect(paths).toEqual(["POST /v1/conversations"]);
+	});
+
 	it("uses strict Run admission and terminal history recovery", async () => {
 		const conversationId = "conversation-1";
 		const workspaceMarker = "workspace-0123456789abcdef0123456789abcdef";
@@ -115,7 +148,10 @@ describe("agent conversation smoke", () => {
 				const url = new URL(request.url);
 				paths.push(`${request.method} ${url.pathname}`);
 				if (request.method === "POST" && url.pathname === "/v1/conversations") {
-					return Response.json({ conversationId }, { status: 201 });
+					return Response.json(
+						{ conversationId, executionRuntime: "agentcore" },
+						{ status: 201 },
+					);
 				}
 				if (
 					request.method === "POST" &&
@@ -210,6 +246,7 @@ describe("agent conversation smoke", () => {
 
 		const result = await runSmoke(`http://127.0.0.1:${server.port}`, {
 			AGENT_SMOKE_EXPECT_GATE_CLOSED: "false",
+			AGENT_SMOKE_EXPECT_EXECUTION_RUNTIME: "agentcore",
 		});
 
 		expect(result).toMatchObject({ exitCode: 0, stderr: "" });

--- a/scripts/smoke/agent-conversation-smoke.ts
+++ b/scripts/smoke/agent-conversation-smoke.ts
@@ -1,11 +1,22 @@
 #!/usr/bin/env bun
 
+// Deployed operator use: run this client through scripts/deploy/prod_smoke.sh
+// only after AgentCore Dispatch is enabled and the synthetic identity is
+// targeted in both Statsig gates. The wrapper pins the expected execution
+// runtime to agentcore. A pass proves that the public creation response selected
+// agentcore before the client admits Runs, then proves done Outcomes, durable
+// history, and Downloadable-artifact listing/download. It licenses the staged
+// runtime-gate rollout in docs/runbooks/agentcore-rollout.md; it does not license
+// skipping that rollout's telemetry checks. The local smoke:local entrypoint
+// instead pins the expected runtime to fargate for break-glass compose.
+
 import { createHash, randomUUID } from "node:crypto";
 import { isDeepStrictEqual } from "node:util";
 import {
 	parseRawAgUiSse as parseSSE,
 	type RawAgUiSseFrame,
 } from "@mymemo/test-support/ag-ui-sse";
+import type { ConversationExecutionRuntime } from "../../packages/agent-db/src/execution-runtime";
 import type { PublicToolName } from "../../packages/agent-db/src/run-events";
 import {
 	type ClientContractMessage,
@@ -113,7 +124,13 @@ if (expectGateClosed) {
 	process.exit(0);
 }
 
-const conversationId = await requireCreatedConversation(create);
+const expectedExecutionRuntime = parseExpectedExecutionRuntime(
+	Bun.env.AGENT_SMOKE_EXPECT_EXECUTION_RUNTIME,
+);
+const conversationId = await requireCreatedConversation(
+	create,
+	expectedExecutionRuntime,
+);
 
 const sessionMarker = `agent-session-${randomUUID()}`;
 const firstTurn = await sendTurn(
@@ -202,6 +219,7 @@ let fullSuiteEvidence = "";
 if (suite === "full") {
 	const interruptConversationId = await requireCreatedConversation(
 		await requestConversationCreate(),
+		expectedExecutionRuntime,
 	);
 	const interruptedTurn = await verifyRunningRunInterruption(
 		interruptConversationId,
@@ -210,6 +228,7 @@ if (suite === "full") {
 
 	const searchableDocumentConversationId = await requireCreatedConversation(
 		await requestConversationCreate(),
+		expectedExecutionRuntime,
 	);
 	const searchableDocumentTurns = await verifySearchableDocumentTools(
 		searchableDocumentConversationId,
@@ -230,19 +249,28 @@ function requestConversationCreate(): Promise<Response> {
 	});
 }
 
-async function requireCreatedConversation(response: Response): Promise<string> {
+async function requireCreatedConversation(
+	response: Response,
+	expectedRuntime: ConversationExecutionRuntime,
+): Promise<string> {
 	if (response.status !== 201) {
 		throw new Error(
 			`expected conversation create 201, got ${response.status}: ${await response.text()}`,
 		);
 	}
 
-	const { conversationId } = (await response.json()) as {
+	const { conversationId, executionRuntime } = (await response.json()) as {
 		conversationId?: string;
+		executionRuntime?: unknown;
 	};
 	if (!conversationId) {
 		throw new Error(
 			"conversation create response did not include conversationId",
+		);
+	}
+	if (executionRuntime !== expectedRuntime) {
+		throw new Error(
+			`conversation create selected ${String(executionRuntime)}, expected ${expectedRuntime}`,
 		);
 	}
 	return conversationId;
@@ -987,4 +1015,13 @@ function parseSuite(value: string | undefined): SmokeSuite {
 	if (value === undefined || value === "core") return "core";
 	if (value === "full") return "full";
 	throw new Error("AGENT_SMOKE_SUITE must be core or full");
+}
+
+function parseExpectedExecutionRuntime(
+	value: string | undefined,
+): ConversationExecutionRuntime {
+	if (value === "fargate" || value === "agentcore") return value;
+	throw new Error(
+		"AGENT_SMOKE_EXPECT_EXECUTION_RUNTIME must be fargate or agentcore",
+	);
 }


### PR DESCRIPTION
## Summary

- expose the immutable `executionRuntime` on public Conversation summaries
- require the existing operator smoke to verify the expected runtime before admitting any Run
- pin deployed smoke to `agentcore` and local smoke to `fargate`
- document gate targeting, deploy placement, and what a successful smoke licenses

## Acceptance criteria

- [x] The existing smoke still creates a Conversation, admits Runs, waits for `done`, verifies durable history and artifact listing/download, and exits nonzero on failures or timeouts.
- [x] Conversation creation exposes `executionRuntime` through the public v1 response, and the smoke refuses to continue unless it is `agentcore` in production.
- [x] The smoke uses only public v1 HTTP endpoints with trusted identity headers; it has no database or queue access.
- [x] The script header and AgentCore rollout runbook document when to run the smoke, both required Statsig gate targets, and the rollout step a pass licenses.

## Verification

- `bun run test` — root tests and all eight workspace suites passed
- Chat API TypeScript check passed
- Biome checks passed for changed TypeScript files
- `bash -n scripts/deploy/prod_smoke.sh`
- GitHub Actions: `test`, `integration`, `agentcore-infrastructure`, `image`, `image-contract`, and `worker-image` passed
- two-axis Standards and Spec review completed with no findings

## Deployment note

The deployed AgentCore smoke remains an operator action after this change reaches the environment and the smoke identity is targeted in both Statsig gates.

Closes #485