### PR TITLE
fix(deploy): allow NAT gateway deletion

### DIFF
--- a/infra/bootstrap-iam/main.tf
+++ b/infra/bootstrap-iam/main.tf
@@ -117,6 +117,7 @@ data "aws_iam_policy_document" "github_actions_deploy" {
       "ec2:DeleteInstanceConnectEndpoint",
       "ec2:DeleteLaunchTemplate",
       "ec2:DeleteLaunchTemplateVersions",
+      "ec2:DeleteNatGateway",
       "ec2:DeleteNetworkInterface",
       "ec2:DeleteSecurityGroup",
       "ec2:DeleteTags",


### PR DESCRIPTION
## Summary

- grant the GitHub deploy role `ec2:DeleteNatGateway` in the existing EC2 infrastructure management statement
- unblock Terraform from removing the managed NAT gateways during the fck-nat migration

## Problem

[Release deploy run 32545306311](https://github.com/X-GPT/mymemo-agent/actions/runs/32545306311) failed during the unified Terraform apply because the deploy role had no identity-based policy allowing `ec2:DeleteNatGateway`.

## Validation

- [x] `terraform -chdir=infra/bootstrap-iam fmt -check -diff`
- [x] `terraform -chdir=infra/bootstrap-iam validate`
- [x] `git diff --check`

## Operational handoff

- production private routes still target the available managed NAT gateways
- both fck-nat ASGs are healthy
- the Dispatch publisher is stable in private subnets through the old NAT path
- bootstrap IAM was not applied, Release was not rerun, and no AWS changes were made as part of this PR

## Risk and rollback

The change adds one narrowly scoped EC2 permission to the existing deploy-role management statement. Reverting this PR removes that permission; no application or database changes are included.
