### PR TITLE
feat(infra): add chat-api Service Connect

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -337,7 +337,7 @@ jobs:
         if: env.FIRST_DEPLOY != 'true'
         run: scripts/deploy/terraform_prod_in_place_plan.sh
 
-      - name: Apply migration task definition and prerequisites
+      - name: Apply migration and chat-api task definitions and prerequisites
         if: env.FIRST_DEPLOY != 'true'
         run: |
           scripts/deploy/terraform_prod_migration_plan.sh
@@ -345,6 +345,10 @@ jobs:
 
       - name: Run agent DB migrations
         run: scripts/deploy/run_agent_migration.sh
+
+      - name: Roll the Service Connect named-port prerequisite
+        if: env.FIRST_DEPLOY != 'true'
+        run: scripts/deploy/prepare_chat_api_service_connect.sh
 
       - name: Plan the unified release after migrations
         run: |

--- a/docs/verification/e2e-smoke.md
+++ b/docs/verification/e2e-smoke.md
@@ -3,6 +3,9 @@
 The Conversation smoke is one public-contract client with two targets. It uses
 `AGENT_SMOKE_BASE_URL` to address either the local compose harness or the
 deployed internal ALB; it does not read databases, logs, or runtime internals.
+The first Service Connect migration stage deliberately keeps this ALB target
+unchanged; the smoke path does not switch to the Service Connect endpoint until
+a later coordinated caller migration.
 This guide records the verification strategy from
 [#300](https://github.com/X-GPT/mymemo-agent/issues/300) and the core artifact
 check from [#302](https://github.com/X-GPT/mymemo-agent/issues/302), plus the

--- a/infra/bootstrap-iam/main.tf
+++ b/infra/bootstrap-iam/main.tf
@@ -139,6 +139,7 @@ data "aws_iam_policy_document" "github_actions_deploy" {
       "elasticloadbalancing:*",
       "logs:*",
       "rds:*",
+      "servicediscovery:*",
       "secretsmanager:CreateSecret",
       "secretsmanager:DeleteSecret",
       "secretsmanager:DescribeSecret",

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -23,6 +23,30 @@ data sources instead of duplicating IDs in this repo.
 Fallback AWS data sources are conditional: Terraform only evaluates them when
 the direct remote-state output is absent and the fallback input is present.
 
+## Chat API Service Connect Migration
+
+This first stage publishes `http://chat-api:<chat_api_port>` in an agent-owned
+Cloud Map namespace. A later `mymemo-service` change must join its ECS service
+to the exported namespace ARN before using the endpoint:
+
+```sh
+terraform -chdir=infra/terraform output -raw chat_api_service_connect_namespace_arn
+terraform -chdir=infra/terraform output -raw chat_api_service_connect_endpoint
+```
+
+The internal ALB, smoke path, target-group alarm, and trusted-caller boundary
+remain unchanged. A separate proxy ingress port admits only the same
+`mymemo_service_api_security_group_ids`. The named HTTP port disables both
+Service Connect request and idle timeouts for long-lived Run Live Streams, and
+the task size includes proxy capacity.
+
+Before the first release, reapply `infra/bootstrap-iam` for Cloud Map authority.
+After migrations, the release rolls the named-port task revision only when the
+deployed revision lacks it; the unified apply then enables Service Connect.
+
+AWS provider `>= 6.50, < 7.0` supports the configured zero timeout values.
+`appProtocol = "http"` is required for the per-request timeout setting.
+
 ## Agent-Owned Resources
 
 - ECR repositories for `mymemo-agent-chat-api`,
@@ -42,6 +66,7 @@ the direct remote-state output is absent and the fallback input is present.
   publisher and maintenance groups that can reach the agent database but not
   the KB database
 - internal agent-owned ALB, ALB security group, listeners, and chat-api target group
+- Cloud Map HTTP namespace and chat-api ECS Service Connect endpoint
 - IAM execution/task roles for the agent tasks
 - CloudWatch log groups and baseline alarms
 - encrypted AgentCore Dispatch and dead-letter queues, their fail-closed SSM
@@ -248,9 +273,9 @@ different settings:
   `AGENT_SMOKE_EXPECT_GATE_CLOSED=true` only when checking the default-deny path
   instead.
 
-The internal ALB accepts traffic only from the configured
-`mymemo_service_api_security_group_ids`. It is not exposed to the public
-internet, and no Cloudflare DNS record is needed for `chat-api`.
+The internal ALB and Service Connect endpoint accept traffic only from the
+configured `mymemo_service_api_security_group_ids`. Neither is exposed to the
+public internet, and no Cloudflare DNS record is needed for `chat-api`.
 
 ## Operator Database Access
 

--- a/infra/terraform/ecs.tf
+++ b/infra/terraform/ecs.tf
@@ -14,9 +14,11 @@ resource "aws_ecs_task_definition" "chat_api" {
       essential = true
       portMappings = [
         {
+          name          = local.chat_api_service_connect_port_name
           containerPort = var.chat_api_port
           hostPort      = var.chat_api_port
           protocol      = "tcp"
+          appProtocol   = "http"
         }
       ]
       environment = local.chat_api_environment
@@ -165,6 +167,27 @@ resource "aws_ecs_service" "chat_api" {
     target_group_arn = aws_lb_target_group.chat_api.arn
     container_name   = "chat-api"
     container_port   = var.chat_api_port
+  }
+
+  service_connect_configuration {
+    enabled   = true
+    namespace = aws_service_discovery_http_namespace.services.arn
+
+    service {
+      port_name             = local.chat_api_service_connect_port_name
+      discovery_name        = local.chat_api_service_connect_dns_name
+      ingress_port_override = local.chat_api_service_connect_ingress_port
+
+      client_alias {
+        dns_name = local.chat_api_service_connect_dns_name
+        port     = var.chat_api_port
+      }
+
+      timeout {
+        idle_timeout_seconds        = 0
+        per_request_timeout_seconds = 0
+      }
+    }
   }
 
   lifecycle {

--- a/infra/terraform/examples/prod.tfvars.example
+++ b/infra/terraform/examples/prod.tfvars.example
@@ -9,8 +9,9 @@ tags = {
 }
 
 # Existing mymemo-service VPC/subnets/ECS cluster are read from Terraform remote
-# state. The internal ALB is owned by mymemo-agent and accepts traffic only from
-# the configured mymemo-service API ECS service security group.
+# state. The internal ALB and chat-api Service Connect endpoint are owned by
+# mymemo-agent and accept traffic only from the configured mymemo-service API
+# ECS service security group.
 mymemo_service_api_security_group_ids = ["sg-REPLACE_WITH_MYMEMO_SERVICE_API_SG"]
 
 # Security group on the existing mymemo-service RDS instance hosting the KB

--- a/infra/terraform/locals.tf
+++ b/infra/terraform/locals.tf
@@ -9,6 +9,11 @@ locals {
   agentcore_dispatch_publisher_name = "${local.common_name}-agentcore-dispatch-publisher"
   alb_name                          = "${local.common_name}-alb"
 
+  service_connect_namespace_name        = "${local.common_name}.local"
+  chat_api_service_connect_port_name    = "chat-api-http"
+  chat_api_service_connect_dns_name     = "chat-api"
+  chat_api_service_connect_ingress_port = var.chat_api_port + 1
+
   agentcore_dispatch_queue_name = coalesce(
     var.agentcore_dispatch_queue_name,
     "mymemo-agent-agentcore-${var.environment}-dispatch",

--- a/infra/terraform/network.tf
+++ b/infra/terraform/network.tf
@@ -95,3 +95,15 @@ resource "aws_security_group_rule" "chat_api_from_alb" {
   to_port                  = var.chat_api_port
   protocol                 = "tcp"
 }
+
+resource "aws_security_group_rule" "chat_api_service_connect_from_trusted_callers" {
+  for_each = toset(local.trusted_caller_security_group_ids)
+
+  type                     = "ingress"
+  description              = "Trusted mymemo-service API to chat-api Service Connect proxy"
+  security_group_id        = aws_security_group.services.id
+  source_security_group_id = each.value
+  from_port                = local.chat_api_service_connect_ingress_port
+  to_port                  = local.chat_api_service_connect_ingress_port
+  protocol                 = "tcp"
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -133,6 +133,16 @@ output "chat_api_target_group_arn" {
   value       = aws_lb_target_group.chat_api.arn
 }
 
+output "chat_api_service_connect_namespace_arn" {
+  description = "Service Connect namespace ARN for the later mymemo-service client configuration."
+  value       = aws_service_discovery_http_namespace.services.arn
+}
+
+output "chat_api_service_connect_endpoint" {
+  description = "Internal Service Connect endpoint for later mymemo-service adoption."
+  value       = "http://${local.chat_api_service_connect_dns_name}:${var.chat_api_port}"
+}
+
 output "agent_internal_alb_dns_name" {
   description = "DNS name of the agent-owned internal ALB."
   value       = aws_lb.agent.dns_name
@@ -144,7 +154,7 @@ output "agent_internal_base_url" {
 }
 
 output "agent_internal_allowed_caller_security_group_ids" {
-  description = "Security group IDs allowed to call the internal agent ALB."
+  description = "Trusted caller security group IDs allowed to call chat-api through the internal ALB or Service Connect."
   value       = local.trusted_caller_security_group_ids
 }
 

--- a/infra/terraform/prod.tfvars
+++ b/infra/terraform/prod.tfvars
@@ -7,8 +7,9 @@ tags = {
 }
 
 # Existing mymemo-service VPC/subnets/ECS cluster are read from Terraform remote
-# state. The internal ALB is owned by mymemo-agent and accepts traffic only from
-# the mymemo-service API ECS service security group.
+# state. The internal ALB and chat-api Service Connect endpoint are owned by
+# mymemo-agent and accept traffic only from the mymemo-service API ECS service
+# security group.
 mymemo_service_api_security_group_ids = ["sg-05d48e36ef8966c9e"]
 
 # Security group on the existing mymemo-service RDS instance (mymemo-staging-pg)

--- a/infra/terraform/service-connect.tf
+++ b/infra/terraform/service-connect.tf
@@ -1,0 +1,4 @@
+resource "aws_service_discovery_http_namespace" "services" {
+  name        = local.service_connect_namespace_name
+  description = "Private ECS Service Connect namespace for ${local.common_name}"
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -78,7 +78,7 @@ variable "consumer_lambda_package" {
 }
 
 variable "mymemo_service_api_security_group_ids" {
-  description = "Security group IDs for mymemo-service API tasks allowed to call the internal agent ALB."
+  description = "Security group IDs for trusted mymemo-service API tasks allowed to call chat-api through the internal ALB or Service Connect."
   type        = list(string)
 
   validation {
@@ -156,15 +156,15 @@ variable "agentcore_dispatch_publisher_desired_count" {
 }
 
 variable "chat_api_cpu" {
-  description = "Fargate CPU units for chat-api."
+  description = "Fargate CPU units for chat-api and its Service Connect proxy."
   type        = number
-  default     = 512
+  default     = 1024
 }
 
 variable "chat_api_memory" {
-  description = "Fargate memory MiB for chat-api."
+  description = "Fargate memory MiB for chat-api and its Service Connect proxy."
   type        = number
-  default     = 1024
+  default     = 2048
 }
 
 variable "agent_maintenance_cpu" {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"module": "index.ts",
 	"scripts": {
 		"smoke:local": "sh scripts/smoke/local-agentcore-compose.sh",
-		"test": "bun test scripts/deploy-config.test.ts scripts/agent-maintenance-infrastructure.test.ts scripts/deploy/agentcore_aws_checks.test.ts scripts/smoke/client-contract.test.ts scripts/smoke/agent-conversation-smoke.test.ts scripts/smoke/local-agentcore-smoke.test.ts && bun run scripts/test-workspaces.ts",
+		"test": "bun test scripts/deploy-config.test.ts scripts/agent-maintenance-infrastructure.test.ts scripts/service-connect-infrastructure.test.ts scripts/deploy/agentcore_aws_checks.test.ts scripts/smoke/client-contract.test.ts scripts/smoke/agent-conversation-smoke.test.ts scripts/smoke/local-agentcore-smoke.test.ts && bun run scripts/test-workspaces.ts",
 		"terraform:fmt": "terraform -chdir=infra/bootstrap-iam fmt && terraform -chdir=infra/terraform fmt && terraform -chdir=infra/ecr fmt && terraform -chdir=infra/dev fmt",
 		"terraform:validate": "terraform -chdir=infra/bootstrap-iam validate && terraform -chdir=infra/terraform validate && terraform -chdir=infra/ecr validate && terraform -chdir=infra/dev validate"
 	},

--- a/scripts/deploy/prepare_chat_api_service_connect.sh
+++ b/scripts/deploy/prepare_chat_api_service_connect.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/deploy/lib/load_config.sh
+source "$script_dir/lib/load_config.sh"
+load_deploy_config
+
+ecs_cluster_arn="$(terraform -chdir=infra/terraform output -raw shared_ecs_cluster_arn)"
+chat_api_service_name="$(terraform -chdir=infra/terraform output -raw chat_api_service_name)"
+desired_task_definition="$(terraform -chdir=infra/terraform output -raw chat_api_task_definition_arn)"
+port_name="chat-api-http"
+
+current_task_definition="$(
+  aws ecs describe-services \
+    --cluster "$ecs_cluster_arn" \
+    --services "$chat_api_service_name" \
+    --query 'services[0].taskDefinition' \
+    --output text
+)"
+
+task_definition_has_service_connect_port() {
+  local task_definition="$1"
+
+  aws ecs describe-task-definition \
+    --task-definition "$task_definition" \
+    --query taskDefinition \
+    --output json \
+    | jq -e \
+      --arg port_name "$port_name" \
+      'any(.containerDefinitions[] | select(.name == "chat-api").portMappings[]; .name == $port_name and .appProtocol == "http")' \
+      >/dev/null
+}
+
+if task_definition_has_service_connect_port "$current_task_definition"; then
+  echo "chat-api already uses the named HTTP port required by Service Connect."
+  exit 0
+fi
+
+if ! task_definition_has_service_connect_port "$desired_task_definition"; then
+  echo "Terraform's chat-api task definition is missing the named HTTP port required by Service Connect." >&2
+  exit 1
+fi
+
+# The ECS service resource intentionally ignores task_definition changes. Roll
+# the named-port revision first so the later unified Terraform apply can enable
+# Service Connect without ECS validating portName against the previous revision.
+aws ecs update-service \
+  --cluster "$ecs_cluster_arn" \
+  --service "$chat_api_service_name" \
+  --task-definition "$desired_task_definition" \
+  --force-new-deployment \
+  >/dev/null
+
+aws ecs wait services-stable \
+  --cluster "$ecs_cluster_arn" \
+  --services "$chat_api_service_name"

--- a/scripts/deploy/terraform_prod_migration_plan.sh
+++ b/scripts/deploy/terraform_prod_migration_plan.sh
@@ -12,4 +12,5 @@ terraform -chdir=infra/terraform plan \
   -var-file="${tfvars_file_abs}" \
   -var-file="${generated_tfvars_file_abs}" \
   -target=aws_ecs_task_definition.agent_migration \
+  -target=aws_ecs_task_definition.chat_api \
   -out="${plan_file}"

--- a/scripts/service-connect-infrastructure.test.ts
+++ b/scripts/service-connect-infrastructure.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+function expectAll(source: string, fragments: string[]): void {
+	for (const fragment of fragments) expect(source).toContain(fragment);
+}
+
+describe("chat-api Service Connect infrastructure", () => {
+	it("adds Service Connect without replacing the trusted ALB path", () => {
+		const ecs = read("infra/terraform/ecs.tf");
+		const alb = read("infra/terraform/alb.tf");
+		const network = read("infra/terraform/network.tf");
+		const outputs = read("infra/terraform/outputs.tf");
+		const workflow = read(".github/workflows/release-deploy.yml");
+
+		expectAll(read("infra/terraform/service-connect.tf"), [
+			'resource "aws_service_discovery_http_namespace" "services"',
+		]);
+		expectAll(ecs, [
+			"name          = local.chat_api_service_connect_port_name",
+			'appProtocol   = "http"',
+			"namespace = aws_service_discovery_http_namespace.services.arn",
+			"ingress_port_override = local.chat_api_service_connect_ingress_port",
+			"idle_timeout_seconds        = 0",
+			"per_request_timeout_seconds = 0",
+			"target_group_arn = aws_lb_target_group.chat_api.arn",
+		]);
+		expectAll(alb, [
+			'resource "aws_lb" "agent"',
+			'resource "aws_lb_target_group" "chat_api"',
+			'resource "aws_lb_listener" "http"',
+		]);
+		expectAll(network, [
+			'resource "aws_security_group_rule" "chat_api_from_alb"',
+			"source_security_group_id = aws_security_group.alb.id",
+			"from_port                = var.chat_api_port",
+			'resource "aws_security_group_rule" "chat_api_service_connect_from_trusted_callers"',
+			"for_each = toset(local.trusted_caller_security_group_ids)",
+			"source_security_group_id = each.value",
+			"from_port                = local.chat_api_service_connect_ingress_port",
+		]);
+		expectAll(outputs, [
+			'output "chat_api_service_connect_namespace_arn"',
+			'output "chat_api_service_connect_endpoint"',
+			'output "chat_api_target_group_arn"',
+			'output "agent_internal_base_url"',
+		]);
+		expectAll(read("infra/terraform/cloudwatch.tf"), [
+			'resource "aws_cloudwatch_metric_alarm" "chat_api_unhealthy"',
+			"TargetGroup  = aws_lb_target_group.chat_api.arn_suffix",
+		]);
+		expect(read("infra/bootstrap-iam/main.tf")).toContain(
+			'"servicediscovery:*"',
+		);
+		expectAll(read("scripts/deploy/terraform_prod_migration_plan.sh"), [
+			"-target=aws_ecs_task_definition.chat_api",
+		]);
+		expectAll(read("scripts/deploy/prepare_chat_api_service_connect.sh"), [
+			"task_definition_has_service_connect_port",
+			"aws ecs update-service",
+			"aws ecs wait services-stable",
+		]);
+
+		const prerequisite = workflow.indexOf(
+			"Roll the Service Connect named-port prerequisite",
+		);
+		expect(prerequisite).toBeGreaterThanOrEqual(0);
+		expect(workflow.indexOf("Apply the unified release")).toBeGreaterThan(
+			prerequisite,
+		);
+	});
+});


### PR DESCRIPTION
## Summary

- create an agent-owned Cloud Map HTTP namespace and publish the chat-api Service Connect endpoint
- add the named HTTP port, unlimited request and idle timeouts, proxy capacity, and trusted-caller ingress while retaining the internal ALB path
- stage the named-port task revision before enabling Service Connect on existing ECS services and export the later caller-migration contract

## Rollout notes

- reapply infra/bootstrap-iam before the first release so the deploy role has Cloud Map authority
- this stage does not change mymemo-service, redirect the ALB, or change the deployed smoke-test path
- no Terraform apply or AWS production mutation was performed while preparing this PR

## Testing

- terraform -chdir=infra/terraform fmt -check
- terraform -chdir=infra/bootstrap-iam fmt -check
- backendless terraform validate with AWS provider 6.61.0
- bash -n scripts/deploy/prepare_chat_api_service_connect.sh scripts/deploy/terraform_prod_migration_plan.sh
- bun test scripts/service-connect-infrastructure.test.ts scripts/agent-maintenance-infrastructure.test.ts
- git diff --check