### PR TITLE
feat(model): default OpenRouter to Claude Sonnet 5

### DIFF
--- a/apps/agentcore-runtime/src/config.test.ts
+++ b/apps/agentcore-runtime/src/config.test.ts
@@ -19,7 +19,7 @@ function bootstrapEnv(): Record<string, string | undefined> {
 		REDIS_URL_SECRET_ARN:
 			"arn:aws:secretsmanager:us-west-2:123456789012:secret:redis-AbCdEf",
 		OPENROUTER_BASE_URL: "https://openrouter.ai/api",
-		OPENROUTER_DEFAULT_MODEL: "anthropic/claude-sonnet-4",
+		OPENROUTER_DEFAULT_MODEL: "anthropic/claude-sonnet-5",
 		WORKER_E2B_TEMPLATE: "mymemo-agent-sandbox",
 		ARTIFACT_BUCKET: "private-artifacts",
 		RDS_CA_BUNDLE_PATH: "/etc/ssl/certs/rds-global-bundle.pem",

--- a/apps/agentcore-runtime/src/model-client.test.ts
+++ b/apps/agentcore-runtime/src/model-client.test.ts
@@ -10,7 +10,7 @@ import { buildModelClientConfig } from "./model-client";
 const openrouter = {
 	apiKey: "sk-or-secret",
 	baseUrl: "https://openrouter.ai/api",
-	defaultModel: "anthropic/claude-sonnet-4",
+	defaultModel: "anthropic/claude-sonnet-5",
 };
 
 describe("buildModelClientConfig — trusted Runtime model path", () => {
@@ -33,7 +33,7 @@ describe("buildModelClientConfig — trusted Runtime model path", () => {
 
 	it("carries the one allowed default model (v1: no fallback)", () => {
 		const config = buildModelClientConfig(openrouter);
-		expect(config.model).toBe("anthropic/claude-sonnet-4");
+		expect(config.model).toBe("anthropic/claude-sonnet-5");
 	});
 
 	it("stays valid for the direct-Anthropic contingency via env flip", () => {

--- a/apps/agentcore-runtime/src/production.test.ts
+++ b/apps/agentcore-runtime/src/production.test.ts
@@ -21,7 +21,7 @@ function bootstrapConfig() {
 		REDIS_URL_SECRET_ARN:
 			"arn:aws:secretsmanager:us-west-2:123456789012:secret:redis-AbCdEf",
 		OPENROUTER_BASE_URL: "https://openrouter.ai/api",
-		OPENROUTER_DEFAULT_MODEL: "anthropic/claude-sonnet-4",
+		OPENROUTER_DEFAULT_MODEL: "anthropic/claude-sonnet-5",
 		WORKER_E2B_TEMPLATE: "mymemo-agent-sandbox",
 		ARTIFACT_BUCKET: "private-artifacts",
 		RDS_CA_BUNDLE_PATH: "/etc/ssl/certs/rds-global-bundle.pem",

--- a/apps/agentcore-runtime/src/runtime-config.test.ts
+++ b/apps/agentcore-runtime/src/runtime-config.test.ts
@@ -12,7 +12,7 @@ function baseEnv(): Record<string, string | undefined> {
 		KB_DATABASE_URL: "postgresql://r:r@localhost:5432/mymemo_kb",
 		OPENROUTER_API_KEY: "sk-or-test",
 		OPENROUTER_BASE_URL: "https://openrouter.ai/api",
-		OPENROUTER_DEFAULT_MODEL: "anthropic/claude-sonnet-4",
+		OPENROUTER_DEFAULT_MODEL: "anthropic/claude-sonnet-5",
 		REDIS_URL: "rediss://default:secret@redis.internal:6379",
 		E2B_API_KEY: "e2b-test",
 		WORKER_E2B_TEMPLATE: "mymemo-agent-sandbox",
@@ -70,7 +70,7 @@ describe("loadRuntimeConfigFromEnv — required settings", () => {
 		const config = loadRuntimeConfigFromEnv(baseEnv());
 		expect(config.openrouter.apiKey).toBe("sk-or-test");
 		expect(config.openrouter.baseUrl).toBe("https://openrouter.ai/api");
-		expect(config.openrouter.defaultModel).toBe("anthropic/claude-sonnet-4");
+		expect(config.openrouter.defaultModel).toBe("anthropic/claude-sonnet-5");
 	});
 });
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -72,7 +72,7 @@ services:
       KB_DATABASE_URL: postgresql://mymemo:mymemo@postgres:5432/mymemo_kb
       OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:?Set OPENROUTER_API_KEY}
       OPENROUTER_BASE_URL: ${OPENROUTER_BASE_URL:-https://openrouter.ai/api}
-      OPENROUTER_DEFAULT_MODEL: ${OPENROUTER_DEFAULT_MODEL:-anthropic/claude-sonnet-4}
+      OPENROUTER_DEFAULT_MODEL: ${OPENROUTER_DEFAULT_MODEL:-anthropic/claude-sonnet-5}
       E2B_API_KEY: ${E2B_API_KEY:?Set E2B_API_KEY}
       WORKER_E2B_TEMPLATE: ${WORKER_E2B_TEMPLATE:-mymemo-agent-sandbox}
       REDIS_URL: redis://127.0.0.1:6379

--- a/infra/terraform/examples/prod.tfvars.example
+++ b/infra/terraform/examples/prod.tfvars.example
@@ -30,7 +30,7 @@ agentcore_dispatch_publisher_image     = "123456789012.dkr.ecr.us-east-1.amazona
 runtime_image_digest                   = "sha256:REPLACE_WITH_64_HEX_CHARACTERS"
 consumer_lambda_package                = "/absolute/path/to/consumer.zip"
 
-openrouter_default_model            = "anthropic/claude-sonnet-4"
+openrouter_default_model            = "anthropic/claude-sonnet-5"
 
 # SNS topics must already have confirmed incident subscriptions.
 # alarm_action_arns = ["arn:aws:sns:us-east-1:123456789012:mymemo-prod-alarms"]

--- a/infra/terraform/prod.tfvars
+++ b/infra/terraform/prod.tfvars
@@ -24,7 +24,7 @@ assign_public_ip = true
 # fck-nat 1.4.0, published by AWS account 568608671756 for us-west-2 ARM64.
 fck_nat_ami_id = "ami-0d1db1251d2b64626"
 
-openrouter_default_model = "anthropic/claude-sonnet-4"
+openrouter_default_model = "anthropic/claude-sonnet-5"
 
 # Established account alarm channel used by the shared staging infrastructure.
 alarm_action_arns = ["arn:aws:sns:us-west-2:637423444544:mymemo-staging-alarms"]

--- a/scripts/deploy-config.test.ts
+++ b/scripts/deploy-config.test.ts
@@ -69,7 +69,7 @@ describe("agent deployment behavior", () => {
 				KB_DATABASE_URL: "postgresql://kb:kb@db.example.com:5432/mymemo_kb",
 				OPENROUTER_API_KEY: "openrouter-test-key",
 				OPENROUTER_BASE_URL: "https://openrouter.ai/api",
-				OPENROUTER_DEFAULT_MODEL: "anthropic/claude-sonnet-4",
+				OPENROUTER_DEFAULT_MODEL: "anthropic/claude-sonnet-5",
 				WORKER_E2B_TEMPLATE: "mymemo-agent-sandbox",
 			}),
 		).not.toThrow();

--- a/scripts/smoke/agentcore-runtime-image-check.sh
+++ b/scripts/smoke/agentcore-runtime-image-check.sh
@@ -66,7 +66,7 @@ if entrypoint_output="$(
     -e OPENROUTER_API_KEY_SECRET_ARN=arn:aws:secretsmanager:us-west-2:123456789012:secret:openrouter-AbCdEf \
     -e E2B_API_KEY_SECRET_ARN=arn:aws:secretsmanager:us-west-2:123456789012:secret:e2b-AbCdEf \
     -e OPENROUTER_BASE_URL=https://openrouter.ai/api \
-    -e OPENROUTER_DEFAULT_MODEL=anthropic/claude-sonnet-4 \
+    -e OPENROUTER_DEFAULT_MODEL=anthropic/claude-sonnet-5 \
     -e WORKER_E2B_TEMPLATE=mymemo-agent-sandbox \
     -e ARTIFACT_BUCKET=private-artifacts \
     "$image" 2>&1


### PR DESCRIPTION
## Summary

- switch the production and local OpenRouter default to `anthropic/claude-sonnet-5`
- keep deployment examples, runtime smoke configuration, and AgentCore tests aligned with the new default

## Testing

- `bun test scripts/deploy-config.test.ts apps/agentcore-runtime/src/config.test.ts apps/agentcore-runtime/src/model-client.test.ts apps/agentcore-runtime/src/production.test.ts apps/agentcore-runtime/src/runtime-config.test.ts`
- `terraform -chdir=infra/terraform fmt -check -recursive`
- `git diff --check origin/main...HEAD`

## Related

- Related to #555; this PR only updates the existing deployment default and does not implement request-selected models.
