### PR TITLE
Refactor AI chat routes to top-level composition

### DIFF
--- a/apps/chat-api/local/index.ts
+++ b/apps/chat-api/local/index.ts
@@ -3,7 +3,7 @@ import pino from "pino";
 import { createApp } from "../src/app";
 import { loadApiConfigFromEnv } from "../src/config/env";
 import { createDeps } from "../src/deps";
-import { createAiChatRoutes } from "../src/features/ai-chat/ai-chat.route";
+import aiChatRoutes from "../src/features/ai-chat/ai-chat.route";
 import { createHttpAgentQueryRuntimeInvoker } from "../src/features/ai-chat/http-agent-query-runtime-invoker";
 import { createS3ArtifactDownloadSigner } from "../src/features/artifacts/s3-artifact-download-signer";
 
@@ -17,6 +17,7 @@ const agentQueryRuntimeUrl =
 const logger = pino({ level: config.logLevel });
 const deps = createDeps(
 	config,
+	createHttpAgentQueryRuntimeInvoker({ runtimeUrl: agentQueryRuntimeUrl }),
 	createLiveStreamTelemetry("chat-api", logger),
 	{ isAgentEnabled: async () => true },
 	createS3ArtifactDownloadSigner(
@@ -35,11 +36,6 @@ process.once("SIGINT", () => void close());
 process.once("SIGTERM", () => void close());
 
 const app = createApp(config, deps);
-app.route(
-	"/api/chat",
-	createAiChatRoutes(
-		createHttpAgentQueryRuntimeInvoker({ runtimeUrl: agentQueryRuntimeUrl }),
-	),
-);
+app.route("/api/chat", aiChatRoutes);
 
 export default app;

--- a/apps/chat-api/src/deps.ts
+++ b/apps/chat-api/src/deps.ts
@@ -8,6 +8,7 @@ import {
 import type { Env as PinoEnv } from "hono-pino";
 import type { ApiConfig } from "./config/env";
 import type { ChatMessageStore } from "./features/ai-chat/chat-message-store";
+import type { AgentQueryRuntimeInvoker } from "./features/ai-chat/http-agent-query-runtime-invoker";
 import { PostgresChatMessageStore } from "./features/ai-chat/postgres-chat-message-store";
 import type { ArtifactDownloadSigner } from "./features/artifacts/artifact-download-signer";
 import type { ArtifactMetadataStore } from "./features/artifacts/artifact-metadata-store";
@@ -27,6 +28,8 @@ import {
 	type RunStore,
 } from "./features/run-store/run-store";
 
+export type { AgentQueryRuntimeInvoker };
+
 /**
  * Application dependencies, built once from a validated `ApiConfig` at the
  * composition root (`createApp`) and injected down the request path instead of
@@ -35,6 +38,8 @@ import {
  */
 export interface AppDeps {
 	config: ApiConfig;
+	/** Staged Agent-query Runtime boundary. */
+	agentQueryRuntimeInvoker: AgentQueryRuntimeInvoker;
 	/** Canonical AI SDK Conversation message persistence. */
 	chatMessageStore: ChatMessageStore;
 	/** Authoritative current Downloadable artifact metadata in Postgres. */
@@ -68,6 +73,7 @@ export type AppEnv = PinoEnv & {
 
 export function createDeps(
 	config: ApiConfig,
+	agentQueryRuntimeInvoker: AgentQueryRuntimeInvoker,
 	liveStreamTelemetry: LiveStreamTelemetry = createLiveStreamTelemetry(
 		"chat-api",
 		{
@@ -97,6 +103,7 @@ export function createDeps(
 	});
 	return {
 		config,
+		agentQueryRuntimeInvoker,
 		artifactMetadataStore: new PostgresArtifactMetadataStore(database),
 		artifactDownloadSigner,
 		conversationStore,

--- a/apps/chat-api/src/features/ai-chat/agent-query-continuity.integration.test.ts
+++ b/apps/chat-api/src/features/ai-chat/agent-query-continuity.integration.test.ts
@@ -25,7 +25,7 @@ import type {
 	ProvisionedSandbox,
 	ProvisionForRunInput,
 } from "../../../../agentcore-runtime/src/e2b/sandbox-provisioner";
-import { createAiChatRoutes } from "./ai-chat.route";
+import aiChatRoutes from "./ai-chat.route";
 import { PostgresChatMessageStore } from "./postgres-chat-message-store";
 
 const headers = {
@@ -184,31 +184,29 @@ describe("non-production Agent-query continuity", () => {
 						return true;
 					},
 				},
+				agentQueryRuntimeInvoker: {
+					async invoke(input: AgentQueryRequest) {
+						const response = await runtimeHandler(
+							new Request("http://runtime/invocations", {
+								method: "POST",
+								headers: {
+									"content-type": "application/json",
+									[AGENTCORE_RUNTIME_SESSION_HEADER]: input.conversationId,
+								},
+								body: JSON.stringify(input),
+							}),
+						);
+						if (!response.ok) throw new Error("Runtime invocation failed");
+						return (await response.text())
+							.trim()
+							.split("\n")
+							.map((line) => JSON.parse(line) as SDKMessage);
+					},
+				},
 			} as unknown as AppDeps);
 			await next();
 		});
-		app.route(
-			"/api/chat",
-			createAiChatRoutes({
-				async invoke(input: AgentQueryRequest) {
-					const response = await runtimeHandler(
-						new Request("http://runtime/invocations", {
-							method: "POST",
-							headers: {
-								"content-type": "application/json",
-								[AGENTCORE_RUNTIME_SESSION_HEADER]: input.conversationId,
-							},
-							body: JSON.stringify(input),
-						}),
-					);
-					if (!response.ok) throw new Error("Runtime invocation failed");
-					return (await response.text())
-						.trim()
-						.split("\n")
-						.map((line) => JSON.parse(line) as SDKMessage);
-				},
-			}),
-		);
+		app.route("/api/chat", aiChatRoutes);
 
 		for (const [messageId, prompt] of [
 			["user-1", "Start"],

--- a/apps/chat-api/src/features/ai-chat/ai-chat.query.test.ts
+++ b/apps/chat-api/src/features/ai-chat/ai-chat.query.test.ts
@@ -16,12 +16,9 @@ import { createTestDatabase, type TestDb } from "@mymemo/agent-db/testing";
 import type { AgentQueryRequest } from "@mymemo/agent-query";
 import { asc } from "drizzle-orm";
 import { Hono } from "hono";
-import type { AppDeps, AppEnv } from "@/deps";
+import type { AgentQueryRuntimeInvoker, AppDeps, AppEnv } from "@/deps";
 import { PostgresConversationStore } from "@/features/conversation-store/postgres-conversation-store";
-import {
-	type AgentQueryRuntimeInvoker,
-	createAiChatRoutes,
-} from "./ai-chat.route";
+import aiChatRoutes from "./ai-chat.route";
 import { PostgresChatMessageStore } from "./postgres-chat-message-store";
 
 type MessageStore = AppDeps["chatMessageStore"];
@@ -185,10 +182,11 @@ function buildApp(
 		c.set("deps", {
 			chatMessageStore: store,
 			exposureGate,
+			agentQueryRuntimeInvoker: runtimeInvoker,
 		} as unknown as AppDeps);
 		await next();
 	});
-	app.route("/api/chat", createAiChatRoutes(runtimeInvoker));
+	app.route("/api/chat", aiChatRoutes);
 	return app;
 }
 

--- a/apps/chat-api/src/features/ai-chat/ai-chat.route.ts
+++ b/apps/chat-api/src/features/ai-chat/ai-chat.route.ts
@@ -7,7 +7,6 @@ import {
 	projectToolUse,
 	publicToolName,
 } from "@mymemo/agent-db/tool-event-projection";
-import type { AgentQueryRequest } from "@mymemo/agent-query";
 import {
 	createUIMessageStream,
 	createUIMessageStreamResponse,
@@ -43,12 +42,6 @@ const AgentQueryChatBody = z.strictObject({
 	model: z.string(),
 	trigger: z.literal("submit-message"),
 });
-
-export type AgentQueryRuntimeInvoker = {
-	invoke(
-		request: AgentQueryRequest,
-	): Promise<AsyncIterable<SDKMessage> | Iterable<SDKMessage>>;
-};
 
 async function writeClaudeMessageStream(
 	writer: UIMessageStreamWriter<UIMessage>,
@@ -213,11 +206,11 @@ async function writeClaudeMessageStream(
 async function handleAgentQueryChat(
 	c: Context<AppEnv>,
 	body: z.infer<typeof AgentQueryChatBody>,
-	runtimeInvoker: AgentQueryRuntimeInvoker,
 ) {
 	if (!(AI_CHAT_MODELS as readonly string[]).includes(body.model)) {
 		return c.json({ error: "Unsupported model" }, 400);
 	}
+	const runtimeInvoker = c.var.deps.agentQueryRuntimeInvoker;
 	const ref = {
 		userId: c.var.identity.memberCode,
 		conversationId: body.id,
@@ -278,21 +271,20 @@ async function handleAgentQueryChat(
 	return createUIMessageStreamResponse({ stream });
 }
 
-export function createAiChatRoutes(runtimeInvoker: AgentQueryRuntimeInvoker) {
-	const routes = new Hono<AppEnv>();
-	routes.post(
-		"/",
-		bodyLimit({
-			maxSize: MAX_REQUEST_BODY_BYTES,
-			onError: (c) => c.json({ error: "Request body too large" }, 413),
-		}),
-		zValidator("json", AgentQueryChatBody, (result, c) => {
-			if (!result.success) {
-				return c.json({ error: "Invalid AI SDK chat input" }, 400);
-			}
-		}),
-		requireInternalIdentity,
-		(c) => handleAgentQueryChat(c, c.req.valid("json"), runtimeInvoker),
-	);
-	return routes;
-}
+const routes = new Hono<AppEnv>();
+routes.post(
+	"/",
+	bodyLimit({
+		maxSize: MAX_REQUEST_BODY_BYTES,
+		onError: (c) => c.json({ error: "Request body too large" }, 413),
+	}),
+	zValidator("json", AgentQueryChatBody, (result, c) => {
+		if (!result.success) {
+			return c.json({ error: "Invalid AI SDK chat input" }, 400);
+		}
+	}),
+	requireInternalIdentity,
+	(c) => handleAgentQueryChat(c, c.req.valid("json")),
+);
+
+export default routes;

--- a/apps/chat-api/src/features/ai-chat/http-agent-query-runtime-invoker.ts
+++ b/apps/chat-api/src/features/ai-chat/http-agent-query-runtime-invoker.ts
@@ -1,6 +1,12 @@
 import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 import type { AgentQueryRequest } from "@mymemo/agent-query";
 
+export type AgentQueryRuntimeInvoker = {
+	invoke(
+		request: AgentQueryRequest,
+	): Promise<AsyncIterable<SDKMessage> | Iterable<SDKMessage>>;
+};
+
 async function* parseNdjson(
 	body: ReadableStream<Uint8Array>,
 ): AsyncIterable<SDKMessage> {

--- a/apps/chat-api/src/index.ts
+++ b/apps/chat-api/src/index.ts
@@ -13,6 +13,11 @@ const productionConfig = loadApiConfigFromEnv(Bun.env);
 const productionLogger = pino({ level: productionConfig.logLevel });
 const productionDeps = createDeps(
 	productionConfig,
+	{
+		async invoke(): Promise<never> {
+			throw new Error("Agent-query Runtime is not enabled in production");
+		},
+	},
 	createLiveStreamTelemetry("chat-api", productionLogger),
 );
 const productionApp = createApp(productionConfig, productionDeps);


### PR DESCRIPTION
## Summary
- export AI chat routes as a top-level Hono route
- require the Agent-query Runtime invoker through AppDeps
- provide the HTTP invoker locally and an explicit disabled production implementation

## Verification
- Biome check
- TypeScript no-emit check
- 21 AI chat/runtime tests
- local Chat API boot test
- independent standards and spec reviews: no findings