### PR TITLE
fix(deploy): align AgentCore Runtime Bun image

### DIFF
--- a/apps/agentcore-runtime/Dockerfile
+++ b/apps/agentcore-runtime/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-ARG BUN_VERSION=1.3.14
+ARG BUN_VERSION=1
 
 FROM oven/bun:${BUN_VERSION} AS base
 RUN apt-get update \

--- a/scripts/agentcore-infra.test.ts
+++ b/scripts/agentcore-infra.test.ts
@@ -31,6 +31,7 @@ describe("production AgentCore dispatch infrastructure", () => {
 		expect(dockerfile).toContain("apt-get update");
 		expect(dockerfile).toContain("apt-get upgrade -y --no-install-recommends");
 		expect(dockerfile).toContain("rm -rf /var/lib/apt/lists/*");
+		expect(dockerfile).toMatch(/^ARG BUN_VERSION=1$/m);
 		expect(dockerfile).toContain(
 			`FROM oven/bun:\${BUN_VERSION}-distroless AS release`,
 		);


### PR DESCRIPTION
## Summary

- align the AgentCore Runtime build and distroless stages with the other service images by using the Bun `1` tag
- add an infrastructure assertion that guards the Runtime's Bun version argument

## Context

The latest GA release failed while Bun 1.3.14 extracted the TypeScript tarball in the ARM64 Runtime image. The chat API, agent worker, and dispatch publisher builds used `oven/bun:1`, which resolved to Bun 1.4.0 and completed successfully.

## Verification

- [x] `bun test scripts/agentcore-infra.test.ts` — 14 passed
- [x] `git diff --check`
- [ ] Full local ARM64 image build — Bun 1.4.0 repeatedly exits 139 under the local QEMU emulator; the GitHub Actions image-contract run remains required
