### PR TITLE
chore(ci): upgrade GitHub Actions

### DIFF
--- a/.github/workflows/agentcore-runtime-image.yml
+++ b/.github/workflows/agentcore-runtime-image.yml
@@ -26,8 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
       - name: Build ARM64 AgentCore Runtime image
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -93,9 +93,9 @@ jobs:
         with:
           terraform_wrapper: false
 
-      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-qemu-action@v4
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
@@ -216,7 +216,7 @@ jobs:
           printf 'TF_VAR_consumer_lambda_package=%s/consumer.zip\n' "${consumer_dir}" >> "${GITHUB_ENV}"
 
       - name: Preserve the planned AgentCore consumer package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: agentcore-consumer-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/agentcore-consumer/consumer.zip
@@ -284,7 +284,7 @@ jobs:
         run: scripts/deploy/ci_prepare_tfvars.sh
 
       - name: Download the planned AgentCore consumer package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: agentcore-consumer-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/agentcore-consumer
@@ -376,7 +376,7 @@ jobs:
 
       - name: Upload AgentCore deployment evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: agentcore-deployment-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/agentcore-deployment

--- a/scripts/agentcore-infra.test.ts
+++ b/scripts/agentcore-infra.test.ts
@@ -386,7 +386,7 @@ describe("production AgentCore dispatch infrastructure", () => {
 		expect(workflow).toContain(
 			"Download the planned AgentCore consumer package",
 		);
-		expect(workflow).toContain("actions/download-artifact@v4");
+		expect(workflow).toContain("actions/download-artifact@v8");
 		expect(workflow.match(/oven-sh\/setup-bun@v2/g)).toHaveLength(2);
 		expect(workflow).not.toContain("deployment-plan.json");
 		expect(workflow).not.toContain(
@@ -400,7 +400,7 @@ describe("production AgentCore dispatch infrastructure", () => {
 		expect(workflow).not.toContain("AGENTCORE_TERRAFORM_DIR");
 		expect(workflow).toContain("enforce_agentcore_mmdsv2.sh");
 		expect(workflow).toContain("inspect_agentcore.sh");
-		expect(workflow).toContain("actions/upload-artifact@v4");
+		expect(workflow).toContain("actions/upload-artifact@v7");
 		for (const retired of [
 			"mymemo/agentcore-canary-runtime",
 			"assert_agentcore_legacy_queues_empty",


### PR DESCRIPTION
## Summary

- upgrade actions/upload-artifact from v4 to v7 and actions/download-artifact from v4 to v8
- upgrade docker/setup-buildx-action and docker/setup-qemu-action from v3 to v4
- apply the upgrades consistently across release and AgentCore image workflows

## Compatibility

- adopt the current Node 24 action runtimes on GitHub-hosted ubuntu-latest runners
- preserve the existing artifact names, paths, retention settings, and Docker build configuration

## Verification

- git diff --check
- parsed both changed workflows as YAML
- confirmed no references to the replaced action majors remain
- actionlint not run because it is not installed locally