### PR TITLE
fix(deploy): allow EIP disassociation

### DIFF
--- a/infra/bootstrap-iam/main.tf
+++ b/infra/bootstrap-iam/main.tf
@@ -122,6 +122,7 @@ data "aws_iam_policy_document" "github_actions_deploy" {
       "ec2:DeleteSecurityGroup",
       "ec2:DeleteTags",
       "ec2:Describe*",
+      "ec2:DisassociateAddress",
       "ec2:ModifyInstanceAttribute",
       "ec2:ModifyInstanceConnectEndpoint",
       "ec2:ModifyNetworkInterfaceAttribute",


### PR DESCRIPTION
## Incident

[Release run 32546385067](https://github.com/X-GPT/mymemo-agent/actions/runs/32546385067) reached the unified Terraform apply after successfully deleting both managed NAT gateways. Terraform then attempted to retire both NAT EIPs and received 403 `UnauthorizedOperation` responses because the GitHub Actions deploy role did not allow `ec2:DisassociateAddress`.

At the failure point, the managed NAT gateways were already deleted, both AgentCore private default routes were blackholes, the fck-nat ASGs were healthy, and the former NAT EIPs were asynchronously disassociating.

## Fix

- Add `ec2:DisassociateAddress` to the existing `AgentInfrastructureManagement` statement, beside the related EC2 EIP and NAT lifecycle permissions.
- Keep the existing `ec2:ReleaseAddress` permission unchanged.

This lets Terraform complete the EIP retirement path when AWS still reports an association after NAT gateway deletion.

## Validation

- `terraform -chdir=infra/bootstrap-iam fmt -check`
- `terraform -chdir=infra/bootstrap-iam init -backend=false`
- `terraform -chdir=infra/bootstrap-iam validate`

## Operational follow-up

Not performed in this PR: applying `infra/bootstrap-iam`, triggering Release, or making any other production change. An authorized operator must apply the bootstrap IAM policy before explicitly starting a new Release attempt.
