### PR TITLE
feat(agentcore): cover complete local Conversation flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ Each project can be developed independently. Navigate to the respective project 
 ## Runtime verification
 
 Conversation creation and the checked-in Compose stack are AgentCore-only.
-`bun run smoke:local` proves one Run from public admission through the durable
-outbox, development bridge, and real local Runtime.
+`bun run smoke:local` proves the complete local Conversation flow from public
+admission through the durable outbox, development bridge, and real local
+Runtime.
 
 The credential-free PR suite covers durable AgentCore acquisition and
 stream/reconnect behavior through the shared Run-serving seam. The process
@@ -67,8 +68,9 @@ writes a unique Downloadable artifact, lists it after `RUN_FINISHED`, obtains a 
 signed URL, and downloads the exact attachment without identity headers. The
 local `full` suite adds one interrupted Run and two seeded searchable-document
 Runs that prove inventory, search, docs-cache load, file read-back, and durable
-Tool history. The smaller `bun run smoke:local` Compose gate proves one real Run;
-the broader suites can target the running local stack directly.
+Tool history. `bun run smoke:local` runs that complete `full` suite against
+Postgres, Redis, the local Dispatch bridge, the real Runtime, and a disposable
+S3-compatible artifact store.
 
 For production, run `scripts/deploy/prod_smoke.sh` from inside the VPC with
 `AGENT_SMOKE_BASE_URL` configured and the checked-in `codex-smoke` identity

--- a/apps/agent-worker/package.json
+++ b/apps/agent-worker/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "agent-worker",
 	"exports": {
+		"./artifact-object-store": "./src/artifacts/s3-artifact-object-store.ts",
 		"./claude-code-executable": "./src/sdk/claude-code-executable.ts",
 		"./config": "./src/config/env.ts",
 		"./logger": "./src/logger.ts",

--- a/apps/agent-worker/src/artifacts/s3-artifact-object-store.ts
+++ b/apps/agent-worker/src/artifacts/s3-artifact-object-store.ts
@@ -26,6 +26,7 @@ export type PutArtifactObject = (
 ) => Promise<void>;
 
 export interface ArtifactObjectStoreDependencies {
+	endpoint?: string;
 	putObject?: PutArtifactObject;
 	createMultipartUpload?: (
 		request: CreateMultipartUploadCommandInput,
@@ -49,7 +50,13 @@ export function createS3ArtifactObjectStore(
 	config: ArtifactBucketConfig,
 	dependencies: ArtifactObjectStoreDependencies = {},
 ): ArtifactObjectStore {
-	const client = new S3Client({ region: config.region, maxAttempts: 3 });
+	const client = new S3Client({
+		region: config.region,
+		maxAttempts: 3,
+		...(dependencies.endpoint
+			? { endpoint: dependencies.endpoint, forcePathStyle: true }
+			: {}),
+	});
 	const putObject =
 		dependencies.putObject ??
 		(async (request: PutObjectCommandInput, signal: AbortSignal) => {

--- a/apps/agent-worker/src/production-run-resources.ts
+++ b/apps/agent-worker/src/production-run-resources.ts
@@ -8,7 +8,10 @@ import {
 	createRedisLiveStreamRelay,
 	type LiveStreamService,
 } from "@mymemo/live-text";
-import { createArtifactPublisher } from "./artifacts/artifact-publication";
+import {
+	type ArtifactObjectStore,
+	createArtifactPublisher,
+} from "./artifacts/artifact-publication";
 import { createS3ArtifactObjectStore } from "./artifacts/s3-artifact-object-store";
 import { createE2bSandboxJanitor } from "./cleanup/e2b-janitor";
 import type { WorkerConfig } from "./config/env";
@@ -29,6 +32,7 @@ export function createProductionRunResources(options: {
 	processEnv?: Record<string, string | undefined>;
 	telemetryService?: LiveStreamService;
 	artifactObjectKeyPrefix?: string;
+	artifactObjectStore?: ArtifactObjectStore;
 }) {
 	const { config, logger } = options;
 	const liveStreamTelemetry = createLiveStreamTelemetry(
@@ -46,7 +50,9 @@ export function createProductionRunResources(options: {
 	const db = createDatabase(config.agentDatabaseUrl);
 	const artifactPublisher = createArtifactPublisher({
 		db,
-		objectStore: createS3ArtifactObjectStore(config.artifact),
+		objectStore:
+			options.artifactObjectStore ??
+			createS3ArtifactObjectStore(config.artifact),
 		objectKeyPrefix: options.artifactObjectKeyPrefix,
 	});
 	const sandboxJanitor = createE2bSandboxJanitor(config.e2bApiKey);

--- a/apps/agentcore-runtime/local/index.ts
+++ b/apps/agentcore-runtime/local/index.ts
@@ -1,3 +1,4 @@
+import { createS3ArtifactObjectStore } from "agent-worker/artifact-object-store";
 import { loadWorkerConfigFromEnv } from "agent-worker/config";
 import { createLogger, toMessage } from "agent-worker/logger";
 import { createProductionRunResources } from "agent-worker/production-run-resources";
@@ -8,12 +9,17 @@ import { createAgentCoreRuntime } from "../src/runtime";
 import { startRuntimeServer } from "../src/server";
 
 const config = loadWorkerConfigFromEnv(Bun.env);
+const artifactEndpoint = Bun.env.LOCAL_ARTIFACT_ENDPOINT?.trim();
+if (!artifactEndpoint) throw new Error("LOCAL_ARTIFACT_ENDPOINT is required");
 const logger = createLogger(config.logLevel);
 const resources = createProductionRunResources({
 	config,
 	logger,
 	processEnv: Bun.env,
 	telemetryService: "agentcore-runtime",
+	artifactObjectStore: createS3ArtifactObjectStore(config.artifact, {
+		endpoint: artifactEndpoint,
+	}),
 });
 const acquisition = createDatabaseAgentCoreAcquisitionBoundary({
 	db: resources.db,

--- a/apps/chat-api/local/index.test.ts
+++ b/apps/chat-api/local/index.test.ts
@@ -1,0 +1,43 @@
+import { expect, it } from "bun:test";
+import { resolve } from "node:path";
+import { findFreePort } from "../../../packages/test-support/redis-test-server";
+
+it("starts without the Compose-only artifact endpoint", async () => {
+	const port = await findFreePort();
+	const { LOCAL_ARTIFACT_ENDPOINT: _, ...processEnv } = Bun.env;
+	const child = Bun.spawn([process.execPath, "run", "local/index.ts"], {
+		cwd: resolve(import.meta.dir, ".."),
+		env: {
+			...processEnv,
+			AGENT_DATABASE_URL: "postgresql://local:local@127.0.0.1:9/local",
+			ARTIFACT_BUCKET: "test-artifacts",
+			AWS_REGION: "us-west-2",
+			DB_SSL: "disable",
+			LIVE_STREAM_ALLOW_INSECURE_LOCAL_REDIS: "true",
+			PORT: String(port),
+			REDIS_URL: "redis://127.0.0.1:9",
+		},
+		stdout: "ignore",
+		stderr: "pipe",
+	});
+
+	try {
+		const deadline = Date.now() + 3_000;
+		let healthy = false;
+		while (Date.now() < deadline && child.exitCode === null) {
+			try {
+				healthy = (await fetch(`http://127.0.0.1:${port}/health`)).ok;
+				if (healthy) break;
+			} catch {}
+			await Bun.sleep(50);
+		}
+
+		const stderr =
+			child.exitCode === null ? "" : await new Response(child.stderr).text();
+		expect(stderr).not.toContain("LOCAL_ARTIFACT_ENDPOINT is required");
+		expect(healthy).toBe(true);
+	} finally {
+		if (child.exitCode === null) child.kill();
+		await child.exited;
+	}
+});

--- a/apps/chat-api/local/index.ts
+++ b/apps/chat-api/local/index.ts
@@ -1,17 +1,38 @@
+import { GetObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { createLiveStreamTelemetry } from "@mymemo/live-text";
 import pino from "pino";
 import { createApp } from "../src/app";
 import { loadApiConfigFromEnv } from "../src/config/env";
 import { createDeps } from "../src/deps";
+import { createS3ArtifactDownloadSigner } from "../src/features/artifacts";
 
 const config = loadApiConfigFromEnv({
 	...Bun.env,
 	STATSIG_SERVER_SECRET: "unused-by-local-composition",
 });
-const logger = pino({ level: config.logLevel });
-const deps = createDeps(config, createLiveStreamTelemetry("chat-api", logger), {
-	isAgentEnabled: async () => true,
+const artifactEndpoint = Bun.env.LOCAL_ARTIFACT_ENDPOINT?.trim();
+if (!artifactEndpoint) throw new Error("LOCAL_ARTIFACT_ENDPOINT is required");
+const artifactClient = new S3Client({
+	region: config.artifactRegion,
+	endpoint: artifactEndpoint,
+	forcePathStyle: true,
 });
+const logger = pino({ level: config.logLevel });
+const deps = createDeps(
+	config,
+	createLiveStreamTelemetry("chat-api", logger),
+	{ isAgentEnabled: async () => true },
+	createS3ArtifactDownloadSigner(
+		{ bucket: config.artifactBucket, region: config.artifactRegion },
+		{
+			presignGetObject: (request, expiresInSeconds) =>
+				getSignedUrl(artifactClient, new GetObjectCommand(request), {
+					expiresIn: expiresInSeconds,
+				}),
+		},
+	),
+);
 let shuttingDown = false;
 async function close(): Promise<void> {
 	if (shuttingDown) return;

--- a/apps/chat-api/local/index.ts
+++ b/apps/chat-api/local/index.ts
@@ -1,5 +1,3 @@
-import { GetObjectCommand, S3Client } from "@aws-sdk/client-s3";
-import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { createLiveStreamTelemetry } from "@mymemo/live-text";
 import pino from "pino";
 import { createApp } from "../src/app";
@@ -12,12 +10,6 @@ const config = loadApiConfigFromEnv({
 	STATSIG_SERVER_SECRET: "unused-by-local-composition",
 });
 const artifactEndpoint = Bun.env.LOCAL_ARTIFACT_ENDPOINT?.trim();
-if (!artifactEndpoint) throw new Error("LOCAL_ARTIFACT_ENDPOINT is required");
-const artifactClient = new S3Client({
-	region: config.artifactRegion,
-	endpoint: artifactEndpoint,
-	forcePathStyle: true,
-});
 const logger = pino({ level: config.logLevel });
 const deps = createDeps(
 	config,
@@ -25,12 +17,7 @@ const deps = createDeps(
 	{ isAgentEnabled: async () => true },
 	createS3ArtifactDownloadSigner(
 		{ bucket: config.artifactBucket, region: config.artifactRegion },
-		{
-			presignGetObject: (request, expiresInSeconds) =>
-				getSignedUrl(artifactClient, new GetObjectCommand(request), {
-					expiresIn: expiresInSeconds,
-				}),
-		},
+		{ endpoint: artifactEndpoint },
 	),
 );
 let shuttingDown = false;

--- a/apps/chat-api/src/deps.ts
+++ b/apps/chat-api/src/deps.ts
@@ -74,6 +74,12 @@ export function createDeps(
 		},
 	),
 	exposureGate: ExposureGate = createExposureGate(config),
+	artifactDownloadSigner: ArtifactDownloadSigner = createS3ArtifactDownloadSigner(
+		{
+			bucket: config.artifactBucket,
+			region: config.artifactRegion,
+		},
+	),
 ): AppDeps {
 	// One Drizzle pool over the writable DB, shared by every store.
 	const database = createDatabase(config.databaseUrl);
@@ -90,10 +96,7 @@ export function createDeps(
 	return {
 		config,
 		artifactMetadataStore: new PostgresArtifactMetadataStore(database),
-		artifactDownloadSigner: createS3ArtifactDownloadSigner({
-			bucket: config.artifactBucket,
-			region: config.artifactRegion,
-		}),
+		artifactDownloadSigner,
 		conversationStore,
 		conversationHistoryStore,
 		runStore,

--- a/apps/chat-api/src/features/artifacts/s3-artifact-download-signer.ts
+++ b/apps/chat-api/src/features/artifacts/s3-artifact-download-signer.ts
@@ -20,6 +20,7 @@ export type PresignGetObject = (
 ) => Promise<string>;
 
 export interface S3ArtifactDownloadSignerDependencies {
+	endpoint?: string;
 	presignGetObject?: PresignGetObject;
 }
 
@@ -34,7 +35,12 @@ export function createS3ArtifactDownloadSigner(
 	const presignGetObject =
 		dependencies.presignGetObject ??
 		(() => {
-			const client = new S3Client({ region: config.region });
+			const client = new S3Client({
+				region: config.region,
+				...(dependencies.endpoint
+					? { endpoint: dependencies.endpoint, forcePathStyle: true }
+					: {}),
+			});
 			return (request: GetObjectCommandInput, expiresInSeconds: number) =>
 				getSignedUrl(client, new GetObjectCommand(request), {
 					expiresIn: expiresInSeconds,

--- a/compose.yaml
+++ b/compose.yaml
@@ -11,6 +11,7 @@
 #   agentcore-runtime — acquires one exact Dispatch and serves its Run
 #   dispatch-bridge — polls the durable outbox and invokes the local Runtime
 #   redis         — disposable Redis 7 for real relay contract testing
+#   artifact-store — disposable S3-compatible Downloadable artifact storage
 #
 # The prototype gateway/sandbox services were removed once the split runtime
 # replaced them end to end (ADR-0002). Bring the demo up with:
@@ -19,6 +20,10 @@
 x-runtime-environment: &runtime-environment
   ARTIFACT_BUCKET: "mymemo-agent-local-artifacts"
   AWS_REGION: "us-west-2"
+  AWS_ACCESS_KEY_ID: "local-artifacts"
+  AWS_SECRET_ACCESS_KEY: "local-artifacts-secret"
+  AWS_EC2_METADATA_DISABLED: "true"
+  LOCAL_ARTIFACT_ENDPOINT: "http://127.0.0.1:9000"
 
 services:
   chat-api:
@@ -46,6 +51,8 @@ services:
         condition: service_completed_successfully
       redis:
         condition: service_healthy
+      artifact-bucket:
+        condition: service_completed_successfully
     restart: unless-stopped
 
   agentcore-runtime:
@@ -81,6 +88,8 @@ services:
         condition: service_completed_successfully
       redis:
         condition: service_healthy
+      artifact-bucket:
+        condition: service_completed_successfully
     restart: unless-stopped
 
   dispatch-bridge:
@@ -114,6 +123,40 @@ services:
         condition: service_started
       dispatch-bridge:
         condition: service_started
+      artifact-bucket:
+        condition: service_completed_successfully
+    restart: "no"
+
+  # Local-only S3-compatible object store. The trusted Runtime uploads private
+  # objects here and chat-api signs loopback URLs that the smoke downloads.
+  artifact-store:
+    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
+    network_mode: "service:redis"
+    command: ["server", "/data", "--address", ":9000"]
+    environment:
+      MINIO_ROOT_USER: "local-artifacts"
+      MINIO_ROOT_PASSWORD: "local-artifacts-secret"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:9000/minio/health/live"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+    depends_on:
+      redis:
+        condition: service_healthy
+    restart: "no"
+
+  artifact-bucket:
+    image: quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+    network_mode: "service:redis"
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - >-
+        mc alias set local http://127.0.0.1:9000 local-artifacts local-artifacts-secret
+        && mc mb --ignore-existing local/mymemo-agent-local-artifacts
+    depends_on:
+      artifact-store:
+        condition: service_healthy
     restart: "no"
 
   # One-shot: apply the writable DB (mymemo_agent) schema from Drizzle migrations,

--- a/compose.yaml
+++ b/compose.yaml
@@ -20,8 +20,6 @@
 x-runtime-environment: &runtime-environment
   ARTIFACT_BUCKET: "mymemo-agent-local-artifacts"
   AWS_REGION: "us-west-2"
-  AWS_ACCESS_KEY_ID: "local-artifacts"
-  AWS_SECRET_ACCESS_KEY: "local-artifacts-secret"
   AWS_EC2_METADATA_DISABLED: "true"
   LOCAL_ARTIFACT_ENDPOINT: "http://127.0.0.1:9000"
 
@@ -40,6 +38,8 @@ services:
       # run_events. Local-only dev credential, so inline. Named AGENT_DATABASE_URL
       # so it never collides with the worker's read-only KB DATABASE_URL.
       AGENT_DATABASE_URL: postgresql://mymemo:mymemo@postgres:5432/mymemo_agent
+      AWS_ACCESS_KEY_ID: "local-artifact-reader"
+      AWS_SECRET_ACCESS_KEY: "local-artifact-reader-secret"
       DB_SSL: disable
       LOG_LEVEL: info
       REDIS_URL: redis://127.0.0.1:6379
@@ -64,6 +64,8 @@ services:
     environment:
       <<: *runtime-environment
       AGENT_DATABASE_URL: postgresql://mymemo:mymemo@postgres:5432/mymemo_agent
+      AWS_ACCESS_KEY_ID: "local-artifact-writer"
+      AWS_SECRET_ACCESS_KEY: "local-artifact-writer-secret"
       DB_SSL: disable
       LOG_LEVEL: info
       WORKER_HEARTBEAT_INTERVAL_MS: "2000"
@@ -134,8 +136,8 @@ services:
     network_mode: "service:redis"
     command: ["server", "/data", "--address", ":9000"]
     environment:
-      MINIO_ROOT_USER: "local-artifacts"
-      MINIO_ROOT_PASSWORD: "local-artifacts-secret"
+      MINIO_ROOT_USER: "local-artifact-admin"
+      MINIO_ROOT_PASSWORD: "local-artifact-admin-secret"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://127.0.0.1:9000/minio/health/live"]
       interval: 2s
@@ -152,8 +154,12 @@ services:
     entrypoint: ["/bin/sh", "-c"]
     command:
       - >-
-        mc alias set local http://127.0.0.1:9000 local-artifacts local-artifacts-secret
+        mc alias set local http://127.0.0.1:9000 local-artifact-admin local-artifact-admin-secret
         && mc mb --ignore-existing local/mymemo-agent-local-artifacts
+        && mc admin user add local local-artifact-reader local-artifact-reader-secret
+        && mc admin policy attach local readonly --user local-artifact-reader
+        && mc admin user add local local-artifact-writer local-artifact-writer-secret
+        && mc admin policy attach local writeonly --user local-artifact-writer
     depends_on:
       artifact-store:
         condition: service_healthy

--- a/docs/verification/e2e-smoke.md
+++ b/docs/verification/e2e-smoke.md
@@ -1,4 +1,4 @@
-# Split-runtime end-to-end smoke verification
+# AgentCore Conversation smoke verification
 
 The Conversation smoke is one public-contract client with two targets. It uses
 `AGENT_SMOKE_BASE_URL` to address either the local compose harness or the
@@ -25,11 +25,11 @@ value fails before the first HTTP request.
   request, with exactly one trailing newline tolerated.
 - `full` is the local pre-merge superset. After the `core` checks it creates a
   second Conversation, asks its Run to start an immediate long-running Bash
-  command, reads the live SSE incrementally, and calls the Run cancellation
+  command, reads the live SSE incrementally, and calls the Run interruption
   resource only after the first Tool invocation arrives. It requires the
-  running-Run `cancel_requested` response, a `RUN_CANCELLED` live outcome with no surviving
+  running-Run `interrupt_requested` response, a `RUN_INTERRUPTED` live Outcome with no surviving
   provisional Assistant text, and terminal recovery through Conversation
-  history with the committed messages and Tool events ending `RUN_CANCELLED`. A third
+  history with the committed messages and Tool events ending `RUN_INTERRUPTED`. A third
   Conversation performs two searchable-document Runs against the local KB seed: the first
   reports the exact inventory count through `ListDocuments`; the second uses
   `SearchDocuments`, `LoadDocuments`, and `Read` to report the seeded title and
@@ -42,7 +42,7 @@ value fails before the first HTTP request.
 
 | Target | Suite | Invocation | Credentials and network |
 | --- | --- | --- | --- |
-| Local compose | one Run | `bun run smoke:local` | Requires OpenRouter and E2B development credentials; uses Postgres, Redis, the development bridge, and the real local Runtime without AWS-managed Dispatch infrastructure. |
+| Local compose | `full` | `bun run smoke:local` | Requires OpenRouter and E2B development credentials; uses Postgres, Redis, a disposable S3-compatible object store, the development bridge, and the real local Runtime. |
 | Deployed internal ALB | `core` | `AGENT_SMOKE_SUITE=core scripts/deploy/prod_smoke.sh` | The wrapper expects `agentcore`. Run inside the VPC under the synthetic identity targeted in the Statsig exposure gate. The caller receives no provider, sandbox, AWS, or database secrets. |
 
 There is no staging target. The credential-free integration suite and local
@@ -55,10 +55,27 @@ command remains manual from a VPC-reachable environment.
 
 ## Local smoke
 
-`bun run smoke:local` builds the local-only Chat API and Runtime targets, waits
-for the durable bridge, and admits one public Run that must reach
-`RUN_FINISHED`. The production images omit both local composition entrypoints
-and the bridge application.
+Export `OPENROUTER_API_KEY` and `E2B_API_KEY`, build the
+`WORKER_E2B_TEMPLATE` described in `apps/agent-worker/e2b-template/`, then run:
+
+```sh
+bun run smoke:local
+```
+
+The command builds the local-only Chat API, Dispatch bridge, and Runtime,
+starts Postgres, Redis, and a disposable MinIO bucket, and runs `full` under the
+seeded `demo-member` identity. It proves three sequential successful Runs in
+one Conversation, Agent-session and Workspace continuity, streaming and
+permanent history, one running-Run interruption, two Searchable-document Runs,
+and public Downloadable-artifact listing, signing, and byte-exact download.
+Cleanup stops the Compose stack when the smoke exits. The production images
+omit both local composition entrypoints and the bridge application.
+
+This local workflow deliberately covers no AWS-managed Dispatch boundary. SQS,
+Lambda, SSM, IAM, VPC networking, the managed AgentCore Runtime, and production
+S3 remain the responsibility of the deployed synthetic smoke and deployment
+checks. A local pass is evidence for application behavior through the Runtime
+HTTP contract, not for those managed boundaries.
 
 The deployed wrapper fixes the expected runtime to `agentcore`. After the
 synthetic identity is targeted in the exposure gate, the public creation response
@@ -76,6 +93,7 @@ recovery, and identity-free signed-object fetching:
 
 ```sh
 bun test scripts/smoke/agent-conversation-smoke.test.ts
+bun test scripts/smoke/local-agentcore-smoke.test.ts
 ```
 
 The broader client-contract decision and release contract are recorded in

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"module": "index.ts",
 	"scripts": {
 		"smoke:local": "sh scripts/smoke/local-agentcore-compose.sh",
-		"test": "bun test scripts/deploy-config.test.ts scripts/deploy/agentcore_aws_checks.test.ts scripts/smoke/client-contract.test.ts scripts/smoke/agent-conversation-smoke.test.ts && bun run scripts/test-workspaces.ts",
+		"test": "bun test scripts/deploy-config.test.ts scripts/deploy/agentcore_aws_checks.test.ts scripts/smoke/client-contract.test.ts scripts/smoke/agent-conversation-smoke.test.ts scripts/smoke/local-agentcore-smoke.test.ts && bun run scripts/test-workspaces.ts",
 		"terraform:fmt": "terraform -chdir=infra/bootstrap-iam fmt && terraform -chdir=infra/terraform fmt && terraform -chdir=infra/ecr fmt && terraform -chdir=infra/dev fmt",
 		"terraform:validate": "terraform -chdir=infra/bootstrap-iam validate && terraform -chdir=infra/terraform validate && terraform -chdir=infra/ecr validate && terraform -chdir=infra/dev validate"
 	},

--- a/scripts/smoke/agent-conversation-smoke.ts
+++ b/scripts/smoke/agent-conversation-smoke.ts
@@ -8,16 +8,16 @@
 // history, and Downloadable-artifact listing/download. It licenses the staged
 // exposure rollout in docs/runbooks/agentcore-rollout.md; it does not license
 // skipping that rollout's telemetry checks. The Compose-level local smoke uses
-// scripts/smoke/local-agentcore-smoke.ts for its smaller one-Run contract.
+// this client's full suite through scripts/smoke/local-agentcore-smoke.ts.
 
 import { createHash, randomUUID } from "node:crypto";
 import { isDeepStrictEqual } from "node:util";
+import type { ConversationExecutionRuntime } from "../../packages/agent-db/src/execution-runtime";
+import type { PublicToolName } from "../../packages/agent-db/src/run-events";
 import {
 	parseRawAgUiSse as parseSSE,
 	type RawAgUiSseFrame,
-} from "@mymemo/test-support/ag-ui-sse";
-import type { ConversationExecutionRuntime } from "../../packages/agent-db/src/execution-runtime";
-import type { PublicToolName } from "../../packages/agent-db/src/run-events";
+} from "../../packages/test-support/ag-ui-sse";
 import {
 	type ClientContractMessage,
 	type ClientContractTerminal,

--- a/scripts/smoke/local-agentcore-smoke.test.ts
+++ b/scripts/smoke/local-agentcore-smoke.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { resolve } from "node:path";
+import { findFreePort } from "../../packages/test-support/redis-test-server";
+
+const root = resolve(import.meta.dir, "../..");
+const script = resolve(import.meta.dir, "local-agentcore-smoke.ts");
+const servers: Bun.Server<unknown>[] = [];
+
+afterEach(() => {
+	for (const server of servers.splice(0)) server.stop(true);
+});
+
+describe("local AgentCore smoke", () => {
+	it("pins the complete local Conversation suite", async () => {
+		let memberCode: string | null = null;
+		let partnerCode: string | null = null;
+		const server = Bun.serve({
+			port: await findFreePort(),
+			fetch(request) {
+				const url = new URL(request.url);
+				if (url.pathname === "/health") return new Response("ok");
+				if (request.method === "POST" && url.pathname === "/v1/conversations") {
+					memberCode = request.headers.get("x-member-code");
+					partnerCode = request.headers.get("x-partner-code");
+					return new Response("fixture stop", { status: 500 });
+				}
+				return new Response("not found", { status: 404 });
+			},
+		});
+		servers.push(server);
+
+		const child = Bun.spawn([process.execPath, "run", script], {
+			cwd: root,
+			env: {
+				...Bun.env,
+				AGENT_SMOKE_BASE_URL: `http://127.0.0.1:${server.port}`,
+				AGENT_SMOKE_EXPECT_EXECUTION_RUNTIME: "fargate",
+				AGENT_SMOKE_EXPECT_GATE_CLOSED: "true",
+				AGENT_SMOKE_MEMBER_CODE: "wrong-member",
+				AGENT_SMOKE_SUITE: "core",
+				AGENT_SMOKE_TURN_TIMEOUT_MS: "5000",
+			},
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const [exitCode, stderr] = await Promise.all([
+			child.exited,
+			new Response(child.stderr).text(),
+		]);
+
+		expect(exitCode).not.toBe(0);
+		expect(memberCode).toBe("demo-member");
+		expect(partnerCode).toBe("local-development");
+		expect(stderr).toContain("expected conversation create 201, got 500");
+	});
+});

--- a/scripts/smoke/local-agentcore-smoke.ts
+++ b/scripts/smoke/local-agentcore-smoke.ts
@@ -1,15 +1,8 @@
 #!/usr/bin/env bun
 
-import { readClientContractSse } from "./client-contract";
-
 const baseUrl = (
 	Bun.env.AGENT_SMOKE_BASE_URL ?? "http://127.0.0.1:3000"
 ).replace(/\/+$/, "");
-const headers = {
-	"content-type": "application/json",
-	"x-member-code": "local-agentcore-smoke",
-	"x-partner-code": "local-development",
-};
 
 const deadline = Date.now() + 60_000;
 while (true) {
@@ -21,63 +14,13 @@ while (true) {
 	await Bun.sleep(250);
 }
 
-const create = await fetch(`${baseUrl}/v1/conversations`, {
-	method: "POST",
-	headers,
-	body: "{}",
+Object.assign(Bun.env, {
+	AGENT_SMOKE_BASE_URL: baseUrl,
+	AGENT_SMOKE_MEMBER_CODE: "demo-member",
+	AGENT_SMOKE_PARTNER_CODE: "local-development",
+	AGENT_SMOKE_EXPECT_GATE_CLOSED: "false",
+	AGENT_SMOKE_EXPECT_EXECUTION_RUNTIME: "agentcore",
+	AGENT_SMOKE_SUITE: "full",
 });
-if (create.status !== 201) {
-	throw new Error(
-		`local Conversation creation returned ${create.status}: ${await create.text()}`,
-	);
-}
-const conversation = (await create.json()) as {
-	conversationId?: string;
-	executionRuntime?: string;
-};
-if (
-	!conversation.conversationId ||
-	conversation.executionRuntime !== "agentcore"
-) {
-	throw new Error("local Conversation creation did not select AgentCore");
-}
 
-const runId = crypto.randomUUID();
-const run = await fetch(
-	`${baseUrl}/v1/conversations/${conversation.conversationId}/runs`,
-	{
-		method: "POST",
-		headers,
-		body: JSON.stringify({
-			threadId: conversation.conversationId,
-			runId,
-			messages: [
-				{
-					id: crypto.randomUUID(),
-					role: "user",
-					content: "Reply with exactly LOCAL_AGENTCORE_OK and nothing else.",
-				},
-			],
-			tools: [],
-			context: [],
-		}),
-		signal: AbortSignal.timeout(180_000),
-	},
-);
-const events = await run.text();
-if (!run.ok) {
-	throw new Error(`local Run returned ${run.status}: ${events}`);
-}
-const snapshot = readClientContractSse(events);
-if (
-	snapshot.terminal !== "done" ||
-	snapshot.messages.length !== 1 ||
-	snapshot.messages[0]?.provisional ||
-	snapshot.messages[0]?.text !== "LOCAL_AGENTCORE_OK"
-) {
-	throw new Error("local Run did not complete through the AgentCore Runtime");
-}
-
-console.log(
-	`local AgentCore smoke passed: conversation ${conversation.conversationId}; run ${runId}`,
-);
+await import("./agent-conversation-smoke");


### PR DESCRIPTION
## Summary

- run the shared full Conversation smoke suite against the local Compose stack
- add disposable S3-compatible artifact storage and wire local upload and signed download paths
- verify sequential Runs, continuity, interruption, searchable documents, durable history, and downloadable artifacts
- document that AWS-managed Dispatch, Runtime, networking, IAM, and production S3 remain deployment-check responsibilities

## Verification

- `bun run test`
- scoped TypeScript checks for agent-worker, agentcore-runtime, and chat-api
- Biome checks for changed TypeScript files
- `docker compose config --quiet`
- `bun run smoke:local` with development OpenRouter and E2B credentials
- production Runtime image build on the host architecture

## Notes

- The ARM64 image build could not be reproduced under local QEMU because Bun exited with an illegal-instruction failure during dependency installation; CI remains the authoritative ARM64 image check.

Closes #524
