### PR TITLE
fix(deploy): remove redundant AgentCore secret ARN validation

### DIFF
--- a/infra/terraform/agentcore-locals.tf
+++ b/infra/terraform/agentcore-locals.tf
@@ -2,7 +2,7 @@ locals {
   agentcore_name_prefix = "mymemo-agent-agentcore-${var.environment}"
   vpc_id                = local.shared_vpc_id
 
-  exact_secret_arn_pattern = "^arn:aws:secretsmanager:${var.aws_region}:${var.aws_account_id}:secret:[A-Za-z0-9/_+=.@-]+$"
+  exact_secret_arn_pattern = "^arn:aws:secretsmanager:${var.aws_region}:${var.aws_account_id}:secret:[^:*?]+$"
   exact_secret_arns = [
     local.agent_db_password_base_secret_arn,
     local.kb_database_url_secret_arn,

--- a/infra/terraform/agentcore-locals.tf
+++ b/infra/terraform/agentcore-locals.tf
@@ -2,7 +2,6 @@ locals {
   agentcore_name_prefix = "mymemo-agent-agentcore-${var.environment}"
   vpc_id                = local.shared_vpc_id
 
-  exact_secret_arn_pattern = "^arn:aws:secretsmanager:${var.aws_region}:${var.aws_account_id}:secret:[^:*?]+$"
   exact_secret_arns = [
     local.agent_db_password_base_secret_arn,
     local.kb_database_url_secret_arn,

--- a/infra/terraform/agentcore-runtime.tf
+++ b/infra/terraform/agentcore-runtime.tf
@@ -40,14 +40,5 @@ resource "aws_bedrockagentcore_agent_runtime" "runtime" {
     server_protocol = "HTTP"
   }
 
-  lifecycle {
-    precondition {
-      condition = alltrue([
-        for arn in local.exact_secret_arns : can(regex(local.exact_secret_arn_pattern, arn))
-      ])
-      error_message = "Every runtime secret input must be an exact same-account, same-region Secrets Manager ARN without a wildcard or JSON-key suffix."
-    }
-  }
-
   depends_on = [aws_iam_role_policy.runtime]
 }

--- a/scripts/agentcore-infra.test.ts
+++ b/scripts/agentcore-infra.test.ts
@@ -215,9 +215,6 @@ describe("production AgentCore dispatch infrastructure", () => {
 		expect(source).toMatch(/network_mode\s*=\s*"VPC"/);
 		expect(source).toMatch(/server_protocol\s*=\s*"HTTP"/);
 		expect(source).toMatch(/max_lifetime\s*=\s*3600/);
-		expect(source).toMatch(
-			/resource\s+"aws_bedrockagentcore_agent_runtime"\s+"runtime"[\s\S]*?precondition[\s\S]*?local\.exact_secret_arn_pattern/,
-		);
 		for (const name of [
 			"AGENT_DATABASE_URL",
 			"DB_PASSWORD_SECRET_ARN",
@@ -250,42 +247,6 @@ describe("production AgentCore dispatch infrastructure", () => {
 			"REDIS_URL",
 		]) {
 			expect(source).not.toMatch(new RegExp(`\\n\\s*${forbiddenSecret}\\s*=`));
-		}
-	});
-
-	it("validates exact Runtime secret scope without validating AWS-generated names", () => {
-		const locals = readFileSync(
-			join(terraformDir, "agentcore-locals.tf"),
-			"utf8",
-		);
-		const terraformPattern = locals.match(
-			/exact_secret_arn_pattern\s*=\s*"([^"]+)"/,
-		)?.[1];
-		if (!terraformPattern) {
-			throw new Error("missing exact_secret_arn_pattern");
-		}
-
-		const terraformRegion = "$" + "{var.aws_region}";
-		const terraformAccountId = "$" + "{var.aws_account_id}";
-		const exactSecretArn = new RegExp(
-			terraformPattern
-				.replace(terraformRegion, "us-west-2")
-				.replace(terraformAccountId, "123456789012"),
-		);
-		const prefix = "arn:aws:secretsmanager:us-west-2:123456789012:secret:";
-
-		expect(exactSecretArn.test(`${prefix}rds!db-example-AbCdEf`)).toBe(true);
-		expect(exactSecretArn.test(`${prefix}future~aws-generated-name`)).toBe(
-			true,
-		);
-		expect(exactSecretArn.test(`${prefix}mymemo-agent-prod-AbCdEf`)).toBe(true);
-		for (const rejectedArn of [
-			`${prefix}rds!db-example-*`,
-			`${prefix}rds!db-example-AbCdEf:password::`,
-			"arn:aws:secretsmanager:us-east-1:123456789012:secret:rds!db-example-AbCdEf",
-			"arn:aws:secretsmanager:us-west-2:210987654321:secret:rds!db-example-AbCdEf",
-		]) {
-			expect(exactSecretArn.test(rejectedArn)).toBe(false);
 		}
 	});
 

--- a/scripts/agentcore-infra.test.ts
+++ b/scripts/agentcore-infra.test.ts
@@ -253,6 +253,42 @@ describe("production AgentCore dispatch infrastructure", () => {
 		}
 	});
 
+	it("validates exact Runtime secret scope without validating AWS-generated names", () => {
+		const locals = readFileSync(
+			join(terraformDir, "agentcore-locals.tf"),
+			"utf8",
+		);
+		const terraformPattern = locals.match(
+			/exact_secret_arn_pattern\s*=\s*"([^"]+)"/,
+		)?.[1];
+		if (!terraformPattern) {
+			throw new Error("missing exact_secret_arn_pattern");
+		}
+
+		const terraformRegion = "$" + "{var.aws_region}";
+		const terraformAccountId = "$" + "{var.aws_account_id}";
+		const exactSecretArn = new RegExp(
+			terraformPattern
+				.replace(terraformRegion, "us-west-2")
+				.replace(terraformAccountId, "123456789012"),
+		);
+		const prefix = "arn:aws:secretsmanager:us-west-2:123456789012:secret:";
+
+		expect(exactSecretArn.test(`${prefix}rds!db-example-AbCdEf`)).toBe(true);
+		expect(exactSecretArn.test(`${prefix}future~aws-generated-name`)).toBe(
+			true,
+		);
+		expect(exactSecretArn.test(`${prefix}mymemo-agent-prod-AbCdEf`)).toBe(true);
+		for (const rejectedArn of [
+			`${prefix}rds!db-example-*`,
+			`${prefix}rds!db-example-AbCdEf:password::`,
+			"arn:aws:secretsmanager:us-east-1:123456789012:secret:rds!db-example-AbCdEf",
+			"arn:aws:secretsmanager:us-west-2:210987654321:secret:rds!db-example-AbCdEf",
+		]) {
+			expect(exactSecretArn.test(rejectedArn)).toBe(false);
+		}
+	});
+
 	it("separates Runtime and consumer authority and grants standard artifact upload", () => {
 		const source = terraformSource();
 		const agentcoreIam = readFileSync(


### PR DESCRIPTION
## Summary
- remove the redundant AgentCore Runtime secret ARN regex
- remove the Runtime precondition that rejected AWS-managed secret names
- keep Runtime secret authority sourced directly from Terraform resources

## Verification
- bun test scripts/agentcore-infra.test.ts
- bunx biome check scripts/agentcore-infra.test.ts
- terraform -chdir=infra/terraform validate
- terraform fmt -check infra/terraform/agentcore-locals.tf infra/terraform/agentcore-runtime.tf