### PR TITLE
fix(iam): allow AgentCore workload identity creation

### DIFF
--- a/infra/bootstrap-iam/main.tf
+++ b/infra/bootstrap-iam/main.tf
@@ -218,6 +218,7 @@ data "aws_iam_policy_document" "github_actions_deploy" {
     actions = [
       "bedrock-agentcore:CreateAgentRuntime",
       "bedrock-agentcore:CreateAgentRuntimeEndpoint",
+      "bedrock-agentcore:CreateWorkloadIdentity",
       "bedrock-agentcore:DeleteAgentRuntime",
       "bedrock-agentcore:GetAgentRuntime",
       "bedrock-agentcore:GetAgentRuntimeEndpoint",


### PR DESCRIPTION
Root cause: creating the new Agent-query Runtime implicitly creates a workload identity, but the GitHub deploy role lacked bedrock-agentcore:CreateWorkloadIdentity. Add the exact missing action to the existing AgentCore runtime-management statement.\n\nVerified with Terraform validate, a live one-resource bootstrap plan/apply, direct IAM policy inspection, and a post-apply no-drift plan.