### PR TITLE
fix(deploy): restore agent-query release verification

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -402,6 +402,7 @@ jobs:
           DEPLOYED_RUNTIME_IMAGE_DIGEST: ${{ needs.plan.outputs.runtime_image_digest }}
           DEPLOYED_AGENT_QUERY_RUNTIME_IMAGE_DIGEST: ${{ needs.plan.outputs.agent_query_runtime_image_digest }}
         run: |
+          set -o pipefail
           record_dir="${RUNNER_TEMP}/agentcore-deployment"
           scripts/deploy/inspect_agentcore.sh | tee "${record_dir}/deployment-inspection.json"
           query_runtime_arn="$(terraform -chdir=infra/terraform output -raw agent_query_runtime_arn)"

--- a/infra/dev/agent-session-policy.json
+++ b/infra/dev/agent-session-policy.json
@@ -3,6 +3,14 @@
 	"Statement": [
 		{
 			"Effect": "Allow",
+			"Action": "s3:ListBucket",
+			"Resource": "arn:aws:s3:::mymemo-agent-local-artifacts",
+			"Condition": {
+				"StringLike": { "s3:prefix": ["agent-sessions/*"] }
+			}
+		},
+		{
+			"Effect": "Allow",
 			"Action": ["s3:GetObject", "s3:PutObject"],
 			"Resource": "arn:aws:s3:::mymemo-agent-local-artifacts/agent-sessions/*"
 		}

--- a/infra/terraform/agentcore-iam.tf
+++ b/infra/terraform/agentcore-iam.tf
@@ -216,6 +216,18 @@ data "aws_iam_policy_document" "query_runtime" {
   }
 
   statement {
+    sid       = "ListAgentSessions"
+    actions   = ["s3:ListBucket"]
+    resources = [aws_s3_bucket.artifacts.arn]
+
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+      values   = ["agent-sessions/*"]
+    }
+  }
+
+  statement {
     sid = "ManageRuntimeLogGroup"
     actions = [
       "logs:CreateLogGroup",

--- a/scripts/agent-query-runtime-infrastructure.test.ts
+++ b/scripts/agent-query-runtime-infrastructure.test.ts
@@ -26,9 +26,11 @@ describe("agent-query Runtime infrastructure", () => {
 		expect(queryRuntimeEnvironment).toContain("aws_s3_bucket.artifacts.bucket");
 		expect(queryRuntimePolicy).toContain('"s3:GetObject"');
 		expect(queryRuntimePolicy).toContain('"s3:PutObject"');
+		expect(queryRuntimePolicy).toContain('"s3:ListBucket"');
+		expect(queryRuntimePolicy).toContain('variable = "s3:prefix"');
+		expect(queryRuntimePolicy).toContain('values   = ["agent-sessions/*"]');
 		expect(queryRuntimePolicy).toContain("/agent-sessions/*");
 		expect(queryRuntimePolicy).not.toContain("/objects/*");
-		expect(queryRuntimePolicy).not.toContain("s3:ListBucket");
 		expect(queryRuntimePolicy).not.toContain("s3:DeleteObject");
 		expect(queryRuntimePolicy).not.toContain("s3:AbortMultipartUpload");
 	});
@@ -54,11 +56,36 @@ describe("agent-query Runtime infrastructure", () => {
 		expect(localPolicy.Statement).toEqual([
 			{
 				Effect: "Allow",
+				Action: "s3:ListBucket",
+				Resource: "arn:aws:s3:::mymemo-agent-local-artifacts",
+				Condition: {
+					StringLike: { "s3:prefix": ["agent-sessions/*"] },
+				},
+			},
+			{
+				Effect: "Allow",
 				Action: ["s3:GetObject", "s3:PutObject"],
 				Resource: "arn:aws:s3:::mymemo-agent-local-artifacts/agent-sessions/*",
 			},
 		]);
 		expect(verifyRuntime).toContain("bedrock-agentcore:InvokeAgentRuntime");
 		expect(verifyRuntime).toContain("bedrock-agentcore:StopRuntimeSession");
+	});
+
+	it("does not hide AgentCore inspection failures behind tee", () => {
+		const release = readFileSync(
+			".github/workflows/release-deploy.yml",
+			"utf8",
+		);
+		const verification = section(
+			release,
+			"- name: Verify AgentCore deployment, query invocation, and unchanged Dispatch control",
+			"- name: Roll ECS services",
+		);
+
+		expect(verification).toContain("set -o pipefail");
+		expect(verification.indexOf("set -o pipefail")).toBeLessThan(
+			verification.indexOf("scripts/deploy/inspect_agentcore.sh | tee"),
+		);
 	});
 });

--- a/scripts/deploy/agentcore_aws_checks.sh
+++ b/scripts/deploy/agentcore_aws_checks.sh
@@ -18,8 +18,8 @@ verify_agentcore_current_secrets() {
       --region "${region}" \
       --secret-id "${secret_arn}" \
       --include-deprecated \
-      --query 'Versions[?contains(VersionStages, `AWSCURRENT`)].VersionId' \
-      --output text | grep -q .
+      --output json \
+      | jq -e 'any(.Versions[]?; ((.VersionStages // []) | index("AWSCURRENT")) != null)' >/dev/null
   done < <(jq -r '.runtime_secret_arns.value[]' <<<"${terraform_output}")
 }
 

--- a/scripts/deploy/agentcore_aws_checks.test.ts
+++ b/scripts/deploy/agentcore_aws_checks.test.ts
@@ -131,6 +131,33 @@ verify_agentcore_dispatch_wiring us-west-2 "$TF_OUTPUT" "$EXPECTED_DISPATCH_VALU
 	});
 }
 
+function verifyCurrentSecrets(versions: Record<string, unknown>[]) {
+	const script = `
+set -euo pipefail
+source "${checksPath}"
+aws() {
+  case "$*" in
+    *"secretsmanager list-secret-version-ids"*)
+      if [[ "$*" == *"--query"* ]]; then exit 96; fi
+      printf '%s\n' "$VERSIONS"
+      ;;
+    *) exit 97 ;;
+  esac
+}
+verify_agentcore_current_secrets us-west-2 "$TF_OUTPUT"
+`;
+	return spawnSync("bash", ["-c", script], {
+		encoding: "utf8",
+		env: {
+			...process.env,
+			TF_OUTPUT: JSON.stringify({
+				runtime_secret_arns: { value: ["arn:secret:database"] },
+			}),
+			VERSIONS: JSON.stringify({ Versions: versions }),
+		},
+	});
+}
+
 function verifyConsumerRuntimeAuthority(simulation: Record<string, unknown>) {
 	const script = `
 set -euo pipefail
@@ -471,6 +498,25 @@ describe("production AgentCore dispatch wiring", () => {
 		const wiring = expectedWiring();
 		mutate(wiring);
 		expect(verify(wiring).status).not.toBe(0);
+	});
+});
+
+describe("production AgentCore current secrets", () => {
+	it("accepts a current version alongside stage-less deprecated versions", () => {
+		const result = verifyCurrentSecrets([
+			{ VersionId: "deprecated" },
+			{ VersionId: "current", VersionStages: ["AWSCURRENT"] },
+		]);
+		expect(result.status, result.stderr).toBe(0);
+	});
+
+	it("rejects a secret without a current version", () => {
+		expect(
+			verifyCurrentSecrets([
+				{ VersionId: "deprecated" },
+				{ VersionId: "previous", VersionStages: ["AWSPREVIOUS"] },
+			]).status,
+		).not.toBe(0);
 	});
 });
 


### PR DESCRIPTION
## Summary
- allow the Agent-query Runtime to distinguish missing session objects with prefix-scoped S3 bucket listing
- tolerate stage-less deprecated Secrets Manager versions during deployment inspection
- propagate inspection failures through the evidence tee pipeline

## Root cause
The query Runtime could read and write session objects but lacked the bucket-list permission S3 uses to return NoSuchKey for a missing object. The release smoke invocation therefore returned an empty stream after an AccessDenied error. A separate nullable VersionStages query also failed, but its exit status was hidden by the tee pipeline.

## Verification
- 35 focused tests pass
- Terraform configuration validates successfully
- the patched current-secret check passes against the affected managed RDS secret metadata
- git diff --check passes

Failed run: https://github.com/X-GPT/mymemo-agent/actions/runs/33020950614