### PR TITLE
fix(iam): allow AgentCore endpoint creation

### DIFF
--- a/infra/bootstrap-iam/main.tf
+++ b/infra/bootstrap-iam/main.tf
@@ -217,6 +217,7 @@ data "aws_iam_policy_document" "github_actions_deploy" {
     sid = "AgentCoreRuntimeManagement"
     actions = [
       "bedrock-agentcore:CreateAgentRuntime",
+      "bedrock-agentcore:CreateAgentRuntimeEndpoint",
       "bedrock-agentcore:DeleteAgentRuntime",
       "bedrock-agentcore:GetAgentRuntime",
       "bedrock-agentcore:GetAgentRuntimeEndpoint",


### PR DESCRIPTION
## Summary

- allow the production deploy role to create AgentCore Runtime endpoints
- unblock creation of the new Agent-query Runtime DEFAULT endpoint

## Verification

- `terraform -chdir=infra/bootstrap-iam validate -no-color`
- `git diff --check`