### PR TITLE
fix(infra): preserve live Redis client security group

### DIFF
--- a/infra/terraform/redis.tf
+++ b/infra/terraform/redis.tf
@@ -10,6 +10,10 @@ resource "aws_security_group" "live_redis_clients" {
   name        = "${local.common_name}-live-redis-clients"
   description = "chat-api and AgentCore Runtime clients of the Redis Live Stream lane"
   vpc_id      = local.shared_vpc_id
+
+  lifecycle {
+    ignore_changes = [description]
+  }
 }
 
 resource "aws_security_group_rule" "live_redis_from_services" {

--- a/scripts/agent-maintenance-infrastructure.test.ts
+++ b/scripts/agent-maintenance-infrastructure.test.ts
@@ -131,6 +131,16 @@ describe("agent-maintenance infrastructure", () => {
 		expect(cloudwatch).toContain('Service = "agentcore-runtime"');
 	});
 
+	it("does not replace the fixed-name Live Stream client security group", () => {
+		const redis = section(
+			terraformFile("redis.tf"),
+			'resource "aws_security_group" "live_redis_clients"',
+			'resource "aws_security_group_rule" "live_redis_from_services"',
+		);
+
+		expect(redis).toContain("ignore_changes = [description]");
+	});
+
 	it("keeps retired repository deletion in the one-time handoff", () => {
 		const ecr = readFileSync("infra/ecr/main.tf", "utf8");
 		const release = readFileSync(


### PR DESCRIPTION
## Summary

- preserve the fixed-name Live Stream client security group across description-only configuration changes
- prevent Terraform from trying to replace a group still attached to chat API and AgentCore Runtime ENIs
- add infrastructure contract coverage for the lifecycle guard

## Incident

Release deploy attempt 2 failed while applying the Fargate-retirement release because Terraform tried for 15 minutes to delete `sg-02d60971c48cd91ec`, then AWS returned `DependencyViolation`. The group remains required by live chat API and AgentCore Runtime network interfaces.

## Validation

- regression test failed before the lifecycle guard and passes afterward
- `bun test scripts/agent-maintenance-infrastructure.test.ts` — 9 passed
- Biome and `git diff --check` pass
- Terraform formatting passes
- local Terraform provider schema validation is unavailable because the installed macOS provider binaries fail their plugin handshake; Linux CI remains authoritative
