### PR TITLE
chore(infra): migrate live relay to Valkey

### DIFF
--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -34,7 +34,7 @@ Every execution mutation is fenced by the live Conversation Ownership epoch and 
 
 ### Live and permanent output
 
-The AgentCore Runtime keeps each active Run's standard AG-UI Live Stream backlog in memory and relays events over Redis pub/sub. Redis stores no stream content. Permanent Assistant messages, Tool activity, UI payloads, and Outcomes commit to Postgres before their matching completion events are published. Relay failure degrades live delivery without changing durable Run execution. See [ADR-0014](../adr/0014-producer-buffered-live-stream-over-pubsub.md).
+The AgentCore Runtime keeps each active Run's standard AG-UI Live Stream backlog in memory and relays events over Redis-compatible pub/sub through ElastiCache for Valkey. The cache stores no stream content. Permanent Assistant messages, Tool activity, UI payloads, and Outcomes commit to Postgres before their matching completion events are published. Relay failure degrades live delivery without changing durable Run execution. See [ADR-0014](../adr/0014-producer-buffered-live-stream-over-pubsub.md).
 
 Workspace persistence, Agent session continuity, Searchable document loading, and Downloadable artifact publication belong to the trusted runtime. Follow [the worker guide](agent-worker.md) for their detailed invariants.
 

--- a/docs/runbooks/live-stream.md
+++ b/docs/runbooks/live-stream.md
@@ -1,10 +1,11 @@
 # Live Stream operations
 
-The Live Stream is buffered in the producing AgentCore Runtime's memory and relayed over
-Redis pub/sub. Redis stores no stream content. Postgres remains authoritative
-for Run execution, complete messages, Tool activity, and terminal Outcomes. A
-Live Stream alarm is a delivery incident: it must not fail service health,
-restart a Run, or be counted as a model or Run failure.
+The Live Stream is buffered in the producing AgentCore Runtime's memory and
+relayed over Redis-compatible pub/sub through ElastiCache for Valkey. The cache
+stores no stream content. Postgres remains authoritative for Run execution,
+complete messages, Tool activity, and terminal Outcomes. A Live Stream alarm is
+a delivery incident: it must not fail service health, restart a Run, or be
+counted as a model or Run failure.
 
 Both trusted services require `REDIS_URL` at startup. It must be an
 authenticated `rediss://` URL; missing, malformed, unauthenticated, or

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -32,8 +32,8 @@ the direct remote-state output is absent and the fallback input is present.
 - dedicated RDS Postgres instance for writable agent state
 - EC2 Instance Connect Endpoint and private EC2 bridge for operator access to
   the agent and KB databases
-- single-node ElastiCache Redis replication group for temporary per-Run Live
-  Streams
+- single-node ElastiCache for Valkey replication group for temporary per-Run
+  Live Streams
 - private S3 bucket for durable Downloadable artifact objects
 - ECS Fargate task definitions and services for chat-api, agent-maintenance,
   and the singleton AgentCore dispatch publisher
@@ -109,24 +109,34 @@ role can read that parameter and publish to the exact encrypted queue. Its
 separate execution role can read only the RDS password secret; it receives no
 KB, OpenRouter, E2B, artifact, or Redis credentials.
 
-## Redis Live Stream Infrastructure
+## Valkey Live Stream Infrastructure
 
-The Redis cache is an ephemeral pub/sub relay for AG-UI Live Streams, not a
-storage or permanent-history authority. Producers keep active-Run backlogs in
-Runtime memory; Redis holds no per-Run keys. It is a single small node with no
-replicas, Multi-AZ failover, automatic snapshots, final snapshot, or backup
-retention. The cache is reachable on its TLS port only from a dedicated client
-security group attached to `chat-api` and the AgentCore Runtime;
-the migration task does not receive that group.
+The ElastiCache for Valkey cache is an ephemeral Redis-compatible pub/sub relay
+for AG-UI Live Streams, not a storage or permanent-history authority. Producers
+keep active-Run backlogs in Runtime memory; the cache holds no per-Run keys. It
+is a single `cache.t4g.micro` node with no replicas, Multi-AZ failover,
+automatic snapshots, final snapshot, or backup retention. The cache is
+reachable on its TLS port only from a dedicated client security group attached
+to `chat-api` and the AgentCore Runtime; the migration task does not receive
+that group.
 ElastiCache does not receive a public address or a CIDR-based ingress rule.
 Authentication and in-transit encryption are mandatory.
+
+Production upgrades the existing Redis OSS 7.1 replication group to Valkey 7.2
+in place. The Terraform resource address, replication-group identifier,
+`cache.t4g.micro` node type, primary endpoint DNS name, TLS port, AUTH token,
+and `rediss://` secret contract remain stable. AWS may change the node's
+underlying IP during the cross-engine upgrade, so clients must continue using
+the endpoint DNS name. Because the relay is deliberately non-durable, the
+upgrade does not add snapshots or persistence; brief publication interruption
+degrades active Live Streams to permanent Postgres history.
 
 Before the first cache plan in an existing environment, reapply
 `infra/bootstrap-iam` with the admin profile as shown below. That updates the
 GitHub Actions deploy role with the ElastiCache permissions used by this root.
 
 `REDIS_URL` is required at chat-api and AgentCore Runtime startup and must be an
-authenticated `rediss://` URL. Runtime Redis availability remains outside
+authenticated `rediss://` URL. Runtime cache availability remains outside
 readiness: an outage degrades live delivery but does not make either service
 unhealthy, and permanent Conversation history and Outcomes remain in Postgres.
 

--- a/infra/terraform/redis.tf
+++ b/infra/terraform/redis.tf
@@ -40,7 +40,9 @@ resource "aws_elasticache_replication_group" "live" {
   replication_group_id = substr(replace("${local.common_name}-live", "_", "-"), 0, 40)
   description          = "Ephemeral Redis pub/sub relay for AG-UI Live Stream delivery"
 
-  engine         = "redis"
+  # Keep the Redis-named Terraform addresses and rediss:// client contract
+  # stable while AWS upgrades the existing replication group in place.
+  engine         = "valkey"
   engine_version = var.live_redis_engine_version
   node_type      = var.live_redis_node_type
   port           = var.live_redis_port

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -245,9 +245,9 @@ variable "live_redis_node_type" {
 }
 
 variable "live_redis_engine_version" {
-  description = "Redis engine version for the per-Run Live Stream relay."
+  description = "Valkey engine version for the per-Run Live Stream relay."
   type        = string
-  default     = "7.1"
+  default     = "7.2"
 }
 
 variable "alarm_action_arns" {

--- a/scripts/agent-maintenance-infrastructure.test.ts
+++ b/scripts/agent-maintenance-infrastructure.test.ts
@@ -156,6 +156,38 @@ describe("agent-maintenance infrastructure", () => {
 		expect(redis).toContain("ignore_changes = [description]");
 	});
 
+	it("keeps the Valkey Live Stream relay ephemeral and endpoint-compatible", () => {
+		const redis = terraformFile("redis.tf");
+		const nodeType = section(
+			terraformFile("variables.tf"),
+			'variable "live_redis_node_type"',
+			'variable "live_redis_engine_version"',
+		);
+		const engineVersion = section(
+			terraformFile("variables.tf"),
+			'variable "live_redis_engine_version"',
+			'variable "alarm_action_arns"',
+		);
+
+		expect(redis).toContain('engine         = "valkey"');
+		expect(engineVersion).toContain('default     = "7.2"');
+		expect(nodeType).toContain('default     = "cache.t4g.micro"');
+		expect(redis).toContain("node_type      = var.live_redis_node_type");
+		expect(redis).toContain("num_cache_clusters         = 1");
+		expect(redis).toContain("automatic_failover_enabled = false");
+		expect(redis).toContain("multi_az_enabled           = false");
+		expect(redis).toContain("transit_encryption_enabled = true");
+		expect(redis).toContain('transit_encryption_mode    = "required"');
+		expect(redis).toContain(
+			"auth_token                 = random_password.live_redis.result",
+		);
+		expect(redis).toContain("snapshot_retention_limit = 0");
+		expect(redis).toContain(
+			"aws_elasticache_replication_group.live.primary_endpoint_address",
+		);
+		expect(redis).toContain('secret_string = "rediss://default:');
+	});
+
 	it("keeps retired repository deletion in the one-time handoff", () => {
 		const ecr = readFileSync("infra/ecr/main.tf", "utf8");
 		const release = readFileSync(


### PR DESCRIPTION
## Summary

- migrate the live-stream ElastiCache replication group from Redis OSS 7.1 to Valkey 7.2
- keep the existing `cache.t4g.micro`, replication-group identity, TLS/AUTH configuration, primary-endpoint-derived `rediss://` secret, and ephemeral single-node/no-snapshot topology
- document the cross-engine behavior and add an infrastructure regression contract for those invariants

## Production-state plan verification

AWS documents Redis OSS 7 to Valkey as an in-place cross-engine upgrade that preserves the endpoint DNS name: https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/VersionManagement.HowTo.html

Against the current production state with AWS provider 6.61.0, a targeted plan through `aws_secretsmanager_secret_version.live_redis_url` reports:

```text
# aws_elasticache_replication_group.live will be updated in-place
~ engine         = "redis" -> "valkey"
~ engine_version = "7.1" -> "7.2"

Plan: 0 to add, 1 to change, 0 to destroy.
```

The plan JSON assertion confirms that node type, port, TLS settings, AUTH token input, snapshot retention, primary endpoint, and the existing secret version are unchanged. The live replication group is `available`, has no pending modifications, and Valkey 7.2 is available in `us-west-2`. This was a read-only targeted migration check; the release workflow will still produce the full plan with its generated immutable artifacts. No production apply was run.

## Verification

- `terraform -chdir=infra/terraform fmt -check`
- `AWS_PROFILE=mymemo terraform -chdir=infra/terraform validate`
- `bunx biome check scripts/agent-maintenance-infrastructure.test.ts`
- `bun test scripts/agent-maintenance-infrastructure.test.ts scripts/deploy-config.test.ts` (12 pass)
- production-state plan invariant assertion

Terraform validation retains the existing third-party fck-nat module warning for its deprecated `ipv6_cidr_block` attribute.