### PR TITLE
feat(runtime): add direct Agent query boundary

### DIFF
--- a/apps/agent-query-runtime/Dockerfile
+++ b/apps/agent-query-runtime/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1.7
+
+ARG BUN_VERSION=1
+
+FROM oven/bun:${BUN_VERSION}-alpine AS base
+WORKDIR /usr/src/app
+
+FROM base AS manifests
+COPY package.json bun.lock ./
+COPY apps apps
+COPY packages packages
+RUN find apps packages -type f ! -name package.json -delete \
+ && find apps packages -type d -empty -delete
+
+FROM base AS install
+COPY --from=manifests /usr/src/app /temp/prod
+RUN cd /temp/prod \
+ && bun install --frozen-lockfile --production --filter agent-query-runtime
+
+FROM base AS release
+COPY --from=install /temp/prod/node_modules node_modules
+COPY apps/agent-query-runtime/src apps/agent-query-runtime/src
+COPY apps/agent-query-runtime/package.json apps/agent-query-runtime/
+COPY packages/agent-query packages/agent-query
+COPY package.json ./
+RUN mkdir -p /workspace/conversations && chown -R bun:bun /workspace
+
+WORKDIR /usr/src/app/apps/agent-query-runtime
+USER bun
+EXPOSE 8080/tcp
+ENTRYPOINT [ "bun", "run", "src/index.ts" ]

--- a/apps/agent-query-runtime/package.json
+++ b/apps/agent-query-runtime/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "agent-query-runtime",
 	"scripts": {
+		"start": "bun run src/index.ts",
 		"test": "bun test",
 		"format": "biome format --write",
 		"lint": "biome lint --write",

--- a/apps/agent-query-runtime/package.json
+++ b/apps/agent-query-runtime/package.json
@@ -1,0 +1,20 @@
+{
+	"name": "agent-query-runtime",
+	"scripts": {
+		"test": "bun test",
+		"format": "biome format --write",
+		"lint": "biome lint --write",
+		"check": "biome check --write"
+	},
+	"dependencies": {
+		"@anthropic-ai/claude-agent-sdk": "0.3.233",
+		"@mymemo/agent-query": "workspace:*",
+		"zod": "4.3.6"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^2.3.11",
+		"@mymemo/test-support": "workspace:*",
+		"@types/bun": "^1.3.11"
+	},
+	"type": "module"
+}

--- a/apps/agent-query-runtime/src/index.ts
+++ b/apps/agent-query-runtime/src/index.ts
@@ -1,0 +1,19 @@
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import { createAgentQueryServerOptions } from "./server";
+
+const port = Number(Bun.env.PORT ?? 8080);
+if (!Number.isSafeInteger(port) || port < 1 || port > 65_535) {
+	throw new Error("PORT must be an integer between 1 and 65535");
+}
+
+Bun.serve(
+	createAgentQueryServerOptions(
+		{
+			query,
+			// Production Postgres epoch/deadline enforcement is composed in #565;
+			// this Runtime remains outside production until then.
+			async verifyResponseAuthority() {},
+		},
+		port,
+	),
+);

--- a/apps/agent-query-runtime/src/index.ts
+++ b/apps/agent-query-runtime/src/index.ts
@@ -1,3 +1,4 @@
+import { mkdir } from "node:fs/promises";
 import { query } from "@anthropic-ai/claude-agent-sdk";
 import { createAgentQueryServerOptions } from "./server";
 
@@ -10,6 +11,9 @@ Bun.serve(
 	createAgentQueryServerOptions(
 		{
 			query,
+			async prepareWorkingDirectory(path) {
+				await mkdir(path, { recursive: true });
+			},
 			// Production Postgres epoch/deadline enforcement is composed in #565;
 			// this Runtime remains outside production until then.
 			async verifyResponseAuthority() {},

--- a/apps/agent-query-runtime/src/server.test.ts
+++ b/apps/agent-query-runtime/src/server.test.ts
@@ -113,6 +113,7 @@ function dependencies(
 		async *query() {
 			yield* messages;
 		},
+		async prepareWorkingDirectory() {},
 		async verifyResponseAuthority() {},
 	};
 }
@@ -124,11 +125,15 @@ describe("direct-response AgentCore Runtime HTTP boundary", () => {
 			conversationId: string;
 			conversationEpoch: number;
 		}> = [];
+		const workingDirectories: string[] = [];
 		const messages = successfulMessages();
 		const handle = createAgentQueryRequestHandler({
 			async *query(input) {
 				queries.push(input);
 				yield* messages;
+			},
+			async prepareWorkingDirectory(path) {
+				workingDirectories.push(path);
 			},
 			async verifyResponseAuthority(authority) {
 				authorities.push(authority);
@@ -157,12 +162,16 @@ describe("direct-response AgentCore Runtime HTTP boundary", () => {
 					cwd: `/workspace/conversations/${conversationId}`,
 					permissionMode: "dontAsk",
 					settingSources: [],
+					thinking: { type: "disabled" },
 					tools: [],
 					resume: "opaque-agent-session",
 				},
 			},
 		]);
 		expect(authorities).toEqual([{ conversationId, conversationEpoch: 7 }]);
+		expect(workingDirectories).toEqual([
+			`/workspace/conversations/${conversationId}`,
+		]);
 	});
 
 	it("starts a fresh Agent session when the opaque session id is absent", async () => {
@@ -172,6 +181,7 @@ describe("direct-response AgentCore Runtime HTTP boundary", () => {
 				options.push(input.options);
 				yield* successfulMessages();
 			},
+			async prepareWorkingDirectory() {},
 			async verifyResponseAuthority() {},
 		})(request());
 
@@ -189,6 +199,7 @@ describe("direct-response AgentCore Runtime HTTP boundary", () => {
 				queries++;
 				yield* successfulMessages();
 			},
+			async prepareWorkingDirectory() {},
 			async verifyResponseAuthority() {
 				verifications++;
 			},
@@ -225,9 +236,30 @@ describe("direct-response AgentCore Runtime HTTP boundary", () => {
 				queries++;
 				yield* successfulMessages();
 			},
+			async prepareWorkingDirectory() {},
 			async verifyResponseAuthority() {
 				throw new Error("stale response authority");
 			},
+		})(request());
+
+		expect(response.status).toBe(503);
+		expect(await response.json()).toEqual({
+			error: "AgentCore invocation failed",
+		});
+		expect(queries).toBe(0);
+	});
+
+	it("rejects working-directory preparation failure before starting Claude", async () => {
+		let queries = 0;
+		const response = await createAgentQueryRequestHandler({
+			async *query() {
+				queries++;
+				yield* successfulMessages();
+			},
+			async prepareWorkingDirectory() {
+				throw new Error("workspace unavailable");
+			},
+			async verifyResponseAuthority() {},
 		})(request());
 
 		expect(response.status).toBe(503);
@@ -251,7 +283,7 @@ describe("direct-response AgentCore Runtime HTTP boundary", () => {
 		expect(lines.some((line) => line.type === "error")).toBe(false);
 	});
 
-	it("truncates the response rather than forwarding unsupported Claude content", async () => {
+	it("truncates unexpected non-text content disabled by the query options", async () => {
 		const hidden = [
 			streamEvent({
 				type: "message_start",
@@ -307,6 +339,7 @@ describe("direct-response AgentCore Runtime HTTP boundary", () => {
 			query() {
 				throw new Error("Claude unavailable");
 			},
+			async prepareWorkingDirectory() {},
 			async verifyResponseAuthority() {},
 		})(request());
 
@@ -324,6 +357,7 @@ describe("direct-response AgentCore Runtime HTTP boundary", () => {
 				}
 				throw new Error("transport failed");
 			},
+			async prepareWorkingDirectory() {},
 			async verifyResponseAuthority() {},
 		})(request());
 		const reader = response.body?.getReader();

--- a/apps/agent-query-runtime/src/server.test.ts
+++ b/apps/agent-query-runtime/src/server.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, it } from "bun:test";
+import { join } from "node:path";
+import type { Options, SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+import { workspaceImportGraph } from "@mymemo/test-support/import-graph";
+import {
+	AGENTCORE_RUNTIME_SESSION_HEADER,
+	type AgentQueryRuntimeDependencies,
+	createAgentQueryRequestHandler,
+} from "./server";
+
+const conversationId = "0198b5a2-0d2b-7b64-9f65-4c9d49045111";
+
+function streamEvent(event: Record<string, unknown>): SDKMessage {
+	return {
+		type: "stream_event",
+		event,
+		parent_tool_use_id: null,
+		uuid: crypto.randomUUID(),
+		session_id: "agent-session-1",
+	} as unknown as SDKMessage;
+}
+
+function resultEvent(overrides: Record<string, unknown> = {}): SDKMessage {
+	return {
+		type: "result",
+		subtype: "success",
+		is_error: false,
+		result: "provider-only terminal echo",
+		session_id: "agent-session-1",
+		...overrides,
+	} as SDKMessage;
+}
+
+function successfulMessages(): SDKMessage[] {
+	return [
+		{ type: "system", subtype: "init" } as unknown as SDKMessage,
+		streamEvent({
+			type: "message_start",
+			message: { id: "provider-message-1", content: [] },
+		}),
+		streamEvent({
+			type: "content_block_start",
+			index: 0,
+			content_block: { type: "text", text: "" },
+		}),
+		streamEvent({
+			type: "content_block_delta",
+			index: 0,
+			delta: { type: "text_delta", text: "A direct answer." },
+		}),
+		streamEvent({ type: "content_block_stop", index: 0 }),
+		streamEvent({ type: "message_stop" }),
+		resultEvent(),
+	];
+}
+
+function request(
+	body: Record<string, unknown> = {},
+	runtimeSessionId = conversationId,
+) {
+	return new Request("http://runtime/invocations", {
+		method: "POST",
+		headers: {
+			"content-type": "application/json",
+			[AGENTCORE_RUNTIME_SESSION_HEADER]: runtimeSessionId,
+		},
+		body: JSON.stringify({
+			version: 1,
+			conversationId,
+			conversationEpoch: 7,
+			prompt: "Tell me something",
+			model: "anthropic/claude-sonnet-5",
+			...body,
+		}),
+	});
+}
+
+function dependencies(
+	messages: SDKMessage[] = successfulMessages(),
+): AgentQueryRuntimeDependencies {
+	return {
+		async *query() {
+			yield* messages;
+		},
+		async verifyResponseAuthority() {},
+	};
+}
+
+describe("direct-response AgentCore Runtime HTTP boundary", () => {
+	it("forwards one validated query and streams the controlled native subset as ordered NDJSON", async () => {
+		const queries: Array<{ prompt: string; options: Options }> = [];
+		const authorities: Array<{
+			conversationId: string;
+			conversationEpoch: number;
+		}> = [];
+		const messages = successfulMessages();
+		const handle = createAgentQueryRequestHandler({
+			async *query(input) {
+				queries.push(input);
+				yield* messages;
+			},
+			async verifyResponseAuthority(authority) {
+				authorities.push(authority);
+			},
+		});
+
+		const response = await handle(
+			request({ agentSessionId: "opaque-agent-session" }),
+		);
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("content-type")).toBe("application/x-ndjson");
+		const lines = (await response.text())
+			.trim()
+			.split("\n")
+			.map((line) => JSON.parse(line));
+		expect(lines).toEqual(messages.slice(1));
+		expect(lines.at(-1)).toEqual(resultEvent());
+		expect(queries).toEqual([
+			{
+				prompt: "Tell me something",
+				options: {
+					model: "anthropic/claude-sonnet-5",
+					includePartialMessages: true,
+					cwd: `/workspace/conversations/${conversationId}`,
+					resume: "opaque-agent-session",
+				},
+			},
+		]);
+		expect(authorities).toEqual([{ conversationId, conversationEpoch: 7 }]);
+	});
+
+	it("starts a fresh Agent session when the opaque session id is absent", async () => {
+		const options: Options[] = [];
+		const response = await createAgentQueryRequestHandler({
+			async *query(input) {
+				options.push(input.options);
+				yield* successfulMessages();
+			},
+			async verifyResponseAuthority() {},
+		})(request());
+
+		expect(response.status).toBe(200);
+		await response.text();
+		expect(options).toHaveLength(1);
+		expect(options[0]).not.toHaveProperty("resume");
+	});
+
+	it("strictly rejects invalid envelopes and Runtime session identities before authority or query work", async () => {
+		let verifications = 0;
+		let queries = 0;
+		const handle = createAgentQueryRequestHandler({
+			async *query() {
+				queries++;
+				yield* successfulMessages();
+			},
+			async verifyResponseAuthority() {
+				verifications++;
+			},
+		});
+		const invalidRequests = [
+			request({ version: 2 }),
+			request({ extra: true }),
+			request({ conversationId: "invalid/id" }, "invalid/id"),
+			request({ conversationEpoch: -1 }),
+			request({ conversationEpoch: 1.5 }),
+			request({ prompt: "" }),
+			request({ model: " " }),
+			request({ agentSessionId: "" }),
+			request({}, "different-session"),
+			new Request("http://runtime/invocations", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: "{",
+			}),
+		];
+
+		for (const invalid of invalidRequests) {
+			const response = await handle(invalid);
+			expect(response.status).toBe(400);
+		}
+		expect(verifications).toBe(0);
+		expect(queries).toBe(0);
+	});
+
+	it("rejects an authority-verifier failure before starting Claude", async () => {
+		let queries = 0;
+		const response = await createAgentQueryRequestHandler({
+			async *query() {
+				queries++;
+				yield* successfulMessages();
+			},
+			async verifyResponseAuthority() {
+				throw new Error("stale response authority");
+			},
+		})(request());
+
+		expect(response.status).toBe(503);
+		expect(await response.json()).toEqual({
+			error: "AgentCore invocation failed",
+		});
+		expect(queries).toBe(0);
+	});
+
+	it("streams a terminal Claude failure without inventing an error event", async () => {
+		const failure = resultEvent({
+			subtype: "error_during_execution",
+			is_error: true,
+			errors: ["private provider failure"],
+		});
+		const response = await createAgentQueryRequestHandler(
+			dependencies([...successfulMessages().slice(0, -1), failure]),
+		)(request());
+
+		const lines = (await response.text())
+			.trim()
+			.split("\n")
+			.map((line) => JSON.parse(line));
+		expect(lines.at(-1)).toEqual(failure);
+		expect(lines.some((line) => line.type === "error")).toBe(false);
+	});
+
+	it("rejects a Claude startup failure without a second error protocol", async () => {
+		const response = await createAgentQueryRequestHandler({
+			query() {
+				throw new Error("Claude unavailable");
+			},
+			async verifyResponseAuthority() {},
+		})(request());
+
+		expect(response.status).toBe(503);
+		expect(await response.json()).toEqual({
+			error: "AgentCore invocation failed",
+		});
+	});
+
+	it("truncates the transport when Claude fails after streaming starts", async () => {
+		const response = await createAgentQueryRequestHandler({
+			async *query() {
+				yield successfulMessages()[1] as SDKMessage;
+				throw new Error("transport failed");
+			},
+			async verifyResponseAuthority() {},
+		})(request());
+		const reader = response.body?.getReader();
+		if (!reader) throw new Error("expected response body");
+
+		const first = await reader.read();
+		expect(new TextDecoder().decode(first.value)).toContain("message_start");
+		await expect(reader.read()).rejects.toThrow("transport failed");
+	});
+
+	it("imports no Run, Dispatch, queue, outbox, or background-execution control path", () => {
+		const root = join(import.meta.dir, "../../..");
+		const graph = workspaceImportGraph(
+			root,
+			join(import.meta.dir, "server.ts"),
+		);
+		for (const path of graph) {
+			for (const forbidden of [
+				"/run-store",
+				"/run-serving",
+				"/agentcore-dispatch",
+				"/queue",
+				"/outbox",
+				"/reclamation",
+				"/conversation-ownership",
+			]) {
+				expect(path).not.toContain(forbidden);
+			}
+		}
+	});
+});

--- a/apps/agent-query-runtime/src/server.test.ts
+++ b/apps/agent-query-runtime/src/server.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { Options, SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 import { workspaceImportGraph } from "@mymemo/test-support/import-graph";
@@ -6,6 +7,7 @@ import {
 	AGENTCORE_RUNTIME_SESSION_HEADER,
 	type AgentQueryRuntimeDependencies,
 	createAgentQueryRequestHandler,
+	createAgentQueryServerOptions,
 } from "./server";
 
 const conversationId = "0198b5a2-0d2b-7b64-9f65-4c9d49045111";
@@ -24,11 +26,40 @@ function resultEvent(overrides: Record<string, unknown> = {}): SDKMessage {
 	return {
 		type: "result",
 		subtype: "success",
+		duration_ms: 100,
+		duration_api_ms: 80,
 		is_error: false,
+		num_turns: 1,
 		result: "provider-only terminal echo",
+		stop_reason: "end_turn",
+		total_cost_usd: 0.01,
+		usage: {},
+		modelUsage: {},
+		permission_denials: [],
+		uuid: crypto.randomUUID(),
 		session_id: "agent-session-1",
 		...overrides,
-	} as SDKMessage;
+	} as unknown as SDKMessage;
+}
+
+function errorResultEvent(overrides: Record<string, unknown> = {}): SDKMessage {
+	return {
+		type: "result",
+		subtype: "error_during_execution",
+		duration_ms: 100,
+		duration_api_ms: 80,
+		is_error: true,
+		num_turns: 1,
+		stop_reason: null,
+		total_cost_usd: 0.01,
+		usage: {},
+		modelUsage: {},
+		permission_denials: [],
+		errors: ["private provider failure"],
+		uuid: crypto.randomUUID(),
+		session_id: "agent-session-1",
+		...overrides,
+	} as unknown as SDKMessage;
 }
 
 function successfulMessages(): SDKMessage[] {
@@ -115,14 +146,18 @@ describe("direct-response AgentCore Runtime HTTP boundary", () => {
 			.split("\n")
 			.map((line) => JSON.parse(line));
 		expect(lines).toEqual(messages.slice(1));
-		expect(lines.at(-1)).toEqual(resultEvent());
+		expect(lines.at(-1)).toEqual(messages.at(-1));
 		expect(queries).toEqual([
 			{
 				prompt: "Tell me something",
 				options: {
+					allowedTools: [],
 					model: "anthropic/claude-sonnet-5",
 					includePartialMessages: true,
 					cwd: `/workspace/conversations/${conversationId}`,
+					permissionMode: "dontAsk",
+					settingSources: [],
+					tools: [],
 					resume: "opaque-agent-session",
 				},
 			},
@@ -203,11 +238,7 @@ describe("direct-response AgentCore Runtime HTTP boundary", () => {
 	});
 
 	it("streams a terminal Claude failure without inventing an error event", async () => {
-		const failure = resultEvent({
-			subtype: "error_during_execution",
-			is_error: true,
-			errors: ["private provider failure"],
-		});
+		const failure = errorResultEvent();
 		const response = await createAgentQueryRequestHandler(
 			dependencies([...successfulMessages().slice(0, -1), failure]),
 		)(request());
@@ -218,6 +249,57 @@ describe("direct-response AgentCore Runtime HTTP boundary", () => {
 			.map((line) => JSON.parse(line));
 		expect(lines.at(-1)).toEqual(failure);
 		expect(lines.some((line) => line.type === "error")).toBe(false);
+	});
+
+	it("truncates the response rather than forwarding unsupported Claude content", async () => {
+		const hidden = [
+			streamEvent({
+				type: "message_start",
+				message: { id: "provider-tool-message", content: [] },
+			}),
+			streamEvent({
+				type: "content_block_start",
+				index: 0,
+				content_block: {
+					type: "tool_use",
+					id: "private-tool-use",
+					name: "PrivateTool",
+					input: {},
+				},
+			}),
+			streamEvent({
+				type: "content_block_delta",
+				index: 0,
+				delta: { type: "input_json_delta", partial_json: "{}" },
+			}),
+			streamEvent({ type: "content_block_stop", index: 0 }),
+			streamEvent({ type: "message_stop" }),
+		];
+		const response = await createAgentQueryRequestHandler(
+			dependencies([...hidden, ...successfulMessages()]),
+		)(request());
+
+		await expect(response.text()).rejects.toThrow(
+			"unsupported Claude content block",
+		);
+	});
+
+	it("truncates invalid or contradictory terminal Claude results", async () => {
+		const invalidResults = [
+			resultEvent({ subtype: "unknown_result" }),
+			resultEvent({ is_error: true }),
+			resultEvent({ duration_ms: undefined }),
+			resultEvent({ subtype: "error_during_execution", errors: [] }),
+		];
+
+		for (const result of invalidResults) {
+			const response = await createAgentQueryRequestHandler(
+				dependencies([...successfulMessages().slice(0, -1), result]),
+			)(request());
+			await expect(response.text()).rejects.toThrow(
+				"invalid terminal Claude result",
+			);
+		}
 	});
 
 	it("rejects a Claude startup failure without a second error protocol", async () => {
@@ -237,7 +319,9 @@ describe("direct-response AgentCore Runtime HTTP boundary", () => {
 	it("truncates the transport when Claude fails after streaming starts", async () => {
 		const response = await createAgentQueryRequestHandler({
 			async *query() {
-				yield successfulMessages()[1] as SDKMessage;
+				for (const message of successfulMessages().slice(1, 4)) {
+					yield message;
+				}
 				throw new Error("transport failed");
 			},
 			async verifyResponseAuthority() {},
@@ -245,17 +329,22 @@ describe("direct-response AgentCore Runtime HTTP boundary", () => {
 		const reader = response.body?.getReader();
 		if (!reader) throw new Error("expected response body");
 
-		const first = await reader.read();
-		expect(new TextDecoder().decode(first.value)).toContain("message_start");
-		await expect(reader.read()).rejects.toThrow("transport failed");
+		let received = "";
+		const decoder = new TextDecoder();
+		const drain = (async () => {
+			for (;;) {
+				const part = await reader.read();
+				if (part.done) return;
+				received += decoder.decode(part.value, { stream: true });
+			}
+		})();
+		await expect(drain).rejects.toThrow("transport failed");
+		expect(received).toContain("message_start");
 	});
 
-	it("imports no Run, Dispatch, queue, outbox, or background-execution control path", () => {
+	it("provides a Bun.serve image without importing Run or background-execution controls", () => {
 		const root = join(import.meta.dir, "../../..");
-		const graph = workspaceImportGraph(
-			root,
-			join(import.meta.dir, "server.ts"),
-		);
+		const graph = workspaceImportGraph(root, join(import.meta.dir, "index.ts"));
 		for (const path of graph) {
 			for (const forbidden of [
 				"/run-store",
@@ -269,5 +358,26 @@ describe("direct-response AgentCore Runtime HTTP boundary", () => {
 				expect(path).not.toContain(forbidden);
 			}
 		}
+
+		const entrypoint = readFileSync(join(import.meta.dir, "index.ts"), "utf8");
+		const dockerfile = readFileSync(
+			join(import.meta.dir, "../Dockerfile"),
+			"utf8",
+		);
+		expect(entrypoint).toContain("Bun.serve(");
+		expect(entrypoint).toContain(
+			'import { query } from "@anthropic-ai/claude-agent-sdk"',
+		);
+		expect(dockerfile).toContain('ENTRYPOINT [ "bun", "run", "src/index.ts" ]');
+	});
+
+	it("disables Bun's idle timeout for a long direct response", () => {
+		const options = createAgentQueryServerOptions(dependencies(), 4510);
+
+		expect(options.hostname).toBe("0.0.0.0");
+		expect(options.port).toBe(4510);
+		expect(options.idleTimeout).toBe(0);
+		expect(options.routes).toHaveProperty("/ping");
+		expect(options.routes).toHaveProperty("/invocations");
 	});
 });

--- a/apps/agent-query-runtime/src/server.ts
+++ b/apps/agent-query-runtime/src/server.ts
@@ -65,6 +65,7 @@ export type ResponseAuthorityVerifier = (authority: {
 
 export type AgentQueryRuntimeDependencies = {
 	query(input: { prompt: string; options: Options }): AsyncIterable<SDKMessage>;
+	prepareWorkingDirectory(path: string): Promise<void>;
 	verifyResponseAuthority: ResponseAuthorityVerifier;
 };
 
@@ -204,15 +205,18 @@ export function createAgentQueryRequestHandler(
 				conversationId: input.conversationId,
 				conversationEpoch: input.conversationEpoch,
 			});
+			const cwd = `/workspace/conversations/${input.conversationId}`;
+			await dependencies.prepareWorkingDirectory(cwd);
 			const messages = dependencies.query({
 				prompt: input.prompt,
 				options: {
 					allowedTools: [],
 					model: input.model,
 					includePartialMessages: true,
-					cwd: `/workspace/conversations/${input.conversationId}`,
+					cwd,
 					permissionMode: "dontAsk",
 					settingSources: [],
+					thinking: { type: "disabled" },
 					tools: [],
 					...(input.agentSessionId ? { resume: input.agentSessionId } : {}),
 				},

--- a/apps/agent-query-runtime/src/server.ts
+++ b/apps/agent-query-runtime/src/server.ts
@@ -1,0 +1,203 @@
+import type { Options, SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+import type { AgentQueryRequest } from "@mymemo/agent-query";
+import { z } from "zod";
+
+export const AGENTCORE_RUNTIME_SESSION_HEADER =
+	"x-amzn-bedrock-agentcore-runtime-session-id";
+
+const MAX_INVOCATION_BYTES = 64 * 1024;
+const identifier = z
+	.string()
+	.min(1)
+	.max(128)
+	.regex(/^[A-Za-z0-9_-]+$/);
+const agentQueryRequest = z.strictObject({
+	version: z.literal(1),
+	conversationId: identifier,
+	conversationEpoch: z.number().int().nonnegative(),
+	prompt: z.string().min(1).max(50_000),
+	model: z
+		.string()
+		.min(1)
+		.max(256)
+		.refine((value) => value.trim().length > 0),
+	agentSessionId: z.string().min(1).max(2_048).optional(),
+});
+
+export type ResponseAuthorityVerifier = (authority: {
+	conversationId: string;
+	conversationEpoch: number;
+}) => Promise<void>;
+
+export type AgentQueryRuntimeDependencies = {
+	query(input: { prompt: string; options: Options }): AsyncIterable<SDKMessage>;
+	verifyResponseAuthority: ResponseAuthorityVerifier;
+};
+
+class InvalidInvocationError extends Error {
+	override readonly name = "InvalidInvocationError";
+}
+
+async function readBoundedBody(request: Request): Promise<string> {
+	const declared = request.headers.get("content-length");
+	if (declared && Number(declared) > MAX_INVOCATION_BYTES) {
+		throw new InvalidInvocationError("AgentCore invocation body is too large");
+	}
+	if (!request.body) return "";
+
+	const reader = request.body.getReader();
+	const decoder = new TextDecoder();
+	let bytes = 0;
+	let body = "";
+	try {
+		for (;;) {
+			const part = await reader.read();
+			if (part.done) break;
+			bytes += part.value.byteLength;
+			if (bytes > MAX_INVOCATION_BYTES) {
+				throw new InvalidInvocationError(
+					"AgentCore invocation body is too large",
+				);
+			}
+			body += decoder.decode(part.value, { stream: true });
+		}
+		return body + decoder.decode();
+	} finally {
+		reader.releaseLock();
+	}
+}
+
+async function parseRequest(request: Request): Promise<AgentQueryRequest> {
+	let decoded: unknown;
+	try {
+		decoded = JSON.parse(await readBoundedBody(request));
+	} catch (error) {
+		if (error instanceof InvalidInvocationError) throw error;
+		throw new InvalidInvocationError("invalid Agent query request");
+	}
+	const parsed = agentQueryRequest.safeParse(decoded);
+	if (!parsed.success) {
+		throw new InvalidInvocationError("invalid Agent query request");
+	}
+	return parsed.data;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function isControlledTextEvent(message: SDKMessage): boolean {
+	if (message.type !== "stream_event" || !isRecord(message.event)) return false;
+	const event = message.event;
+	switch (event.type) {
+		case "message_start":
+		case "message_stop":
+		case "content_block_stop":
+			return true;
+		case "content_block_start":
+			return (
+				isRecord(event.content_block) && event.content_block.type === "text"
+			);
+		case "content_block_delta":
+			return isRecord(event.delta) && event.delta.type === "text_delta";
+		default:
+			return false;
+	}
+}
+
+function isValidResult(message: SDKMessage): boolean {
+	return (
+		message.type === "result" &&
+		typeof message.session_id === "string" &&
+		message.session_id.length > 0 &&
+		typeof message.subtype === "string" &&
+		typeof message.is_error === "boolean"
+	);
+}
+
+function createNdjsonStream(messages: AsyncIterable<SDKMessage>) {
+	const encoder = new TextEncoder();
+	return new ReadableStream<Uint8Array>({
+		async start(controller) {
+			try {
+				for await (const message of messages) {
+					if (message.type === "result") {
+						if (!isValidResult(message)) {
+							throw new Error("invalid terminal Claude result");
+						}
+						controller.enqueue(encoder.encode(`${JSON.stringify(message)}\n`));
+						controller.close();
+						return;
+					}
+					if (isControlledTextEvent(message)) {
+						controller.enqueue(encoder.encode(`${JSON.stringify(message)}\n`));
+					}
+				}
+				throw new Error("Claude stream ended before its terminal result");
+			} catch (error) {
+				controller.error(error);
+			}
+		},
+	});
+}
+
+function jsonError(message: string, status: number): Response {
+	return Response.json({ error: message }, { status });
+}
+
+export function createAgentQueryRequestHandler(
+	dependencies: AgentQueryRuntimeDependencies,
+) {
+	return async (request: Request): Promise<Response> => {
+		const { pathname } = new URL(request.url);
+		if (pathname === "/ping") {
+			if (request.method !== "GET") return jsonError("method not allowed", 405);
+			return Response.json({ status: "Healthy" });
+		}
+		if (pathname !== "/invocations") return jsonError("not found", 404);
+		if (request.method !== "POST") return jsonError("method not allowed", 405);
+		if (!request.headers.get("content-type")?.startsWith("application/json")) {
+			return jsonError("content type must be application/json", 415);
+		}
+
+		try {
+			const runtimeSessionId = request.headers.get(
+				AGENTCORE_RUNTIME_SESSION_HEADER,
+			);
+			if (
+				!runtimeSessionId ||
+				!identifier.safeParse(runtimeSessionId).success
+			) {
+				throw new InvalidInvocationError(
+					"Runtime session identity is required",
+				);
+			}
+			const input = await parseRequest(request);
+			if (runtimeSessionId !== input.conversationId) {
+				throw new InvalidInvocationError("Runtime session mismatch");
+			}
+			await dependencies.verifyResponseAuthority({
+				conversationId: input.conversationId,
+				conversationEpoch: input.conversationEpoch,
+			});
+			const messages = dependencies.query({
+				prompt: input.prompt,
+				options: {
+					model: input.model,
+					includePartialMessages: true,
+					cwd: `/workspace/conversations/${input.conversationId}`,
+					...(input.agentSessionId ? { resume: input.agentSessionId } : {}),
+				},
+			});
+			return new Response(createNdjsonStream(messages), {
+				status: 200,
+				headers: { "content-type": "application/x-ndjson" },
+			});
+		} catch (error) {
+			if (error instanceof InvalidInvocationError) {
+				return jsonError(error.message, 400);
+			}
+			return jsonError("AgentCore invocation failed", 503);
+		}
+	};
+}

--- a/apps/agent-query-runtime/src/server.ts
+++ b/apps/agent-query-runtime/src/server.ts
@@ -24,6 +24,40 @@ const agentQueryRequest = z.strictObject({
 	agentSessionId: z.string().min(1).max(2_048).optional(),
 });
 
+const resultBase = z
+	.object({
+		type: z.literal("result"),
+		duration_ms: z.number().nonnegative(),
+		duration_api_ms: z.number().nonnegative(),
+		is_error: z.boolean(),
+		num_turns: z.number().int().nonnegative(),
+		stop_reason: z.string().nullable(),
+		total_cost_usd: z.number().nonnegative(),
+		usage: z.record(z.string(), z.unknown()),
+		modelUsage: z.record(z.string(), z.unknown()),
+		permission_denials: z.array(z.unknown()),
+		uuid: z.string().min(1),
+		session_id: z.string().min(1),
+	})
+	.passthrough();
+const resultMessage = z.discriminatedUnion("subtype", [
+	resultBase.extend({
+		subtype: z.literal("success"),
+		is_error: z.literal(false),
+		result: z.string(),
+	}),
+	resultBase.extend({
+		subtype: z.enum([
+			"error_during_execution",
+			"error_max_turns",
+			"error_max_budget_usd",
+			"error_max_structured_output_retries",
+		]),
+		is_error: z.literal(true),
+		errors: z.array(z.string()),
+	}),
+]);
+
 export type ResponseAuthorityVerifier = (authority: {
 	conversationId: string;
 	conversationEpoch: number;
@@ -82,55 +116,52 @@ async function parseRequest(request: Request): Promise<AgentQueryRequest> {
 	return parsed.data;
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null;
-}
-
-function isControlledTextEvent(message: SDKMessage): boolean {
-	if (message.type !== "stream_event" || !isRecord(message.event)) return false;
-	const event = message.event;
-	switch (event.type) {
-		case "message_start":
-		case "message_stop":
-		case "content_block_stop":
-			return true;
-		case "content_block_start":
-			return (
-				isRecord(event.content_block) && event.content_block.type === "text"
-			);
-		case "content_block_delta":
-			return isRecord(event.delta) && event.delta.type === "text_delta";
-		default:
-			return false;
-	}
-}
-
-function isValidResult(message: SDKMessage): boolean {
-	return (
-		message.type === "result" &&
-		typeof message.session_id === "string" &&
-		message.session_id.length > 0 &&
-		typeof message.subtype === "string" &&
-		typeof message.is_error === "boolean"
-	);
-}
-
 function createNdjsonStream(messages: AsyncIterable<SDKMessage>) {
 	const encoder = new TextEncoder();
 	return new ReadableStream<Uint8Array>({
 		async start(controller) {
+			const write = (message: SDKMessage) => {
+				controller.enqueue(encoder.encode(`${JSON.stringify(message)}\n`));
+			};
 			try {
 				for await (const message of messages) {
 					if (message.type === "result") {
-						if (!isValidResult(message)) {
+						const result = resultMessage.safeParse(message);
+						if (!result.success) {
 							throw new Error("invalid terminal Claude result");
 						}
-						controller.enqueue(encoder.encode(`${JSON.stringify(message)}\n`));
+						write(message);
 						controller.close();
 						return;
 					}
-					if (isControlledTextEvent(message)) {
-						controller.enqueue(encoder.encode(`${JSON.stringify(message)}\n`));
+					if (message.type !== "stream_event") {
+						continue;
+					}
+
+					switch (message.event.type) {
+						case "message_start":
+						case "content_block_stop":
+						case "message_stop":
+							write(message);
+							break;
+						case "content_block_start":
+							if (
+								message.event.index !== 0 ||
+								message.event.content_block.type !== "text"
+							) {
+								throw new Error("unsupported Claude content block");
+							}
+							write(message);
+							break;
+						case "content_block_delta":
+							if (
+								message.event.index !== 0 ||
+								message.event.delta.type !== "text_delta"
+							) {
+								throw new Error("unsupported Claude content delta");
+							}
+							write(message);
+							break;
 					}
 				}
 				throw new Error("Claude stream ended before its terminal result");
@@ -149,13 +180,6 @@ export function createAgentQueryRequestHandler(
 	dependencies: AgentQueryRuntimeDependencies,
 ) {
 	return async (request: Request): Promise<Response> => {
-		const { pathname } = new URL(request.url);
-		if (pathname === "/ping") {
-			if (request.method !== "GET") return jsonError("method not allowed", 405);
-			return Response.json({ status: "Healthy" });
-		}
-		if (pathname !== "/invocations") return jsonError("not found", 404);
-		if (request.method !== "POST") return jsonError("method not allowed", 405);
 		if (!request.headers.get("content-type")?.startsWith("application/json")) {
 			return jsonError("content type must be application/json", 415);
 		}
@@ -183,9 +207,13 @@ export function createAgentQueryRequestHandler(
 			const messages = dependencies.query({
 				prompt: input.prompt,
 				options: {
+					allowedTools: [],
 					model: input.model,
 					includePartialMessages: true,
 					cwd: `/workspace/conversations/${input.conversationId}`,
+					permissionMode: "dontAsk",
+					settingSources: [],
+					tools: [],
 					...(input.agentSessionId ? { resume: input.agentSessionId } : {}),
 				},
 			});
@@ -199,5 +227,25 @@ export function createAgentQueryRequestHandler(
 			}
 			return jsonError("AgentCore invocation failed", 503);
 		}
+	};
+}
+
+export function createAgentQueryServerOptions(
+	dependencies: AgentQueryRuntimeDependencies,
+	port = 8080,
+) {
+	return {
+		hostname: "0.0.0.0",
+		port,
+		idleTimeout: 0,
+		routes: {
+			"/ping": {
+				GET: () => Response.json({ status: "Healthy" }),
+			},
+			"/invocations": {
+				POST: createAgentQueryRequestHandler(dependencies),
+			},
+		},
+		fetch: () => jsonError("not found", 404),
 	};
 }

--- a/apps/agent-query-runtime/tsconfig.json
+++ b/apps/agent-query-runtime/tsconfig.json
@@ -1,0 +1,19 @@
+{
+	"compilerOptions": {
+		"lib": ["ESNext"],
+		"target": "ESNext",
+		"module": "Preserve",
+		"moduleDetection": "force",
+		"moduleResolution": "bundler",
+		"allowImportingTsExtensions": true,
+		"verbatimModuleSyntax": true,
+		"noEmit": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"noFallthroughCasesInSwitch": true,
+		"noUncheckedIndexedAccess": true,
+		"noImplicitOverride": true,
+		"types": ["bun"]
+	},
+	"include": ["src/**/*.ts"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -28,6 +28,19 @@
         "drizzle-orm": "^0.45.2",
       },
     },
+    "apps/agent-query-runtime": {
+      "name": "agent-query-runtime",
+      "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "0.3.233",
+        "@mymemo/agent-query": "workspace:*",
+        "zod": "4.3.6",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "^2.3.11",
+        "@mymemo/test-support": "workspace:*",
+        "@types/bun": "^1.3.11",
+      },
+    },
     "apps/agentcore-dispatch-consumer": {
       "name": "agentcore-dispatch-consumer",
       "dependencies": {
@@ -469,6 +482,8 @@
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "agent-maintenance": ["agent-maintenance@workspace:apps/agent-maintenance"],
+
+    "agent-query-runtime": ["agent-query-runtime@workspace:apps/agent-query-runtime"],
 
     "agent-worker": ["agent-worker@workspace:packages/agent-worker"],
 
@@ -918,6 +933,8 @@
 
     "agent-maintenance/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
+    "agent-query-runtime/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+
     "agent-worker/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
     "agentcore-dispatch-consumer/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
@@ -1031,6 +1048,8 @@
     "@mymemo/test-support/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
     "agent-maintenance/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+
+    "agent-query-runtime/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
     "agent-worker/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -12,6 +12,7 @@ Use this guide when a change crosses service or package boundaries. For canonica
 | `apps/agentcore-dispatch-publisher` | Dedicated AgentCore Dispatch publication app. Runs as one ECS task, separate from chat-api and AgentCore Runtime. |
 | `apps/agentcore-dispatch-consumer` | AgentCore dispatch consumer Lambda and shared dispatch-boundary modules. Its production composition validates strict content-free SQS envelopes, invokes the Runtime, and returns partial-batch acknowledgements; the Runtime composes exact acquisition directly. |
 | `apps/agentcore-runtime` | Sole production execution runtime. The Linux ARM64 image exposes `/ping` and `/invocations`, exactly acquires one dispatched Run, and owns its Run-serving behavior. |
+| `apps/agent-query-runtime` | Non-production direct-response Runtime boundary. It validates one Agent query, invokes Claude once, and streams controlled native text events as NDJSON without Run or Dispatch control logic. |
 | `apps/agentcore-local-dispatch-bridge` | Development-only outbox poller that composes the shared publisher and consumer contracts against a local AgentCore Runtime. It is absent from production startup paths and images. |
 | `packages/agent-db` | Shared writable `mymemo_agent` data layer: schema, migrations, Run and Conversation Ownership transactions, runtime pointers, session transcripts, artifact metadata, and PGlite test support. |
 | `packages/agentcore-dispatch` | Production-neutral AgentCore Dispatch publication behavior, strict envelope serialization, and separately importable SQS and SSM adapters. |
@@ -55,6 +56,7 @@ Workspace persistence, Agent session continuity, Searchable document loading, an
 | `apps/agentcore-runtime/src/run-serving.ts` | Serving behavior for an already-running Run |
 | `apps/agentcore-runtime/src/sdk/` | SDK query wiring, transcript mirroring, tools, and AG-UI event projection |
 | `apps/agentcore-runtime/src/artifacts/` | Artifact discovery, upload, and publication for Runs with a `done` Outcome |
+| `apps/agent-query-runtime/src/server.ts` | Strict direct invocation, response-authority seam, one-query Claude projection, and NDJSON transport |
 | `packages/agentcore-dispatch/src/` | Shared AgentCore Dispatch publisher policy, envelope serialization, and isolated SQS/SSM adapters |
 | `packages/agent-db/src/conversation-ownership.ts` | Live Ownership renew, release, and mutation fence |
 | `packages/agent-db/src/run-store.ts` | Fenced Run state and Run event transactions |


### PR DESCRIPTION
Closes #563

## Summary

- add a separate non-production direct-response AgentCore Runtime application
- strictly validate `AgentQueryRequest` and Conversation-derived Runtime session identity
- verify injected response authority, invoke Claude exactly once with fail-closed options, and stream controlled native text events plus the terminal result as ordered NDJSON
- keep Run, Dispatch, queue, outbox, Ownership, Reclamation, and retry control paths out of the new app

## Problem

The existing AgentCore Runtime serves durable Runs through Dispatch and must remain unchanged while the direct-response architecture is built independently. This PR adds the producer half of the shared Agent-query contract without composing it into production.

## Key changes

- add a runnable `apps/agent-query-runtime` application with a `Bun.serve` entrypoint, exact `/invocations` and `/ping` routes, and a production container image
- prepare the deterministic Conversation working directory, then forward the validated prompt, model, optional opaque Agent session, and epoch authority to exactly one SDK query
- disable SDK tools, thinking, settings, and interactive permission prompts at this initial text-only boundary
- pass only the controlled native text-event subset, reject unsupported content, and require a structurally valid terminal Claude result
- truncate the transport on mid-stream Runtime failure and use native terminal Claude failures instead of a custom error event
- add an injectable response-authority verifier for later Postgres epoch/deadline enforcement
- add an import-graph invariant proving no durable Run execution controls are reachable

## Verification

- `bun test apps/agent-query-runtime/src/server.test.ts`: 12 passed, 0 failed
- `bun x tsc --noEmit -p apps/agent-query-runtime/tsconfig.json`: passed
- `bun x biome check apps/agent-query-runtime`: passed
- `git diff --check`: passed
- `bun run test`: 45 root tests and all 11 workspace suites passed
- local `linux/amd64` `docker build --target release -f apps/agent-query-runtime/Dockerfile -t mymemo-agent-query-runtime:review .`: passed
- release-image `/ping` smoke: `200 {"status":"Healthy"}`
- release-image invocation smoke: `200 application/x-ndjson` and the Conversation `cwd` was created before SDK startup
- release-image Claude executable smoke: `2.1.233 (Claude Code)`

The repository defines no general build script.

## Risks, limitations, and follow-up

- the controlled public subset is text streaming plus terminal Claude results; Tool UI and artifact publication remain out of scope
- real SessionStore, Workspace continuity, and non-production Chat API composition are deferred to #564
- production response fencing, resumption, deployment, Terraform, and cutover remain deferred to #565 and #566
- native `linux/arm64` release build/publish verification is deferred with the AgentCore deployment work in #566; the local container smoke used `linux/amd64`
- production composition is unchanged

## Screenshots

Not applicable; this is a trusted-service HTTP streaming boundary.
