### PR TITLE
feat(agentcore): complete one local Run through AgentCore

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ architecture and trust boundaries.
 |-----|----------|------|
 | **chat-api** | `apps/chat-api/` | AI chat service; owns Conversation resources, strict Run admission, producer-buffered Live Stream attachment, history, and artifact delivery |
 | **agent-worker** | `apps/agent-worker/` | Split-runtime Fargate worker; claims Runs, holds worker-only credentials, executes Claude Agent SDK turns, and publishes standard AG-UI events including validated display-only UI payloads |
+| **agentcore-runtime** | `apps/agentcore-runtime/` | Request-oriented AgentCore Runtime using shared Run-serving behavior |
+| **agentcore-local-dispatch-bridge** | `apps/agentcore-local-dispatch-bridge/` | Development-only durable-outbox bridge to the local Runtime |
 
 Shared libraries live under `packages/` (e.g. `@mymemo/agent-db`).
 
@@ -32,7 +34,7 @@ See [the chat API guide](./docs/agents/chat-api.md) for chat-api documentation.
 │   └── agent-worker/       # Split-runtime worker (claims + runs turns)
 ├── packages/               # Shared libraries (e.g. @mymemo/agent-db)
 ├── AGENTS.md               # Architecture & agent guidance
-├── compose.yaml            # Legacy Fargate local stack (new turns unavailable until #523)
+├── compose.yaml            # Local AgentCore Runtime stack
 └── README.md               # This file
 ```
 
@@ -42,9 +44,9 @@ Each project can be developed independently. Navigate to the respective project 
 
 ## Runtime verification
 
-Conversation creation is AgentCore-only. The checked-in Compose stack still
-runs the legacy Fargate worker and cannot execute a new turn; #523 owns the
-local AgentCore bridge. Do not use Compose as current end-to-end evidence.
+Conversation creation and the checked-in Compose stack are AgentCore-only.
+`bun run smoke:local` proves one Run from public admission through the durable
+outbox, development bridge, and real local Runtime.
 
 The credential-free PR suite covers durable AgentCore acquisition and
 stream/reconnect behavior through the shared Run-serving seam. The process
@@ -65,10 +67,8 @@ writes a unique Downloadable artifact, lists it after `RUN_FINISHED`, obtains a 
 signed URL, and downloads the exact attachment without identity headers. The
 local `full` suite adds one interrupted Run and two seeded searchable-document
 Runs that prove inventory, search, docs-cache load, file read-back, and durable
-Tool history. It is temporarily unavailable: Conversation creation is
-AgentCore-only, while #523 owns the local AgentCore bridge. `bun run smoke:local`
-exits immediately with that explanation instead of exercising the incompatible
-Fargate-only stack.
+Tool history. The smaller `bun run smoke:local` Compose gate proves one real Run;
+the broader suites can target the running local stack directly.
 
 For production, run `scripts/deploy/prod_smoke.sh` from inside the VPC with
 `AGENT_SMOKE_BASE_URL` configured and the checked-in `codex-smoke` identity
@@ -78,8 +78,8 @@ Run. OpenRouter and E2B credentials stay in the deployed worker; the smoke calle
 receives none of them. To check only the default-closed gate, set
 `AGENT_SMOKE_EXPECT_GATE_CLOSED=true`.
 
-`AGENT_SMOKE_SUITE` defaults to `core`; `full` remains the local superset that
-#523 will restore. See [the two-target smoke verification guide](./docs/verification/e2e-smoke.md)
+`AGENT_SMOKE_SUITE` defaults to `core`; `full` remains the local superset. See
+[the two-target smoke verification guide](./docs/verification/e2e-smoke.md)
 for suite contents, target selection, and deterministic harness tests.
 
 ### Worker image check

--- a/apps/agentcore-dispatch-consumer/package.json
+++ b/apps/agentcore-dispatch-consumer/package.json
@@ -4,6 +4,7 @@
 		"./acquisition-boundary": "./src/acquisition-boundary.ts",
 		"./aws-adapters": "./src/aws-adapters.ts",
 		"./config-utils": "./src/config-utils.ts",
+		"./consumer": "./src/consumer.ts",
 		"./contract": "./src/contract.ts",
 		"./production": "./src/production.ts",
 		"./secret-config": "./src/secret-config.ts"

--- a/apps/agentcore-local-dispatch-bridge/Dockerfile
+++ b/apps/agentcore-local-dispatch-bridge/Dockerfile
@@ -1,0 +1,24 @@
+FROM oven/bun:1 AS base
+WORKDIR /usr/src/app
+
+FROM base AS manifests
+COPY package.json bun.lock ./
+COPY apps apps
+COPY packages packages
+RUN find apps packages -type f ! -name package.json -delete \
+ && find apps packages -type d -empty -delete
+
+FROM base AS install
+COPY --from=manifests /usr/src/app /temp/prod
+RUN cd /temp/prod && bun install --frozen-lockfile --production --filter=agentcore-local-dispatch-bridge
+
+FROM base AS local
+COPY --from=install /temp/prod/node_modules node_modules
+COPY apps/agentcore-local-dispatch-bridge apps/agentcore-local-dispatch-bridge
+COPY apps/agentcore-dispatch-consumer apps/agentcore-dispatch-consumer
+COPY packages/agent-db packages/agent-db
+COPY packages/agentcore-dispatch packages/agentcore-dispatch
+COPY package.json .
+WORKDIR /usr/src/app/apps/agentcore-local-dispatch-bridge
+USER bun
+ENTRYPOINT [ "bun", "run", "src/index.ts" ]

--- a/apps/agentcore-local-dispatch-bridge/package.json
+++ b/apps/agentcore-local-dispatch-bridge/package.json
@@ -1,0 +1,20 @@
+{
+	"name": "agentcore-local-dispatch-bridge",
+	"scripts": {
+		"test": "bun test --timeout=30000",
+		"check": "biome check --write"
+	},
+	"dependencies": {
+		"@mymemo/agent-db": "workspace:*",
+		"@mymemo/agentcore-dispatch": "workspace:*",
+		"agentcore-dispatch-consumer": "workspace:*",
+		"drizzle-orm": "^0.45.2",
+		"pg": "^8.22.0"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^2.3.11",
+		"@electric-sql/pglite": "^0.5.3",
+		"@types/bun": "^1.3.11"
+	},
+	"type": "module"
+}

--- a/apps/agentcore-local-dispatch-bridge/src/bridge.test.ts
+++ b/apps/agentcore-local-dispatch-bridge/src/bridge.test.ts
@@ -11,6 +11,7 @@ import { admitQueuedRunInTx } from "@mymemo/agent-db/run-store";
 import {
 	agentCoreDispatchOutbox,
 	conversations,
+	runs,
 } from "@mymemo/agent-db/schema";
 import { createTestDatabase, type TestDb } from "@mymemo/agent-db/testing";
 import { createAcquisitionReceipt } from "agentcore-dispatch-consumer/contract";
@@ -211,5 +212,31 @@ describe("local AgentCore Dispatch bridge", () => {
 		await expect(bridge.pollOnce()).resolves.toMatchObject({
 			publishedRunIds: [dispatch.runId],
 		});
+	});
+
+	it("observes a correlated Runtime receipt even when the Run is terminal", async () => {
+		await tdb.db.update(runs).set({ status: "done" });
+		let invoked = false;
+		const receipt = createAcquisitionReceipt(dispatch, {
+			disposition: "terminal",
+			status: "done",
+		});
+		const bridge = createLocalAgentCoreDispatchBridge({
+			db: tdb.db,
+			publisherId: "local-bridge",
+			runtimeUrl: "http://runtime:8080",
+			fetch: async () => {
+				invoked = true;
+				return new Response(`${JSON.stringify(receipt)}\n`, {
+					headers: { "content-type": "application/x-ndjson" },
+				});
+			},
+			now: () => new Date("2026-08-21T12:01:00.000Z"),
+		});
+
+		await expect(bridge.pollOnce()).resolves.toMatchObject({
+			publishedRunIds: [dispatch.runId],
+		});
+		expect(invoked).toBe(true);
 	});
 });

--- a/apps/agentcore-local-dispatch-bridge/src/bridge.test.ts
+++ b/apps/agentcore-local-dispatch-bridge/src/bridge.test.ts
@@ -28,6 +28,15 @@ const dispatch = {
 	runtimeSessionId: "0198c9f6-cf40-7de1-9cb6-5cb7a57b5101",
 	admittedAt,
 };
+const acquiredReceipt = createAcquisitionReceipt(dispatch, {
+	disposition: "acquired",
+	owner: {
+		userId: dispatch.userId,
+		conversationId: dispatch.conversationId,
+		epoch: 1,
+	},
+	workerId: "local-runtime/1",
+});
 
 beforeAll(async () => {
 	tdb = await createTestDatabase();
@@ -64,22 +73,13 @@ beforeEach(async () => {
 describe("local AgentCore Dispatch bridge", () => {
 	it("acknowledges a real outbox row after a correlated Acquisition receipt", async () => {
 		const requests: Request[] = [];
-		const receipt = createAcquisitionReceipt(dispatch, {
-			disposition: "acquired",
-			owner: {
-				userId: dispatch.userId,
-				conversationId: dispatch.conversationId,
-				epoch: 1,
-			},
-			workerId: "local-runtime/1",
-		});
 		const bridge = createLocalAgentCoreDispatchBridge({
 			db: tdb.db,
 			publisherId: "local-bridge",
 			runtimeUrl: "http://runtime:8080",
 			fetch: async (request) => {
 				requests.push(request);
-				return new Response(`${JSON.stringify(receipt)}\n`, {
+				return new Response(`${JSON.stringify(acquiredReceipt)}\n`, {
 					headers: { "content-type": "application/x-ndjson" },
 				});
 			},
@@ -135,15 +135,6 @@ describe("local AgentCore Dispatch bridge", () => {
 	])("leaves the Dispatch retryable after $name", async ({ respond }) => {
 		let now = new Date("2026-08-21T12:01:00.000Z");
 		let failing = true;
-		const receipt = createAcquisitionReceipt(dispatch, {
-			disposition: "acquired",
-			owner: {
-				userId: dispatch.userId,
-				conversationId: dispatch.conversationId,
-				epoch: 1,
-			},
-			workerId: "local-runtime/1",
-		});
 		const bridge = createLocalAgentCoreDispatchBridge({
 			db: tdb.db,
 			publisherId: "local-bridge",
@@ -151,7 +142,7 @@ describe("local AgentCore Dispatch bridge", () => {
 			invocationTimeoutMs: 5,
 			fetch: async (request) => {
 				if (failing) return await respond(request);
-				return new Response(`${JSON.stringify(receipt)}\n`, {
+				return new Response(`${JSON.stringify(acquiredReceipt)}\n`, {
 					headers: { "content-type": "application/x-ndjson" },
 				});
 			},
@@ -178,22 +169,13 @@ describe("local AgentCore Dispatch bridge", () => {
 	it("does not acknowledge a receipt correlated to another Dispatch", async () => {
 		let now = new Date("2026-08-21T12:01:00.000Z");
 		let mismatched = true;
-		const receipt = createAcquisitionReceipt(dispatch, {
-			disposition: "acquired",
-			owner: {
-				userId: dispatch.userId,
-				conversationId: dispatch.conversationId,
-				epoch: 1,
-			},
-			workerId: "local-runtime/1",
-		});
 		const bridge = createLocalAgentCoreDispatchBridge({
 			db: tdb.db,
 			publisherId: "local-bridge",
 			runtimeUrl: "http://runtime:8080",
 			fetch: async () =>
 				new Response(
-					`${JSON.stringify(mismatched ? { ...receipt, runId: "another-run" } : receipt)}\n`,
+					`${JSON.stringify(mismatched ? { ...acquiredReceipt, runId: "another-run" } : acquiredReceipt)}\n`,
 					{ headers: { "content-type": "application/x-ndjson" } },
 				),
 			now: () => now,

--- a/apps/agentcore-local-dispatch-bridge/src/bridge.test.ts
+++ b/apps/agentcore-local-dispatch-bridge/src/bridge.test.ts
@@ -1,0 +1,215 @@
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+} from "bun:test";
+import { recordAgentCoreDispatchInTx } from "@mymemo/agent-db/agentcore-dispatch";
+import { admitQueuedRunInTx } from "@mymemo/agent-db/run-store";
+import {
+	agentCoreDispatchOutbox,
+	conversations,
+} from "@mymemo/agent-db/schema";
+import { createTestDatabase, type TestDb } from "@mymemo/agent-db/testing";
+import { createAcquisitionReceipt } from "agentcore-dispatch-consumer/contract";
+import { createLocalAgentCoreDispatchBridge } from "./bridge";
+
+let tdb: TestDb;
+
+const admittedAt = new Date("2026-08-21T12:00:00.000Z");
+const dispatch = {
+	schemaVersion: 2 as const,
+	userId: "local-user",
+	conversationId: "0198c9f6-cf40-7de1-9cb6-5cb7a57b5101",
+	runId: "0198c9f6-daf0-74cd-8d13-0c60c25df102",
+	runtimeSessionId: "0198c9f6-cf40-7de1-9cb6-5cb7a57b5101",
+	admittedAt,
+};
+
+beforeAll(async () => {
+	tdb = await createTestDatabase();
+});
+
+afterAll(async () => {
+	await tdb.close();
+});
+
+beforeEach(async () => {
+	await tdb.db.delete(agentCoreDispatchOutbox);
+	await tdb.db.delete(conversations);
+	await tdb.db.insert(conversations).values({
+		userId: dispatch.userId,
+		conversationId: dispatch.conversationId,
+		scope: "general",
+		executionRuntime: "agentcore",
+	});
+	await tdb.db.transaction(async (tx) => {
+		await admitQueuedRunInTx(tx, {
+			runId: dispatch.runId,
+			userId: dispatch.userId,
+			conversationId: dispatch.conversationId,
+			messageId: "0198c9f6-e490-77dd-b72e-a85079c08103",
+			text: "Complete one local AgentCore Run.",
+			scope: "general",
+			collectionId: null,
+			summaryId: null,
+		});
+		await recordAgentCoreDispatchInTx(tx, dispatch);
+	});
+});
+
+describe("local AgentCore Dispatch bridge", () => {
+	it("acknowledges a real outbox row after a correlated Acquisition receipt", async () => {
+		const requests: Request[] = [];
+		const receipt = createAcquisitionReceipt(dispatch, {
+			disposition: "acquired",
+			owner: {
+				userId: dispatch.userId,
+				conversationId: dispatch.conversationId,
+				epoch: 1,
+			},
+			workerId: "local-runtime/1",
+		});
+		const bridge = createLocalAgentCoreDispatchBridge({
+			db: tdb.db,
+			publisherId: "local-bridge",
+			runtimeUrl: "http://runtime:8080",
+			fetch: async (request) => {
+				requests.push(request);
+				return new Response(`${JSON.stringify(receipt)}\n`, {
+					headers: { "content-type": "application/x-ndjson" },
+				});
+			},
+			now: () => new Date("2026-08-21T12:01:00.000Z"),
+		});
+
+		await expect(bridge.pollOnce()).resolves.toEqual({
+			status: "enabled",
+			publishedRunIds: [dispatch.runId],
+			ambiguousRunIds: [],
+		});
+		expect(requests).toHaveLength(1);
+		expect(requests[0]?.url).toBe("http://runtime:8080/invocations");
+		expect(
+			requests[0]?.headers.get("x-amzn-bedrock-agentcore-runtime-session-id"),
+		).toBe(dispatch.runtimeSessionId);
+		expect(await requests[0]?.json()).toMatchObject({
+			runId: dispatch.runId,
+			runtimeSessionId: dispatch.runtimeSessionId,
+		});
+
+		const [outbox] = await tdb.db.select().from(agentCoreDispatchOutbox);
+		expect(outbox?.publishedAt).toEqual(new Date("2026-08-21T12:01:00.000Z"));
+	});
+
+	it.each([
+		{
+			name: "invocation failure",
+			respond: async (_request: Request) => {
+				throw new Error("Runtime unavailable");
+			},
+		},
+		{
+			name: "timeout",
+			respond: async (request: Request) =>
+				await new Promise<Response>((_resolve, reject) => {
+					request.signal.addEventListener("abort", () => {
+						reject(request.signal.reason);
+					});
+				}),
+		},
+		{
+			name: "invalid response",
+			respond: async (_request: Request) => Response.json({ ok: true }),
+		},
+		{
+			name: "missing receipt",
+			respond: async (_request: Request) =>
+				new Response("", {
+					headers: { "content-type": "application/x-ndjson" },
+				}),
+		},
+	])("leaves the Dispatch retryable after $name", async ({ respond }) => {
+		let now = new Date("2026-08-21T12:01:00.000Z");
+		let failing = true;
+		const receipt = createAcquisitionReceipt(dispatch, {
+			disposition: "acquired",
+			owner: {
+				userId: dispatch.userId,
+				conversationId: dispatch.conversationId,
+				epoch: 1,
+			},
+			workerId: "local-runtime/1",
+		});
+		const bridge = createLocalAgentCoreDispatchBridge({
+			db: tdb.db,
+			publisherId: "local-bridge",
+			runtimeUrl: "http://runtime:8080",
+			invocationTimeoutMs: 5,
+			fetch: async (request) => {
+				if (failing) return await respond(request);
+				return new Response(`${JSON.stringify(receipt)}\n`, {
+					headers: { "content-type": "application/x-ndjson" },
+				});
+			},
+			now: () => now,
+		});
+
+		await expect(bridge.pollOnce()).resolves.toMatchObject({
+			publishedRunIds: [],
+			ambiguousRunIds: [dispatch.runId],
+		});
+		let [outbox] = await tdb.db.select().from(agentCoreDispatchOutbox);
+		expect(outbox?.publishedAt).toBeNull();
+
+		failing = false;
+		now = new Date("2026-08-21T12:05:00.000Z");
+		await expect(bridge.pollOnce()).resolves.toMatchObject({
+			publishedRunIds: [dispatch.runId],
+			ambiguousRunIds: [],
+		});
+		[outbox] = await tdb.db.select().from(agentCoreDispatchOutbox);
+		expect(outbox?.publishedAt).toEqual(now);
+	});
+
+	it("does not acknowledge a receipt correlated to another Dispatch", async () => {
+		let now = new Date("2026-08-21T12:01:00.000Z");
+		let mismatched = true;
+		const receipt = createAcquisitionReceipt(dispatch, {
+			disposition: "acquired",
+			owner: {
+				userId: dispatch.userId,
+				conversationId: dispatch.conversationId,
+				epoch: 1,
+			},
+			workerId: "local-runtime/1",
+		});
+		const bridge = createLocalAgentCoreDispatchBridge({
+			db: tdb.db,
+			publisherId: "local-bridge",
+			runtimeUrl: "http://runtime:8080",
+			fetch: async () =>
+				new Response(
+					`${JSON.stringify(mismatched ? { ...receipt, runId: "another-run" } : receipt)}\n`,
+					{ headers: { "content-type": "application/x-ndjson" } },
+				),
+			now: () => now,
+		});
+
+		await expect(bridge.pollOnce()).resolves.toMatchObject({
+			publishedRunIds: [],
+			ambiguousRunIds: [dispatch.runId],
+		});
+		expect(
+			(await tdb.db.select().from(agentCoreDispatchOutbox))[0]?.publishedAt,
+		).toBeNull();
+
+		mismatched = false;
+		now = new Date("2026-08-21T12:05:00.000Z");
+		await expect(bridge.pollOnce()).resolves.toMatchObject({
+			publishedRunIds: [dispatch.runId],
+		});
+	});
+});

--- a/apps/agentcore-local-dispatch-bridge/src/bridge.ts
+++ b/apps/agentcore-local-dispatch-bridge/src/bridge.ts
@@ -1,7 +1,4 @@
-import {
-	type AgentCoreDispatchIdentity,
-	loadAgentCoreDispatchRunStatus,
-} from "@mymemo/agent-db/agentcore-dispatch";
+import type { AgentCoreDispatchIdentity } from "@mymemo/agent-db/agentcore-dispatch";
 import type { Database } from "@mymemo/agent-db/client";
 import { createDatabaseAgentCoreDispatchPublisherStore } from "@mymemo/agentcore-dispatch/database-store";
 import { serializeAgentCoreDispatchEnvelope } from "@mymemo/agentcore-dispatch/envelope";
@@ -87,8 +84,7 @@ export function createLocalAgentCoreDispatchBridge(options: {
 	const control = { isEnabled: async () => true };
 	const consumer = createAgentCoreDispatchConsumer({
 		control,
-		loadRunStatus: (dispatch) =>
-			loadAgentCoreDispatchRunStatus(options.db, dispatch),
+		loadRunStatus: async () => null,
 		runtime: createLocalRuntimeInvoker({
 			runtimeUrl: options.runtimeUrl,
 			invocationTimeoutMs: options.invocationTimeoutMs ?? 30_000,

--- a/apps/agentcore-local-dispatch-bridge/src/bridge.ts
+++ b/apps/agentcore-local-dispatch-bridge/src/bridge.ts
@@ -12,25 +12,6 @@ const RUNTIME_SESSION_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id";
 
 type Fetch = (request: Request) => Promise<Response>;
 
-function responseChunks(
-	body: ReadableStream<Uint8Array>,
-): AsyncIterable<Uint8Array> {
-	return {
-		async *[Symbol.asyncIterator]() {
-			const reader = body.getReader();
-			try {
-				for (;;) {
-					const part = await reader.read();
-					if (part.done) return;
-					yield part.value;
-				}
-			} finally {
-				reader.releaseLock();
-			}
-		},
-	};
-}
-
 function createLocalRuntimeInvoker(options: {
 	runtimeUrl: string;
 	invocationTimeoutMs: number;
@@ -65,7 +46,7 @@ function createLocalRuntimeInvoker(options: {
 				throw new Error("local AgentCore Runtime returned an invalid response");
 			}
 			return {
-				chunks: responseChunks(response.body),
+				chunks: response.body,
 				close: () => response.body?.cancel(),
 			};
 		},

--- a/apps/agentcore-local-dispatch-bridge/src/bridge.ts
+++ b/apps/agentcore-local-dispatch-bridge/src/bridge.ts
@@ -1,0 +1,124 @@
+import {
+	type AgentCoreDispatchIdentity,
+	loadAgentCoreDispatchRunStatus,
+} from "@mymemo/agent-db/agentcore-dispatch";
+import type { Database } from "@mymemo/agent-db/client";
+import { createDatabaseAgentCoreDispatchPublisherStore } from "@mymemo/agentcore-dispatch/database-store";
+import { serializeAgentCoreDispatchEnvelope } from "@mymemo/agentcore-dispatch/envelope";
+import { createAgentCoreDispatchPublisher } from "@mymemo/agentcore-dispatch/publisher";
+import {
+	type AgentCoreRuntimeInvocation,
+	createAgentCoreDispatchConsumer,
+} from "agentcore-dispatch-consumer/consumer";
+
+const RUNTIME_SESSION_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id";
+
+type Fetch = (request: Request) => Promise<Response>;
+
+function responseChunks(
+	body: ReadableStream<Uint8Array>,
+): AsyncIterable<Uint8Array> {
+	return {
+		async *[Symbol.asyncIterator]() {
+			const reader = body.getReader();
+			try {
+				for (;;) {
+					const part = await reader.read();
+					if (part.done) return;
+					yield part.value;
+				}
+			} finally {
+				reader.releaseLock();
+			}
+		},
+	};
+}
+
+function createLocalRuntimeInvoker(options: {
+	runtimeUrl: string;
+	invocationTimeoutMs: number;
+	fetch: Fetch;
+}) {
+	return {
+		async invoke(
+			dispatch: AgentCoreDispatchIdentity,
+		): Promise<AgentCoreRuntimeInvocation> {
+			const response = await options.fetch(
+				new Request(`${options.runtimeUrl.replace(/\/+$/, "")}/invocations`, {
+					method: "POST",
+					headers: {
+						"content-type": "application/json",
+						[RUNTIME_SESSION_HEADER]: dispatch.runtimeSessionId,
+					},
+					body: serializeAgentCoreDispatchEnvelope(dispatch),
+					signal: AbortSignal.timeout(options.invocationTimeoutMs),
+				}),
+			);
+			if (!response.ok) {
+				await response.body?.cancel().catch(() => {});
+				throw new Error(`local AgentCore Runtime returned ${response.status}`);
+			}
+			if (
+				!response.headers
+					.get("content-type")
+					?.startsWith("application/x-ndjson") ||
+				!response.body
+			) {
+				await response.body?.cancel().catch(() => {});
+				throw new Error("local AgentCore Runtime returned an invalid response");
+			}
+			return {
+				chunks: responseChunks(response.body),
+				close: () => response.body?.cancel(),
+			};
+		},
+	};
+}
+
+/** Development-only bridge from the durable outbox to a local Runtime. */
+export function createLocalAgentCoreDispatchBridge(options: {
+	db: Database;
+	publisherId: string;
+	runtimeUrl: string;
+	invocationTimeoutMs?: number;
+	fetch?: Fetch;
+	now?: () => Date;
+}) {
+	const control = { isEnabled: async () => true };
+	const consumer = createAgentCoreDispatchConsumer({
+		control,
+		loadRunStatus: (dispatch) =>
+			loadAgentCoreDispatchRunStatus(options.db, dispatch),
+		runtime: createLocalRuntimeInvoker({
+			runtimeUrl: options.runtimeUrl,
+			invocationTimeoutMs: options.invocationTimeoutMs ?? 30_000,
+			fetch: options.fetch ?? fetch,
+		}),
+		alarm: { raise: async () => {} },
+	});
+	const publisher = createAgentCoreDispatchPublisher({
+		publisherId: options.publisherId,
+		control,
+		store: createDatabaseAgentCoreDispatchPublisherStore({
+			db: options.db,
+			now: options.now,
+		}),
+		queue: {
+			async send(dispatch) {
+				const response = await consumer.handle({
+					Records: [
+						{
+							messageId: dispatch.runId,
+							body: serializeAgentCoreDispatchEnvelope(dispatch),
+						},
+					],
+				});
+				if (response.batchItemFailures.length > 0) {
+					throw new Error("local AgentCore Dispatch remains retryable");
+				}
+			},
+		},
+	});
+
+	return { pollOnce: () => publisher.publishPending() };
+}

--- a/apps/agentcore-local-dispatch-bridge/src/index.ts
+++ b/apps/agentcore-local-dispatch-bridge/src/index.ts
@@ -1,0 +1,64 @@
+import { createDatabase } from "@mymemo/agent-db/client";
+import { resolveDatabaseUrl } from "@mymemo/agent-db/database-url";
+import { createLocalAgentCoreDispatchBridge } from "./bridge";
+
+function required(name: string): string {
+	const value = Bun.env[name]?.trim();
+	if (!value) throw new Error(`${name} is required`);
+	return value;
+}
+
+function positiveInt(name: string, fallback: number): number {
+	const raw = Bun.env[name];
+	if (raw === undefined) return fallback;
+	const value = Number(raw);
+	if (!Number.isInteger(value) || value <= 0) {
+		throw new Error(`${name} must be a positive integer`);
+	}
+	return value;
+}
+
+const databaseUrl = resolveDatabaseUrl(
+	required("AGENT_DATABASE_URL"),
+	Bun.env.DB_PASSWORD,
+	Bun.env.DB_SSL,
+);
+const db = createDatabase(databaseUrl);
+const bridge = createLocalAgentCoreDispatchBridge({
+	db,
+	publisherId: `local-bridge/${crypto.randomUUID()}`,
+	runtimeUrl: required("AGENTCORE_RUNTIME_URL"),
+	invocationTimeoutMs: positiveInt("AGENTCORE_INVOCATION_TIMEOUT_MS", 30_000),
+});
+const pollIntervalMs = positiveInt("AGENTCORE_POLL_INTERVAL_MS", 250);
+let stopping = false;
+process.once("SIGINT", () => {
+	stopping = true;
+});
+process.once("SIGTERM", () => {
+	stopping = true;
+});
+
+while (!stopping) {
+	try {
+		const result = await bridge.pollOnce();
+		if (result.publishedRunIds.length > 0) {
+			console.info(
+				JSON.stringify({
+					message: "local AgentCore Dispatch handled",
+					runIds: result.publishedRunIds,
+				}),
+			);
+		}
+	} catch (error) {
+		console.error(
+			JSON.stringify({
+				message: "local AgentCore Dispatch poll failed",
+				error: error instanceof Error ? error.message : String(error),
+			}),
+		);
+	}
+	if (!stopping) await Bun.sleep(pollIntervalMs);
+}
+
+await db.$client.end();

--- a/apps/agentcore-local-dispatch-bridge/src/index.ts
+++ b/apps/agentcore-local-dispatch-bridge/src/index.ts
@@ -8,16 +8,6 @@ function required(name: string): string {
 	return value;
 }
 
-function positiveInt(name: string, fallback: number): number {
-	const raw = Bun.env[name];
-	if (raw === undefined) return fallback;
-	const value = Number(raw);
-	if (!Number.isInteger(value) || value <= 0) {
-		throw new Error(`${name} must be a positive integer`);
-	}
-	return value;
-}
-
 const databaseUrl = resolveDatabaseUrl(
 	required("AGENT_DATABASE_URL"),
 	Bun.env.DB_PASSWORD,
@@ -28,9 +18,7 @@ const bridge = createLocalAgentCoreDispatchBridge({
 	db,
 	publisherId: `local-bridge/${crypto.randomUUID()}`,
 	runtimeUrl: required("AGENTCORE_RUNTIME_URL"),
-	invocationTimeoutMs: positiveInt("AGENTCORE_INVOCATION_TIMEOUT_MS", 30_000),
 });
-const pollIntervalMs = positiveInt("AGENTCORE_POLL_INTERVAL_MS", 250);
 let stopping = false;
 process.once("SIGINT", () => {
 	stopping = true;
@@ -58,7 +46,7 @@ while (!stopping) {
 			}),
 		);
 	}
-	if (!stopping) await Bun.sleep(pollIntervalMs);
+	if (!stopping) await Bun.sleep(250);
 }
 
 await db.$client.end();

--- a/apps/agentcore-local-dispatch-bridge/src/index.ts
+++ b/apps/agentcore-local-dispatch-bridge/src/index.ts
@@ -1,15 +1,10 @@
 import { createDatabase } from "@mymemo/agent-db/client";
 import { resolveDatabaseUrl } from "@mymemo/agent-db/database-url";
+import { requireEnv } from "agentcore-dispatch-consumer/config-utils";
 import { createLocalAgentCoreDispatchBridge } from "./bridge";
 
-function required(name: string): string {
-	const value = Bun.env[name]?.trim();
-	if (!value) throw new Error(`${name} is required`);
-	return value;
-}
-
 const databaseUrl = resolveDatabaseUrl(
-	required("AGENT_DATABASE_URL"),
+	requireEnv(Bun.env, "AGENT_DATABASE_URL"),
 	Bun.env.DB_PASSWORD,
 	Bun.env.DB_SSL,
 );
@@ -17,7 +12,7 @@ const db = createDatabase(databaseUrl);
 const bridge = createLocalAgentCoreDispatchBridge({
 	db,
 	publisherId: `local-bridge/${crypto.randomUUID()}`,
-	runtimeUrl: required("AGENTCORE_RUNTIME_URL"),
+	runtimeUrl: requireEnv(Bun.env, "AGENTCORE_RUNTIME_URL"),
 });
 let stopping = false;
 process.once("SIGINT", () => {

--- a/apps/agentcore-local-dispatch-bridge/tsconfig.json
+++ b/apps/agentcore-local-dispatch-bridge/tsconfig.json
@@ -1,19 +1,17 @@
 {
 	"compilerOptions": {
 		"lib": ["ESNext"],
+		"strict": true,
 		"target": "ESNext",
 		"module": "Preserve",
 		"moduleDetection": "force",
 		"moduleResolution": "bundler",
-		"allowImportingTsExtensions": true,
-		"verbatimModuleSyntax": true,
 		"noEmit": true,
-		"strict": true,
 		"skipLibCheck": true,
 		"noFallthroughCasesInSwitch": true,
 		"noUncheckedIndexedAccess": true,
 		"noImplicitOverride": true,
 		"types": ["bun"]
 	},
-	"include": ["src/**/*.ts", "local/**/*.ts"]
+	"include": ["src/**/*.ts"]
 }

--- a/apps/agentcore-runtime/Dockerfile
+++ b/apps/agentcore-runtime/Dockerfile
@@ -28,6 +28,23 @@ RUN chmod 0444 /etc/ssl/certs/rds-global-bundle.pem \
  && mkdir -p /workspace/conversations \
  && chown -R 65532:65532 /workspace
 
+# Development-only direct-env composition. Kept in a separate target so the
+# local entrypoint is absent from the production release image below.
+FROM base AS local
+COPY --from=install /temp/prod/node_modules node_modules
+COPY apps/agentcore-runtime apps/agentcore-runtime
+COPY apps/agentcore-dispatch-consumer apps/agentcore-dispatch-consumer
+COPY apps/agent-worker apps/agent-worker
+COPY packages/agent-db packages/agent-db
+COPY packages/agentcore-dispatch packages/agentcore-dispatch
+COPY packages/live-text packages/live-text
+COPY package.json .
+RUN mkdir -p /workspace/conversations && chown -R bun:bun /workspace
+WORKDIR /usr/src/app/apps/agentcore-runtime
+USER bun
+EXPOSE 8080/tcp
+ENTRYPOINT [ "bun", "run", "local/index.ts" ]
+
 FROM oven/bun:${BUN_VERSION}-distroless AS release
 LABEL com.mymemo.agentcore-runtime.request-oriented="true"
 WORKDIR /usr/src/app
@@ -51,20 +68,3 @@ WORKDIR /usr/src/app/apps/agentcore-runtime
 USER 65532:65532
 EXPOSE 8080/tcp
 ENTRYPOINT [ "bun", "run", "src/index.ts" ]
-
-# Development-only direct-env composition. Kept in a separate target so the
-# local entrypoint is absent from the production release image above.
-FROM base AS local
-COPY --from=install /temp/prod/node_modules node_modules
-COPY apps/agentcore-runtime apps/agentcore-runtime
-COPY apps/agentcore-dispatch-consumer apps/agentcore-dispatch-consumer
-COPY apps/agent-worker apps/agent-worker
-COPY packages/agent-db packages/agent-db
-COPY packages/agentcore-dispatch packages/agentcore-dispatch
-COPY packages/live-text packages/live-text
-COPY package.json .
-RUN mkdir -p /workspace/conversations && chown -R bun:bun /workspace
-WORKDIR /usr/src/app/apps/agentcore-runtime
-USER bun
-EXPOSE 8080/tcp
-ENTRYPOINT [ "bun", "run", "local/index.ts" ]

--- a/apps/agentcore-runtime/Dockerfile
+++ b/apps/agentcore-runtime/Dockerfile
@@ -32,7 +32,9 @@ FROM oven/bun:${BUN_VERSION}-distroless AS release
 LABEL com.mymemo.agentcore-runtime.request-oriented="true"
 WORKDIR /usr/src/app
 COPY --from=install /temp/prod/node_modules node_modules
-COPY apps/agentcore-runtime apps/agentcore-runtime
+COPY apps/agentcore-runtime/src apps/agentcore-runtime/src
+COPY apps/agentcore-runtime/package.json apps/agentcore-runtime/
+COPY apps/agentcore-runtime/tsconfig.json apps/agentcore-runtime/
 COPY apps/agentcore-dispatch-consumer apps/agentcore-dispatch-consumer
 COPY apps/agent-worker apps/agent-worker
 COPY packages/agent-db packages/agent-db
@@ -49,3 +51,20 @@ WORKDIR /usr/src/app/apps/agentcore-runtime
 USER 65532:65532
 EXPOSE 8080/tcp
 ENTRYPOINT [ "bun", "run", "src/index.ts" ]
+
+# Development-only direct-env composition. Kept in a separate target so the
+# local entrypoint is absent from the production release image above.
+FROM base AS local
+COPY --from=install /temp/prod/node_modules node_modules
+COPY apps/agentcore-runtime apps/agentcore-runtime
+COPY apps/agentcore-dispatch-consumer apps/agentcore-dispatch-consumer
+COPY apps/agent-worker apps/agent-worker
+COPY packages/agent-db packages/agent-db
+COPY packages/agentcore-dispatch packages/agentcore-dispatch
+COPY packages/live-text packages/live-text
+COPY package.json .
+RUN mkdir -p /workspace/conversations && chown -R bun:bun /workspace
+WORKDIR /usr/src/app/apps/agentcore-runtime
+USER bun
+EXPOSE 8080/tcp
+ENTRYPOINT [ "bun", "run", "local/index.ts" ]

--- a/apps/agentcore-runtime/local/index.ts
+++ b/apps/agentcore-runtime/local/index.ts
@@ -1,0 +1,63 @@
+import { loadWorkerConfigFromEnv } from "agent-worker/config";
+import { createLogger, toMessage } from "agent-worker/logger";
+import { createProductionRunResources } from "agent-worker/production-run-resources";
+import { createRunServing } from "agent-worker/run-serving";
+import { createDatabaseAgentCoreAcquisitionBoundary } from "agentcore-dispatch-consumer/acquisition-boundary";
+import { createAgentCoreExecutionServices } from "../src/execution-services";
+import { createAgentCoreRuntime } from "../src/runtime";
+import { startRuntimeServer } from "../src/server";
+
+const config = loadWorkerConfigFromEnv(Bun.env);
+const logger = createLogger(config.logLevel);
+const resources = createProductionRunResources({
+	config,
+	logger,
+	processEnv: Bun.env,
+	telemetryService: "agentcore-runtime",
+});
+const acquisition = createDatabaseAgentCoreAcquisitionBoundary({
+	db: resources.db,
+	bootId: `local/${crypto.randomUUID()}`,
+	control: { isEnabled: async () => true },
+});
+const runServing = createRunServing({
+	db: resources.db,
+	processor: resources.processor,
+	liveStreamRelay: resources.liveStreamRelay,
+	liveStreamTelemetry: resources.liveStreamTelemetry,
+	logger,
+});
+const runtime = createAgentCoreRuntime({
+	...createAgentCoreExecutionServices({
+		db: resources.db,
+		acquire: acquisition.acquireDispatch,
+		runServing,
+		logger,
+	}),
+	heartbeatIntervalMs: config.heartbeatIntervalMs,
+	onExecutionError(error, dispatch) {
+		logger.error({
+			message: "local AgentCore execution abandoned",
+			conversationId: dispatch.conversationId,
+			runId: dispatch.runId,
+			error: toMessage(error),
+		});
+	},
+});
+const server = startRuntimeServer(runtime, config.port);
+
+logger.info({ message: "local AgentCore Runtime started", port: config.port });
+let stopping = false;
+async function stop(signal: NodeJS.Signals): Promise<void> {
+	if (stopping) return;
+	stopping = true;
+	logger.info({ message: "local AgentCore Runtime stopping", signal });
+	void server.stop(false);
+	await runtime.shutdown(config.shutdownTimeoutMs);
+	await resources.liveStreamRelay.close().catch(() => {});
+	await resources.db.$client.end().catch(() => {});
+	await server.stop(true);
+	process.exit(0);
+}
+process.on("SIGINT", (signal) => void stop(signal));
+process.on("SIGTERM", (signal) => void stop(signal));

--- a/apps/chat-api/Dockerfile
+++ b/apps/chat-api/Dockerfile
@@ -36,6 +36,19 @@ COPY packages/agent-db/ packages/agent-db/
 COPY packages/live-text/ packages/live-text/
 COPY package.json .
 
+# Development-only composition. The production release stage below copies only
+# src/, so this always-open local entrypoint cannot ship in the release image.
+FROM base AS local
+COPY --from=install /temp/prod/node_modules node_modules
+COPY --from=prerelease /usr/src/app/apps/chat-api apps/chat-api
+COPY --from=prerelease /usr/src/app/packages/agent-db packages/agent-db
+COPY --from=prerelease /usr/src/app/packages/live-text packages/live-text
+COPY --from=prerelease /usr/src/app/package.json .
+WORKDIR /usr/src/app/apps/chat-api
+USER bun
+EXPOSE 3000/tcp
+ENTRYPOINT [ "bun", "run", "local/index.ts" ]
+
 # Final release image
 FROM base AS release
 COPY --from=install /temp/prod/node_modules node_modules

--- a/apps/chat-api/local/index.ts
+++ b/apps/chat-api/local/index.ts
@@ -1,0 +1,25 @@
+import { createLiveStreamTelemetry } from "@mymemo/live-text";
+import pino from "pino";
+import { createApp } from "../src/app";
+import { loadApiConfigFromEnv } from "../src/config/env";
+import { createDeps } from "../src/deps";
+
+const config = loadApiConfigFromEnv({
+	...Bun.env,
+	STATSIG_SERVER_SECRET: "unused-by-local-composition",
+});
+const logger = pino({ level: config.logLevel });
+const deps = createDeps(config, createLiveStreamTelemetry("chat-api", logger), {
+	isAgentEnabled: async () => true,
+});
+let shuttingDown = false;
+async function close(): Promise<void> {
+	if (shuttingDown) return;
+	shuttingDown = true;
+	await deps.closeLiveResources().catch(() => {});
+	process.exit(0);
+}
+process.once("SIGINT", () => void close());
+process.once("SIGTERM", () => void close());
+
+export default createApp(config, deps);

--- a/apps/chat-api/src/config/env.test.ts
+++ b/apps/chat-api/src/config/env.test.ts
@@ -106,24 +106,16 @@ describe("loadApiConfigFromEnv — worker-secret boundary", () => {
 });
 
 describe("loadApiConfigFromEnv — Statsig exposure config", () => {
-	it("requires STATSIG_SERVER_SECRET when break-glass is off", () => {
+	it("always requires STATSIG_SERVER_SECRET", () => {
 		const env = baseEnv();
 		delete env.STATSIG_SERVER_SECRET;
 		expect(() => loadApiConfigFromEnv(env)).toThrow(/STATSIG_SERVER_SECRET/);
-	});
-
-	it("allows boot without the Statsig secret under operator break-glass", () => {
-		const env = baseEnv();
-		delete env.STATSIG_SERVER_SECRET;
 		env.AGENT_EXPOSURE_BREAK_GLASS = "true";
-		const config = loadApiConfigFromEnv(env);
-		expect(config.agentExposureBreakGlass).toBe(true);
-		expect(config.statsigServerSecret).toBeUndefined();
+		expect(() => loadApiConfigFromEnv(env)).toThrow(/STATSIG_SERVER_SECRET/);
 	});
 
 	it("carries the Statsig secret when configured normally", () => {
 		const config = loadApiConfigFromEnv(baseEnv());
-		expect(config.agentExposureBreakGlass).toBe(false);
 		expect(config.statsigServerSecret).toBe("secret-statsig");
 	});
 	it("ignores legacy prototype provider settings", () => {

--- a/apps/chat-api/src/config/env.ts
+++ b/apps/chat-api/src/config/env.ts
@@ -47,17 +47,9 @@ export interface ApiConfig {
 	databaseUrl: string;
 	/**
 	 * Statsig server secret backing the production exposure gate.
-	 * Required unless operator break-glass is on; undefined only in that case.
 	 * Never sent to the sandbox or logged.
 	 */
-	statsigServerSecret: string | undefined;
-	/**
-	 * Operator break-glass for Statsig exposure. When true, new agent work is
-	 * allowed without Statsig (local dev, or an incident where Statsig is
-	 * unavailable). When false (production default), the exposure gate fails
-	 * closed and a Statsig secret is required.
-	 */
-	agentExposureBreakGlass: boolean;
+	statsigServerSecret: string;
 	/** Required authenticated TLS Redis secret for the Live Stream relay. */
 	redisUrl: string;
 }
@@ -86,25 +78,15 @@ export function loadApiConfigFromEnv(env: Env): ApiConfig {
 	const artifactRegion = env.AWS_REGION?.trim();
 	assert(artifactRegion, "AWS_REGION is required");
 
-	// Statsig exposure fails closed: a Statsig secret is required unless an operator
-	// explicitly enables break-glass (local dev, or an incident where Statsig is
-	// unavailable). Worker-only secrets (OpenRouter,
-	// KB) are intentionally NOT read here — chat-api must not hold them.
-	const agentExposureBreakGlass = env.AGENT_EXPOSURE_BREAK_GLASS === "true";
-	if (!agentExposureBreakGlass) {
-		assert(
-			env.STATSIG_SERVER_SECRET,
-			"STATSIG_SERVER_SECRET is required (or set AGENT_EXPOSURE_BREAK_GLASS=true to open the gate without Statsig)",
-		);
-	}
+	const statsigServerSecret = env.STATSIG_SERVER_SECRET?.trim();
+	assert(statsigServerSecret, "STATSIG_SERVER_SECRET is required");
 
 	return {
 		logLevel: env.LOG_LEVEL || "info",
 		databaseUrl,
 		artifactBucket,
 		artifactRegion,
-		statsigServerSecret: env.STATSIG_SERVER_SECRET,
-		agentExposureBreakGlass,
+		statsigServerSecret,
 		redisUrl: resolveLiveStreamRedisUrl(env.REDIS_URL, {
 			allowInsecureLoopback:
 				env.LIVE_STREAM_ALLOW_INSECURE_LOCAL_REDIS === "true",

--- a/apps/chat-api/src/deps.ts
+++ b/apps/chat-api/src/deps.ts
@@ -73,6 +73,7 @@ export function createDeps(
 			warn() {},
 		},
 	),
+	exposureGate: ExposureGate = createExposureGate(config),
 ): AppDeps {
 	// One Drizzle pool over the writable DB, shared by every store.
 	const database = createDatabase(config.databaseUrl);
@@ -99,6 +100,6 @@ export function createDeps(
 		liveStreamRelay,
 		liveStreamTelemetry,
 		closeLiveResources: () => liveStreamRelay.close(),
-		exposureGate: createExposureGate(config),
+		exposureGate,
 	};
 }

--- a/apps/chat-api/src/features/exposure-gate/exposure-gate.test.ts
+++ b/apps/chat-api/src/features/exposure-gate/exposure-gate.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "bun:test";
 import type { InternalIdentity } from "@/features/conversations/conversations.schema";
 import {
 	AGENT_EXPOSURE_GATE,
-	BreakGlassExposureGate,
 	type StatsigClientLike,
 	StatsigExposureGate,
 } from "./exposure-gate";
@@ -11,19 +10,6 @@ const allowedIdentity: InternalIdentity = {
 	memberCode: "member-allowed",
 	partnerCode: "partner-1",
 };
-const deniedIdentity: InternalIdentity = {
-	memberCode: "member-denied",
-	partnerCode: "partner-1",
-};
-
-describe("BreakGlassExposureGate", () => {
-	it("always allows (operator override)", async () => {
-		const gate = new BreakGlassExposureGate();
-		expect(await gate.isAgentEnabled(allowedIdentity)).toBe(true);
-		expect(await gate.isAgentEnabled(deniedIdentity)).toBe(true);
-	});
-});
-
 describe("StatsigExposureGate — fail closed", () => {
 	it("denies when initialization fails", async () => {
 		const client: StatsigClientLike = {

--- a/apps/chat-api/src/features/exposure-gate/exposure-gate.ts
+++ b/apps/chat-api/src/features/exposure-gate/exposure-gate.ts
@@ -24,26 +24,12 @@ export interface ExposureGate {
 }
 
 /**
- * Operator break-glass gate: always allows. Used for local dev and for incident
- * response when Statsig is unavailable and an operator has explicitly opted in
- * via `AGENT_EXPOSURE_BREAK_GLASS=true`. Never the production default.
- */
-export class BreakGlassExposureGate implements ExposureGate {
-	async isAgentEnabled(_identity: InternalIdentity): Promise<boolean> {
-		return true;
-	}
-}
-
-/**
  * Statsig-backed production gate. Fails CLOSED: if initialization fails or an
  * evaluation throws, new work is denied. The Statsig secret is never logged.
  *
  * Initialization is kicked off in the constructor and awaited on the first
  * `isAgentEnabled`, so it overlaps boot (the gate is warm before the first
- * turn). Tests never construct this against the real Statsig client — the local
- * harness and `test-setup` run with `AGENT_EXPOSURE_BREAK_GLASS=true`, so the
- * entrypoint builds a `BreakGlassExposureGate` instead and no Statsig network
- * I/O fires at import.
+ * turn).
  */
 export class StatsigExposureGate implements ExposureGate {
 	private readonly gate: StatsigBooleanGate;

--- a/apps/chat-api/src/features/exposure-gate/index.ts
+++ b/apps/chat-api/src/features/exposure-gate/index.ts
@@ -1,13 +1,8 @@
 import type { ApiConfig } from "@/config/env";
-import {
-	BreakGlassExposureGate,
-	createStatsigExposureGate,
-	type ExposureGate,
-} from "./exposure-gate";
+import { createStatsigExposureGate, type ExposureGate } from "./exposure-gate";
 
 export {
 	AGENT_EXPOSURE_GATE,
-	BreakGlassExposureGate,
 	type ExposureGate,
 	StatsigExposureGate,
 } from "./exposure-gate";
@@ -17,22 +12,11 @@ interface GateLogger {
 }
 
 /**
- * Pick the exposure gate from config. Operator break-glass short-circuits to an
- * always-allow gate (and needs no Statsig secret); otherwise build the
- * Statsig-backed, fail-closed gate. `statsigServerSecret` is guaranteed present
- * here when break-glass is off — env validation requires it.
+ * Build the production fail-closed Statsig exposure gate.
  */
 export function createExposureGate(
 	config: ApiConfig,
 	logger?: GateLogger,
 ): ExposureGate {
-	if (config.agentExposureBreakGlass) {
-		return new BreakGlassExposureGate();
-	}
-	// Non-null: loadApiConfigFromEnv requires the secret unless break-glass is on.
-	return createStatsigExposureGate(
-		config.statsigServerSecret as string,
-		{},
-		logger,
-	);
+	return createStatsigExposureGate(config.statsigServerSecret, {}, logger);
 }

--- a/apps/chat-api/src/test-setup.ts
+++ b/apps/chat-api/src/test-setup.ts
@@ -8,11 +8,7 @@ Bun.env.AGENT_DATABASE_URL =
 Bun.env.ARTIFACT_BUCKET =
 	Bun.env.ARTIFACT_BUCKET ?? "mymemo-agent-test-artifacts";
 Bun.env.AWS_REGION = Bun.env.AWS_REGION ?? "us-west-2";
-// Run tests with the exposure gate in break-glass mode. This lets config load
-// without a Statsig secret AND, crucially, makes the entrypoint's default export
-// (`createApp(loadApiConfigFromEnv(Bun.env))`, evaluated whenever a test imports
-// `@/index`) builds break-glass exposure — so no real Statsig
-// client is constructed and no network I/O fires at import time. Gate-specific
-// tests construct Statsig-backed gates directly with fake/offline clients.
-Bun.env.AGENT_EXPOSURE_BREAK_GLASS =
-	Bun.env.AGENT_EXPOSURE_BREAK_GLASS ?? "true";
+// Production composition always requires Statsig. Tests inject their own gates;
+// this placeholder only lets imports of the production entrypoint validate.
+Bun.env.STATSIG_SERVER_SECRET =
+	Bun.env.STATSIG_SERVER_SECRET ?? "test-statsig-secret";

--- a/bun.lock
+++ b/bun.lock
@@ -69,6 +69,21 @@
         "@types/pg": "^8.20.0",
       },
     },
+    "apps/agentcore-local-dispatch-bridge": {
+      "name": "agentcore-local-dispatch-bridge",
+      "dependencies": {
+        "@mymemo/agent-db": "workspace:*",
+        "@mymemo/agentcore-dispatch": "workspace:*",
+        "agentcore-dispatch-consumer": "workspace:*",
+        "drizzle-orm": "^0.45.2",
+        "pg": "^8.22.0",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "^2.3.11",
+        "@electric-sql/pglite": "^0.5.3",
+        "@types/bun": "^1.3.11",
+      },
+    },
     "apps/agentcore-runtime": {
       "name": "agentcore-runtime",
       "dependencies": {
@@ -422,6 +437,8 @@
     "agentcore-dispatch-consumer": ["agentcore-dispatch-consumer@workspace:apps/agentcore-dispatch-consumer"],
 
     "agentcore-dispatch-publisher": ["agentcore-dispatch-publisher@workspace:apps/agentcore-dispatch-publisher"],
+
+    "agentcore-local-dispatch-bridge": ["agentcore-local-dispatch-bridge@workspace:apps/agentcore-local-dispatch-bridge"],
 
     "agentcore-runtime": ["agentcore-runtime@workspace:apps/agentcore-runtime"],
 
@@ -837,6 +854,8 @@
 
     "@mymemo/agent-db/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
+    "@mymemo/agentcore-dispatch/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+
     "@mymemo/live-text/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
     "@mymemo/test-support/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
@@ -856,6 +875,8 @@
     "agentcore-dispatch-consumer/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
     "agentcore-dispatch-publisher/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+
+    "agentcore-local-dispatch-bridge/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
     "agentcore-runtime/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
@@ -955,6 +976,8 @@
 
     "@mymemo/agent-db/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
+    "@mymemo/agentcore-dispatch/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+
     "@mymemo/live-text/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
     "@mymemo/test-support/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
@@ -964,6 +987,8 @@
     "agentcore-dispatch-consumer/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
     "agentcore-dispatch-publisher/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+
+    "agentcore-local-dispatch-bridge/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
     "agentcore-runtime/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -93,8 +93,6 @@ services:
       AGENT_DATABASE_URL: postgresql://mymemo:mymemo@postgres:5432/mymemo_agent
       DB_SSL: disable
       AGENTCORE_RUNTIME_URL: http://127.0.0.1:8080
-      AGENTCORE_POLL_INTERVAL_MS: "250"
-      AGENTCORE_INVOCATION_TIMEOUT_MS: "30000"
     depends_on:
       migrate:
         condition: service_completed_successfully

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,55 +1,44 @@
-# Local end-to-end harness — real split runtime. The client contract is
-# chat-api's /v1 conversation API: create a Conversation, admit a strict AG-UI
-# Run, and attach to its producer-buffered Live Stream over SSE. A queued Run is claimed
-# and processed by the agent-worker. The worker runs the real Claude Agent SDK
-# processor, so export
+# Local end-to-end harness using the real AgentCore Runtime implementation.
+# Export
 # OPENROUTER_API_KEY and E2B_API_KEY before starting the stack and build the
 # WORKER_E2B_TEMPLATE described in apps/agent-worker/e2b-template/.
 #
-# Split-runtime services (non-secret wiring inline; local-only dev credentials):
+# Services (non-secret wiring inline; local-only dev credentials):
 #   postgres      — the writable mymemo_agent DB (conversations/runs/run_events)
 #                   AND the read-only mymemo_kb (seeded for the retained doc path)
 #   migrate       — one-shot: applies the @mymemo/agent-db migrations, then exits
 #   chat-api      — creates Conversations, admits Runs, and attaches SSE
-#   agent-worker  — claims Runs and publishes standard AG-UI events through E2B
+#   agentcore-runtime — acquires one exact Dispatch and serves its Run
+#   dispatch-bridge — polls the durable outbox and invokes the local Runtime
 #   redis         — disposable Redis 7 for real relay contract testing
 #
 # The prototype gateway/sandbox services were removed once the split runtime
 # replaced them end to end (ADR-0002). Bring the demo up with:
 #     docker compose up --build
 
-x-artifact-aws-environment: &artifact-aws-environment
+x-runtime-environment: &runtime-environment
   ARTIFACT_BUCKET: "mymemo-agent-local-artifacts"
   AWS_REGION: "us-west-2"
-  AWS_PROFILE: "${AWS_PROFILE:-}"
-  AWS_ACCESS_KEY_ID: "${AWS_ACCESS_KEY_ID:-}"
-  AWS_SECRET_ACCESS_KEY: "${AWS_SECRET_ACCESS_KEY:-}"
-  AWS_SESSION_TOKEN: "${AWS_SESSION_TOKEN:-}"
 
 services:
   chat-api:
     build:
       context: .
       dockerfile: apps/chat-api/Dockerfile
+      target: local
     # Share the local Redis network namespace so the deliberately narrow plaintext
     # development escape hatch can use the literal loopback host.
     network_mode: "service:redis"
     environment:
-      <<: *artifact-aws-environment
+      <<: *runtime-environment
       # chat-api's writable database (mymemo_agent): conversations, runs,
       # run_events. Local-only dev credential, so inline. Named AGENT_DATABASE_URL
       # so it never collides with the worker's read-only KB DATABASE_URL.
       AGENT_DATABASE_URL: postgresql://mymemo:mymemo@postgres:5432/mymemo_agent
       DB_SSL: disable
       LOG_LEVEL: info
-      # Open the agent exposure gate locally without wiring Statsig (break-glass).
-      AGENT_EXPOSURE_BREAK_GLASS: "true"
       REDIS_URL: redis://127.0.0.1:6379
       LIVE_STREAM_ALLOW_INSECURE_LOCAL_REDIS: "true"
-    # The mounted developer AWS profile is trusted-runtime-only and signs
-    # artifact downloads. Chat-api still receives no provider/KB/E2B secrets.
-    volumes:
-      - ${HOME}/.aws:/home/bun/.aws:ro
     depends_on:
       postgres:
         condition: service_healthy
@@ -59,20 +48,17 @@ services:
         condition: service_healthy
     restart: unless-stopped
 
-  # Claims queued runs from the shared mymemo_agent DB, heartbeats ownership,
-  # and serves each with the real Claude Agent SDK over OpenRouter + E2B.
-  agent-worker:
+  agentcore-runtime:
     build:
       context: .
-      dockerfile: apps/agent-worker/Dockerfile
+      dockerfile: apps/agentcore-runtime/Dockerfile
+      target: local
     network_mode: "service:redis"
     environment:
-      <<: *artifact-aws-environment
+      <<: *runtime-environment
       AGENT_DATABASE_URL: postgresql://mymemo:mymemo@postgres:5432/mymemo_agent
       DB_SSL: disable
       LOG_LEVEL: info
-      # The control loop ticks (claim + heartbeat) at this interval; keep it short
-      # locally so a queued run is picked up promptly (prod default is 15s).
       WORKER_HEARTBEAT_INTERVAL_MS: "2000"
       KB_DATABASE_URL: postgresql://mymemo:mymemo@postgres:5432/mymemo_kb
       OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:?Set OPENROUTER_API_KEY}
@@ -82,10 +68,12 @@ services:
       WORKER_E2B_TEMPLATE: ${WORKER_E2B_TEMPLATE:-mymemo-agent-sandbox}
       REDIS_URL: redis://127.0.0.1:6379
       LIVE_STREAM_ALLOW_INSECURE_LOCAL_REDIS: "true"
-    # AWS credentials remain in this trusted worker. buildSandboxEnv accepts
-    # only the Run binding, so none of them are copied into the E2B sandbox.
-    volumes:
-      - ${HOME}/.aws:/home/bun/.aws:ro
+      PORT: "8080"
+    healthcheck:
+      test: ["CMD", "bun", "-e", "const r=await fetch('http://127.0.0.1:8080/ping');process.exit(r.ok?0:1)"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
     depends_on:
       postgres:
         condition: service_healthy
@@ -94,6 +82,40 @@ services:
       redis:
         condition: service_healthy
     restart: unless-stopped
+
+  dispatch-bridge:
+    build:
+      context: .
+      dockerfile: apps/agentcore-local-dispatch-bridge/Dockerfile
+      target: local
+    network_mode: "service:redis"
+    environment:
+      AGENT_DATABASE_URL: postgresql://mymemo:mymemo@postgres:5432/mymemo_agent
+      DB_SSL: disable
+      AGENTCORE_RUNTIME_URL: http://127.0.0.1:8080
+      AGENTCORE_POLL_INTERVAL_MS: "250"
+      AGENTCORE_INVOCATION_TIMEOUT_MS: "30000"
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+      agentcore-runtime:
+        condition: service_healthy
+    restart: unless-stopped
+
+  smoke:
+    image: oven/bun:1
+    network_mode: "service:redis"
+    command: ["bun", "run", "/smoke/local-agentcore-smoke.ts"]
+    environment:
+      AGENT_SMOKE_BASE_URL: http://127.0.0.1:3000
+    volumes:
+      - ./scripts/smoke/local-agentcore-smoke.ts:/smoke/local-agentcore-smoke.ts:ro
+    depends_on:
+      chat-api:
+        condition: service_started
+      dispatch-bridge:
+        condition: service_started
+    restart: "no"
 
   # One-shot: apply the writable DB (mymemo_agent) schema from Drizzle migrations,
   # then exit. The postgres init only creates the database; the tables are owned

--- a/compose.yaml
+++ b/compose.yaml
@@ -105,11 +105,12 @@ services:
   smoke:
     image: oven/bun:1
     network_mode: "service:redis"
-    command: ["bun", "run", "/smoke/local-agentcore-smoke.ts"]
+    command: ["bun", "run", "/workspace/scripts/smoke/local-agentcore-smoke.ts"]
     environment:
       AGENT_SMOKE_BASE_URL: http://127.0.0.1:3000
     volumes:
-      - ./scripts/smoke/local-agentcore-smoke.ts:/smoke/local-agentcore-smoke.ts:ro
+      - ./scripts/smoke:/workspace/scripts/smoke:ro
+      - ./packages/test-support:/workspace/packages/test-support:ro
     depends_on:
       chat-api:
         condition: service_started

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -11,6 +11,7 @@ Use this guide when a change crosses service or package boundaries. For canonica
 | `apps/agentcore-dispatch-publisher` | Dedicated AgentCore Dispatch publication app. Runs as one ECS task, separate from Conversation-serving workers. |
 | `apps/agentcore-dispatch-consumer` | AgentCore dispatch consumer Lambda and shared dispatch-boundary modules. Its production composition validates strict content-free SQS envelopes, invokes the Runtime, and returns partial-batch acknowledgements; the Runtime composes exact acquisition directly. |
 | `apps/agentcore-runtime` | Linux ARM64 AgentCore Runtime exposing `/ping` and `/invocations`. It serves one acquired AgentCore Run and delegates the already-running Run to shared Run-serving behavior. It does not run Fargate Claim, drain, expiration, Reclamation, or cleanup loops. |
+| `apps/agentcore-local-dispatch-bridge` | Development-only outbox poller that composes the shared publisher and consumer contracts against a local AgentCore Runtime. It is absent from production startup paths and images. |
 | `packages/agent-db` | Shared writable `mymemo_agent` data layer: schema, migrations, Run and Conversation Ownership transactions, runtime pointers, session transcripts, artifact metadata, and PGlite test support. |
 | `packages/agentcore-dispatch` | Production-neutral AgentCore Dispatch publication behavior, strict envelope serialization, and separately importable SQS and SSM adapters. |
 | `packages/live-text` | Redis configuration, event validation, and producer-buffered in-memory/Redis Live Stream relay implementations. |
@@ -39,7 +40,7 @@ Workspace persistence, Agent session continuity, Searchable document loading, an
 | `apps/chat-api/src/features/conversation-history/` | Owner-scoped permanent history over canonical Run events |
 | `apps/chat-api/src/features/artifacts/` | Current-artifact listing and five-minute S3 download signing |
 | `apps/chat-api/src/features/conversation-store/` | Durable Conversation registry and frozen Scope |
-| `apps/chat-api/src/features/exposure-gate/` | Statsig and break-glass implementations of the new-work gate |
+| `apps/chat-api/src/features/exposure-gate/` | Production Statsig implementation of the new-work gate |
 | `apps/chat-api/src/features/run-store/` | Run admission, owner-scoped Run reads, and durable interruption |
 | `apps/chat-api/src/db/` | Thin bindings to `@mymemo/agent-db` and the shared migration runner |
 | `apps/agent-worker/src/run-loop.ts` | Fargate-only Claim, ordering, expiration, Reclamation, and release control plane |

--- a/docs/agents/configuration.md
+++ b/docs/agents/configuration.md
@@ -51,7 +51,7 @@ Runtime shutdown grace is fixed at 30 seconds and concurrency is fixed at one ex
 Required:
 
 - `AGENT_DATABASE_URL`: writable `mymemo_agent` database. It is deliberately not named `DATABASE_URL`, which denotes the read-only KB credential elsewhere. It is separate from the worker's read-only `mymemo_kb` credential. The process fails at startup when it is absent. `bun run db:migrate` in `apps/chat-api` applies migrations owned by `packages/agent-db` through its exported `MIGRATIONS_DIR`.
-- `STATSIG_SERVER_SECRET`: production exposure-gate secret; required unless `AGENT_EXPOSURE_BREAK_GLASS=true`
+- `STATSIG_SERVER_SECRET`: required production exposure-gate secret
 - `ARTIFACT_BUCKET`: private artifact bucket; chat-api receives read-only object access
 - `AWS_REGION`: artifact S3 region
 - `REDIS_URL`: authenticated `rediss://` URL. Missing, malformed, unauthenticated, or non-TLS values fail startup. Never log it.
@@ -60,9 +60,10 @@ Optional:
 
 - `LOG_LEVEL` (default `info`)
 - `PORT` (default `3000`)
-- `AGENT_EXPOSURE_BREAK_GLASS` (default off): when exactly `true`, allow new work without Statsig; keep it off by default in production
 
 chat-api has no AgentCore dispatch queue or SSM parameter configuration. Admission ends after the transactional Postgres outbox write; publisher and consumer processes own queue delivery and the dispatch kill switch.
+
+The local Compose target starts `apps/chat-api/local/index.ts`, which injects an always-open development gate. The production entrypoint and image contain no configuration switch to select that composition.
 - `DB_PASSWORD`: splice into a passwordless `AGENT_DATABASE_URL`
 - `DB_SSL` (default on; `disable` only for local non-TLS Postgres)
 - `LIVE_STREAM_ALLOW_INSECURE_LOCAL_REDIS` (default off): when exactly `true`, allow unauthenticated `redis://` only for `localhost`, `127.0.0.1`, or `[::1]` in integration tests

--- a/docs/agents/security.md
+++ b/docs/agents/security.md
@@ -13,7 +13,7 @@ Use this guide for changes involving identity, authorization, feature exposure, 
 
 New agent work is gated by the server-side Statsig gate `mymemo_agent_split_runtime_enabled` in `apps/chat-api/src/features/exposure-gate/`. Evaluate it on trusted identity after identity parsing and before any Conversation or Run write. A denial returns `403 { error: "Agent is not enabled" }`; gate errors fail closed.
 
-`createExposureGate(config)` selects the fail-closed `StatsigExposureGate` or the explicitly configured always-allow `BreakGlassExposureGate`.
+Production `createExposureGate(config)` always selects the fail-closed `StatsigExposureGate`. The development-only Chat API composition injects its always-open gate directly and is not selectable through production configuration.
 
 After exposure allows Conversation creation, chat-api explicitly persists the AgentCore-only execution-runtime compatibility marker. Runtime selection is not an input or operational control, and Statsig failures cannot select Fargate. chat-api records AgentCore dispatch only in Postgres and holds no SQS or SSM authority.
 

--- a/docs/verification/e2e-smoke.md
+++ b/docs/verification/e2e-smoke.md
@@ -42,22 +42,23 @@ value fails before the first HTTP request.
 
 | Target | Suite | Invocation | Credentials and network |
 | --- | --- | --- | --- |
-| Local compose | `full` | Unavailable until #523 | AgentCore-only creation cannot use the current Fargate-only compose runtime. `bun run smoke:local` fails immediately with this explanation. |
+| Local compose | one Run | `bun run smoke:local` | Requires OpenRouter and E2B development credentials; uses Postgres, Redis, the development bridge, and the real local Runtime without AWS-managed Dispatch infrastructure. |
 | Deployed internal ALB | `core` | `AGENT_SMOKE_SUITE=core scripts/deploy/prod_smoke.sh` | The wrapper expects `agentcore`. Run inside the VPC under the synthetic identity targeted in the Statsig exposure gate. The caller receives no provider, sandbox, AWS, or database secrets. |
 
-There is no staging target. The credential-free integration suite remains the
-pre-merge bar until #523 restores local-real; the deployed core suite is the
-post-deploy bar. The smoke identity must be allowlisted in the
+There is no staging target. The credential-free integration suite and local
+Compose smoke are the pre-merge bars; the deployed core suite is the post-deploy
+bar. The smoke identity must be allowlisted in the
 `mymemo_agent_split_runtime_enabled` Statsig gate before a gate-open deployed
 run. Until the in-VPC release one-shot in
 [#305](https://github.com/X-GPT/mymemo-agent/issues/305) lands, the deployed
 command remains manual from a VPC-reachable environment.
 
-## Local smoke transition
+## Local smoke
 
-Issue #523 owns the local AgentCore bridge and restoration of `smoke:local`.
-Until then, use the credential-free integration suite as the pre-merge bar;
-the local command fails immediately rather than advertising an impossible run.
+`bun run smoke:local` builds the local-only Chat API and Runtime targets, waits
+for the durable bridge, and admits one public Run that must reach
+`RUN_FINISHED`. The production images omit both local composition entrypoints
+and the bridge application.
 
 The deployed wrapper fixes the expected runtime to `agentcore`. After the
 synthetic identity is targeted in the exposure gate, the public creation response

--- a/e2e/integration.test.ts
+++ b/e2e/integration.test.ts
@@ -187,21 +187,6 @@ function interruptRun(
 	);
 }
 
-/** Spawn `bun run src/index.ts` for an app under apps/<name>. Output is inherited
- * so a boot failure surfaces directly in the test/CI logs. */
-function spawnApp(
-	name: string,
-	env: Record<string, string>,
-	entrypoint = "src/index.ts",
-) {
-	return Bun.spawn(["bun", "run", entrypoint], {
-		cwd: resolve(REPO_ROOT, "apps", name),
-		env: { ...process.env, ...env },
-		stdout: "inherit",
-		stderr: "inherit",
-	});
-}
-
 /** Spawn the deterministic test-only AgentCore Runtime. */
 function spawnAgentCoreRuntime(env: Record<string, string>) {
 	return Bun.spawn(["bun", "run", "e2e/synthetic-agentcore-runtime.ts"], {
@@ -420,9 +405,10 @@ describe.skipIf(!RUN)("AgentCore integration (real Postgres and Redis)", () => {
 			INTEGRATION_RESUME_DELAY_MS: "1500",
 			INTEGRATION_RUNTIME_PORT: String(runtimePort),
 		};
-		chat = spawnApp(
-			"chat-api",
-			{
+		chat = Bun.spawn(["bun", "run", "local/index.ts"], {
+			cwd: resolve(REPO_ROOT, "apps", "chat-api"),
+			env: {
+				...process.env,
 				AGENT_DATABASE_URL: dbUrl,
 				ARTIFACT_BUCKET: "mymemo-agent-integration-artifacts",
 				AWS_REGION: "us-west-2",
@@ -432,8 +418,9 @@ describe.skipIf(!RUN)("AgentCore integration (real Postgres and Redis)", () => {
 				PORT: String(chatPort),
 				LOG_LEVEL: "warn",
 			},
-			"local/index.ts",
-		);
+			stdout: "inherit",
+			stderr: "inherit",
+		});
 
 		if (!(await waitForHealthy(30_000))) {
 			throw new Error(

--- a/e2e/integration.test.ts
+++ b/e2e/integration.test.ts
@@ -189,8 +189,12 @@ function interruptRun(
 
 /** Spawn `bun run src/index.ts` for an app under apps/<name>. Output is inherited
  * so a boot failure surfaces directly in the test/CI logs. */
-function spawnApp(name: string, env: Record<string, string>) {
-	return Bun.spawn(["bun", "run", "src/index.ts"], {
+function spawnApp(
+	name: string,
+	env: Record<string, string>,
+	entrypoint = "src/index.ts",
+) {
+	return Bun.spawn(["bun", "run", entrypoint], {
 		cwd: resolve(REPO_ROOT, "apps", name),
 		env: { ...process.env, ...env },
 		stdout: "inherit",
@@ -416,17 +420,20 @@ describe.skipIf(!RUN)("AgentCore integration (real Postgres and Redis)", () => {
 			INTEGRATION_RESUME_DELAY_MS: "1500",
 			INTEGRATION_RUNTIME_PORT: String(runtimePort),
 		};
-		chat = spawnApp("chat-api", {
-			AGENT_DATABASE_URL: dbUrl,
-			ARTIFACT_BUCKET: "mymemo-agent-integration-artifacts",
-			AWS_REGION: "us-west-2",
-			DB_SSL: "disable",
-			AGENT_EXPOSURE_BREAK_GLASS: "true",
-			REDIS_URL: redisUrl,
-			LIVE_STREAM_ALLOW_INSECURE_LOCAL_REDIS: "true",
-			PORT: String(chatPort),
-			LOG_LEVEL: "warn",
-		});
+		chat = spawnApp(
+			"chat-api",
+			{
+				AGENT_DATABASE_URL: dbUrl,
+				ARTIFACT_BUCKET: "mymemo-agent-integration-artifacts",
+				AWS_REGION: "us-west-2",
+				DB_SSL: "disable",
+				REDIS_URL: redisUrl,
+				LIVE_STREAM_ALLOW_INSECURE_LOCAL_REDIS: "true",
+				PORT: String(chatPort),
+				LOG_LEVEL: "warn",
+			},
+			"local/index.ts",
+		);
 
 		if (!(await waitForHealthy(30_000))) {
 			throw new Error(

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "mymemo-agent",
 	"module": "index.ts",
 	"scripts": {
-		"smoke:local": "bun -e 'console.error(\"smoke:local is unavailable until #523 adds the local AgentCore bridge\"); process.exit(1)'",
+		"smoke:local": "docker compose up --build --abort-on-container-exit --exit-code-from smoke smoke",
 		"test": "bun test scripts/deploy-config.test.ts scripts/deploy/agentcore_aws_checks.test.ts scripts/smoke/client-contract.test.ts scripts/smoke/agent-conversation-smoke.test.ts && bun run scripts/test-workspaces.ts",
 		"terraform:fmt": "terraform -chdir=infra/bootstrap-iam fmt && terraform -chdir=infra/terraform fmt && terraform -chdir=infra/ecr fmt && terraform -chdir=infra/dev fmt",
 		"terraform:validate": "terraform -chdir=infra/bootstrap-iam validate && terraform -chdir=infra/terraform validate && terraform -chdir=infra/ecr validate && terraform -chdir=infra/dev validate"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "mymemo-agent",
 	"module": "index.ts",
 	"scripts": {
-		"smoke:local": "docker compose up --build --abort-on-container-exit --exit-code-from smoke smoke",
+		"smoke:local": "sh scripts/smoke/local-agentcore-compose.sh",
 		"test": "bun test scripts/deploy-config.test.ts scripts/deploy/agentcore_aws_checks.test.ts scripts/smoke/client-contract.test.ts scripts/smoke/agent-conversation-smoke.test.ts && bun run scripts/test-workspaces.ts",
 		"terraform:fmt": "terraform -chdir=infra/bootstrap-iam fmt && terraform -chdir=infra/terraform fmt && terraform -chdir=infra/ecr fmt && terraform -chdir=infra/dev fmt",
 		"terraform:validate": "terraform -chdir=infra/bootstrap-iam validate && terraform -chdir=infra/terraform validate && terraform -chdir=infra/ecr validate && terraform -chdir=infra/dev validate"

--- a/scripts/smoke/agent-conversation-smoke.ts
+++ b/scripts/smoke/agent-conversation-smoke.ts
@@ -7,8 +7,8 @@
 // agentcore before the client admits Runs, then proves done Outcomes, durable
 // history, and Downloadable-artifact listing/download. It licenses the staged
 // exposure rollout in docs/runbooks/agentcore-rollout.md; it does not license
-// skipping that rollout's telemetry checks. The local smoke:local entrypoint
-// is unavailable until #523 adds the local AgentCore bridge.
+// skipping that rollout's telemetry checks. The Compose-level local smoke uses
+// scripts/smoke/local-agentcore-smoke.ts for its smaller one-Run contract.
 
 import { createHash, randomUUID } from "node:crypto";
 import { isDeepStrictEqual } from "node:util";

--- a/scripts/smoke/client-contract.test.ts
+++ b/scripts/smoke/client-contract.test.ts
@@ -1,7 +1,44 @@
 import { describe, expect, it } from "bun:test";
-import { createClientContractFixture } from "./client-contract";
+import {
+	createClientContractFixture,
+	readClientContractSse,
+} from "./client-contract";
 
 describe("AG-UI smoke client contract", () => {
+	it("assembles split data-only SSE deltas around a heartbeat", () => {
+		const raw = [
+			{ type: "RUN_STARTED", threadId: "conv-1", runId: "run-1" },
+			{ type: "ping" },
+			{ type: "TEXT_MESSAGE_START", messageId: "assistant-1" },
+			{
+				type: "TEXT_MESSAGE_CONTENT",
+				messageId: "assistant-1",
+				delta: "LOCAL_AGENTCORE",
+			},
+			{
+				type: "TEXT_MESSAGE_CONTENT",
+				messageId: "assistant-1",
+				delta: "_OK",
+			},
+			{ type: "TEXT_MESSAGE_END", messageId: "assistant-1" },
+			{ type: "RUN_FINISHED", threadId: "conv-1", runId: "run-1" },
+		]
+			.map((data) => `data: ${JSON.stringify(data)}\n\n`)
+			.join("");
+
+		expect(readClientContractSse(raw)).toEqual({
+			messages: [
+				{
+					messageId: "assistant-1",
+					text: "LOCAL_AGENTCORE_OK",
+					provisional: false,
+				},
+			],
+			toolEvents: [],
+			terminal: "done",
+		});
+	});
+
 	it("assembles standard Assistant text, Tool activity, and a successful Outcome", () => {
 		const client = createClientContractFixture();
 		for (const data of [

--- a/scripts/smoke/client-contract.ts
+++ b/scripts/smoke/client-contract.ts
@@ -1,3 +1,5 @@
+import { parseRawAgUiSse } from "../../packages/test-support/ag-ui-sse";
+
 export interface ClientContractFrame {
 	event: string;
 	data: unknown;
@@ -152,6 +154,15 @@ export function createClientContractFixture(): ClientContractFixture {
 			};
 		},
 	};
+}
+
+export function readClientContractSse(raw: string): ClientContractSnapshot {
+	const client = createClientContractFixture();
+	for (const frame of parseRawAgUiSse(raw)) {
+		if (frame.event === "ping") continue;
+		client.receive({ event: frame.event, data: JSON.parse(frame.data) });
+	}
+	return client.snapshot();
 }
 
 function requireRecord(value: unknown): Record<string, unknown> {

--- a/scripts/smoke/local-agentcore-compose.sh
+++ b/scripts/smoke/local-agentcore-compose.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -eu
+
+cleanup() {
+	docker compose down --remove-orphans
+}
+
+trap cleanup EXIT HUP INT TERM
+
+docker compose up --build --detach chat-api dispatch-bridge
+docker compose run --rm --no-deps smoke

--- a/scripts/smoke/local-agentcore-smoke.ts
+++ b/scripts/smoke/local-agentcore-smoke.ts
@@ -1,0 +1,78 @@
+#!/usr/bin/env bun
+
+const baseUrl = (
+	Bun.env.AGENT_SMOKE_BASE_URL ?? "http://127.0.0.1:3000"
+).replace(/\/+$/, "");
+const headers = {
+	"content-type": "application/json",
+	"x-member-code": "local-agentcore-smoke",
+	"x-partner-code": "local-development",
+};
+
+const deadline = Date.now() + 60_000;
+while (true) {
+	try {
+		if ((await fetch(`${baseUrl}/health`)).ok) break;
+	} catch {}
+	if (Date.now() >= deadline)
+		throw new Error("local Chat API did not become healthy");
+	await Bun.sleep(250);
+}
+
+const create = await fetch(`${baseUrl}/v1/conversations`, {
+	method: "POST",
+	headers,
+	body: "{}",
+});
+if (create.status !== 201) {
+	throw new Error(
+		`local Conversation creation returned ${create.status}: ${await create.text()}`,
+	);
+}
+const conversation = (await create.json()) as {
+	conversationId?: string;
+	executionRuntime?: string;
+};
+if (
+	!conversation.conversationId ||
+	conversation.executionRuntime !== "agentcore"
+) {
+	throw new Error("local Conversation creation did not select AgentCore");
+}
+
+const runId = crypto.randomUUID();
+const run = await fetch(
+	`${baseUrl}/v1/conversations/${conversation.conversationId}/runs`,
+	{
+		method: "POST",
+		headers,
+		body: JSON.stringify({
+			threadId: conversation.conversationId,
+			runId,
+			messages: [
+				{
+					id: crypto.randomUUID(),
+					role: "user",
+					content: "Reply with exactly LOCAL_AGENTCORE_OK and nothing else.",
+				},
+			],
+			tools: [],
+			context: [],
+		}),
+		signal: AbortSignal.timeout(180_000),
+	},
+);
+const events = await run.text();
+if (!run.ok) {
+	throw new Error(`local Run returned ${run.status}: ${events}`);
+}
+if (
+	!events.includes("LOCAL_AGENTCORE_OK") ||
+	!events.includes("RUN_FINISHED")
+) {
+	throw new Error("local Run did not complete through the AgentCore Runtime");
+}
+
+console.log(
+	`local AgentCore smoke passed: conversation ${conversation.conversationId}; run ${runId}`,
+);

--- a/scripts/smoke/local-agentcore-smoke.ts
+++ b/scripts/smoke/local-agentcore-smoke.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env bun
 
+import { readClientContractSse } from "./client-contract";
+
 const baseUrl = (
 	Bun.env.AGENT_SMOKE_BASE_URL ?? "http://127.0.0.1:3000"
 ).replace(/\/+$/, "");
@@ -66,9 +68,12 @@ const events = await run.text();
 if (!run.ok) {
 	throw new Error(`local Run returned ${run.status}: ${events}`);
 }
+const snapshot = readClientContractSse(events);
 if (
-	!events.includes("LOCAL_AGENTCORE_OK") ||
-	!events.includes("RUN_FINISHED")
+	snapshot.terminal !== "done" ||
+	snapshot.messages.length !== 1 ||
+	snapshot.messages[0]?.provisional ||
+	snapshot.messages[0]?.text !== "LOCAL_AGENTCORE_OK"
 ) {
 	throw new Error("local Run did not complete through the AgentCore Runtime");
 }


### PR DESCRIPTION
## Summary

- add development-only Chat API and AgentCore Runtime compositions
- add a durable local Dispatch bridge that confirms work only after a correlated Acquisition receipt and preserves retryability on failures
- add a Compose smoke covering one real Run end to end, including parsed AG-UI delta and heartbeat handling
- remove the obsolete exposure break-glass path and keep local entry points out of production images

## Verification

- `bun run test`
- credentialed `bun run smoke:local`
- local and production Docker image builds
- production image inspection confirming local-only sources are absent

Closes #523