### PR TITLE
refactor(infra): move AgentCore Runtime repository to ECR bootstrap state

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -123,6 +123,26 @@ jobs:
       - name: Ensure ECR repositories
         run: |
           terraform -chdir=infra/ecr init
+
+          ecr_state_addresses="$(terraform -chdir=infra/ecr state list)"
+          if ! grep -Fxq "aws_ecr_repository.agentcore_runtime" <<<"${ecr_state_addresses}"; then
+            repository_error="${RUNNER_TEMP}/agentcore-runtime-repository-error"
+            if aws ecr describe-repositories \
+              --region "${AWS_REGION}" \
+              --repository-names mymemo/agentcore-runtime \
+              >/dev/null 2>"${repository_error}"; then
+              terraform -chdir=infra/ecr import \
+                -var="aws_region=${AWS_REGION}" \
+                aws_ecr_repository.agentcore_runtime \
+                mymemo/agentcore-runtime
+            elif grep -q "RepositoryNotFoundException" "${repository_error}"; then
+              echo "AgentCore Runtime repository does not exist yet; Terraform will create it."
+            else
+              sed -n '1,120p' "${repository_error}" >&2
+              exit 1
+            fi
+          fi
+
           terraform -chdir=infra/ecr apply -auto-approve -var="aws_region=${AWS_REGION}"
 
       - name: Resolve image references
@@ -131,9 +151,11 @@ jobs:
           chat_api_repository_url="$(terraform -chdir=infra/ecr output -raw chat_api_ecr_repository_url)"
           agent_worker_repository_url="$(terraform -chdir=infra/ecr output -raw agent_worker_ecr_repository_url)"
           agentcore_dispatch_publisher_repository_url="$(terraform -chdir=infra/ecr output -raw agentcore_dispatch_publisher_ecr_repository_url)"
+          agentcore_runtime_repository_url="$(terraform -chdir=infra/ecr output -raw agentcore_runtime_ecr_repository_url)"
           printf 'chat_api_image=%s:%s\n' "${chat_api_repository_url}" "${IMAGE_TAG}" >> "${GITHUB_OUTPUT}"
           printf 'agent_worker_image=%s:%s\n' "${agent_worker_repository_url}" "${IMAGE_TAG}" >> "${GITHUB_OUTPUT}"
           printf 'agentcore_dispatch_publisher_image=%s:%s\n' "${agentcore_dispatch_publisher_repository_url}" "${IMAGE_TAG}" >> "${GITHUB_OUTPUT}"
+          printf 'agentcore_runtime_repository_url=%s\n' "${agentcore_runtime_repository_url}" >> "${GITHUB_OUTPUT}"
 
       - name: Prepare Terraform variables
         run: scripts/deploy/ci_prepare_tfvars.sh
@@ -156,8 +178,8 @@ jobs:
       - name: Build, verify, and push the ARM64 AgentCore Runtime image
         id: agentcore_runtime_image
         run: |
-          terraform -chdir=infra/terraform init
-          repository_uri="$(terraform -chdir=infra/terraform output -raw runtime_repository_url)"
+          repository_uri="${{ steps.images.outputs.agentcore_runtime_repository_url }}"
+          repository_name="${repository_uri#*/}"
           docker buildx build \
             --platform linux/arm64 \
             --load \
@@ -171,7 +193,7 @@ jobs:
           docker push "${repository_uri}:${IMAGE_TAG}"
           runtime_image_digest="$(aws ecr describe-images \
             --region "${AWS_REGION}" \
-            --repository-name mymemo/agentcore-runtime \
+            --repository-name "${repository_name}" \
             --image-ids imageTag="${IMAGE_TAG}" \
             --query 'imageDetails[0].imageDigest' \
             --output text)"
@@ -181,7 +203,7 @@ jobs:
           fi
           aws ecr wait image-scan-complete \
             --region "${AWS_REGION}" \
-            --repository-name mymemo/agentcore-runtime \
+            --repository-name "${repository_name}" \
             --image-id imageDigest="${runtime_image_digest}"
           printf 'TF_VAR_runtime_image_digest=%s\n' "${runtime_image_digest}" >> "${GITHUB_ENV}"
           printf 'runtime_image_digest=%s\n' "${runtime_image_digest}" >> "${GITHUB_OUTPUT}"

--- a/docs/adr/0028-unify-production-terraform-state.md
+++ b/docs/adr/0028-unify-production-terraform-state.md
@@ -3,11 +3,19 @@
 Status: accepted (2026-08-19). Supersedes ADR-0021's independent-state
 consequence for the now-production AgentCore path.
 
+Amended (2026-08-20): immutable image repositories are build prerequisites,
+not executable release resources. The existing `infra/ecr` bootstrap root owns
+all four repositories, including `mymemo/agentcore-runtime`; the production
+root resolves the Runtime repository by its exact name.
+
 The ECS applications, dedicated Dispatch publisher, consumer Lambda, and
 AgentCore Runtime share `infra/terraform` and the
 `mymemo-agent/prod.tfstate` backend. They use one AWS provider line
 (`>= 6.50, < 7.0`) and one Release deploy because their database schema,
 dispatch envelope, and executable versions have one compatibility cycle.
+The separate `infra/ecr` state owns only durable image storage that must exist
+before those executable artifacts can be built and the unified plan can be
+created; it does not independently deploy any executable surface.
 
 This is a lifecycle boundary, not a process or authority merger. The publisher,
 consumer, Runtime, chat-api, and agent-worker keep their separate compute and
@@ -27,18 +35,25 @@ Every complete Terraform plan receives the same operator authorization; there
 is no automatic application lane or attribute-level release classifier.
 Replacement is not a universal error: Terraform lifecycle rules prevent
 destruction only for durable Dispatch queues, its KMS key and SSM control, and
-the immutable Runtime image repository.
+the immutable Runtime image repository in the ECR root.
 
 The existing AgentCore addresses were moved from the historical
 `mymemo-agent/agentcore-canary-prod.tfstate` backend into the production state
 before the unified release path was enabled. The historical state now owns no
 managed resources. S3 object versions retain the migration's recovery record.
+The Runtime repository is subsequently imported into
+`mymemo-agent/ecr-prod.tfstate` before the production root forgets its old
+address without destroying the repository. The ordered handoff permits a
+temporary duplicate state record if a release stops between those operations,
+but never a period in which the physical repository is deleted or recreated.
 
 ## Considered options
 
-- **Keep two roots and apply them sequentially.** Rejected because it preserves
-  duplicate provider configuration, remote-state coupling, two plan policies,
-  and a false lifecycle boundary for components that always ship together.
+- **Keep separate executable roots and apply them sequentially.** Rejected
+  because it preserves duplicate provider configuration, remote-state
+  coupling, two plan policies, and a false lifecycle boundary for components
+  that always ship together. The pre-existing ECR bootstrap root is different:
+  it owns stable image storage and performs no executable deployment.
 - **Apply the complete unified plan before migration.** Rejected because an
   enabled consumer mapping or existing Runtime traffic could execute new code
   against the old schema.
@@ -55,8 +70,9 @@ managed resources. S3 object versions retain the migration's recovery record.
 ## Consequences
 
 - AgentCore resources can directly reference the production database, secrets,
-  artifact bucket, Redis, network, alarms, queue, KMS key, and SSM parameter;
-  the `mymemo_agent` remote-state dependency is removed.
+  artifact bucket, Redis, network, alarms, queue, KMS key, and SSM parameter.
+  The Runtime repository is resolved through an exact ECR data lookup after the
+  bootstrap root is applied; no Terraform remote-state dependency is added.
 - Provider upgrades and drift review happen once for the whole production
   stack.
 - A normal release updates all executable surfaces together after an explicit

--- a/infra/ecr/main.tf
+++ b/infra/ecr/main.tf
@@ -24,3 +24,25 @@ resource "aws_ecr_repository" "agentcore_dispatch_publisher" {
     scan_on_push = true
   }
 }
+
+resource "aws_ecr_repository" "agentcore_runtime" {
+  name                 = "mymemo/agentcore-runtime"
+  image_tag_mutability = "IMMUTABLE"
+  force_delete         = false
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+
+  tags = {
+    Environment = "prod"
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/infra/ecr/outputs.tf
+++ b/infra/ecr/outputs.tf
@@ -12,3 +12,8 @@ output "agentcore_dispatch_publisher_ecr_repository_url" {
   description = "ECR repository URL for AgentCore dispatch publisher images."
   value       = aws_ecr_repository.agentcore_dispatch_publisher.repository_url
 }
+
+output "agentcore_runtime_ecr_repository_url" {
+  description = "ECR repository URL for AgentCore Runtime images."
+  value       = aws_ecr_repository.agentcore_runtime.repository_url
+}

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -25,9 +25,9 @@ the direct remote-state output is absent and the fallback input is present.
 
 ## Agent-Owned Resources
 
-- ECR repositories for `mymemo-agent-chat-api`, `mymemo-agent-worker`, and
-  `mymemo-agentcore-dispatch-publisher` in the separate `infra/ecr` Terraform
-  root
+- ECR repositories for `mymemo-agent-chat-api`, `mymemo-agent-worker`,
+  `mymemo-agentcore-dispatch-publisher`, and `mymemo/agentcore-runtime` in the
+  separate `infra/ecr` Terraform root
 - dedicated RDS Postgres instance for writable agent state
 - EC2 Instance Connect Endpoint and private EC2 bridge for operator access to
   the agent and KB databases
@@ -44,8 +44,8 @@ the direct remote-state output is absent and the fallback input is present.
 - CloudWatch log groups and baseline alarms
 - encrypted AgentCore Dispatch and dead-letter queues, their fail-closed SSM
   control, and the batch-size-one consumer Lambda
-- digest-pinned ARM64 AgentCore Runtime, immutable Runtime ECR repository,
-  private subnets, zonal NAT egress, workload IAM, and Dispatch alarms
+- digest-pinned ARM64 AgentCore Runtime, private subnets, zonal NAT egress,
+  workload IAM, and Dispatch alarms
 
 The AgentCore Runtime, consumer, and dedicated Dispatch publisher share this
 state because they ship on the same compatibility cycle as the ECS services and
@@ -159,8 +159,9 @@ Terraform-owned production inputs live in checked-in
 `infra/deploy/prod.env` for CI/deploy settings such as AWS region, AWS account,
 and smoke-test inputs, then generates `infra/terraform/generated.auto.tfvars`
 with release-specific Terraform values: AWS region and the three immutable ECS
-image URIs. The Runtime digest and consumer package path are supplied through
-Terraform environment variables by the same workflow. The plan step uses both:
+image URIs. The Runtime repository URL comes from the separately applied ECR
+root; its digest and the consumer package path are supplied through Terraform
+environment variables by the same workflow. The plan step uses both:
 
 ```sh
 terraform -chdir=infra/terraform plan -var-file=prod.tfvars -var-file=generated.auto.tfvars
@@ -168,6 +169,37 @@ terraform -chdir=infra/terraform plan -var-file=prod.tfvars -var-file=generated.
 
 Placeholder values such as `REPLACE_ME_*` in `prod.tfvars` or the generated
 image overlay fail the plan entrypoint before Terraform changes are proposed.
+
+### AgentCore Runtime repository state handoff
+
+The Runtime repository predates its ownership by `infra/ecr`. During the first
+authorized release containing this handoff, the ECR step checks whether
+`aws_ecr_repository.agentcore_runtime` is already in `ecr-prod.tfstate`. If it
+is absent but `mymemo/agentcore-runtime` exists in AWS, the step imports that
+repository before the normal ECR apply. A repository absent from both AWS and
+state is created normally for a clean environment.
+
+The later unified production apply uses a Terraform `removed` block with
+`destroy = false` to forget the historical
+`aws_ecr_repository.production_runtime` address. An interrupted release may
+temporarily leave the repository recorded in both states, but never deletes or
+recreates it; rerun the same reviewed release to finish the handoff. Do not
+manually remove or import either state address during that recovery.
+
+After the release succeeds, verify the single owner without reading image
+contents:
+
+```sh
+AWS_PROFILE=mymemo terraform -chdir=infra/ecr state show aws_ecr_repository.agentcore_runtime
+if AWS_PROFILE=mymemo terraform -chdir=infra/terraform state list \
+  | rg -q '^aws_ecr_repository\.production_runtime$'; then
+  echo "Production state still records the Runtime repository" >&2
+  exit 1
+fi
+```
+
+The first command must succeed and the guard must exit without printing an
+error.
 
 ECS service `task_definition` changes are intentionally ignored by Terraform.
 For an ordinary release, the workflow first applies a strictly classified,

--- a/infra/terraform/agentcore-iam.tf
+++ b/infra/terraform/agentcore-iam.tf
@@ -41,7 +41,7 @@ data "aws_iam_policy_document" "runtime" {
   statement {
     sid       = "PullFromRuntimeRepoOnly"
     actions   = ["ecr:BatchGetImage", "ecr:GetDownloadUrlForLayer"]
-    resources = [aws_ecr_repository.production_runtime.arn]
+    resources = [data.aws_ecr_repository.production_runtime.arn]
   }
 
   statement {

--- a/infra/terraform/agentcore-outputs.tf
+++ b/infra/terraform/agentcore-outputs.tf
@@ -1,8 +1,8 @@
 // AgentCore Runtime, Dispatch, and consumer outputs share the production state
 // with the ECS applications that consume the same release configuration.
 output "runtime_repository_url" {
-  description = "Immutable ECR repository used by the production AgentCore Runtime."
-  value       = aws_ecr_repository.production_runtime.repository_url
+  description = "Resolved immutable ECR repository used by the production AgentCore Runtime."
+  value       = data.aws_ecr_repository.production_runtime.repository_url
 }
 
 output "runtime_image_digest" {

--- a/infra/terraform/agentcore-runtime.tf
+++ b/infra/terraform/agentcore-runtime.tf
@@ -1,18 +1,12 @@
-resource "aws_ecr_repository" "production_runtime" {
-  name                 = "mymemo/agentcore-runtime"
-  image_tag_mutability = "IMMUTABLE"
-  force_delete         = false
+data "aws_ecr_repository" "production_runtime" {
+  name = "mymemo/agentcore-runtime"
+}
 
-  image_scanning_configuration {
-    scan_on_push = true
-  }
-
-  encryption_configuration {
-    encryption_type = "AES256"
-  }
+removed {
+  from = aws_ecr_repository.production_runtime
 
   lifecycle {
-    prevent_destroy = true
+    destroy = false
   }
 }
 
@@ -24,7 +18,7 @@ resource "aws_bedrockagentcore_agent_runtime" "runtime" {
 
   agent_runtime_artifact {
     container_configuration {
-      container_uri = "${aws_ecr_repository.production_runtime.repository_url}@${var.runtime_image_digest}"
+      container_uri = "${data.aws_ecr_repository.production_runtime.repository_url}@${var.runtime_image_digest}"
     }
   }
 

--- a/scripts/agentcore-infra.test.ts
+++ b/scripts/agentcore-infra.test.ts
@@ -5,6 +5,7 @@ import { AGENTCORE_DISPATCH_QUEUE_INVARIANTS } from "../apps/agentcore-dispatch-
 
 const root = process.cwd();
 const terraformDir = join(root, "infra", "terraform");
+const ecrTerraformDir = join(root, "infra", "ecr");
 const terraformEnvironment = "$" + "{var.environment}";
 
 function terraformFiles(): string[] {
@@ -165,6 +166,11 @@ describe("production AgentCore dispatch infrastructure", () => {
 			join(terraformDir, "agentcore-runtime.tf"),
 			"utf8",
 		);
+		const ecr = readFileSync(join(ecrTerraformDir, "main.tf"), "utf8");
+		const ecrOutputs = readFileSync(
+			join(ecrTerraformDir, "outputs.tf"),
+			"utf8",
+		);
 		const variables = readFileSync(join(terraformDir, "variables.tf"), "utf8");
 		const agentOutputs = readFileSync(
 			join(root, "infra", "terraform", "outputs.tf"),
@@ -180,8 +186,17 @@ describe("production AgentCore dispatch infrastructure", () => {
 		expect(source).toContain(
 			`agentcore_name_prefix = "mymemo-agent-agentcore-${terraformEnvironment}"`,
 		);
+		expect(ecr).toMatch(
+			/resource\s+"aws_ecr_repository"\s+"agentcore_runtime"[\s\S]*?name\s*=\s*"mymemo\/agentcore-runtime"[\s\S]*?image_tag_mutability\s*=\s*"IMMUTABLE"[\s\S]*?force_delete\s*=\s*false[\s\S]*?scan_on_push\s*=\s*true[\s\S]*?encryption_type\s*=\s*"AES256"[\s\S]*?prevent_destroy\s*=\s*true/,
+		);
+		expect(ecrOutputs).toMatch(
+			/output\s+"agentcore_runtime_ecr_repository_url"[\s\S]*?aws_ecr_repository\.agentcore_runtime\.repository_url/,
+		);
 		expect(runtime).toMatch(
-			/resource\s+"aws_ecr_repository"\s+"production_runtime"[\s\S]*?name\s*=\s*"mymemo\/agentcore-runtime"/,
+			/data\s+"aws_ecr_repository"\s+"production_runtime"[\s\S]*?name\s*=\s*"mymemo\/agentcore-runtime"/,
+		);
+		expect(runtime).toMatch(
+			/removed\s*\{[\s\S]*?from\s*=\s*aws_ecr_repository\.production_runtime[\s\S]*?destroy\s*=\s*false/,
 		);
 		expect(runtime).not.toContain(
 			'resource "aws_ecr_repository" "legacy_runtime"',
@@ -194,7 +209,7 @@ describe("production AgentCore dispatch infrastructure", () => {
 			'variable "runtime_repository_force_delete"',
 		);
 		expect(source).toMatch(
-			/container_uri\s*=\s*"\$\{aws_ecr_repository\.production_runtime\.repository_url\}@\$\{var\.runtime_image_digest\}"/,
+			/container_uri\s*=\s*"\$\{data\.aws_ecr_repository\.production_runtime\.repository_url\}@\$\{var\.runtime_image_digest\}"/,
 		);
 		expect(source).toMatch(/network_mode\s*=\s*"VPC"/);
 		expect(source).toMatch(/server_protocol\s*=\s*"HTTP"/);
@@ -249,6 +264,9 @@ describe("production AgentCore dispatch infrastructure", () => {
 		}
 		expect(source).toMatch(
 			/sid\s*=\s*"WriteProductionArtifacts"[\s\S]*?"s3:AbortMultipartUpload"[\s\S]*?"s3:DeleteObject"[\s\S]*?"s3:PutObject"[\s\S]*?resources\s*=\s*\["\$\{aws_s3_bucket\.artifacts\.arn\}\/objects\/\*"\]/,
+		);
+		expect(agentcoreIam).toContain(
+			"resources = [data.aws_ecr_repository.production_runtime.arn]",
 		);
 		expect(source).toMatch(
 			/data\s+"aws_iam_policy_document"\s+"runtime_trust"[\s\S]*?runtime\/mymemo_agentcore_prod-\*/,
@@ -412,7 +430,7 @@ describe("production AgentCore dispatch infrastructure", () => {
 		);
 	});
 
-	it("preserves remaining state-address moves while removing canary resources", () => {
+	it("preserves remaining state-address moves while handing off the Runtime repository", () => {
 		const source = terraformSource();
 		const moves = readFileSync(
 			join(terraformDir, "agentcore-moved.tf"),
@@ -429,6 +447,9 @@ describe("production AgentCore dispatch infrastructure", () => {
 			expect(moves).toContain(`from = ${oldAddress}`);
 		}
 		expect(moves).not.toContain("aws_ecr_repository");
+		expect(source).toMatch(
+			/removed\s*\{[\s\S]*?from\s*=\s*aws_ecr_repository\.production_runtime[\s\S]*?destroy\s*=\s*false/,
+		);
 		expect(source).not.toContain("legacy_runtime");
 		expect(source).not.toMatch(/resource\s+"[^"]+"\s+"canary"/);
 		expect(source).not.toContain(
@@ -448,9 +469,11 @@ describe("production AgentCore dispatch infrastructure", () => {
 			join(terraformDir, "agentcore-runtime.tf"),
 			"utf8",
 		);
+		const ecr = readFileSync(join(ecrTerraformDir, "main.tf"), "utf8");
 
 		expect(queue.match(/prevent_destroy\s*=\s*true/g)).toHaveLength(4);
-		expect(runtime.match(/prevent_destroy\s*=\s*true/g)).toHaveLength(1);
+		expect(ecr.match(/prevent_destroy\s*=\s*true/g)).toHaveLength(1);
+		expect(runtime).not.toContain("prevent_destroy");
 		expect(runtime).not.toMatch(
 			/resource "aws_bedrockagentcore_agent_runtime" "runtime"[\s\S]*?prevent_destroy/,
 		);

--- a/scripts/deploy-config.test.ts
+++ b/scripts/deploy-config.test.ts
@@ -525,8 +525,31 @@ describe("agent deployment config", () => {
 		expect(ecrCombined).toContain(
 			'resource "aws_ecr_repository" "agentcore_dispatch_publisher"',
 		);
+		expect(ecrCombined).toContain(
+			'resource "aws_ecr_repository" "agentcore_runtime"',
+		);
+		expect(ecrCombined).toContain('name                 = "mymemo/agentcore-runtime"');
+		expect(ecrCombined).toContain(
+			'output "agentcore_runtime_ecr_repository_url"',
+		);
+		expect(releaseDeployWorkflow).toContain(
+			'ecr_state_addresses="$(terraform -chdir=infra/ecr state list)"',
+		);
+		expect(releaseDeployWorkflow).toContain(
+			"terraform -chdir=infra/ecr import",
+		);
+		expect(releaseDeployWorkflow).toContain(
+			"aws_ecr_repository.agentcore_runtime",
+		);
 		expect(releaseDeployWorkflow).toContain(
 			"terraform -chdir=infra/ecr apply -auto-approve",
+		);
+		expect(
+			releaseDeployWorkflow.indexOf("terraform -chdir=infra/ecr import"),
+		).toBeLessThan(
+			releaseDeployWorkflow.indexOf(
+				"terraform -chdir=infra/ecr apply -auto-approve",
+			),
 		);
 		expect(releaseDeployWorkflow).not.toContain("-target=");
 		expect(releaseDeployWorkflow).not.toContain(
@@ -745,6 +768,12 @@ describe("agent deployment config", () => {
 		);
 		expect(prepareScript).toContain(
 			"terraform -chdir=infra/ecr output -raw agentcore_dispatch_publisher_ecr_repository_url",
+		);
+		expect(releaseDeployWorkflow).toContain(
+			"terraform -chdir=infra/ecr output -raw agentcore_runtime_ecr_repository_url",
+		);
+		expect(releaseDeployWorkflow).not.toContain(
+			"terraform -chdir=infra/terraform output -raw runtime_repository_url",
 		);
 		expect(releaseDeployWorkflow).not.toContain("AWS_REGION: us-west-2");
 		expect(releaseDeployWorkflow).not.toContain(


### PR DESCRIPTION
## Summary

- Move ownership of the existing immutable `mymemo/agentcore-runtime` repository into the `infra/ecr` Terraform root.
- Import the production repository during the authorized release, while allowing the same configuration to create it in a clean environment.
- Resolve the repository through an exact ECR data lookup in the production stack and forget its historical state address with `destroy = false`.
- Preserve digest-pinned Runtime deployment, least-privilege pull IAM, repository protection, documentation, and infrastructure contract coverage.

## Why

The Runtime image must be built and pushed before the unified production plan can be created. Keeping its repository in that production state introduced a bootstrap dependency that the other application image repositories do not have.

Placing all durable image repositories in the ECR bootstrap state separates artifact storage from executable deployment without changing the shared compatibility cycle of the AgentCore Runtime, consumer, publisher, ECS services, and database schema.

## Operational impact

- The first manually authorized **Release deploy** imports `mymemo/agentcore-runtime` into `mymemo-agent/ecr-prod.tfstate` before the normal ECR apply.
- The later unified production apply forgets `aws_ecr_repository.production_runtime` without deleting or recreating the physical repository or its images.
- A release interrupted between those operations may temporarily record the repository in both states. Rerunning the same reviewed release completes the handoff; operators should not manually remove or import either address.
- AgentCore Dispatch controls and Runtime traffic behavior are unchanged.

## Verification

- `bun test scripts/deploy-config.test.ts scripts/agentcore-infra.test.ts` — 52 tests passed.
- `terraform fmt -check` and `terraform validate` passed for `infra/ecr` and `infra/terraform`.
- Release workflow YAML parsing and `git diff --check` passed.
- GitHub Actions `test`, `infrastructure`, and `integration` checks passed on the final head.