### PR TITLE
docs(agentcore): record sole runtime decision

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -41,10 +41,9 @@ The set of documents a conversation may access — `general`, `collection`, or
 _Avoid_: permissions, access level
 
 **Execution runtime**:
-The immutable choice, made once at Conversation creation, of which trusted
-runtime executes a Conversation's Runs: `fargate` or `agentcore`. A
-Conversation never mixes runtimes; reassignment exists only as a documented
-operator break-glass step.
+The trusted runtime that executes a Conversation's Runs. AgentCore is the only
+supported execution runtime; there is no runtime reassignment or Fargate
+fallback path.
 _Avoid_: Run target, worker preference, routing hint
 
 **AgentCore dispatch**:
@@ -307,9 +306,8 @@ An SDK initialization id and subagent-only mirrors do not count, and a
 _Avoid_: SDK result id, initialization id, transcript contents
 
 **Split runtime**:
-The target architecture: the agent loop runs in a trusted runtime — the
-Fargate worker or the AgentCore Runtime — while untrusted filesystem and shell
-execution stays in E2B.
+The architecture in which the agent loop runs in the trusted AgentCore Runtime
+while untrusted filesystem and shell execution stays in E2B.
 
 **Prototype path**:
 The superseded daemon-based architecture — agent loop inside the sandbox,

--- a/docs/adr/0025-select-the-execution-runtime-at-conversation-creation.md
+++ b/docs/adr/0025-select-the-execution-runtime-at-conversation-creation.md
@@ -7,6 +7,8 @@ Amended (2026-08-20) by
 [ADR-0029](./0029-recover-production-releases-by-rolling-forward.md), which
 supersedes the binary-rollback procedure while retaining the deployment fence
 as defense in depth.
+Runtime-selection, Fargate-fallback, and reassignment decisions are superseded
+by [ADR-0031](./0031-make-agentcore-the-sole-execution-runtime.md).
 
 Every Conversation carries an immutable execution runtime — `fargate` or
 `agentcore` — selected exactly once at creation by a server-side Statsig gate

--- a/docs/adr/0029-recover-production-releases-by-rolling-forward.md
+++ b/docs/adr/0029-recover-production-releases-by-rolling-forward.md
@@ -2,6 +2,9 @@
 
 Status: accepted (2026-08-20). Amends ADR-0025 and ADR-0027 by superseding
 their production binary-rollback consequences.
+Amended by
+[ADR-0031](./0031-make-agentcore-the-sole-execution-runtime.md), which removes
+the Execution runtime gate from rollout and incident recovery.
 
 Production recovery for the AgentCore release train is roll-forward only. An
 incident is contained before another binary is deployed: disable the SSM

--- a/docs/adr/0031-make-agentcore-the-sole-execution-runtime.md
+++ b/docs/adr/0031-make-agentcore-the-sole-execution-runtime.md
@@ -1,0 +1,79 @@
+# Make AgentCore the sole execution runtime
+
+Status: accepted (2026-08-21). Amends ADR-0025 and ADR-0029 by retiring
+runtime selection, the Fargate creation fallback, runtime reassignment, and the
+Execution runtime gate.
+
+AgentCore is the sole supported execution runtime. Production's remaining
+Fargate Conversations were permanently deleted before this decision, so there
+is no legacy execution or migration path to preserve. Conversation creation
+must produce AgentCore state without consulting Statsig, and every newly
+admitted Run must record AgentCore Dispatch unconditionally. The SSM Dispatch
+control remains; the Execution runtime gate no longer participates in rollout
+or incident recovery.
+
+Retirement is planned as two ordered releases so database migrations remain
+compatible with old processes during rolling deployment. The first release is
+implemented and deployed before work begins on the second. It retains
+`execution_runtime` as an AgentCore-only compatibility marker and may continue
+returning `executionRuntime: "agentcore"` in the public Conversation shape,
+while removing runtime selection and conditional Dispatch. The following
+retirement release removes the marker and the remaining Fargate Claim,
+doorbell, deployment-readiness, and Run-serving machinery during controlled
+maintenance, after every still-running process is independent of them and the
+old worker is stopped. It removes the public `executionRuntime` field in a
+coordinated client change and moves global queued-Run expiration, Reclamation,
+and cleanup from agent-worker into a smaller, least-privilege agent-maintenance
+ECS service. The service remains always running, preserves the existing
+Reclamation cadence, and holds only the database, E2B-cleanup, and S3-deletion
+authority its maintenance responsibilities require. Until that release,
+agent-worker remains for those global maintenance responsibilities.
+
+The second release is a controlled maintenance event because the old
+agent-worker still reads the compatibility marker. With Dispatch paused, zero
+Active Runs, and the old worker stopped, its migration removes the marker and
+must refuse to proceed if any non-AgentCore Conversation exists. A migration
+never deletes Conversations to satisfy that precondition. The new
+agent-maintenance service starts after the compatible schema is installed.
+
+Local development runs the AgentCore Runtime application rather than retaining
+Fargate execution. A dedicated development-only Dispatch bridge app combines
+the production-neutral publisher and consumer behavior in one process: it
+polls the durable outbox, validates the dispatch, invokes the local Runtime
+through `/invocations`, and handles the Acquisition receipt. It is excluded
+from production images and deliberately omits SQS, Lambda, SSM, IAM, VPC, and
+managed Runtime behavior; deployed smoke tests remain responsible for those
+AWS boundaries. Local chat-api composition allows exposure without Statsig
+through a separate entrypoint that cannot be selected by production
+configuration. The bridge marks a local outbox record handled only after a
+correlated Acquisition receipt; an invocation, validation, or receipt failure
+leaves the record available for retry.
+
+## Considered options
+
+- **Keep the runtime gate dormant.** Rejected because it preserves a Fargate
+  creation path and an operational control whose fallback no longer exists.
+- **Remove the discriminator and all Fargate machinery in the first release.**
+  Rejected because migrations run before old chat-api and agent-worker tasks
+  leave service; those binaries still read the column and Fargate-specific
+  database objects.
+- **Keep Fargate for local development.** Rejected because local behavior would
+  no longer exercise the supported Runtime application or its HTTP contract.
+- **Emulate SQS and Lambda with LocalStack.** Rejected because commercial use
+  requires a paid LocalStack license and the local queue boundary is not needed
+  for interactive development.
+
+## Consequences
+
+- Runtime assignment is no longer a product or operator decision.
+- The first release must prevent old gate-aware chat-api tasks from recreating
+  Fargate state while the database invariant is narrowed to AgentCore-only.
+- The public `executionRuntime` field is compatibility output during the first
+  release, not evidence of an available runtime choice, and is removed with a
+  coordinated frontend change in the second release.
+- Fargate execution code and its broad worker authority remain temporary debt
+  with an explicit deletion condition, not a supported fallback.
+- Production images do not contain the local Dispatch bridge or its combined
+  publisher-and-consumer dependency graph.
+- Schema retirement fails closed on any remaining Fargate data and never uses
+  destructive migration behavior to force the invariant.


### PR DESCRIPTION
## Summary

- record AgentCore as the sole supported execution runtime in ADR-0031
- define the two-release retirement path for the compatibility marker and remaining Fargate machinery
- document the local-only Dispatch bridge and future least-privilege maintenance service
- update the domain glossary and link the superseding decision from ADR-0025 and ADR-0029

## Context

Production no longer contains Fargate Conversations. This PR records the agreed architecture and rollout boundaries before implementation begins. It makes no runtime or infrastructure changes.

## Verification

- `git diff --cached --check`
- Full test suite not run because this PR changes documentation only
