### PR TITLE
fix(deploy): unblock unified Terraform release

### DIFF
--- a/infra/bootstrap-iam/main.tf
+++ b/infra/bootstrap-iam/main.tf
@@ -222,6 +222,7 @@ data "aws_iam_policy_document" "github_actions_deploy" {
       "lambda:CreateFunction",
       "lambda:DeleteFunction",
       "lambda:GetFunction",
+      "lambda:GetFunctionCodeSigningConfig",
       "lambda:GetFunctionConfiguration",
       "lambda:GetFunctionConcurrency",
       "lambda:ListTags",

--- a/infra/bootstrap-iam/main.tf
+++ b/infra/bootstrap-iam/main.tf
@@ -242,6 +242,9 @@ data "aws_iam_policy_document" "github_actions_deploy" {
       "lambda:DeleteEventSourceMapping",
       "lambda:GetEventSourceMapping",
       "lambda:ListEventSourceMappings",
+      "lambda:ListTags",
+      "lambda:TagResource",
+      "lambda:UntagResource",
       "lambda:UpdateEventSourceMapping",
     ]
     resources = ["*"]

--- a/infra/bootstrap-iam/main.tf
+++ b/infra/bootstrap-iam/main.tf
@@ -225,6 +225,7 @@ data "aws_iam_policy_document" "github_actions_deploy" {
       "lambda:GetFunctionConfiguration",
       "lambda:GetFunctionConcurrency",
       "lambda:ListTags",
+      "lambda:ListVersionsByFunction",
       "lambda:TagResource",
       "lambda:UntagResource",
       "lambda:UpdateFunctionCode",

--- a/scripts/deploy-config.test.ts
+++ b/scripts/deploy-config.test.ts
@@ -885,6 +885,7 @@ describe("agent deployment config", () => {
 			"bedrock-agentcore:CreateAgentRuntime",
 			"bedrock-agentcore:UpdateAgentRuntime",
 			"bedrock-agentcore:GetAgentRuntimeEndpoint",
+			"lambda:GetFunctionCodeSigningConfig",
 			"lambda:ListVersionsByFunction",
 			"lambda:UpdateFunctionCode",
 			"lambda:CreateEventSourceMapping",

--- a/scripts/deploy-config.test.ts
+++ b/scripts/deploy-config.test.ts
@@ -885,6 +885,7 @@ describe("agent deployment config", () => {
 			"bedrock-agentcore:CreateAgentRuntime",
 			"bedrock-agentcore:UpdateAgentRuntime",
 			"bedrock-agentcore:GetAgentRuntimeEndpoint",
+			"lambda:ListVersionsByFunction",
 			"lambda:UpdateFunctionCode",
 			"lambda:CreateEventSourceMapping",
 			"sqs:SetQueueAttributes",

--- a/scripts/deploy-config.test.ts
+++ b/scripts/deploy-config.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "bun:test";
 import {
+	chmodSync,
 	existsSync,
 	mkdtempSync,
 	readdirSync,
 	readFileSync,
 	rmSync,
+	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -68,6 +70,12 @@ const configurationGuide = readFileSync(
 	join(root, "docs", "agents", "configuration.md"),
 	"utf8",
 );
+const classifyMigrationPlanScript = join(
+	root,
+	"scripts",
+	"deploy",
+	"classify_migration_plan.sh",
+);
 
 function terraformFiles(dir = terraformDir): string[] {
 	return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
@@ -75,6 +83,37 @@ function terraformFiles(dir = terraformDir): string[] {
 		if (entry.isDirectory()) return terraformFiles(path);
 		return entry.name.endsWith(".tf") ? [path] : [];
 	});
+}
+
+function classifyMigrationPlan(terraformShowOutput: string) {
+	const tempDir = mkdtempSync(join(tmpdir(), "mymemo-migration-plan-"));
+	const terraform = join(tempDir, "terraform");
+
+	writeFileSync(
+		terraform,
+		`#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$*" != "-chdir=infra/terraform show -no-color fixture.tfplan" ]]; then
+	exit 97
+fi
+printf '%s\\n' "\${TERRAFORM_SHOW_OUTPUT}"
+`,
+	);
+	chmodSync(terraform, 0o755);
+
+	try {
+		return Bun.spawnSync({
+			cmd: [classifyMigrationPlanScript, "fixture.tfplan"],
+			cwd: root,
+			env: {
+				...process.env,
+				PATH: `${tempDir}:${process.env.PATH ?? ""}`,
+				TERRAFORM_SHOW_OUTPUT: terraformShowOutput,
+			},
+		});
+	} finally {
+		rmSync(tempDir, { recursive: true, force: true });
+	}
 }
 
 describe("agent deployment config", () => {
@@ -627,6 +666,33 @@ describe("agent deployment config", () => {
 		expect(rolloutIndex).toBeGreaterThan(-1);
 		expect(migrationIndex).toBeLessThan(rolloutIndex);
 		expect(releaseDeployWorkflow).not.toContain("scripts/deploy/prod_smoke.sh");
+	});
+
+	it("classifies migration-only plans without decoding stale prior state", () => {
+		const migrationOnly = classifyMigrationPlan(`
+  # data.aws_iam_policy_document.migration will be read during apply
+  # aws_ecs_task_definition.agent_migration must be replaced
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+Warning: Failed to decode resource from state
+unsupported attribute "inference_accelerator"
+`);
+
+		expect(migrationOnly.exitCode).toBe(0);
+		expect(migrationOnly.stdout.toString()).toContain("migration-only");
+
+		const unexpectedChange = classifyMigrationPlan(`
+  # aws_ecs_task_definition.agent_migration must be replaced
+  # aws_iam_role.agent_migration_task will be updated in-place
+
+Plan: 1 to add, 1 to change, 1 to destroy.
+`);
+
+		expect(unexpectedChange.exitCode).not.toBe(0);
+		expect(unexpectedChange.stderr.toString()).toContain(
+			"aws_iam_role.agent_migration_task",
+		);
 	});
 
 	it("terraform does not roll ECS services before migrations", () => {

--- a/scripts/deploy-config.test.ts
+++ b/scripts/deploy-config.test.ts
@@ -852,6 +852,10 @@ describe("agent deployment config", () => {
 	});
 
 	it("bootstrap IAM owns the agent-specific GitHub Actions deploy role", () => {
+		const bootstrapIamConfig = readFileSync(
+			join(bootstrapIamTerraformDir, "main.tf"),
+			"utf8",
+		);
 		const combined = terraformFiles(bootstrapIamTerraformDir)
 			.map((path) => readFileSync(path, "utf8"))
 			.join("\n");
@@ -895,6 +899,21 @@ describe("agent deployment config", () => {
 			"iam:SimulatePrincipalPolicy",
 		]) {
 			expect(combined).toContain(`"${action}"`);
+		}
+		const mappingManagement = bootstrapIamConfig.slice(
+			bootstrapIamConfig.indexOf(
+				'sid = "AgentCoreConsumerMappingManagement"',
+			),
+			bootstrapIamConfig.indexOf(
+				'sid = "AgentCoreDispatchQueueManagement"',
+			),
+		);
+		for (const action of [
+			"lambda:ListTags",
+			"lambda:TagResource",
+			"lambda:UntagResource",
+		]) {
+			expect(mappingManagement).toContain(`"${action}"`);
 		}
 		expect(combined).not.toContain('"bedrock-agentcore:ListAgentRuntimes"');
 		expect(combined).not.toContain('"ecr:DescribeImageScanFindings"');

--- a/scripts/deploy-config.test.ts
+++ b/scripts/deploy-config.test.ts
@@ -967,12 +967,8 @@ Plan: 1 to add, 1 to change, 1 to destroy.
 			expect(combined).toContain(`"${action}"`);
 		}
 		const mappingManagement = bootstrapIamConfig.slice(
-			bootstrapIamConfig.indexOf(
-				'sid = "AgentCoreConsumerMappingManagement"',
-			),
-			bootstrapIamConfig.indexOf(
-				'sid = "AgentCoreDispatchQueueManagement"',
-			),
+			bootstrapIamConfig.indexOf('sid = "AgentCoreConsumerMappingManagement"'),
+			bootstrapIamConfig.indexOf('sid = "AgentCoreDispatchQueueManagement"'),
 		);
 		for (const action of [
 			"lambda:ListTags",

--- a/scripts/deploy/classify_migration_plan.sh
+++ b/scripts/deploy/classify_migration_plan.sh
@@ -2,16 +2,20 @@
 set -euo pipefail
 
 plan_file="${1:-agent-migration.tfplan}"
-unexpected_changes="$({
-  terraform -chdir=infra/terraform show -json "${plan_file}" |
-    jq -r '
-      .resource_changes[]?
-      | select(.mode == "managed")
-      | select((.change.actions - ["no-op", "read"]) != [])
-      | select(.address != "aws_ecs_task_definition.agent_migration")
-      | .address
-    '
-} || exit 1)"
+plan_text="$(terraform -chdir=infra/terraform show -no-color "${plan_file}")"
+unexpected_changes="$(
+  awk '
+    /^  # / {
+      change = $0
+      sub(/^  # /, "", change)
+      if (change ~ / will be read during apply$/) next
+
+      address = change
+      sub(/ (will|must) .*/, "", address)
+      if (address != "aws_ecs_task_definition.agent_migration") print address
+    }
+  ' <<<"${plan_text}"
+)"
 
 if [[ -n "${unexpected_changes}" ]]; then
   echo "The migration-only plan includes unexpected managed changes:" >&2


### PR DESCRIPTION
## Summary

- grant the deploy role the Lambda read and tag permissions required by Terraform AWS provider 6.61.0
- make the migration-only plan guard tolerate stale provider-state fields without weakening its scope check
- add regression coverage for IAM placement, stale-state tolerance, and unexpected managed changes

## Problem

GA Release deploy run 32448441687 failed while Terraform refreshed the production AgentCore consumer resources. After the missing permissions were restored, the migration classifier failed because terraform show -json attempted to decode removed attributes on unrelated resources in prior state.

## Solution

- add lambda:ListVersionsByFunction and lambda:GetFunctionCodeSigningConfig for the consumer function
- add lambda:ListTags, lambda:TagResource, and lambda:UntagResource for event-source mappings
- classify the targeted migration plan from stable no-color change headings, allowing only aws_ecs_task_definition.agent_migration and data-source reads

## Validation

- [x] bun test scripts/deploy-config.test.ts — 40 passed
- [x] bash -n scripts/deploy/classify_migration_plan.sh
- [x] terraform -chdir=infra/bootstrap-iam fmt -check
- [x] terraform -chdir=infra/bootstrap-iam validate
- [x] real production migration plan classified as migration-only
- [x] CI test, infrastructure, and integration jobs passed
- [x] GA Release deploy attempt 5 completed successfully: https://github.com/X-GPT/mymemo-agent/actions/runs/32448441687

## Operational impact

The production deploy-role policy was updated in place. A refresh-only Terraform state repair completed with 0 resources added, changed, or destroyed. The successful rerun completed migrations, the unified apply, AgentCore verification, and all ECS rollouts.

## Risk and rollback

Risk is limited to deploy-role permissions and plan classification. The classifier remains fail-closed for every managed change except the migration task definition. Reverting this PR restores the previous policy and classifier; no application data migration is introduced by this change.