### PR TITLE
fix(deploy): allow private route replacement

### DIFF
--- a/infra/bootstrap-iam/main.tf
+++ b/infra/bootstrap-iam/main.tf
@@ -127,6 +127,7 @@ data "aws_iam_policy_document" "github_actions_deploy" {
       "ec2:ModifyInstanceConnectEndpoint",
       "ec2:ModifyNetworkInterfaceAttribute",
       "ec2:ReleaseAddress",
+      "ec2:ReplaceRoute",
       "ec2:RevokeSecurityGroupEgress",
       "ec2:RevokeSecurityGroupIngress",
       "ec2:RunInstances",


### PR DESCRIPTION
## Incident

The fck-nat production cutover exposed two missing EC2 permissions in consecutive Release runs:

1. [Release run 32546385067](https://github.com/X-GPT/mymemo-agent/actions/runs/32546385067) failed while retiring the old managed-NAT EIPs because the GitHub Actions deploy role did not allow `ec2:DisassociateAddress`. [PR #531](https://github.com/X-GPT/mymemo-agent/pull/531) added that permission and is already merged.
2. [Release run 32548632838](https://github.com/X-GPT/mymemo-agent/actions/runs/32548632838) then failed with 403 `UnauthorizedOperation` responses for both AgentCore private route tables because the same role did not allow `ec2:ReplaceRoute`.

At the latest failure point, both managed NAT gateways and their old EIPs were gone, both AgentCore private default routes still targeted the deleted NAT gateways and were `blackhole`, and both fck-nat Auto Scaling groups were healthy and InService.

## Fix

- Retain `ec2:DisassociateAddress` from #531 beside the existing EIP lifecycle permissions. Terraform needs it when AWS still reports an EIP association while retiring an old NAT allocation.
- Add `ec2:ReplaceRoute` to the same `AgentInfrastructureManagement` statement, beside the related EIP and route lifecycle permissions. Terraform uses `ReplaceRoute` to retarget each existing private `0.0.0.0/0` route from its deleted managed NAT gateway to the zonal fck-nat static ENI.

No broader EC2 wildcard or unrelated permission is added.

## Validation

- policy regression check confirms both `ec2:DisassociateAddress` and `ec2:ReplaceRoute` are present
- `terraform -chdir=infra/bootstrap-iam fmt -check`
- `terraform -chdir=infra/bootstrap-iam init -backend=false`
- `terraform -chdir=infra/bootstrap-iam validate`
- `git diff --check`

## Operational follow-up

Not performed in this PR: applying `infra/bootstrap-iam`, triggering Release, or making any other production change. An authorized operator must apply the bootstrap IAM policy before explicitly starting another Release attempt.