### PR TITLE
fix(agentcore): accept RDS-managed secret references

### DIFF
--- a/apps/agentcore-dispatch-consumer/src/production.test.ts
+++ b/apps/agentcore-dispatch-consumer/src/production.test.ts
@@ -30,7 +30,7 @@ describe("AgentCore dispatch production configuration", () => {
 
 	it("resolves the Lambda database URL from the worker URL and current RDS password secret", async () => {
 		const passwordSecretArn =
-			"arn:aws:secretsmanager:us-west-2:123456789012:secret:agent-db-password-AbCdEf";
+			"arn:aws:secretsmanager:us-west-2:123456789012:secret:rds!db-example-AbCdEf";
 		const reads: string[] = [];
 		const config = await resolveAgentCoreDispatchConfigFromSecretArns(
 			{

--- a/apps/agentcore-dispatch-consumer/src/production.ts
+++ b/apps/agentcore-dispatch-consumer/src/production.ts
@@ -17,7 +17,6 @@ import { createAgentCoreConsumerHandler } from "./handlers";
 import {
 	type CurrentSecretReader,
 	createAwsCurrentSecretReader,
-	exactSecretArn,
 	resolveVerifiedAgentDatabaseUrl,
 } from "./secret-config";
 
@@ -46,10 +45,7 @@ export async function resolveAgentCoreDispatchConfigFromSecretArns(
 	env: Env,
 	readCurrentSecret: CurrentSecretReader,
 ): Promise<AgentCoreDispatchConfig> {
-	const passwordSecretArn = exactSecretArn(
-		env.DB_PASSWORD_SECRET_ARN,
-		"DB_PASSWORD_SECRET_ARN",
-	);
+	const passwordSecretArn = requireEnv(env, "DB_PASSWORD_SECRET_ARN");
 	return loadAgentCoreDispatchConfigFromEnv({
 		...env,
 		AGENT_DATABASE_URL: resolveVerifiedAgentDatabaseUrl(

--- a/apps/agentcore-dispatch-consumer/src/secret-config.ts
+++ b/apps/agentcore-dispatch-consumer/src/secret-config.ts
@@ -3,23 +3,10 @@ import {
 	SecretsManagerClient,
 } from "@aws-sdk/client-secrets-manager";
 
-const SECRET_ARN_PATTERN =
-	/^arn:aws:secretsmanager:[a-z0-9-]+:\d{12}:secret:[A-Za-z0-9/_+=.@-]+$/;
-
 export type CurrentSecretReader = (arn: string) => Promise<string>;
 
 export interface SecretCommandClient {
 	send(command: GetSecretValueCommand): Promise<{ SecretString?: string }>;
-}
-
-export function exactSecretArn(
-	value: string | undefined,
-	name: string,
-): string {
-	if (!value || !SECRET_ARN_PATTERN.test(value)) {
-		throw new Error(`${name} must be an exact Secrets Manager ARN`);
-	}
-	return value;
 }
 
 export function verifiedDatabaseUrl(value: string, name: string): string {

--- a/apps/agentcore-runtime/src/config.test.ts
+++ b/apps/agentcore-runtime/src/config.test.ts
@@ -12,7 +12,7 @@ function bootstrapEnv(): Record<string, string | undefined> {
 		AGENT_DATABASE_URL:
 			"postgresql://mymemo_agent@agent.example:5432/mymemo_agent",
 		DB_PASSWORD_SECRET_ARN:
-			"arn:aws:secretsmanager:us-west-2:123456789012:secret:agent-db-password-AbCdEf",
+			"arn:aws:secretsmanager:us-west-2:123456789012:secret:rds!db-example-AbCdEf",
 		KB_DATABASE_URL_SECRET_ARN:
 			"arn:aws:secretsmanager:us-west-2:123456789012:secret:kb-db-AbCdEf",
 		OPENROUTER_API_KEY_SECRET_ARN:
@@ -31,7 +31,7 @@ function bootstrapEnv(): Record<string, string | undefined> {
 }
 
 describe("AgentCore Runtime configuration", () => {
-	it("accepts only exact secret ARNs and non-secret boot values", () => {
+	it("requires secret references and non-secret boot values", () => {
 		const config = loadRuntimeBootstrapConfig(bootstrapEnv());
 
 		expect(config.port).toBe(8080);
@@ -56,20 +56,11 @@ describe("AgentCore Runtime configuration", () => {
 		}
 	});
 
-	it("distinguishes a missing secret ARN from a malformed one", () => {
+	it("rejects a missing secret reference", () => {
 		const env = bootstrapEnv();
 		delete env.REDIS_URL_SECRET_ARN;
 		expect(() => loadRuntimeBootstrapConfig(env)).toThrow(
 			"REDIS_URL_SECRET_ARN is required",
-		);
-	});
-
-	it("rejects secret ARNs outside the commercial AWS partition", () => {
-		const env = bootstrapEnv();
-		env.DB_PASSWORD_SECRET_ARN =
-			"arn:aws-us-gov:secretsmanager:us-gov-west-1:123456789012:secret:agent-db-AbCdEf";
-		expect(() => loadRuntimeBootstrapConfig(env)).toThrow(
-			"DB_PASSWORD_SECRET_ARN must be an exact Secrets Manager ARN",
 		);
 	});
 

--- a/apps/agentcore-runtime/src/config.ts
+++ b/apps/agentcore-runtime/src/config.ts
@@ -4,7 +4,6 @@ import {
 } from "agent-worker/config";
 import { type Env, requireEnv } from "agentcore-dispatch-consumer/config-utils";
 import {
-	exactSecretArn,
 	resolveVerifiedAgentDatabaseUrl,
 	verifiedDatabaseUrl,
 } from "agentcore-dispatch-consumer/secret-config";
@@ -38,10 +37,6 @@ export interface RuntimeBootstrapConfig {
 	heartbeatIntervalMs: number;
 	shutdownTimeoutMs: typeof RUNTIME_SHUTDOWN_TIMEOUT_MS;
 	logLevel: string;
-}
-
-function secretArn(env: Env, name: string): string {
-	return exactSecretArn(requireEnv(env, name), name);
 }
 
 function positiveInt(
@@ -80,11 +75,11 @@ export function loadRuntimeBootstrapConfig(env: Env): RuntimeBootstrapConfig {
 			"AGENTCORE_DISPATCH_ENABLED_PARAMETER_NAME",
 		),
 		secretArns: {
-			agentDatabasePassword: secretArn(env, "DB_PASSWORD_SECRET_ARN"),
-			kbDatabaseUrl: secretArn(env, "KB_DATABASE_URL_SECRET_ARN"),
-			openrouterApiKey: secretArn(env, "OPENROUTER_API_KEY_SECRET_ARN"),
-			e2bApiKey: secretArn(env, "E2B_API_KEY_SECRET_ARN"),
-			redisUrl: secretArn(env, "REDIS_URL_SECRET_ARN"),
+			agentDatabasePassword: requireEnv(env, "DB_PASSWORD_SECRET_ARN"),
+			kbDatabaseUrl: requireEnv(env, "KB_DATABASE_URL_SECRET_ARN"),
+			openrouterApiKey: requireEnv(env, "OPENROUTER_API_KEY_SECRET_ARN"),
+			e2bApiKey: requireEnv(env, "E2B_API_KEY_SECRET_ARN"),
+			redisUrl: requireEnv(env, "REDIS_URL_SECRET_ARN"),
 		},
 		agentDatabaseUrl: requireEnv(env, "AGENT_DATABASE_URL"),
 		openrouterBaseUrl: requireEnv(env, "OPENROUTER_BASE_URL"),


### PR DESCRIPTION
## Summary

- remove the redundant application-level Secrets Manager ARN regex from the AgentCore dispatch consumer and Runtime bootstrap
- keep every secret reference required and continue resolving only `AWSCURRENT` under resource-scoped IAM
- cover the AWS-managed `rds!db-…` secret-name shape in both consumer and Runtime configuration tests

## Root cause

The production dispatch consumer rejected the valid RDS-managed password-secret ARN before calling Secrets Manager because the local regex excluded `!`. Dispatch therefore retried without invoking AgentCore Runtime. This completes the application-side follow-up to #509, which removed the equivalent Terraform precondition.

## Verification

- `bun test --timeout=30000` in `apps/agentcore-dispatch-consumer` — 39 passed
- `bun test --timeout=30000` in `apps/agentcore-runtime` — 22 passed
- `bunx tsc --noEmit -p apps/agentcore-dispatch-consumer/tsconfig.json`
- `bunx tsc --noEmit -p apps/agentcore-runtime/tsconfig.json`
- `bunx biome check` on all five changed files
- `git diff --check`

## Operational note

A coordinated production deployment is required before rerunning the AgentCore smoke test; this PR does not change SSM or Statsig controls.