### PR TITLE
chore(infra): downsize fck-nat instances

### DIFF
--- a/infra/terraform/agentcore-network.tf
+++ b/infra/terraform/agentcore-network.tf
@@ -75,7 +75,7 @@ module "fck_nat_egress" {
   vpc_id               = local.vpc_id
   subnet_id            = one(local.shared_public_subnet_ids_by_az[each.key])
   ami_id               = data.aws_ami.fck_nat.id
-  instance_type        = "t4g.micro"
+  instance_type        = "t4g.nano"
   ha_mode              = true
   auto_rollout         = true
   eip_allocation_ids   = [aws_eip.fck_nat_egress[each.key].id]


### PR DESCRIPTION
## Summary

- run each zonal fck-nat Auto Scaling group on a `t4g.nano` instead of a `t4g.micro`
- preserve the existing two-AZ, static-EIP egress topology

## Verification

- `terraform -chdir=infra/terraform fmt -check -diff`
- `git diff --check`
- `terraform -chdir=infra/terraform validate` — blocked locally because cached provider binaries exit before Terraform can load their schemas

## Rollout

Applying Terraform replaces the two fck-nat instances through their Auto Scaling groups; each AZ can briefly lose egress during its replacement.