### PR TITLE
docs(research): HarnessAgent on Vercel Sandbox research notes

### DIFF
--- a/docs/research/ai-sdk-harness-agent-api-2026.md
+++ b/docs/research/ai-sdk-harness-agent-api-2026.md
@@ -1,0 +1,202 @@
+# AI SDK `HarnessAgent` API
+
+**Research date: 2026-08-26.** This note reflects `@ai-sdk/harness` **1.0.87** and
+the corresponding Vercel AI SDK `main` source. The package is experimental, so
+minor releases can change this surface. Sources are limited to Vercel's official
+documentation and repository.
+
+## Short answer
+
+`HarnessAgent` is AI SDK 7's wrapper for running established agent runtimes such
+as Claude Code, Codex, Deep Agents, OpenCode, and Pi through the standard AI SDK
+`Agent` interface. It is published by Vercel in `@ai-sdk/harness` and imported
+from the `/agent` subpath:
+
+```ts
+import { HarnessAgent } from '@ai-sdk/harness/agent';
+```
+
+The package manifest identifies version 1.0.87 and maps `./agent` to its own
+JavaScript and declaration entry points
+([package manifest](https://github.com/vercel/ai/blob/main/packages/harness/package.json)).
+Vercel describes the abstraction as a common interface over external harnesses,
+with AI SDK-compatible generation and streaming results
+([AI SDK 7 announcement](https://vercel.com/changelog/ai-sdk-7),
+[harness architecture](https://github.com/vercel/ai/blob/main/architecture/harness-abstraction.md)).
+
+## `HarnessAgent` public properties
+
+| Property | Type | Purpose |
+| --- | --- | --- |
+| `version` | `'agent-v1'` | AI SDK `Agent` interface version used for compatibility. |
+| `id` | `string \| undefined` | Optional stable ID supplied in the constructor. |
+| `tools` | merged `ToolSet` | Adapter built-in tools plus user tools. A user tool wins if its name collides with a built-in. |
+| `harnessId` | `string` getter | Identifier of the configured underlying harness adapter. |
+
+These are the only public instance properties/getters declared by the class
+([`HarnessAgent` source](https://github.com/vercel/ai/blob/main/packages/harness/src/agent/harness-agent.ts#L119-L203)).
+
+## `HarnessAgent` public methods
+
+| Method | Purpose |
+| --- | --- |
+| `createSession(options?)` | Creates a new sandbox/runtime session or restores one. Returns a `HarnessAgentSession`, which must be supplied to turn methods. |
+| `generate(options)` | Runs a prompted turn and waits for completion, returning an AI SDK `GenerateTextResult`. |
+| `stream(options)` | Starts a prompted turn and returns an AI SDK `StreamTextResult` for incremental consumption. |
+| `continueGenerate(options)` | Continues an unfinished turn **without a new prompt**, waits for it, and returns a complete result. |
+| `continueStream(options)` | Streaming equivalent of `continueGenerate()`. |
+| `experimental_steer(options)` | Submits another user message to a currently running turn for the runtime's next safe input boundary. The resulting output stays in the current stream; the adapter must support steering. |
+
+The complete signatures and behavior are in the
+[`HarnessAgent` implementation](https://github.com/vercel/ai/blob/main/packages/harness/src/agent/harness-agent.ts#L204-L592).
+Steering was added in 1.0.78 and remains explicitly experimental
+([changelog](https://github.com/vercel/ai/blob/main/packages/harness/CHANGELOG.md#L268-L272)).
+
+### `createSession()` options
+
+```ts
+await agent.createSession({
+  sessionId?,       // generated when omitted
+  resumeFrom?,      // state from session.detach() or session.stop()
+  continueFrom?,    // state from session.suspendTurn()
+  sandboxSession?,  // caller-owned existing sandbox
+  abortSignal?,
+});
+```
+
+`resumeFrom` and `continueFrom` are mutually exclusive. For cross-process
+restoration, reuse the original `sessionId`. If `sandboxSession` is supplied,
+the caller retains its lifecycle; otherwise the configured sandbox provider
+creates or resumes it
+([source](https://github.com/vercel/ai/blob/main/packages/harness/src/agent/harness-agent.ts#L204-L458)).
+
+### Turn method inputs and results
+
+`generate()` and `stream()` take the normal AI SDK Agent call/stream parameters
+plus a required `session`. A prompt may be a string or model messages. With a
+message array, `HarnessAgent` uses pending approval/tool-result continuations
+when present; otherwise it forwards the last user message rather than replaying
+the full history, because the harness session owns prior-turn state
+([source](https://github.com/vercel/ai/blob/main/packages/harness/src/agent/harness-agent.ts#L459-L510),
+[input projection](https://github.com/vercel/ai/blob/main/packages/harness/src/agent/harness-agent.ts#L654-L703)).
+
+`continueGenerate()` and `continueStream()` accept:
+
+```ts
+{
+  session,
+  toolApprovalContinuations?,
+  toolResultContinuations?,
+  abortSignal?,
+}
+```
+
+They are for an already-started, unfinished turn restored with `continueFrom`;
+they do not send another prompt
+([source](https://github.com/vercel/ai/blob/main/packages/harness/src/agent/harness-agent.ts#L512-L579)).
+
+## Constructor settings
+
+```ts
+new HarnessAgent({
+  harness,           // required adapter
+  id?,
+  tools?,
+  skills?,
+  instructions?,
+  output?,           // typed/schema-backed output for every turn
+  stopWhen?,
+  permissionMode?,   // defaults to 'allow-all'
+  toolApproval?,
+  sandbox?,          // optional if every createSession supplies sandboxSession
+  sandboxConfig?: {
+    workDir?,
+    bootstrapHash?,
+    onBootstrap?,
+    onSession?,
+  },
+  activeTools?,       // mutually exclusive with inactiveTools
+  inactiveTools?,
+  telemetry?,
+  debug?,
+  onLog?,
+  onSandboxSession?,  // deprecated; use sandboxConfig.onSession
+});
+```
+
+The authoritative descriptions and generic types are in
+[`HarnessAgentSettings`](https://github.com/vercel/ai/blob/main/packages/harness/src/agent/harness-agent-settings.ts#L28-L199).
+Structured output via `output` was added in 1.0.73
+([changelog](https://github.com/vercel/ai/blob/main/packages/harness/CHANGELOG.md#L305-L309)).
+
+## Returned `HarnessAgentSession` surface
+
+Most lifecycle operations deliberately live on the session rather than the
+stateless agent definition:
+
+| Member | Purpose |
+| --- | --- |
+| `sessionId` | Stable session identifier used when restoring state. |
+| `isResume` | Whether this handle was created from resume/continuation state. |
+| `hasUnfinishedTurn()` | Reports whether the session has a non-idle turn. |
+| `compact(customInstructions?)` | Asks a supporting runtime to compact its context. Unsupported adapters throw `HarnessCapabilityUnsupportedError`. |
+| `experimental_steerTurn(text)` | Session-level implementation used by `agent.experimental_steer()`. |
+| `detach()` | Returns resumable state and invalidates the local handle while leaving the runtime/sandbox running. |
+| `stop()` | Returns resumable state, then stops the runtime and any harness-owned sandbox. |
+| `destroy()` | Cleans up without keeping resume state. |
+| `suspendTurn()` | Freezes an unfinished turn and returns serializable continuation state, leaving the runtime/sandbox running. |
+
+See the official
+[`HarnessAgentSession` source](https://github.com/vercel/ai/blob/main/packages/harness/src/agent/harness-agent-session.ts#L57-L167)
+and its
+[consumer lifecycle methods](https://github.com/vercel/ai/blob/main/packages/harness/src/agent/harness-agent-session.ts#L329-L492).
+`getSandboxSession()`, `getSessionWorkDir()`, `promptTurn()`, and `continueTurn()`
+are technically methods on the exported class, but the source documents or uses
+them as framework plumbing rather than the normal consumer API.
+
+## Other value exports from `@ai-sdk/harness/agent`
+
+The `/agent` module also exports:
+
+- `HarnessAgentSession`, `HarnessError`,
+  `HarnessCapabilityUnsupportedError`, and
+  `HarnessSandboxAuthenticationError`.
+- `collectHarnessAgentToolApprovalContinuations()` and
+  `collectHarnessAgentToolResultContinuations()` for recovering client-submitted
+  approval decisions and tool results from AI SDK message history.
+- `prepareHarnessSandboxTemplate()` for prewarming a provider-managed reusable
+  sandbox template; `prewarmHarness` is its deprecated alias.
+- `prepareSandboxForHarness()` for applying one or more harness bootstrap
+  recipes to a caller-owned sandbox before the caller snapshots or persists it.
+- `getHarnessErrorMessage()` for producing the public-facing message from a
+  harness error.
+- `createFileReporter()` and `createTraceTreeReporter()` for harness diagnostics.
+
+The exact value and type exports are listed in the official
+[`/agent` barrel](https://github.com/vercel/ai/blob/main/packages/harness/agent/index.ts).
+The continuation helpers' transformations are documented in their
+[approval source](https://github.com/vercel/ai/blob/main/packages/harness/src/agent/harness-agent-tool-approval-continuation.ts)
+and
+[tool-result source](https://github.com/vercel/ai/blob/main/packages/harness/src/agent/harness-agent-tool-result-continuation.ts).
+The sandbox preparation semantics are documented in
+[`prepareHarnessSandboxTemplate`](https://github.com/vercel/ai/blob/main/packages/harness/src/agent/prepare-harness-sandbox-template.ts)
+and
+[`prepareSandboxForHarness`](https://github.com/vercel/ai/blob/main/packages/harness/src/agent/prepare-sandbox-for-harness.ts).
+
+## Minimal lifecycle
+
+```ts
+const agent = new HarnessAgent({ harness, sandbox });
+const session = await agent.createSession();
+
+try {
+  const result = await agent.generate({ session, prompt: 'Inspect the repo.' });
+  console.log(result.text);
+} finally {
+  await session.destroy();
+}
+```
+
+There is no `respond()` method on `HarnessAgent`. Its direct turn APIs are
+`generate()` and `stream()`, plus the continuation and experimental steering
+methods above.

--- a/docs/research/ai-sdk-harness-agentcore-sandbox-feasibility-2026.md
+++ b/docs/research/ai-sdk-harness-agentcore-sandbox-feasibility-2026.md
@@ -1,0 +1,305 @@
+# Claude Harness inside MyMemo AgentCore: local session feasibility
+
+**Researched:** 2026-08-26
+
+**Updated scope:** Claude Code is the only AI SDK Harness adapter. Every Claude built-in tool is disabled. The only model-callable tools are MCP-shaped host tools whose implementations operate on the existing per-Conversation E2B sandbox.
+
+## Decision summary
+
+The exact **host-driven** design is feasible and is the best fit if MyMemo is willing to own a small `HarnessV1` adapter: keep `@anthropic-ai/claude-agent-sdk` in the trusted AgentCore process, keep every Claude built-in disabled, and expose only host tools whose effects go through the Conversation's E2B clients. This reuses MyMemo's current execution model and needs no Claude bridge, loopback port, `localWorkspace`, or bridge bootstrap.
+
+The caller-owned local-session design below remains a feasible alternative when the priority is using Vercel's upstream `createClaudeCode` adapter without owning the Claude-to-Harness protocol translation. It is bridge-backed, not host-driven.
+
+For that upstream alternative, use a caller-owned AI SDK basic `SandboxSession` backed by local Node/Bun filesystem and child-process APIs. Pass it to `HarnessAgent.createSession({ sandboxSession })`, and configure the Claude adapter with a fixed loopback bridge endpoint such as `ws://127.0.0.1:<port>`. This is **not** using AgentCore as the untrusted sandbox; it is using AgentCore as the trusted host for the Claude bridge.
+
+This preserves MyMemo's current trust boundary **if and only if**:
+
+- `activeTools` is an allowlist containing only MyMemo's E2B-backed user tools, which automatically excludes every present and future Claude built-in;
+- no untrusted/native `mcpServers` are configured directly on `createClaudeCode`;
+- every tool implementation ignores the local `experimental_sandbox` capability and explicitly uses the Conversation's E2B client;
+- any provider-executed built-in tool event is treated as a security failure, never approved;
+- the Claude adapter, bridge, Agent SDK, and their installed packages are treated as trusted code with access to the AgentCore container.
+
+The result is materially smaller than an AgentCore command-API sandbox provider. It avoids AWS command/file/port adapters entirely. The main work moves to the runtime image, process cleanup, persistence across AgentCore compute replacement, and security regression tests.
+
+## True Host-Driven Runtime
+
+**Verdict: yes, with a custom adapter.** Vercel defines the preferred host-driven shape as a runtime created in the host Node process, with remote file and shell operations translated to the supplied sandbox session; it explicitly requires no in-sandbox bridge and no sandbox port ([Vercel Harness architecture](https://github.com/vercel/ai/blob/main/architecture/harness-abstraction.md#host-driven-runtime)). That describes MyMemo more closely than `createClaudeCode`: the Claude Agent SDK already runs directly in AgentCore, while all prompt-directed file and command effects are implemented by E2B-backed clients.
+
+The qualification is important: this is a true host-driven Harness only while Claude's local `cwd`/home is adapter-private state and **not** the user workspace. The supplied E2B `sandboxSession` and its `sessionWorkDir` must remain the semantic workspace reached by the custom tools. If a future Claude feature requires native local workspace, process, or home access, Vercel's architecture says that feature requires bridge mode instead ([runtime-placement boundary](https://github.com/vercel/ai/blob/main/architecture/harness-abstraction.md#harness-and-sandbox-interaction)).
+
+```text
+HarnessAgent (AgentCore host)
+  -> custom MyMemo Claude HarnessV1
+       -> Claude Agent SDK query() (AgentCore host; native tools = [])
+            -> in-process MCP relay for this turn
+                 -> Harness tool-call (providerExecuted = false)
+                      -> HarnessAgent executes MyMemo ToolSet
+                           -> existing bounded/audited E2B clients
+```
+
+This is **not** a configuration of `createClaudeCode`. It is a new `HarnessV1` implementation around MyMemo's current direct SDK integration. The adapter should declare `specificationVersion: 'harness-v1'`, a stable `harnessId`, and `builtinTools: {}`; omit built-in approval/filtering claims and `getBootstrap`; optionally publish a schema for its serialized Claude session state; and implement `doStart()` ([`HarnessV1` contract](https://github.com/vercel/ai/blob/main/packages/harness/src/v1/harness-v1.ts)). A caller-owned **E2B-backed basic** `SandboxSession` is the honest session to pass to `HarnessAgent.createSession`: no network extension or provider is needed, and the object supplied to host tools as `experimental_sandbox` then represents the same E2B workspace as their existing bounded clients. The adapter must never stop or destroy that caller-owned sandbox ([start options](https://github.com/vercel/ai/blob/main/packages/harness/src/v1/harness-v1-session.ts#L15-L85)).
+
+### Concrete `HarnessV1` implementation surface
+
+| Required surface | MyMemo implementation |
+|---|---|
+| `doStart(options)` | Validate `resumeFrom`/`continueFrom`, bind `sessionId`, the supplied E2B session, and the persisted native Claude session id, then return the session object. Do not start a bridge. |
+| `doPromptTurn(options)` | Convert each `HarnessV1ToolSpec` (`name`, description, JSON Schema) into an in-process Claude MCP tool, call `query()`, and translate SDK messages into ordered `HarnessV1StreamPart` events. Reject unsupported JSON response formats explicitly. |
+| `HarnessV1PromptControl.submitToolResult()` | Resolve the pending MCP handler for that `toolCallId`, returning the host tool's output/error to Claude; `done` resolves only after all stream events are emitted. `submitUserMessage` and built-in approval support can be omitted initially. |
+| `doCompact()` | Required method; throw `HarnessCapabilityUnsupportedError` until the pinned Claude SDK exposes a tested manual-compaction mapping. |
+| `doContinueTurn(options)` | Continue without a new user prompt. Reattach in-process when possible; after compute replacement, re-drive from persisted Claude state and durably inject any pending host-tool result. The V1 contract permits lossy recomputation for host-resident runtimes, but not dropping a submitted tool result. |
+| `doSuspendTurn()` | Interrupt/close host-side consumption, persist the Claude session id plus the adapter cursor/journal needed to re-drive the unfinished turn, and return `continue-turn` state. |
+| `doDetach()` | Between turns, return `resume-session` state without deleting the E2B sandbox or Claude transcript. |
+| `doStop()` | Persist resumable state, interrupt/close the active SDK query, and return `resume-session` state. |
+| `doDestroy()` | Interrupt/close SDK work and discard adapter-local resumability state; leave the caller-owned E2B lifecycle to MyMemo. |
+
+Those methods are mandatory on every `HarnessV1Session`; the official contract specifically notes that host-resident runtimes may have to recompute the in-flight tail on `doContinueTurn()` ([session contract](https://github.com/vercel/ai/blob/main/packages/harness/src/v1/harness-v1-session.ts#L167-L272)). The stream translation must cover start, text/reasoning blocks, host tool calls/results, step and turn finish with usage, and errors ([stream-part contract](https://github.com/vercel/ai/blob/main/packages/harness/src/v1/harness-v1-stream-part.ts)).
+
+The tool loop should use the Harness host-tool rail rather than execute tools opaquely inside the adapter. `HarnessV1ToolSpec` explicitly says the adapter translates tool metadata for its native runtime, emits a tool call, and waits; it does not execute the tool itself ([tool-spec source](https://github.com/vercel/ai/blob/main/packages/harness/src/v1/harness-v1-tool-spec.ts)). `HarnessAgent` validates and executes any `providerExecuted: false` call, passes the supplied sandbox as `experimental_sandbox`, and returns the result through `submitToolResult` ([host-tool execution](https://github.com/vercel/ai/blob/main/packages/harness/src/agent/internal/run-prompt.ts#L1108-L1174)). This gives MyMemo native Harness tool approval, continuation, telemetry, and stream semantics while the actual handlers retain their current E2B bindings.
+
+MyMemo already has most of the execution core. Its pinned Claude Agent SDK is `0.3.233` ([runtime package](../../apps/agentcore-runtime/package.json)); `buildQueryOptions()` already sets `tools: []`, `settingSources: []`, `permissionMode: 'dontAsk'`, allows only the qualified executor MCP names, and installs one in-process MCP server ([current query options](../../apps/agentcore-runtime/src/sdk/start-run-query.ts)). `createRunMcpServer()` and the workspace handlers already close over the Run's fenced, bounded, audited E2B file/command clients ([current MCP tools](../../apps/agentcore-runtime/src/sdk/run-tools.ts), [workspace tools](../../apps/agentcore-runtime/src/sdk/workspace-tools.ts)). The migration work is to split the framework-neutral tool catalog from the Anthropic wrappers, replace the MCP handlers with pending-result resolvers, and translate the existing SDK stream into the V1 stream contract; the current `agent-stream.ts` provides parsing behavior but emits MyMemo Run events rather than `HarnessV1StreamPart` ([current stream adapter](../../apps/agentcore-runtime/src/sdk/agent-stream.ts)).
+
+| Design | Where Claude SDK runs | E2B access | Bridge/port | Assessment |
+|---|---|---|---|---|
+| **Custom Host-Driven `HarnessV1`** | AgentCore host, direct SDK | Harness host tools call E2B | None | **Recommended**; matches current MyMemo architecture, but MyMemo owns protocol/lifecycle correctness. |
+| `createClaudeCode` + caller-owned local session | AgentCore local bridge | Harness host tools call E2B | Required loopback bridge | Lower adapter ownership; adds bridge/bootstrap/process state. |
+| `createClaudeCode` + `localWorkspace` | AgentCore local bridge | Harness host tools call E2B | Required, managed by local workspace | Convenience wrapper for the same bridge-backed design; not isolation and not host-driven. |
+
+Estimated effort is **5–8 engineer-days for a spike** (one text turn, one E2B host tool, stream/usage mapping, stop/detach, built-in invariant test) and **3–5 engineer-weeks for production** (complete event mapping, durable resume/suspend/continue with pending results, structured-output policy, tool catalog migration, security/telemetry/load tests). The hardest item is cross-process continuation, not E2B execution. Recommendation: spike this host-driven adapter first and keep the existing direct SDK path as the rollback; use `createClaudeCode` only if maintaining the V1 translation proves costlier than accepting its bridge/runtime-image requirements.
+
+## Bridge-backed alternative: `createClaudeCode` in AgentCore
+
+```text
+Chat API -> dispatch -> trusted AgentCore Runtime (one Conversation session)
+                         |-- HarnessAgent
+                         |-- caller-owned LocalSandboxSession
+                         |     |-- fs/promises + streams
+                         |     |-- child_process.spawn + process groups
+                         |     `-- ws://127.0.0.1:<fixed-port>
+                         |-- Claude Code bridge + Claude Agent SDK
+                         `-- in-process "harness-tools" MCP relay
+                               `-- host tool execute() -> E2B API
+                                                     `-- untrusted Bash/files/workspace
+```
+
+The local `SandboxSession` is a compatibility adapter for trusted bridge bootstrap and process control. It must not be described or relied upon as MyMemo's security sandbox. E2B remains the only place where prompt-injectable commands and filesystem operations run.
+
+That matches MyMemo's documented `Split runtime`: the trusted AgentCore loop owns credentials and service coordination; E2B isolates prompt-injectable execution ([AgentCore Runtime guidance](../agents/agentcore-runtime.md), [Security boundaries](../agents/security.md), [ADR-0031](../adr/0031-make-agentcore-the-sole-execution-runtime.md)).
+
+## Why a basic caller-owned session is sufficient
+
+`HarnessAgent.createSession` accepts either a provider-managed network session or an existing basic `Experimental_SandboxSession`. When the caller supplies the session, the caller retains its lifecycle; Harness does not stop or destroy the surrounding AgentCore runtime ([Vercel `HarnessAgent` source](https://github.com/vercel/ai/blob/main/packages/harness/src/agent/harness-agent.ts#L204-L458)).
+
+The current Claude adapter explicitly supports this mode. With a basic session, `createClaudeCode` requires both:
+
+- `port: <number>`
+- `portEndpoint: { url: 'ws://127.0.0.1:<number>' }`
+
+It then starts the bridge through `sandboxSession.spawn()` and connects through that endpoint. The bridge token is added as an `agent_bridge_token` query parameter ([Vercel Claude adapter source](https://github.com/vercel/ai/blob/main/packages/harness-claude-code/src/claude-code-harness.ts#L817-L1140), [basic-session validation](https://github.com/vercel/ai/blob/main/packages/harness-claude-code/src/claude-code-harness.ts#L1144-L1205)).
+
+Because bridge and caller are in the same AgentCore microVM, the endpoint is ordinary loopback. AgentCore's public `/ws` route, SigV4 WebSocket signing, arbitrary port publication, `InvokeAgentRuntimeCommand`, and `StopRuntimeSession` are not involved.
+
+The local implementation only needs the AI SDK base contract:
+
+- `description` and a stable `defaultWorkingDirectory`
+- text, bytes, and stream file reads/writes
+- `run({ command, workingDirectory?, env?, abortSignal? })`
+- `spawn(...)` returning stdout/stderr byte streams, `wait()`, and `kill()`
+
+The authoritative type is Vercel's [`SandboxSession`/`SandboxProcess` source](https://github.com/vercel/ai/blob/main/packages/provider-utils/src/types/sandbox.ts). Implement `run` on top of the same `spawn` primitive; use a real POSIX shell because the Claude bootstrap and adapter issue shell command strings.
+
+## Tool routing and the trust boundary
+
+### What the current Claude adapter actually does
+
+`HarnessAgent` executes user-defined tools on the host and sends their results back to the adapter. Built-ins such as Claude's Bash normally execute inside the Claude runtime ([Vercel `HarnessAgent` source](https://github.com/vercel/ai/blob/main/packages/harness/src/agent/harness-agent.ts#L85-L117)).
+
+For Claude, the bridge turns user tools into an in-process MCP server named `harness-tools`. A model tool call is emitted to the host with `providerExecuted: false`; the bridge waits for the host result and returns it to Claude ([Vercel Claude bridge source](https://github.com/vercel/ai/blob/main/packages/harness-claude-code/src/bridge/index.ts#L231-L286)). This is a clean seam for MyMemo: each `execute()` callback resolves the Conversation's E2B sandbox and runs the operation there.
+
+Do not confuse these HarnessAgent `tools` with `createClaudeCode({ mcpServers })`. Native MCP server configuration is passed directly into the Claude Agent SDK inside the trusted bridge. Such a server would execute or be contacted from AgentCore unless its own implementation deliberately proxies to E2B. For the proposed design, leave adapter-level `mcpServers` empty and use only HarnessAgent user tools.
+
+### Disable all native tools with an allowlist
+
+Use `activeTools` containing only the user-tool names, rather than maintaining an `inactiveTools` denylist. Harness resolves this into an allow-mode built-in filter with an empty native allowlist and separately keeps only the named user tools ([Vercel filtering implementation](https://github.com/vercel/ai/blob/main/packages/harness/src/agent/internal/tool-filtering.ts)). The Claude bridge passes the resolved native set as the Agent SDK `tools` option and inactive names as `disallowedTools` ([Vercel Claude bridge source](https://github.com/vercel/ai/blob/main/packages/harness-claude-code/src/bridge/index.ts#L294-L365)).
+
+Illustrative shape:
+
+```ts
+const e2bTools = createConversationE2BTools(/* dependencies */);
+const harness = createClaudeCode({
+  port: 43127,
+  portEndpoint: { url: 'ws://127.0.0.1:43127' },
+  mcpServers: {},
+  env: { ENABLE_TOOL_SEARCH: 'false' },
+});
+
+const agent = new HarnessAgent({
+  harness,
+  tools: e2bTools,
+  activeTools: Object.keys(e2bTools),
+  // Built-ins are filtered, not made safe by this permission mode.
+  permissionMode: 'allow-all',
+});
+
+const session = await agent.createSession({
+  sessionId: conversationId,
+  sandboxSession: localBridgeSession,
+  resumeFrom,
+});
+```
+
+`ENABLE_TOOL_SEARCH=false` needs a live compatibility test and version pin. Claude Code may defer MCP tools and ask its native `ToolSearch` tool to hydrate them. Disabling every built-in also disables `ToolSearch`; preloading MCP definitions avoids that dependency. This behavior and workaround are documented in Vercel's official [Claude adapter issue #16694](https://github.com/vercel/ai/issues/16694), and current main recognizes `ToolSearch` as a native built-in ([Vercel Claude adapter source](https://github.com/vercel/ai/blob/main/packages/harness-claude-code/src/claude-code-harness.ts#L496-L503)).
+
+### What this does and does not protect
+
+It protects against the normal model tool-call path reaching local Bash, local files, web fetch, subagents, worktrees, skills, or other Claude built-ins. The only advertised model capabilities are audited MyMemo tools, and their effects occur in E2B.
+
+It does **not** create an OS boundary inside AgentCore:
+
+- the Claude bridge and Agent SDK are ordinary trusted processes in the same microVM as MyMemo credentials;
+- a compromised npm package, malicious adapter update, or bug allowing raw local execution can read the container environment and execution-role credentials;
+- `HarnessAgent` supplies the caller-owned session as `experimental_sandbox` to user-tool execution. MyMemo tools must not call it; route every prompt-derived path/command to E2B explicitly;
+- MCP tool outputs return through the trusted bridge and may be written to Claude's local transcript, so secrets from E2B responses must be minimized and redacted;
+- a model-emitted `providerExecuted: true` built-in call is an invariant violation. Fail the turn and alert rather than entering an approval path.
+
+AgentCore's microVM isolation is between different `runtimeSessionId` values, not between processes inside one session. AWS says commands and processes in a Runtime session share its container, filesystem, environment, and credentials ([AWS sessions](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-sessions.html), [AWS Runtime security best practices](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-security-best-practices.html)). The proposed safety therefore depends on capability filtering plus trusted dependencies, while E2B remains the hard boundary for model-directed effects.
+
+## MyMemo's AI SDK `ToolSet` adapter work
+
+MyMemo already has the right handlers, but not the shape `HarnessAgent` consumes. `buildRunTools()` currently returns Anthropic `SdkMcpToolDefinition[]`, and `createRunMcpServer()` wraps them in the SDK-native `mymemo-executor` MCP server ([current run tools](../../apps/agentcore-runtime/src/sdk/run-tools.ts), [workspace tools](../../apps/agentcore-runtime/src/sdk/workspace-tools.ts)). The handlers are already bound per Run to the E2B file/command clients, frozen document scope, audit hooks, limits, and taint handling.
+
+For HarnessAgent, expose the same handlers as an AI SDK `ToolSet` passed through `new HarnessAgent({ tools })`. Do not pass the existing `createRunMcpServer()` through `createClaudeCode({ mcpServers })`; that would bypass the HarnessAgent host-tool rail and its active-tool filtering.
+
+The maintainable implementation is a small framework-neutral definition layer:
+
+```text
+RunToolDefinition { name, description, Zod schema, execute }
+                 |-> Anthropic SDK MCP definition (legacy path)
+                 `-> AI SDK ToolSet entry (Harness path)
+```
+
+This avoids trying to reverse-engineer schemas and handlers out of `SdkMcpToolDefinition` objects and prevents the two tool catalogs from drifting. Construct the ToolSet per acquired Run so every closure retains the existing fenced `{ userId, conversationId, runId, sandboxId }` binding. Although `HarnessAgent` is designed to be reusable, its `tools` are construction-time state and its current runtime context is not a per-call dependency injection channel; a per-Run agent definition is the simplest safe choice.
+
+Three compatibility details need explicit tests:
+
+1. **Names.** Existing Claude events are MCP-qualified as `mcp__mymemo-executor__Bash`; the Harness bridge internally exposes `mcp__harness-tools__Bash` but emits the short user-tool name `Bash` back to HarnessAgent. MyMemo's durable tool-event projection currently recognizes the old qualified prefix, so add a single canonical name mapping at the projection boundary rather than encoding MCP transport names into the new ToolSet keys.
+2. **Results and errors.** Existing handlers return MCP `CallToolResult` envelopes (`content[]`, optional `isError`). An AI SDK tool `execute` should adapt that into the semantic output expected by the Harness relay and preserve error/repair behavior. Do not blindly return the MCP envelope or Claude will receive a JSON-encoded envelope inside another MCP result. Pin success, bounded error, and `PresentUI` repair cases with integration tests.
+3. **Sandbox argument.** HarnessAgent invokes user tools on the host and supplies the caller-owned session as `experimental_sandbox`. The adapter wrapper must deliberately discard that argument. Add a regression test whose local session methods throw if called during any tool execution; only the E2B clients captured in `RunToolDefinition.execute` may observe prompt-derived input.
+
+The active allowlist is then `Object.keys(toolSet)`. This replaces the current SDK-qualified `EXECUTOR_ALLOWED_TOOLS` only on the Harness path; the legacy path can keep its existing allowlist until removed.
+
+## Runtime image and bootstrap gaps
+
+This is the largest immediate implementation gap in the current repo.
+
+MyMemo's production image uses `oven/bun:1-distroless`, runs as UID 65532, and has no general shell-oriented toolchain ([current Dockerfile](../../apps/agentcore-runtime/Dockerfile)). The Claude adapter cannot run unchanged in that image:
+
+- both `@ai-sdk/harness` and `@ai-sdk/harness-claude-code` declare Node 22 or newer ([Harness package](https://github.com/vercel/ai/blob/main/packages/harness/package.json#L80-L82), [Claude adapter package](https://github.com/vercel/ai/blob/main/packages/harness-claude-code/package.json#L55-L57));
+- the bridge is launched with the literal `node .../bridge.mjs` command;
+- first bootstrap writes the bridge assets, runs `pnpm install --frozen-lockfile`, then executes the installed Claude CLI version check ([Vercel Claude bootstrap source](https://github.com/vercel/ai/blob/main/packages/harness-claude-code/src/claude-code-bootstrap.ts));
+- adapter setup uses POSIX commands such as `mkdir -p` and shell quoting.
+
+For a spike, use a non-distroless ARM64 image containing Node 22, `pnpm`, `/bin/sh`, and the minimal process/file utilities needed by the adapter. Run it as the existing non-root UID, make the selected working directory writable, and allow registry/model egress.
+
+For production, prefer a build-time-pinned bridge dependency set instead of installing packages from the public registry on first customer traffic. Current upstream does not expose a supported “preinstalled bridge; skip bootstrap” mode; Vercel tracks that limitation in [issue #18609](https://github.com/vercel/ai/issues/18609). Until upstream supports it, the practical choices are:
+
+1. keep the upstream runtime bootstrap, pin package versions/lockfile, use an internal registry/cache, and persist its output; or
+2. maintain a small, well-tested adapter patch that accepts an immutable preinstalled bridge path.
+
+Do not assume Bun's Node compatibility or a `node -> bun` symlink is sufficient. The bridge and Claude Agent SDK must be smoke-tested under the exact production image, architecture, UID, CA bundle, and network mode.
+
+## Persistence, stop, and resume
+
+AgentCore preserves the same filesystem and processes while a microVM is active, but idle timeout, maximum lifetime, explicit stop, or unhealthy compute replaces it. The logical Runtime session can wake on a new microVM using the same ID; only a configured session-storage mount survives ([AWS isolated sessions](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-sessions.html), [AWS lifecycle settings](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-lifecycle-settings.html)).
+
+The Claude adapter stores important state below the sandbox's default working directory:
+
+- `.harness-bootstrap/claude-code` for installed bridge assets and its bootstrap marker;
+- `.agent-runs/<sessionId>/bridge` for replay/lifecycle state;
+- the Harness session work directory.
+
+It can attach to a still-running bridge after `detach()`/`suspendTurn()`. If the process is gone, it respawns: a continued in-flight turn may replay its disk event log, while a between-turn resume asks Claude to continue its on-disk thread ([Vercel lifecycle source](https://github.com/vercel/ai/blob/main/packages/harness-claude-code/src/claude-code-harness.ts#L770-L791), [restart ladder](https://github.com/vercel/ai/blob/main/packages/harness-claude-code/src/claude-code-harness.ts#L928-L1006)).
+
+Required persistence design:
+
+- Configure AgentCore managed session storage and set the local session's `defaultWorkingDirectory` to its mounted subdirectory, not `/tmp` or the image filesystem.
+- Put Claude's effective `HOME` under the same mount, because Claude CLI thread history/config can otherwise remain in the ephemeral container home. Use a Conversation-specific directory and do not persist credentials there.
+- Persist `resumeFrom`/`continueFrom` and the exact `sessionId` in MyMemo's Postgres Run state. Recreate a new local session wrapper on the next invocation and pass it back to `createSession`.
+- Treat loopback bridge coordinates as an optimization only. A new microVM invalidates the old socket/process; disk replay or rerun must work.
+- Implement process groups and reaping in `spawn().kill()`. `session.stop()`/`destroy()` stops the bridge but, because the basic sandbox is caller-owned, it correctly does not stop the whole AgentCore Runtime.
+
+Managed session storage is currently Preview, limited, expires after 14 idle days, and is cleared on a Runtime version update. It also has filesystem feature gaps. EFS or S3 Files are alternatives but need tenant-path controls ([AWS filesystem configurations](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-filesystem-configurations.html), [AWS quotas](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/bedrock-agentcore-limits.html)). MyMemo's Postgres transcript mirror remains the durable product record; it is not automatically sufficient to reconstruct Claude's private native thread after local state loss. Define a clean “start new native Claude thread from product history/summary” fallback for storage expiry and deployments.
+
+One fixed bridge port is acceptable because MyMemo documents concurrency one per AgentCore Runtime session. Enforce one live Claude bridge per Conversation session, kill stale owners before binding, and fail closed on an unexpected listener. If that concurrency invariant changes, introduce a port allocator and per-session process registry.
+
+## Why a separate AgentCore sandbox Runtime is unnecessary here
+
+A second low-privilege AgentCore Runtime per Harness session remains the correct design if Claude built-ins must execute, arbitrary untrusted MCP servers must run, or model-controlled local code becomes a requirement. It would restore a hard microVM boundary but require an AWS file/process control RPC plus a `/ws` bridge proxy because AgentCore exposes fixed `/invocations` and `/ws` application routes rather than arbitrary child ports ([AWS HTTP contract](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-http-protocol-contract.html), [AWS WebSocket contract](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-get-started-websocket.html)).
+
+Under the narrowed scope, that second Runtime duplicates E2B without moving any model-directed work into it. It adds lifecycle, storage, auth, network, observability, and cost complexity for no new boundary. Keep E2B.
+
+## PR #19108: `localWorkspace` can replace the custom local session
+
+[PR #19108](https://github.com/vercel/ai/pull/19108) is open, stacked on #19107, and explicitly supersedes #18383. Its supported API is `workspace: localWorkspace({ path?, env? })`: `path` defaults to `process.cwd()`, is resolved and lazily created, and becomes the session work directory; `env` overlays the complete inherited host environment. The API rejects the filesystem root and home directory, but its source stresses that `path` selects where the harness works, not what it can reach. `workspace` and `sandbox` are mutually exclusive. If neither is set and `createSession` receives no caller-owned session, Harness creates an implicit current-directory workspace and warns once per process ([public API](https://github.com/vercel/ai/blob/039f675c38e1ca33c1c9f1b25caa3719f4fa661f/packages/harness/src/workspace/local-workspace.ts), [agent selection logic](https://github.com/vercel/ai/blob/039f675c38e1ca33c1c9f1b25caa3719f4fa661f/packages/harness/src/agent/harness-agent.ts#L210-L424)). MyMemo should always configure an explicit workspace path.
+
+The branch is a deep stack rather than a standalone patch: it includes open PRs #19099, #19100, #19102, and #19103 through #19108. Those prerequisites add graceful Claude interruption, bootstrap-on-resume, exact Claude conversation resume, `stateDirectory`, the history contract and Claude history reader, install consent, and use of the environment's own Claude executable. On 2026-08-26 the PR had no reviews and still required review. One latest Node 26 edge CI run was red in `kills the entire process tree on stop`; the corresponding Node suite passed, and the edge failure read an empty PID file because the test waits only for file existence before reading it, so it appears to be a test race rather than observed process-tree cleanup failure. It still makes the current branch unsuitable as a production dependency.
+
+The earlier “no public provider” description needs precision: the public `LocalWorkspace` value deliberately hides its `provider` as `@internal`, but its lazy implementation **does implement `HarnessV1SandboxProvider`**. It allocates one free loopback port, creates a network session, separates Harness state from the project, implements resume by rebinding to the same durable directories, and lets `HarnessAgent` own stop/destroy. Consumers are expected to use `workspace`, not import or depend on `LocalWorkspaceProvider` ([provider source](https://github.com/vercel/ai/blob/039f675c38e1ca33c1c9f1b25caa3719f4fa661f/packages/harness/src/workspace/local-workspace-provider.ts)). This is a higher-level alternative to merged [PR #19053](https://github.com/vercel/ai/pull/19053): #19053 remains the escape hatch for a caller-owned `sandboxSession`, while #19108 supplies and owns the local session internally.
+
+Internally, the local session is exactly the compatibility layer proposed in this note, with several useful hardening details already implemented:
+
+- File APIs and `bash -c` child processes run against the real host filesystem, accept absolute paths, inherit the host environment, and apply **no containment**. Children use detached process groups; abort, stop, destroy, and a process-exit reaper kill the group. The filesystem functions are captured before adapters can monkey-patch Node built-ins ([filesystem/process session](https://github.com/vercel/ai/blob/039f675c38e1ca33c1c9f1b25caa3719f4fa661f/packages/harness/src/workspace/local-workspace-sandbox-session.ts)).
+- The network session exposes `127.0.0.1` endpoints and intentionally omits `setNetworkPolicy` and `setPorts` because it cannot enforce either. Its allocated port is found by binding port zero and then closing the probe socket, so binding is not atomic, although one-Conversation-at-a-time makes the race small ([network session](https://github.com/vercel/ai/blob/039f675c38e1ca33c1c9f1b25caa3719f4fa661f/packages/harness/src/workspace/local-workspace-network-sandbox-session.ts), [allocator](https://github.com/vercel/ai/blob/039f675c38e1ca33c1c9f1b25caa3719f4fa661f/packages/harness/src/workspace/local-workspace-provider.ts#L182-L199)).
+- Harness-owned state goes to `~/.ai-sdk/harness/projects/<basename>-<path-hash>/` with a project manifest, or beneath the process-level `AI_SDK_HARNESS_STATE_DIR`. That override is read from `process.env`; passing it only in `localWorkspace({ env })` does not relocate the store. Bootstrap is cached by identity with a marker file and in-process promise, but different host processes are not lock-coordinated ([state layout](https://github.com/vercel/ai/blob/039f675c38e1ca33c1c9f1b25caa3719f4fa661f/packages/harness/src/workspace/local-workspace-state.ts), [bootstrap coordination](https://github.com/vercel/ai/blob/039f675c38e1ca33c1c9f1b25caa3719f4fa661f/packages/harness/src/workspace/local-workspace-provider.ts#L111-L180)).
+
+The forced complete environment inheritance is worth treating as a production constraint, not merely a convenience. `localWorkspace({ env })` can overlay values but cannot remove ambient AgentCore variables before bootstrap, bridge, and Claude child processes inherit them. MyMemo's current direct SDK path already supplies the trusted Runtime environment to Claude, so this is not a new regression, but it preserves that broad trusted-compute blast radius. If migration is also meant to narrow child-process credentials, the public workspace API is currently insufficient; use a caller-owned filtered session or request an upstream environment-filtering option.
+
+For Claude Code, the bootstrap is written beneath that state directory and runs `pnpm install --frozen-lockfile --no-optional`; omitting optional dependencies avoids bundled CLI binaries, but the environment must still provide `node`, `pnpm`, `bash`, and a working `claude`. The bridge is launched as `node .../bridge.mjs --workdir <project> --bridge-state-dir <state>/.agent-runs/<sessionId>/bridge`. Because a local workspace declares `environmentOwner: 'user'`, a missing Claude executable is not installed by default; server-side MyMemo should bake and pin it rather than enable runtime global `npm install` ([Claude bootstrap](https://github.com/vercel/ai/blob/039f675c38e1ca33c1c9f1b25caa3719f4fa661f/packages/harness-claude-code/src/claude-code-bootstrap.ts), [bridge start](https://github.com/vercel/ai/blob/039f675c38e1ca33c1c9f1b25caa3719f4fa661f/packages/harness-claude-code/src/claude-code-harness.ts#L919-L1170), [executable resolution](https://github.com/vercel/ai/blob/039f675c38e1ca33c1c9f1b25caa3719f4fa661f/packages/harness-claude-code/src/resolve-claude-executable.ts)). This makes MyMemo's current Bun distroless image a hard blocker; adopting #19108 does not remove the image work described above.
+
+Lifecycle is split between Harness and the runtime's durable stores. `detach()` keeps a live bridge attachable within the same AgentCore process; the exit reaper kills it when that process exits. On resume in a replacement process, the provider reopens the same project/state paths and the Claude adapter first tries the saved loopback coordinates, then respawns and uses disk replay or the Claude thread ID. `stop()` and `destroy()` reap bridge process trees but never delete the project or central state ([local resume](https://github.com/vercel/ai/blob/039f675c38e1ca33c1c9f1b25caa3719f4fa661f/packages/harness/src/workspace/local-workspace-provider.ts#L79-L109), [Claude recovery ladder](https://github.com/vercel/ai/blob/039f675c38e1ca33c1c9f1b25caa3719f4fa661f/packages/harness-claude-code/src/claude-code-harness.ts#L982-L1168)). The central Harness store does **not** contain Claude's native `~/.claude/projects/<workdir>` history. For AgentCore compute replacement, MyMemo must place all three of the explicit workspace, `AI_SDK_HARNESS_STATE_DIR`, and Claude's effective writable home on the per-Conversation persistent mount, while keeping credentials out of persisted home state.
+
+For MyMemo, therefore, #19108 can replace both the proposed handwritten local basic session and any custom local `HarnessV1SandboxProvider` once the stacked work lands in a consumable release. Configure one explicit workspace per Conversation/AgentCore session and retain the Conversation UUID as Harness `sessionId`; let the internal provider allocate loopback and own bridge cleanup. It does **not** replace E2B and does not strengthen isolation. Continue to pass only E2B-backed host tools in `activeTools`, keep Claude native built-ins empty, and keep the regression test that fails if any host tool touches `experimental_sandbox`—under `localWorkspace`, that object has unrestricted host file/process authority. Until #19108 and its prerequisite stack merge, the caller-owned session from #19053 remains the stable implementation path; copying the internal provider would couple MyMemo to an open, changing API.
+
+## Upstream issues and PRs
+
+Status checked 2026-08-26 against the Vercel AI GitHub repository:
+
+- The provider/session foundation is shipped: [PR #15919](https://github.com/vercel/ai/pull/15919) merged `HarnessV1NetworkSandboxSession`, `HarnessV1SandboxProvider`, and the initial Vercel/just-bash providers.
+- Provider expansion remains open. The umbrella [issue #16100](https://github.com/vercel/ai/issues/16100) was split into eight open provider issues: [#17635 Sprites](https://github.com/vercel/ai/issues/17635), [#17636 E2B](https://github.com/vercel/ai/issues/17636), [#17637 Modal](https://github.com/vercel/ai/issues/17637), [#17638 Cloudflare](https://github.com/vercel/ai/issues/17638), [#17639 OpenSandbox](https://github.com/vercel/ai/issues/17639), [#17640 Tensorlake](https://github.com/vercel/ai/issues/17640), [#17641 Daytona](https://github.com/vercel/ai/issues/17641), and [#17642 Runloop](https://github.com/vercel/ai/issues/17642). The E2B issue specifically targets a first-party bridge-capable provider and a live WebSocket `101` verification. Two provider implementations are open: [PR #16265 Tensorlake](https://github.com/vercel/ai/pull/16265) and [PR #16270 Sprites](https://github.com/vercel/ai/pull/16270).
+- The exact primitive proposed here is upstream: merged [PR #19053](https://github.com/vercel/ai/pull/19053) added `createSession({ sandboxSession })`, made the constructor's provider optional, and kept caller-supplied lifecycle caller-owned.
+- Host-local work is still active. Open [PR #19108](https://github.com/vercel/ai/pull/19108) supersedes closed [PR #18383](https://github.com/vercel/ai/pull/18383); its supported surface is `workspace: localWorkspace(...)`, backed internally by a non-public `HarnessV1SandboxProvider`. If released, it can replace MyMemo's custom caller-owned local session; until then, #19053 is the shipped path.
+- Native Claude SDK sandbox-option forwarding for host-based providers is still open as [issue #17085](https://github.com/vercel/ai/issues/17085) and [PR #17096](https://github.com/vercel/ai/pull/17096). It matters if Claude built-ins execute locally; MyMemo's all-built-ins-disabled design should not depend on it.
+- The microVM bootstrap-cache problem reported in [issue #18210](https://github.com/vercel/ai/issues/18210) is fixed: merged [PR #18294](https://github.com/vercel/ai/pull/18294) moved relative adapter bootstrap state from `/tmp` under the sandbox default working directory. This supports the persistent-directory plan above.
+- Repository searches found no AgentCore- or AWS-specific Harness sandbox provider issue/PR. Existing AgentCore hits concern the unrelated tools registry/docs, not `@ai-sdk/harness`; see the live GitHub [issue search](https://github.com/vercel/ai/issues?q=repo%3Avercel%2Fai+AgentCore+harness+sandbox) and [PR search](https://github.com/vercel/ai/pulls?q=repo%3Avercel%2Fai+AgentCore+harness+sandbox).
+
+## Effort estimate
+
+These are engineering estimates inferred from the current code and contracts.
+
+| Deliverable | Estimate | Includes |
+|---|---:|---|
+| Host-driven custom `HarnessV1` proof of concept | **5–8 engineer-days** | Direct SDK wrapper, one text turn, one E2B host tool, V1 stream/usage mapping, stop/detach, and built-in invariant test. |
+| Host-driven production integration | **3–5 engineer-weeks** | Full event translation, tool catalog migration, durable suspend/continue with pending results, structured-output policy, telemetry, security/load tests, and rollback. |
+| Local-session proof of concept | **3–5 engineer-days** | Node-capable dev image, local file/process adapter, loopback bridge, all-built-ins-off test, one E2B tool, one turn and cleanup. |
+| MyMemo integration spike | **1–2 engineer-weeks** | ARM64 image, Conversation mapping, E2B tool relay, Run streaming, resume payload persistence, forced bridge restart, basic metrics. |
+| Production hardening | **3–6 engineer-weeks** | pinned/bootstrap strategy, managed-storage/deployment fallback, process registry/reaping, security regression suite, dependency/egress policy, load/failure tests, observability and rollback. |
+| Separate AgentCore sandbox Runtime | **add 6–10+ engineer-weeks** | Only justified if untrusted execution moves out of E2B; includes control RPC, WebSocket proxy, IAM/network isolation, cleanup, and conformance tests. |
+
+## Spike acceptance criteria
+
+1. In a captured Claude SDK start, the native `tools` set is empty and all native tools are disallowed; only expected `mcp__harness-tools__*` calls can complete.
+2. Attempts to elicit Bash, Read, WebFetch, Agent/subagent, Skill, worktree, or an unknown future built-in produce no local effect and fail the turn if emitted.
+3. Every prompt-derived command/path is observed at the E2B client boundary, never at local `spawn` except adapter-owned bootstrap/bridge commands.
+4. The bridge binds loopback only, requires its random token, and no non-loopback port is exposed.
+5. A stopped bridge respawns from persisted state; a simulated fresh microVM restores the mounted directories and resumes or cleanly falls back to a new native thread.
+6. Aborted turns, bootstrap failure, timeout, and handler shutdown leave no child/process-group or port owner behind.
+7. The production ARM64/non-root image passes a live Claude tool call through E2B without writing model credentials into the persistent mount.
+
+## Conclusion
+
+For Claude-only with all native tools disabled, MyMemo should first spike a custom host-driven `HarnessV1` around its existing direct Claude SDK path. It is the only option here that is genuinely host-driven: E2B remains the supplied semantic workspace, custom Harness tools are relayed to Claude through in-process MCP, and no Claude bridge, local workspace provider, or network sandbox session is involved.
+
+A caller-owned local `SandboxSession` remains a sensible compatibility layer for the alternative upstream `createClaudeCode` path and does not need to become an AgentCore sandbox provider. That bridge-backed design also preserves MyMemo's security model when every model-directed effect remains in E2B, but it carries more runtime/bootstrap/process machinery.
+
+The claim is conditional, not absolute: the local Claude dependency chain shares the trusted AgentCore microVM and credentials. The design must enforce a custom-tool allowlist, treat any built-in execution as a fault, avoid native MCP servers, and keep tool implementations explicitly E2B-backed. With those controls, the remaining risks are conventional trusted-runtime supply chain, image/bootstrap, and persistence risks—not prompt-injectable local shell access.

--- a/docs/research/ai-sdk-harness-bun-host-compatibility-2026.md
+++ b/docs/research/ai-sdk-harness-bun-host-compatibility-2026.md
@@ -1,0 +1,326 @@
+# AI SDK Harness host packages under Bun (chat-api)
+
+**Research date: 2026-08-26.** This note answers
+[issue #586](https://github.com/X-GPT/mymemo-agent/issues/586): can `@ai-sdk/harness`
+and `@ai-sdk/harness-claude-code` run inside the chat-api process under **Bun**, given
+both declare `engines.node >= 22`? Scope is the **host side only**: the process that
+constructs `HarnessAgent`, talks to the Vercel Sandbox API, and holds the WebSocket to
+the bridge. The bridge and the Claude CLI run inside the Vercel Sandbox and are out of
+scope. Versions checked: `@ai-sdk/harness` 1.0.91, `@ai-sdk/harness-claude-code`
+1.0.94, `@ai-sdk/sandbox-vercel` 1.0.91, `@vercel/sandbox` 3.1.0, `ai` 7.0.83,
+Bun 1.3.0, Node 24.19.0 (macOS x86_64). Companion notes:
+[`HarnessAgent` API](ai-sdk-harness-agent-api-2026.md) and
+[Claude Harness inside AgentCore](ai-sdk-harness-agentcore-sandbox-feasibility-2026.md);
+the latter's warning against relying on Bun's Node compatibility is about running the
+**bridge** inside MyMemo's Bun image, which this note does not contradict.
+
+## Short answer
+
+**Yes, with high confidence, and there is no Node-only host dependency.** Concretely:
+
+- The `>= 22` engines field is the only Node-specific claim. Vercel's own code path is
+  explicitly Bun-aware: merged PR
+  [vercel/ai#16069 "make listening for sandbox bridge readiness compatible with Bun"](https://github.com/vercel/ai/pull/16069)
+  (merged 2026-06-12) exists because Bun hosts were already in use. Bun does not enforce
+  `engines` at install or run time.
+- Every Node built-in the host side imports (`crypto`, `fs`, `fs/promises`, `path`, `os`,
+  `url`, `child_process`, `stream`, `zlib`, `timers/promises`) is listed as fully
+  implemented by Bun, with caveats that do not touch the used surface.
+- The WebSocket client to the bridge is the npm `ws` package. Bun replaces `ws` with a
+  built-in shim; the four calls the adapter makes (`new WebSocket(url, { headers })`,
+  `on`/`off` for `open|message|close|error`, `terminate()`) all work, verified with a
+  loopback round-trip under Bun 1.3.0.
+- `@vercel/sandbox` passes an `undici` `Agent({ bodyTimeout: 0 })` as `dispatcher`; Bun
+  substitutes its own inert `undici` shim and its `fetch` ignores `dispatcher`, so the
+  call succeeds, and the intent (no body-idle timeout on long log streams) is preserved
+  because Bun's `fetch` has no default timeout.
+- `ai` 7's `toUIMessageStreamResponse()` returns a standard `Response`; through Hono on
+  `Bun.serve` it streamed 7 SSE chunks at the model's 200 ms cadence with no buffering.
+- `import { HarnessAgent } from "@ai-sdk/harness/agent"` and `createClaudeCode()` load
+  and construct under Bun with zero errors.
+
+Not verified: a live bridge connection (needs Vercel Sandbox credentials) and the exact
+Bun version in the floating `oven/bun:1` image. Both belong in the adoption spike's smoke
+test, not in this note.
+
+**Fallback if Bun ever blocks:** keep Bun for install and tests, add a
+`bun build --target=node` stage, run the bundle on a `node:22` image behind
+`@hono/node-server`. The bundle already boots under Node 24 with a two-line shim; the
+real code change is three `Bun.env` reads and one `serve()` call. Roughly a day.
+
+## What the `engines` field actually says
+
+- `@ai-sdk/harness` 1.0.91: `"engines": { "node": ">=22" }`; `ws ^8.21.0` is an
+  **optional** peer dependency
+  ([package.json](https://github.com/vercel/ai/blob/main/packages/harness/package.json)).
+- `@ai-sdk/harness-claude-code` 1.0.94: `"engines": { "node": ">=22" }`; `ws ^8.21.0`
+  is a **hard** dependency
+  ([package.json](https://github.com/vercel/ai/blob/main/packages/harness-claude-code/package.json)).
+- `@ai-sdk/sandbox-vercel` 1.0.91 also declares `node >= 22`; `@vercel/sandbox` 3.1.0
+  declares no engines (local `jq` over the installed manifests, output below).
+- Vercel's docs state "Node.js 22 or later" as a prerequisite
+  ([KB guide](https://vercel.com/kb/guide/sandboxed-coding-agent-with-harnessagent)),
+  and the `HarnessAgent` docs' `runtime: 'node24'` refers to the **sandbox** image, not
+  the host ([HarnessAgent docs](https://ai-sdk.dev/docs/ai-sdk-harnesses/harness-agent)).
+  Neither the [harness overview](https://ai-sdk.dev/docs/ai-sdk-harnesses/overview) nor
+  the [Claude Code adapter page](https://ai-sdk.dev/providers/ai-sdk-harnesses/claude-code)
+  says anything for or against Bun; the adapter page only requires "a network sandbox
+  with at least one exposed port, e.g. `@ai-sdk/sandbox-vercel`".
+- Bun ignores `engines`: `bun add` installed all three packages silently (output below),
+  and the open Bun issue
+  [oven-sh/bun#14030](https://github.com/oven-sh/bun/issues/14030) asks for
+  `engineStrict` precisely because Bun currently does not check it.
+
+The strongest primary signal is upstream itself. PR
+[#16069](https://github.com/vercel/ai/pull/16069) describes the bug as "Bun can miss
+`stdout` from detached sandbox bridge processes that bind an exposed port, so Claude
+Code/Codex startup timed out waiting for `bridge-ready`", and the fix as "a shared
+harness readiness helper that keeps `stdout` as the primary signal, falls back to the
+bridge metadata file, and marks startup state". That helper ships today as
+`waitForBridgeReady` in `@ai-sdk/harness/dist/utils/index.js`, which races the
+sandbox process's stdout against a poll of the bridge metadata file (local read of
+`src/utils/bridge-ready.ts` in the installed dist). It is part of the Vercel Sandbox
+path, so chat-api gets it for free.
+
+## Host-side Node API surface and Bun coverage
+
+Imports were enumerated from the installed dists with
+`grep -ohE '(from|require\()\s*"[^./][^"]*"' node_modules/<pkg>/dist/**/*.js | sort | uniq -c`.
+Bun statuses are quoted from
+[Bun's Node.js APIs page](https://bun.com/docs/runtime/nodejs-apis) ("reflects the
+latest version of Bun's compatibility with Node.js v26").
+
+| Module | Used by (host) | Bun status |
+| --- | --- | --- |
+| `crypto` (`randomBytes`) | harness, adapter | Partially implemented; missing `encapsulate`/`decapsulate` and some key/cipher types, none used |
+| `fs`, `fs/promises` | harness, adapter, `@vercel/sandbox` | "Fully implemented. 98% of Node.js's test suite passes." |
+| `path`, `os`, `url` | harness, adapter, `@vercel/sandbox` | "Fully implemented." |
+| `child_process` (`execFileSync`) | adapter only, see below | Implemented; caveats are IPC handle passing and `subprocess.channel.ref()`, not used |
+| `stream`, `stream/promises` | `@vercel/sandbox` | "Fully implemented." |
+| `zlib` | `@vercel/sandbox` | "Fully implemented. 98% of Node.js's test suite passes." |
+| `node:timers/promises` | `@vercel/sandbox` | Not on the page's caveat list; used only for `setTimeout` delays |
+| `ws` | adapter (bridge WebSocket client) | Replaced by Bun's built-in shim, see next section |
+| `undici` (`Agent`) | `@vercel/sandbox` | Replaced by Bun's built-in shim, see below |
+| `fetch` (global) | `@vercel/sandbox` API client | "Fully implemented. The `integrity` option is ignored." |
+
+`@ai-sdk/harness` itself imports only `crypto`, `fs`, `path` plus `ai`,
+`@ai-sdk/provider`, `@ai-sdk/provider-utils`, `zod/v4`. The Claude adapter's single
+`child_process` use is
+`execFileSync("sh", ["-c", command])` to run the `apiKeyHelper` from `~/.claude/settings.json`
+when present (adapter dist around line 224); it never spawns the bridge locally in the
+Vercel Sandbox configuration, where `spawn` goes through `sandboxSession.spawn()` (the
+HTTP sandbox API). Third-party pure-JS deps of `@vercel/sandbox` (`jose`, `tar-stream`,
+`jsonlines`, `async-retry`, `lru-cache`, `@vercel/oidc`, `@workflow/serde`) rely on the
+modules above.
+
+## The WebSocket client: `ws` under Bun
+
+What the adapter calls (grep over `@ai-sdk/harness-claude-code/dist/index.js`):
+
+```js
+import { WebSocket } from "ws";                       // line 32
+const ws = new WebSocket(endpoint.url, {              // line 1261
+  headers: endpoint.headers == null ? void 0 : { ...endpoint.headers }
+});
+ws.on("open"|"message"|"close"|"error", ...)          // 4 × ws.on, 4 × ws.off
+ws.terminate();                                       // on failure
+bridgeUrl.searchParams.set("agent_bridge_token", token);
+```
+
+No `handshakeTimeout`, `perMessageDeflate`, `ping`, `Sender`/`Receiver`, or
+`createWebSocketStream`; the adapter runs its own open/hello timers.
+
+Bun does not load the installed `ws` package at all. Its runtime hardcodes a module named
+`ws` whose header reads "Hardcoded module "ws" / Mocking https://github.com/websockets/ws
+/ this just wraps WebSocket to look like an EventEmitter"
+([oven-sh/bun `src/js/thirdparty/ws.js`](https://github.com/oven-sh/bun/blob/main/src/js/thirdparty/ws.js)).
+That shim implements `headers`, `perMessageDeflate`, `rejectUnauthorized`, `on`, `send`,
+`close`, `terminate`, `ping`; only `Sender`, `Receiver`, and `createWebSocketStream`
+throw "Not supported yet in Bun", and `handshakeTimeout` is not handled. Bun's client
+`WebSocket` supports `ws://` and `wss://` and custom constructor headers as "a
+Bun-specific extension of the `WebSocket` standard"
+([Bun WebSocket docs](https://bun.com/docs/api/websockets)).
+
+Local proof that the shim is what resolves, and that the adapter's call pattern works
+(`ws-resolve.ts`, `ws-roundtrip.ts` in a scratch directory outside the repo; the
+round-trip connects to a loopback `Bun.serve` WebSocket server that rejects the upgrade
+unless both the custom header and the `agent_bridge_token` query parameter are present):
+
+```text
+$ bun run ws-resolve.ts
+runtime bun 1.3.0
+require.resolve('ws'): ws
+Bun.resolveSync('ws'): ws
+ws package.json version on disk: 8.21.3
+ctor name: WebSocket | on(): function | terminate(): function | ping(): function | once(): function
+=== globalThis.WebSocket: false | extends global WebSocket: false
+WebSocketServer exported: function
+
+$ bun run ws-roundtrip.ts
+runtime bun 1.3.0 | readyState after open: 1
+received: [ "{\"type\":\"bridge-hello\"}", "{\"type\":\"echo\",\"got\":\"{\\\"type\\\":\\\"prompt\\\",\\\"text\\\":\\\"hi\\\"}\"}" ]
+close event after terminate(): { code: 1006 } | readyState: 3
+OK
+```
+
+`require.resolve("ws")` returning the bare string `ws` instead of a filesystem path is the
+builtin override; the on-disk 8.21.3 copy is inert.
+
+## `undici` `Agent` in `@vercel/sandbox`
+
+`@vercel/sandbox/dist/api-client/base-client.js` does
+`const DEFAULT_AGENT = new Agent({ bodyTimeout: 0 })` and passes `dispatcher: this.agent`
+to `globalThis.fetch` on every API call. Under Bun, `undici` is also a hardcoded module
+([oven-sh/bun `src/js/thirdparty/undici.js`](https://github.com/oven-sh/bun/blob/main/src/js/thirdparty/undici.js))
+whose `Agent extends Dispatcher {}` is an empty `EventEmitter` subclass, and Bun's native
+`fetch` documents no `dispatcher` option and ignored it in the check below
+(`undici-check.ts`):
+
+```text
+$ bun run undici-check.ts
+runtime bun 1.3.0
+require.resolve('undici'): undici | Bun.resolveSync: undici
+undici version on disk: 7.29.0 | @vercel/sandbox 3.1.0 | @ai-sdk/sandbox-vercel 1.0.91
+@ai-sdk/sandbox-vercel exports: [ "VercelSandboxProvider", "createVercelSandbox" ]
+Agent constructed; own keys: [ "_events", "_eventsCount", "_maxListeners" ] | proto methods: [ "constructor" ]
+global fetch with { dispatcher }: 200 pong
+undici fetch with { dispatcher }: 200 pong
+```
+
+The `bodyTimeout: 0` exists to disable undici's default body-idle timeout on long-lived
+sandbox log streams. Bun's `fetch` documents no default timeout at all ("To fetch a URL
+with a timeout, use `AbortSignal.timeout`") and streams bodies as `ReadableStream`
+([Bun fetch docs](https://bun.com/docs/api/fetch)), so the intent survives the shim.
+
+## Streaming `toUIMessageStreamResponse()` through Hono on Bun
+
+chat-api is served by Bun's fetch-handler convention (`export default productionApp` in
+[`apps/chat-api/src/index.ts`](../../apps/chat-api/src/index.ts)), which is the documented
+way to run Hono on Bun ([Hono on Bun](https://hono.dev/docs/getting-started/bun)), and it
+already streams SSE in production via `streamSSE` in
+[`conversations.route.ts`](../../apps/chat-api/src/features/conversations/conversations.route.ts).
+`streamText().toUIMessageStreamResponse()` is typed as
+`(options?: ResponseInit & UIMessageStreamOptions) => Response`
+([streamText reference](https://ai-sdk.dev/docs/reference/ai-sdk-core/stream-text)); the AI
+SDK's own Hono cookbook uses `@hono/node-server` but returns the same `Response`
+([Hono cookbook](https://ai-sdk.dev/cookbook/api-servers/hono)).
+
+Credential-free check with `MockLanguageModelV3` from `ai/test` emitting one chunk every
+200 ms, served by Hono on `Bun.serve` and read back with `fetch` (`hono-stream.ts`):
+
+```text
+$ bun run hono-stream.ts
+runtime bun 1.3.0 | hono 4.13.5 | ai 7.0.83
+status 200 | content-type: text/event-stream | x-vercel-ai-ui-message-stream: v1 | transfer-encoding: chunked
++  32ms chunk#1: "data: {\"type\":\"start\"}\n\n"
++ 235ms chunk#2: "data: {\"type\":\"start-step\"}\n\ndata: {\"type\":\"text-start\",\"id\":\"t\"}\n\n"
++ 435ms chunk#3: "data: {\"type\":\"text-delta\",\"id\":\"t\",\"delta\":\"one \"}\n\n"
++ 635ms chunk#4: "data: {\"type\":\"text-delta\",\"id\":\"t\",\"delta\":\"two \"}\n\n"
++ 838ms chunk#5: "data: {\"type\":\"text-delta\",\"id\":\"t\",\"delta\":\"three\"}\n\n"
++1037ms chunk#6: "data: {\"type\":\"text-end\",\"id\":\"t\"}\n\n"
++1243ms chunk#7: "data: {\"type\":\"finish-step\"}\n\ndata: {\"type\":\"finish\",\"finishReason\":\"stop\"}\n\ndata: ...
+chunks received: 7 | total ms: 1244
+```
+
+Chunks arrive at the producer's cadence, so nothing in Hono or `Bun.serve` buffers the
+body. (chat-api's lockfile pins `hono` 4.12.12; the scratch check used 4.13.5.)
+
+## Local import check
+
+```text
+$ mkdir <scratch> && cd <scratch> && printf '{"name":"harness-bun-check","private":true,"type":"module"}\n' > package.json
+$ bun add @ai-sdk/harness @ai-sdk/harness-claude-code ai
+bun add v1.3.0 (b0a6feca)
+installed @ai-sdk/harness@1.0.91
+installed @ai-sdk/harness-claude-code@1.0.94
+installed ai@7.0.83
+14 packages installed [429.00ms]
+
+$ bun run import-check.ts
+runtime bun 1.3.0
+@ai-sdk/harness 1.0.91
+@ai-sdk/harness-claude-code 1.0.94
+ai 7.0.83
+ws 8.21.3
+HarnessAgent: function createClaudeCode: function streamText: function
+harness.id: undefined harness.version: undefined
+agent.harnessId: claude-code agent.version: agent-v1
+exit=0
+```
+
+`import-check.ts` imports `HarnessAgent` from `@ai-sdk/harness/agent`, calls
+`createClaudeCode({ port: 43127, portEndpoint: { url: "ws://127.0.0.1:43127" } })`, and
+constructs `new HarnessAgent({ harness, activeTools: [] })`. No session is created, so
+nothing needs credentials. The scratch directory lives outside the repo; the repo's
+`package.json` and `bun.lock` were not touched.
+
+## Fallback: a plain Node container for chat-api
+
+If Bun ever blocks, the fallback is **not** `node src/index.ts`:
+
+- chat-api and its workspace deps use extensionless relative imports (148 in runtime
+  code, 0 with `.ts`), and `@mymemo/agent-db` / `@mymemo/live-text` export `.ts` sources
+  directly. Node's type stripping (default since v22.18.0) requires explicit extensions
+  and "refuses to handle TypeScript files inside folders under a `node_modules` path"
+  ([Node TypeScript docs](https://nodejs.org/api/typescript.html)).
+
+The lazy, verified path is to bundle with Bun and run with Node:
+
+```text
+$ bun install --frozen-lockfile   # in the worktree; node_modules is gitignored
+$ bun build apps/chat-api/src/index.ts --target=node --outdir=apps/chat-api/.node-bundle \
+    --external @statsig/statsig-node-core --external pg-native --external @electric-sql/pglite \
+    --external pino --external hono-pino
+Bundled 929 modules in 162ms
+  index.js  3.0 MB  (entry point)
+
+$ grep -n 'Bun\.' apps/chat-api/.node-bundle/index.js
+77395:  const version3 = typeof Bun !== "undefined" ? Bun.version : undefined;
+87673:var productionConfig = loadApiConfigFromEnv(Bun.env);
+
+$ AGENT_DATABASE_URL=postgresql://x:y@127.0.0.1:1/db ARTIFACT_BUCKET=dummy AWS_REGION=us-east-1 \
+  STATSIG_SERVER_SECRET=secret-dummy REDIS_URL=redis://127.0.0.1:6379 \
+  LIVE_STREAM_ALLOW_INSECURE_LOCAL_REDIS=true LOG_LEVEL=warn \
+  node --import ./bun-shim.mjs apps/chat-api/.node-bundle/index.js
+... [Statsig 401 warnings for the dummy key] ...
+BOOT_OK: module graph loaded and app constructed under v24.19.0 - still alive after 8s
+```
+
+`bun-shim.mjs` is `globalThis.Bun = { env: process.env }` plus an 8 s timer that prints
+`BOOT_OK`; the dummy Statsig key produced 401s but no real credential was used. The bundle
+was deleted from the worktree afterwards. What a real fallback needs:
+
+1. Replace the three `Bun.env` reads (`src/index.ts`, `src/db/migrate.ts`,
+   `local/index.ts`) with `process.env`; the other `Bun.*` hits are test-only
+   (`Bun.gc` in `agent-db/src/testing.ts`, `bun:test` in a `.contract.ts`).
+2. Add a Node entry that calls `serve({ fetch: app.fetch, port })` from
+   `@hono/node-server` ([Hono on Node.js](https://hono.dev/docs/getting-started/nodejs));
+   `export default app` only serves under Bun. `@hono/node-server` 1.19.13 is already in
+   `bun.lock` (transitively) but must become a direct dependency.
+3. Add a Dockerfile stage `FROM node:22-bookworm-slim` that copies `node_modules` and
+   the bundle from the existing `oven/bun:1` install stage; keep `bun install`,
+   `bun test`, and the compose `local` target's install flow unchanged. Give
+   `package.json` `"type": "module"` or emit `.mjs` to silence Node's reparse warning.
+
+Node 22.18+ carries type stripping, but the bundle avoids depending on it. Effort is
+about a day, dominated by the Dockerfile stage and CI wiring, not by code.
+
+## Residual risks and what to smoke-test in the spike
+
+- **Not tested live:** an actual `wss://` connection to a Vercel-Sandbox-exposed port
+  with `endpoint.headers`, and `@vercel/sandbox` log streaming under Bun. Both use only
+  the surfaces exercised above, but the spike should run one real session on the
+  production image before anything ships.
+- **Bun version drift:** `apps/chat-api/Dockerfile` uses the floating `oven/bun:1` tag
+  (last pushed 2026-08-20 per Docker Hub); the local checks ran on Bun 1.3.0, so they are
+  conservative relative to the image but not identical to it. Pin the tag in the spike.
+- **`ws` shim gaps** (`handshakeTimeout`, `Sender`/`Receiver`, `createWebSocketStream`)
+  are not used by the adapter today; a future adapter release could start using them.
+  Re-run `ws-resolve.ts`/`ws-roundtrip.ts` when bumping `@ai-sdk/harness-claude-code`.
+- **`undici` stub:** any future `@vercel/sandbox` feature that relies on a real undici
+  `Dispatcher` (proxy, interceptors, `undici.stream`) would silently no-op or throw under
+  Bun; today only `Agent({ bodyTimeout: 0 })` is used.
+- **Image weight:** the Dockerfile's `--filter=chat-api` install currently keeps
+  chat-api's `node_modules` around 145 MB; adding `ai`, `@ai-sdk/*`, `@vercel/sandbox`,
+  and `undici` grows it modestly (20 packages for the sandbox SDK alone) and the
+  unused `ws`/`undici` copies still land on disk.

--- a/docs/research/claude-code-harness-turn-persistence-2026.md
+++ b/docs/research/claude-code-harness-turn-persistence-2026.md
@@ -1,0 +1,338 @@
+# What Survives Between Turns on the Claude Code Harness
+
+**Research date: 2026-08-26.** This note resolves
+[What survives between turns on the Claude Code harness?](https://github.com/X-GPT/mymemo-agent/issues/588)
+for the `HarnessAgent` + `createClaudeCode` + `createVercelSandbox` path charted in
+[#585](https://github.com/X-GPT/mymemo-agent/issues/585). Every upstream claim is pinned to
+`vercel/ai` commit
+[`56d492f`](https://github.com/vercel/ai/commit/56d492f61652af7bad16f56ed33cf41924ef5496)
+(main, 2026-08-26) and to first-party Claude Code and Vercel Sandbox documentation as read on
+the research date. Package versions at that commit: `@ai-sdk/harness` 1.0.91,
+`@ai-sdk/harness-claude-code` 1.0.94, `@ai-sdk/sandbox-vercel` 1.0.91 (peer
+`@vercel/sandbox ^2.0.1 || ^3.0.0`); the in-sandbox bridge pins
+`@anthropic-ai/claude-agent-sdk` 0.3.213 and `@anthropic-ai/claude-code` 2.1.213
+([bridge package.json](https://github.com/vercel/ai/blob/56d492f61652af7bad16f56ed33cf41924ef5496/packages/harness-claude-code/src/bridge/package.json)).
+
+The prior notes #585 tells every session to load
+(`docs/research/ai-sdk-harness-agent-api-2026.md` and
+`docs/research/ai-sdk-harness-agentcore-sandbox-feasibility-2026.md`) are not present on
+`main` or any remote branch as of `4a494e5`; this note therefore stands alone and does not
+assume their content. Upstream PR [#19108](https://github.com/vercel/ai/pull/19108) ("local
+workspaces") is still open and adds a host-local workspace mode; it does not change anything
+below.
+
+## Short answer
+
+The S3 `agent-sessions/<conversationId>` blob **is not enough on its own**. On this harness the
+conversation transcript never leaves the sandbox filesystem; the resume state the adapter hands
+back is a pointer set, not a transcript. What has to outlive the turn is the **named, persistent
+Vercel Sandbox** (specifically its auto-snapshot), not a running VM and not the bridge process.
+
+1. **`detach()` / `stop()` return pointers only.** `detach()` yields `{ bridge: { port, token,
+   lastSeenEventId, sandboxId? }, sandboxCredentialEnvironment? }`; `stop()` yields structurally
+   `{}` plus the optional credential map. Neither contains a Claude session id, a thread id, or
+   any transcript. The framework wraps it as
+   `{ type: 'resume-session', harnessId: 'claude-code', specificationVersion: 'harness-v1', data }`.
+2. **Claude's thread history lives only in the sandbox.** The bridge calls the Claude Agent SDK
+   with `cwd: <workdir>` and `continue: true`, and passes no `sessionStore` and no `resume` id.
+   The transcript is the CLI's own `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`
+   (or `$CLAUDE_CONFIG_DIR/projects/...`). The bridge's replay log sits under
+   `<defaultWorkingDirectory>/.agent-runs/<sessionId>/bridge/event-log.ndjson`. When the
+   sandbox is deleted, or a non-persistent sandbox stops, all of it is gone.
+3. **A Vercel Sandbox snapshot restores it.** Vercel sandboxes are persistent by default: stop
+   or timeout auto-snapshots the filesystem, and `Sandbox.get({ name })` plus the next SDK call
+   boots a new session from that snapshot. The provider names the per-session sandbox
+   `ai-sdk-harness-session-<sessionId>` for exactly this reason, and strips `persistent` from
+   the fork params so the per-session sandbox always takes Vercel's persistent default.
+4. **`createSession({ resumeFrom })` fallback ladder** (after the framework has reattached the
+   sandbox via `provider.resumeSession({ sessionId })`): **attach** to the still-running bridge
+   using the persisted `port`/`token`; if that socket fails, **respawn** the bridge and send the
+   next prompt with Claude `continue: true` (the "rerun" rung). Disk **replay** of
+   `event-log.ndjson` is used only for `continueFrom` (a suspended, unfinished turn), never for
+   a between-turn `resumeFrom`. There is no fresh-thread rung: if the workdir transcript is
+   missing, `continue: true` simply starts a new Claude session in that cwd, silently.
+
+For MyMemo this means: keep storing the `detach()`/`stop()` payload in S3 (it is small and
+needed for attach and for credential brokering), **and** keep the Vercel sandbox
+`ai-sdk-harness-session-<sessionId>` alive as a persistent resource for the Conversation's
+lifetime, with `sessionId` = the Conversation's stable id so `resumeSession` can find it. The
+only ways to make the S3 blob self-sufficient are to bypass the adapter's bridge and mirror
+transcripts yourself (see [What would make S3 sufficient](#what-would-make-s3-sufficient)).
+
+## Evidence
+
+### 1. The serialized resume state
+
+The v1 contract defines the envelope. Adapter payload is an opaque `data: JSONValue`; the
+framework validates `type`, `specificationVersion`, and `harnessId`, then parses `data` against
+the adapter's `lifecycleStateSchema`
+([harness-v1-lifecycle-state.ts#L17-L45](https://github.com/vercel/ai/blob/56d492f61652af7bad16f56ed33cf41924ef5496/packages/harness/src/v1/harness-v1-lifecycle-state.ts#L17-L45),
+[lifecycle-state-validation.ts](https://github.com/vercel/ai/blob/56d492f61652af7bad16f56ed33cf41924ef5496/packages/harness/src/agent/internal/lifecycle-state-validation.ts)).
+
+The Claude Code adapter's schema, verbatim
+([claude-code-harness.ts#L784-L803](https://github.com/vercel/ai/blob/56d492f61652af7bad16f56ed33cf41924ef5496/packages/harness-claude-code/src/claude-code-harness.ts#L784-L803)):
+
+```ts
+const claudeCodeBridgeCoordsSchema = z.object({
+  port: z.number(),
+  token: z.string(),
+  lastSeenEventId: z.number(),
+  sandboxId: z.string().optional(),
+});
+
+/**
+ * A `doStop()` payload is structurally empty (`{}`): the framework derives the
+ * sandbox via `provider.resumeSession({ sessionId })`, and the Claude SDK's
+ * `{ continue: true }` flag rehydrates the thread from the workdir. A
+ * `doDetach()` payload additionally carries `bridge` coordinates for
+ * cross-process `attach`. A loose object keeps both shapes valid.
+ */
+const claudeCodeResumeStateSchema = z.looseObject({
+  bridge: claudeCodeBridgeCoordsSchema.optional(),
+  sandboxCredentialEnvironment: z.record(z.string(), z.string()).optional(),
+});
+```
+
+`doDetach` suspends the channel (bridge and sandbox keep running) and returns
+([#L1820-L1841](https://github.com/vercel/ai/blob/56d492f61652af7bad16f56ed33cf41924ef5496/packages/harness-claude-code/src/claude-code-harness.ts#L1820-L1841)):
+
+```json
+{
+  "type": "resume-session",
+  "harnessId": "claude-code",
+  "specificationVersion": "harness-v1",
+  "data": {
+    "sandboxCredentialEnvironment": { "...": "only when credential brokering is active" },
+    "bridge": { "port": 3000, "token": "<64 hex>", "lastSeenEventId": 42, "sandboxId": "<vercel sandbox id>" }
+  }
+}
+```
+
+`doStop` sends `stop` to the bridge, whose `onStop` returns `{}` with the comment "Claude
+Code's session state lives in the workdir on the sandbox filesystem (captured by the sandbox
+snapshot on stop); the resume payload is empty"
+([bridge/index.ts#L132-L134](https://github.com/vercel/ai/blob/56d492f61652af7bad16f56ed33cf41924ef5496/packages/harness-claude-code/src/bridge/index.ts#L132-L134)).
+If the socket is already closed the adapter synthesizes `{}` without a round-trip
+([#L1879-L1955](https://github.com/vercel/ai/blob/56d492f61652af7bad16f56ed33cf41924ef5496/packages/harness-claude-code/src/claude-code-harness.ts#L1879-L1955)).
+The `stop()` payload is therefore:
+
+```json
+{ "type": "resume-session", "harnessId": "claude-code", "specificationVersion": "harness-v1",
+  "data": { "sandboxCredentialEnvironment": { "...": "optional" } } }
+```
+
+`doSuspendTurn` (what `detach()`/`stop()` call when a turn is still running) returns the same
+`bridge` coordinates under `type: 'continue-turn'`; the framework nests it as
+`resumeFrom.continueFrom`
+([#L1962-L1990](https://github.com/vercel/ai/blob/56d492f61652af7bad16f56ed33cf41924ef5496/packages/harness-claude-code/src/claude-code-harness.ts#L1962-L1990),
+[harness-agent-session.ts#L404-L462](https://github.com/vercel/ai/blob/56d492f61652af7bad16f56ed33cf41924ef5496/packages/harness/src/agent/harness-agent-session.ts#L404-L462)).
+
+No field anywhere in these payloads names a Claude `session_id`; the bridge never reads one
+from the SDK stream (grep of `session_id`/`sessionId` in the bridge finds nothing). The
+framework's own `sessionId` is the caller-supplied `HarnessAgent` id, which is why
+`createSession({ sessionId, resumeFrom })` requires the original id
+([harness-agent.ts#L219-L233](https://github.com/vercel/ai/blob/56d492f61652af7bad16f56ed33cf41924ef5496/packages/harness/src/agent/harness-agent.ts#L219-L233)).
+
+### 2. Where the transcript lives
+
+The bridge drives the Claude Agent SDK with the session work dir as `cwd` and applies the
+continuation rule "the host can force-continue (resume after a cross-process detach) by setting
+`start.continue: true`; otherwise we continue every subsequent turn after the first one in this
+bridge process"
+([bridge/index.ts#L380-L388](https://github.com/vercel/ai/blob/56d492f61652af7bad16f56ed33cf41924ef5496/packages/harness-claude-code/src/bridge/index.ts#L380-L388)).
+The `query()` options contain neither `sessionStore` nor `resume` nor `persistSession`
+([#L339-L390](https://github.com/vercel/ai/blob/56d492f61652af7bad16f56ed33cf41924ef5496/packages/harness-claude-code/src/bridge/index.ts#L339-L390)).
+
+Per Anthropic, "Claude Code stores sessions under `~/.claude/projects/<encoded-cwd>/*.jsonl`.
+If you set the `CLAUDE_CONFIG_DIR` environment variable, look under
+`$CLAUDE_CONFIG_DIR/projects/` instead", `continue` "finds the most recent session in the
+current directory", and "Session files are local to the machine that created them"
+([Agent SDK: Work with sessions](https://code.claude.com/docs/en/agent-sdk/sessions)). The
+CLI page adds the 30-day `cleanupPeriodDays` retention and that the JSONL "entry format is
+internal to Claude Code and changes between versions"
+([Manage sessions: Where transcripts are stored](https://code.claude.com/docs/en/sessions#where-transcripts-are-stored)).
+
+The work dir is `<defaultWorkingDirectory>/<harnessId>-<sessionId>` unless
+`sandboxConfig.workDir` overrides it
+([sandbox-bootstrap.ts#L68-L83](https://github.com/vercel/ai/blob/56d492f61652af7bad16f56ed33cf41924ef5496/packages/harness/src/agent/internal/sandbox-bootstrap.ts#L68-L83)),
+so "most recent session in this cwd" is unambiguous per `HarnessAgent` session. On Vercel
+`defaultWorkingDirectory` is the sandbox session's `cwd`
+([vercel-network-sandbox-session.ts#L36](https://github.com/vercel/ai/blob/56d492f61652af7bad16f56ed33cf41924ef5496/packages/sandbox-vercel/src/vercel-network-sandbox-session.ts#L36)).
+
+The bridge's own state is under `<defaultWorkingDirectory>/.agent-runs/<sessionId>/bridge/`
+([claude-code-harness.ts#L923-L924](https://github.com/vercel/ai/blob/56d492f61652af7bad16f56ed33cf41924ef5496/packages/harness-claude-code/src/claude-code-harness.ts#L923-L924)):
+`bridge-meta.json`, `start-config.json`, `rerun-start-config.json`, and `event-log.ndjson`, the
+"disk mirror of the in-memory replay log" that lets a respawned bridge serve a host's resume
+cursor
+([harness/bridge/index.ts#L362-L365](https://github.com/vercel/ai/blob/56d492f61652af7bad16f56ed33cf41924ef5496/packages/harness/src/bridge/index.ts#L362-L365),
+[#L404-L410](https://github.com/vercel/ai/blob/56d492f61652af7bad16f56ed33cf41924ef5496/packages/harness/src/bridge/index.ts#L404-L410)).
+
+Upstream states the design intent outright: the work dir and bridge-state dir live under the
+provider's persistent mount "so the workdir's CLI state (Claude's `~/.claude/projects/<dir>/*.jsonl`
+thread history is keyed by working directory) and the bridge state files survive both
+detach -> attach/replay and stop -> snapshot -> resume cycles"
+([claude-code-bootstrap.ts#L5-L16](https://github.com/vercel/ai/blob/56d492f61652af7bad16f56ed33cf41924ef5496/packages/harness-claude-code/src/claude-code-bootstrap.ts#L5-L16)).
+Note the adapter only sets `HOME` on the bridge process when skills are configured
+([claude-code-harness.ts#L1060](https://github.com/vercel/ai/blob/56d492f61652af7bad16f56ed33cf41924ef5496/packages/harness-claude-code/src/claude-code-harness.ts#L1060));
+otherwise `~/.claude` is wherever the sandbox user's `HOME` points. On Vercel that is moot
+because the snapshot covers the whole filesystem (next section), but it matters for any provider
+that persists only a mount.
+
+Consequence: when the sandbox is deleted (`session.destroy()` calls `sandbox.stop()` then
+`sandbox.delete()`,
+[vercel-network-sandbox-session.ts#L119-L123](https://github.com/vercel/ai/blob/56d492f61652af7bad16f56ed33cf41924ef5496/packages/sandbox-vercel/src/vercel-network-sandbox-session.ts#L119-L123)),
+or when a non-persistent sandbox stops, the transcript, the bridge log, and any files the
+agent wrote are all gone, and nothing in S3 can rebuild them.
+
+### 3. What a Vercel Sandbox snapshot restores
+
+Vercel: "Persistence is the default. Every sandbox created with `Sandbox.create()` ... is
+persistent unless you explicitly opt out." "When you stop a persistent sandbox, the SDK
+automatically snapshots the filesystem. When you resume it, a new session boots from that
+snapshot with a fresh session timeout." Stopping happens on manual `stop()` or on timeout.
+"If a persistent sandbox is stopped and you call `runCommand`, `writeFiles`, or other SDK
+methods on it, the SDK automatically starts a new session and retries the operation."
+([Persistence](https://vercel.com/docs/sandbox/concepts/persistent-sandboxes), last updated
+2026-08-25; [Snapshots](https://vercel.com/docs/sandbox/concepts/snapshots), 2026-08-26.)
+Snapshots "capture the state of a running sandbox, including the filesystem and installed
+packages", and resuming "boots" a new session from the snapshot, so the bridge and the
+`claude` process are never restored, only their files.
+
+Retention that bounds the Conversation lifetime:
+
+- `snapshotExpiration` "Defaults to 30 days", measured from the snapshot's last use; `0` keeps
+  indefinitely. `keepLastSnapshots: { count: 1 }` keeps storage flat.
+- "Vercel removes sandboxes that can't resume from a snapshot after 14 days of inactivity."
+- Snapshots are region-pinned; resuming in another region fails with
+  `snapshot_region_mismatch`.
+- `sandbox.stop()` "returns the final session state. For persistent sandboxes, the resolved
+  value also includes metadata for the snapshot captured during shutdown"; `Sandbox.get`'s
+  `resume` option "Defaults to `true`"
+  ([JS SDK Reference](https://vercel.com/docs/sandbox/sdk-reference), 2026-08-21).
+
+How the provider uses this
+([vercel-sandbox.ts](https://github.com/vercel/ai/blob/56d492f61652af7bad16f56ed33cf41924ef5496/packages/sandbox-vercel/src/vercel-sandbox.ts)):
+
+- `createSession({ sessionId })` names the sandbox `ai-sdk-harness-session-<sessionId>` "so a
+  future `resumeSession({ sessionId })` can locate it via `Sandbox.get({ name })`"
+  ([#L150-L156](https://github.com/vercel/ai/blob/56d492f61652af7bad16f56ed33cf41924ef5496/packages/sandbox-vercel/src/vercel-sandbox.ts#L150-L156)).
+- With the Claude Code bootstrap recipe present (it always is), the per-session sandbox is a
+  fork of a persistent template snapshot, and the fork params drop `persistent`, so the session
+  sandbox always inherits Vercel's persistent default; `snapshotExpiration` and `timeout` from
+  your settings are forwarded ([#L221-L244](https://github.com/vercel/ai/blob/56d492f61652af7bad16f56ed33cf41924ef5496/packages/sandbox-vercel/src/vercel-sandbox.ts#L221-L244)).
+  Default `timeout` is 30 minutes ([#L61-L65](https://github.com/vercel/ai/blob/56d492f61652af7bad16f56ed33cf41924ef5496/packages/sandbox-vercel/src/vercel-sandbox.ts#L61-L65)).
+- `resumeSession({ sessionId })` is `Sandbox.get({ name })` with the same derived name
+  ([#L246-L272](https://github.com/vercel/ai/blob/56d492f61652af7bad16f56ed33cf41924ef5496/packages/sandbox-vercel/src/vercel-sandbox.ts#L246-L272)).
+  No sandbox id is read from `resumeFrom.data.bridge.sandboxId`; the `sessionId` is the lookup key.
+- `session.stop()` on a harness-owned sandbox calls `sandbox.stop()` (the auto-snapshot
+  point); `destroy()` deletes it
+  ([vercel-network-sandbox-session.ts#L114-L123](https://github.com/vercel/ai/blob/56d492f61652af7bad16f56ed33cf41924ef5496/packages/sandbox-vercel/src/vercel-network-sandbox-session.ts#L114-L123),
+  [harness-agent-session.ts#L459](https://github.com/vercel/ai/blob/56d492f61652af7bad16f56ed33cf41924ef5496/packages/harness/src/agent/harness-agent-session.ts#L459)).
+
+So a snapshot does restore the Claude transcript, the bridge state, the work dir, and the
+installed CLI, provided the sandbox was persistent and the resume happens within the snapshot
+and 14-day inactivity windows, in the same region.
+
+### 4. The exact fallback ladder on `createSession({ resumeFrom })`
+
+Framework step first: `HarnessAgent.createSession` validates the payload, then, because
+`resumeFrom` is set, requires `provider.resumeSession` (throws
+`HarnessCapabilityUnsupportedError` for providers without it) and calls it with the
+`sessionId`
+([harness-agent.ts#L326-L350](https://github.com/vercel/ai/blob/56d492f61652af7bad16f56ed33cf41924ef5496/packages/harness/src/agent/harness-agent.ts#L326-L350),
+[harness-v1-sandbox-provider.ts#L57-L70](https://github.com/vercel/ai/blob/56d492f61652af7bad16f56ed33cf41924ef5496/packages/harness/src/v1/harness-v1-sandbox-provider.ts#L57-L70)).
+If the named sandbox no longer exists, `Sandbox.get` fails and `createSession` throws; there
+is no silent fresh-sandbox fallback. If a caller-owned `sandboxSession` is passed instead, the
+framework uses it as-is and re-applies the idempotent bootstrap recipe.
+
+Adapter step, `doStart`
+([claude-code-harness.ts#L961-L1175](https://github.com/vercel/ai/blob/56d492f61652af7bad16f56ed33cf41924ef5496/packages/harness-claude-code/src/claude-code-harness.ts#L961-L1175)):
+
+| Rung | Condition | Action | Claude thread |
+| --- | --- | --- | --- |
+| 1 ATTACH | `data.bridge` present and a WebSocket to `port` with `token` opens (bridge process still alive, so the VM never stopped) | Reuse the running bridge; no spawn, no new token; `continueOnFirstPrompt: false` | Bridge process is past its first turn, so the SDK's in-process `continue: true` rule applies |
+| 2 REPLAY | Only for `continueFrom` (suspended turn) **and** `.agent-runs/<id>/bridge/event-log.ndjson` classifies as replayable | Respawn bridge with `BRIDGE_REPLAY_FROM_DISK=1`, seed `lastSeenEventId`, open with `{ resume: true }`; streams the finished tail | Not re-driven; the disk log is the source |
+| 3 RERUN | Any `resumeFrom` whose attach failed (bridge gone: VM stopped, timed out, or snapshot-resumed); or `continueFrom` with an unusable log | Respawn bridge, skip `mkdir`/skills rewrite ("they already exist in the sandbox snapshot"), force `continue: true` on the next `start` | CLI reloads the most recent session in the work dir from `~/.claude/projects/...` |
+
+The ladder comment is explicit that between-turn resumes never replay: "`resumeFrom` is a
+between-turn resume; even when it carries bridge coordinates, replaying the previous turn would
+re-deliver stale events into the next turn. Those resumes always `rerun` when attach is
+unavailable (the CLI continues its own thread from the workdir snapshot via `continue: true`)"
+([#L1019-L1040](https://github.com/vercel/ai/blob/56d492f61652af7bad16f56ed33cf41924ef5496/packages/harness-claude-code/src/claude-code-harness.ts#L1019-L1040)).
+The forced flag is applied once, on the first `start` after a respawn
+([#L1529-L1534](https://github.com/vercel/ai/blob/56d492f61652af7bad16f56ed33cf41924ef5496/packages/harness-claude-code/src/claude-code-harness.ts#L1529-L1534),
+[#L1729](https://github.com/vercel/ai/blob/56d492f61652af7bad16f56ed33cf41924ef5496/packages/harness-claude-code/src/claude-code-harness.ts#L1729)).
+For a suspended turn that fell to rerun, `doContinueTurn` sends a literal `'Continue.'`
+prompt with `continue: true` and documents it as "Lossy — work in flight at the suspension is
+recomputed"
+([#L1736-L1800](https://github.com/vercel/ai/blob/56d492f61652af7bad16f56ed33cf41924ef5496/packages/harness-claude-code/src/claude-code-harness.ts#L1736-L1800)).
+
+There is no rung that consults an external transcript, and no rung that detects a missing
+transcript. Under `continue: true` with no session on disk in that cwd, the TypeScript SDK
+"starts a fresh session"; Anthropic documents this for the store-miss case
+([Persist sessions to external storage](https://code.claude.com/docs/en/agent-sdk/session-storage#resume-from-the-store)),
+and the no-store case is not documented, so #590 should confirm it. Either way the user would
+see a Claude that has forgotten the Conversation, with no error from the harness.
+
+### 5. What this means for MyMemo's S3 blob
+
+Today `agent-query-runtime` stores a *real* transcript: it runs the SDK in-process with an
+`InMemorySessionStore`, `CLAUDE_CONFIG_DIR` pointed at a temp dir, and `resume: sessionId`,
+then serializes `{ version: 1, sessionId, transcripts: [...] }` to
+`agent-sessions/<conversationId>`
+([response-execution.ts](https://github.com/X-GPT/mymemo-agent/blob/4a494e5147cf179e4dc867a2d10ee14076093b43/apps/agent-query-runtime/src/response-execution.ts#L19-L38),
+[#L110-L127](https://github.com/X-GPT/mymemo-agent/blob/4a494e5147cf179e4dc867a2d10ee14076093b43/apps/agent-query-runtime/src/response-execution.ts#L110-L127),
+[detached-session-store.ts](https://github.com/X-GPT/mymemo-agent/blob/4a494e5147cf179e4dc867a2d10ee14076093b43/apps/agent-query-runtime/src/detached-session-store.ts)).
+That blob is self-sufficient because the SDK's `SessionStore` mirror is the transcript.
+
+On the harness path the same key would hold the `HarnessAgentResumeSessionState` above:
+a few hundred bytes of bridge coordinates and, with credential brokering, the sandbox-side
+credential environment. It is worth keeping (attach is the fast path, and re-minting a
+credential environment on every turn is avoidable), but it is not a transcript. The durable
+unit of Conversation memory becomes the Vercel sandbox `ai-sdk-harness-session-<sessionId>`
+and its latest snapshot. Two design consequences follow:
+
+- `sessionId` passed to `createSession` must be stable per Conversation (use the
+  Conversation id), because it is the only key `resumeSession` has.
+- The sandbox must not be `destroy()`ed at end of turn. `stop()` (auto-snapshot) or
+  `detach()` (leave running until `timeout`, then auto-snapshot) are both fine; the Conversation
+  then lives as long as the snapshot (`snapshotExpiration`, default 30 days from last use)
+  and the 14-day inactivity sweep allow. Set `keepLastSnapshots: { count: 1 }` to avoid a
+  snapshot per turn accumulating.
+
+Also note `stop()` after a suspended turn does **not** stop the sandbox in the same call path
+as an idle `stop()` (it returns `continueFrom` and the finally block still calls
+`sandboxSession.stop()`, which kills the in-flight bridge); resumption then lands on the
+lossy rerun rung. Treat interrupted turns as a separate ticket, as #585 already defers.
+
+### What would make S3 sufficient
+
+Only by moving the transcript into MyMemo's hands, which the shipped adapter does not expose:
+
+1. **Copy the JSONL yourself.** Anthropic documents "Move the session file": persist
+   `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl` and restore it before resuming
+   ([Resume across hosts](https://code.claude.com/docs/en/agent-sdk/sessions#resume-across-hosts)).
+   With the harness this means reading the file out of the sandbox after each turn and
+   writing it back in `sandboxConfig.onSession` (which "runs for fresh and resumed sessions",
+   [harness README](https://github.com/vercel/ai/blob/56d492f61652af7bad16f56ed33cf41924ef5496/packages/harness/README.md)),
+   then creating a fresh sandbox and calling `createSession` with `resumeFrom` omitted but
+   the same work dir. The format is "internal to Claude Code and changes between versions",
+   and the bridge pins CLI 2.1.213, which predates the cross-directory lookup added in
+   2.1.223, so the restored path must match the encoded cwd exactly.
+2. **Own the bridge.** A MyMemo-specific `HarnessV1` adapter (the host-driven shape #585 rules
+   out for this map) could pass `sessionStore` + `resume` to the SDK the way
+   `agent-query-runtime` does today, making the S3 blob the transcript again.
+
+Neither is needed for stage 1 if the persistent sandbox is accepted as the Conversation's
+memory. Decide that explicitly; do not assume the blob covers it.
+
+## Open items for #590 (the spike)
+
+- Confirm rung 3 in practice: `stop()` the session, wait for the sandbox to report `stopped`,
+  then `createSession({ sessionId, resumeFrom })` in a new process and check that turn two
+  recalls turn one. This exercises `Sandbox.get` auto-resume plus `continue: true`.
+- Record the `resumeFrom` byte size and whether `sandboxCredentialEnvironment` is present under
+  the OpenRouter `env` configuration (it is only set when the sandbox session supports
+  `addRequestTransformations`, which the Vercel network session does).
+- Check what `HOME` resolves to for the bridge process in the Vercel `node24` runtime, so the
+  `~/.claude/projects` location is known for the JSONL-copy option above.

--- a/docs/research/vercel-sandbox-harness-provider-2026.md
+++ b/docs/research/vercel-sandbox-harness-provider-2026.md
@@ -1,0 +1,506 @@
+# Vercel Sandbox provider for `HarnessAgent`
+
+**Research date: 2026-08-26.** Resolves
+[#587](https://github.com/X-GPT/mymemo-agent/issues/587) for the
+[HarnessAgent-on-Vercel-Sandbox map (#585)](https://github.com/X-GPT/mymemo-agent/issues/585).
+Versions read: `@ai-sdk/sandbox-vercel` **1.0.91**, `@ai-sdk/harness` **1.0.91**,
+`@ai-sdk/harness-claude-code` **1.0.94** (vercel/ai `main` at
+[`56d492f`](https://github.com/vercel/ai/commit/56d492f61652af7bad16f56ed33cf41924ef5496),
+2026-08-26, and the same versions pinned in the repo's
+[`codex/prototype-harness-agent` lockfile](https://github.com/X-GPT/mymemo-agent/commit/6cdfc3d2f95944d13399c720ea10033ee4ead2c7));
+`@vercel/sandbox` **3.1.0** (released 2026-08-21; source from vercel/sandbox `main` at
+[`92535f1`](https://github.com/vercel/sandbox/commit/92535f1c72644524537f86daecaa649eae520513)).
+Vercel doc pages cite their own `last_updated` dates (2026-08-11 to 2026-08-26). All harness
+packages are marked experimental
+([README](https://github.com/vercel/ai/blob/main/packages/sandbox-vercel/README.md)).
+
+This note does not repeat the `HarnessAgent` surface
+([`ai-sdk-harness-agent-api-2026.md`](ai-sdk-harness-agent-api-2026.md)) or the bridge-vs-host
+analysis and AgentCore image gaps
+([`ai-sdk-harness-agentcore-sandbox-feasibility-2026.md`](ai-sdk-harness-agentcore-sandbox-feasibility-2026.md)).
+It pins down what the **Vercel** provider specifically does.
+
+## Short answer
+
+- **Package/import.** `import { createVercelSandbox } from '@ai-sdk/sandbox-vercel'`. There
+  is no `vercelSandbox` export; the factory returns a `HarnessV1SandboxProvider`
+  (`providerId: 'vercel-sandbox'`). Options are the `@vercel/sandbox` `Sandbox.create()`
+  parameters minus `onResume`, plus `name`; or `{ sandbox }` to wrap a caller-owned sandbox.
+  Provider defaults: `timeout` 30 min (SDK default is 5), `runtime: 'node24'`. Claude Code
+  needs `ports: [<n>]`.
+- **Auth.** `@vercel/sandbox` resolves credentials as: explicit `token`+`teamId`+`projectId`
+  (all three or none) → `VERCEL_OIDC_TOKEN` (team/project decoded from the JWT) → an
+  interactive device flow only on a dev TTY. **It does not read `VERCEL_TOKEN`,
+  `VERCEL_TEAM_ID`, or `VERCEL_PROJECT_ID` from the environment.** chat-api runs on ECS, so
+  MyMemo must pass an access token, team ID, and project ID to `createVercelSandbox()`; the
+  `vercel env pull` OIDC token expires after 12 hours and is only auto-refreshed on Vercel.
+- **Lifecycle.** Fresh `createSession` → per-recipe template sandbox via
+  `Sandbox.getOrCreate` (bootstrap baked in `onCreate`, stopped to publish a snapshot) → a
+  per-session `Sandbox.create({ source: { type: 'snapshot' } })` named
+  `ai-sdk-harness-session-<sessionId>`. `detach()` leaves the microVM running (until its
+  `timeout`); `stop()` kills the bridge then `sandbox.stop()` (auto-snapshot, sandboxes are
+  persistent by default); `destroy()` = `stop()` + `sandbox.delete()`;
+  `createSession({ resumeFrom })` → `Sandbox.get({ name })`, which auto-resumes a stopped
+  sandbox from its last snapshot on the first SDK call.
+- **Limits/pricing (Pro, `iad1`).** No idle timeout; a wall-clock session `timeout` (default
+  5 min, extendable, max 24 h Pro / 45 min Hobby). 2 vCPU + 4 GB default, max 8 vCPU / 16 GB
+  Pro. 10,000 concurrent sandboxes Pro (10 Hobby). Regions `iad1` (default), `sfo1`, `cle1`,
+  `cdg1`; snapshots are region-bound. Egress `allow-all` by default; `deny-all` and domain
+  allowlists with credential-injecting `transform` rules are available. $0.128/active-CPU-hour,
+  $0.0212/GB-hour provisioned memory, $0.60 per million creations, $0.15/GB egress (downloads
+  such as npm installs are free), $0.00263/GB-month snapshot storage.
+- **Bootstrap.** The Claude recipe writes `.harness-bootstrap/claude-code/` and runs
+  `pnpm install --frozen-lockfile` of `@anthropic-ai/claude-code` 2.1.213 +
+  `@anthropic-ai/claude-agent-sdk` 0.3.213, then `claude --version`. On Vercel this runs
+  **once per recipe identity** inside the template's `onCreate` and is snapshotted;
+  per-session sandboxes fork from the snapshot and only hit the marker check.
+  `prepareHarnessSandboxTemplate()` does the same ahead of time from CI. Registry egress is
+  only needed while the template is created. No primary source states the first-turn
+  wall-clock; it is unmeasured and belongs to the #590 spike.
+- **Credentials to the CLI.** `createClaudeCode({ auth: 'direct', env })` reads
+  `ANTHROPIC_BASE_URL`/`ANTHROPIC_AUTH_TOKEN`/`ANTHROPIC_API_KEY` from the **host** process
+  env, merges `settings.env` over them, and — because the Vercel session supports
+  `addRequestTransformations` — replaces each credential with an `aisdkhc_…` placeholder
+  before sending the env to the bridge. The Vercel firewall swaps the placeholder for the
+  real bearer token on requests to the `ANTHROPIC_BASE_URL` host (TLS terminated with the
+  per-sandbox CA). The real OpenRouter key never enters the sandbox. The env reaches the
+  `claude` CLI via the Agent SDK `query({ options: { env } })`; Bash-tool children inherit it
+  unless `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1` is set, so Bash can read the placeholder and
+  can still *spend* the key by calling the allowed host from inside the sandbox.
+- **`auth: 'auto'` trap.** Auto mode treats `VERCEL_OIDC_TOKEN` as an AI Gateway credential
+  and routes Claude at the Vercel AI Gateway. With the OIDC token present for sandbox auth,
+  MyMemo must pin `auth: 'direct'` (the prototype does).
+
+## 1. Package, import, and options
+
+`@ai-sdk/sandbox-vercel` 1.0.91 exports exactly `createVercelSandbox`, `VercelSandboxProvider`,
+and the `VercelSandboxSettings` type
+([index](https://github.com/vercel/ai/blob/main/packages/sandbox-vercel/src/index.ts)). It
+depends on `@ai-sdk/harness`, `@ai-sdk/provider-utils`, and `@vercel/sandbox` `^2.0.1 || ^3.0.0`,
+and requires Node `>=22`
+([package.json](https://github.com/vercel/ai/blob/main/packages/sandbox-vercel/package.json)).
+The AI SDK docs pair it with the Claude Code adapter because "bridge-backed harnesses such as
+Claude Code and Codex require using real network sandbox like `@ai-sdk/sandbox-vercel`"
+([HarnessAgent docs](https://github.com/vercel/ai/blob/main/content/docs/03-ai-sdk-harnesses/02-harness-agent.mdx)).
+
+`VercelSandboxSettings` is a union of two shapes
+([source L42-59](https://github.com/vercel/ai/blob/main/packages/sandbox-vercel/src/vercel-sandbox.ts#L42-L59)):
+
+- `{ sandbox: Sandbox }` — wrap an already-created `@vercel/sandbox` instance. The caller owns
+  its lifecycle; the provider's `stop()` and `destroy()` are no-ops.
+- `Sandbox.create()` parameters (the SDK type is aliased directly, minus `onResume`), plus
+  `name` to override the auto-derived template name. So `runtime`, `image`, `source`, `env`,
+  `ports`, `timeout`, `resources.vcpus`, `region`, `failoverRegions`, `networkPolicy`,
+  `persistent`, `snapshotExpiration`, `keepLastSnapshots`, `tags`, `mounts`, `fetch`, and the
+  credential fields `token`/`teamId`/`projectId` all pass straight through
+  ([SDK reference, `Sandbox.create`](https://vercel.com/docs/sandbox/sdk-reference#sandbox.create)).
+
+Provider-imposed defaults
+([source L61-66, L136-145](https://github.com/vercel/ai/blob/main/packages/sandbox-vercel/src/vercel-sandbox.ts#L61-L66)):
+
+- `timeout` defaults to **30 minutes** ("The `@vercel/sandbox` SDK defaults to 5 minutes which
+  is too short for multi-step workflows — the VM expires between steps").
+- When neither `runtime`, `image`, nor a snapshot `source` is given, `runtime: 'node24'` is
+  set explicitly so the adapter's default stays stable across `@vercel/sandbox` v2 and v3
+  (v3 otherwise defaults to the `vercel/sandbox/universal` image). Support for v3 landed in
+  sandbox-vercel 1.0.87
+  ([CHANGELOG](https://github.com/vercel/ai/blob/main/packages/sandbox-vercel/CHANGELOG.md)).
+
+The Claude Code adapter uses the first port in `sandbox.ports` for its WebSocket bridge and
+throws `HarnessCapabilityUnsupportedError` if none is exposed: "Create the sandbox with
+`ports: [<port>]` or pass `createClaudeCode({ port })`"
+([adapter L1196-1205](https://github.com/vercel/ai/blob/main/packages/harness-claude-code/src/claude-code-harness.ts#L1196-L1205)).
+The endpoint is `sandbox.domain(port)` rewritten to `wss:`
+([network session L50-78](https://github.com/vercel/ai/blob/main/packages/sandbox-vercel/src/vercel-network-sandbox-session.ts#L50-L78)),
+i.e. a **public** Vercel URL; the bridge authenticates the host with `BRIDGE_CHANNEL_TOKEN`, a
+random 32-byte token rotated per spawn
+([adapter L1054-1064](https://github.com/vercel/ai/blob/main/packages/harness-claude-code/src/claude-code-harness.ts#L1054-L1064),
+[bridge transport L358](https://github.com/vercel/ai/blob/main/packages/harness/src/bridge/index.ts#L358)).
+Vercel bills "all traffic to and from exposed ports"
+([pricing, Network](https://vercel.com/docs/sandbox/pricing#network)), so the bridge stream
+is metered egress.
+
+The provider's tool-safe session runs every `run()` as `bash -c <command>` and every `spawn()`
+as `runCommand({ detached: true })`
+([session L39-45, L59-75](https://github.com/vercel/ai/blob/main/packages/sandbox-vercel/src/vercel-sandbox-session.ts#L39-L75)).
+
+MyMemo's prototype uses `createVercelSandbox({ runtime: 'node24', ports: [4000] })` with
+`createClaudeCode({ auth: 'direct', model })`
+([prototype](https://github.com/X-GPT/mymemo-agent/blob/codex/prototype-harness-agent/apps/agentcore-runtime/prototype-harness-agent.ts)).
+
+## 2. Authentication
+
+### What the provider checks
+
+`createVercelSandbox()` performs no I/O; credentials are resolved by `@vercel/sandbox` inside
+`Sandbox.create`/`getOrCreate`/`get`. Any 401/403 or Vercel auth error is rethrown as
+`HarnessSandboxAuthenticationError` with the message "Vercel Sandbox authentication failed.
+Set VERCEL_OIDC_TOKEN, or pass token, teamId, and projectId to createVercelSandbox(), then
+verify that they can access Vercel Sandbox."
+([source L323-357](https://github.com/vercel/ai/blob/main/packages/sandbox-vercel/src/vercel-sandbox.ts#L323-L357)).
+`hasConfiguredCredentials` is true when `process.env.VERCEL_OIDC_TOKEN` is set, a wrapped
+`sandbox` is supplied, or all of `token`, `teamId`, `projectId` are passed.
+
+### What `@vercel/sandbox` 3.1.0 actually does
+
+[`getCredentials()`](https://github.com/vercel/sandbox/blob/main/packages/vercel-sandbox/src/utils/get-credentials.ts#L81-L153):
+
+1. If `token`, `teamId`, and `projectId` are **all** passed as parameters, use them. Passing
+   one or two throws `Missing credentials parameters to access the Vercel API: …`.
+2. Otherwise call `@vercel/oidc`'s `getVercelOidcToken()` (reads `VERCEL_OIDC_TOKEN`) and
+   decode `project_id` and `owner_id` from the JWT payload as `projectId`/`teamId`
+   ([L59-79, L166-187](https://github.com/vercel/sandbox/blob/main/packages/vercel-sandbox/src/utils/get-credentials.ts#L59-L79)).
+3. If that fails and `shouldPromptForCredentials()` is true (`NODE_ENV !== 'production'`, `CI`
+   unset, stdin/stdout are TTYs), start a browser device-authorization flow and cache the
+   result for the process
+   ([dev-credentials L12-19, L135-140](https://github.com/vercel/sandbox/blob/main/packages/vercel-sandbox/src/utils/dev-credentials.ts#L12-L19));
+   otherwise throw `LocalOidcContextError` / `VercelOidcContextError`.
+
+There is no code path that reads `VERCEL_TOKEN`, `VERCEL_TEAM_ID`, or `VERCEL_PROJECT_ID`
+from the environment. Vercel's docs list those names only as suggested shell variables that
+you "then pass … to `Sandbox.create()`"
+([Authentication](https://vercel.com/docs/sandbox/concepts/authentication#access-tokens)).
+With the harness provider that means
+`createVercelSandbox({ token, teamId, projectId, … })`.
+
+### Where each value comes from
+
+| Value | Source | Notes |
+| --- | --- | --- |
+| `VERCEL_OIDC_TOKEN` | `vercel link` + `vercel env pull` → `.env.local` | "The token expires after 12 hours"; on Vercel-hosted compute "Vercel manages token expiration automatically" ([Authentication](https://vercel.com/docs/sandbox/concepts/authentication#vercel-oidc-token-recommended)). |
+| `token` | A Vercel access token with access to the team ([REST API](https://vercel.com/docs/rest-api#creating-an-access-token)) | Vercel's recommendation for "External CI/CD" and "Non-Vercel hosting". |
+| `teamId` | Team settings ([find your team ID](https://vercel.com/docs/accounts#find-your-team-id)) | `team_…`. |
+| `projectId` | Project general settings ([project ID](https://vercel.com/docs/project-configuration/general-settings#project-id)) | `prj_…`. Sandboxes, snapshots, and VCR images are project-scoped; names are unique per project ([Persistence](https://vercel.com/docs/sandbox/concepts/persistent-sandboxes#sandbox-names)). |
+
+chat-api runs as an ECS service
+([`infra/terraform/cloudwatch.tf`](../../infra/terraform/cloudwatch.tf)), not on Vercel, so
+production must use the access-token triple stored the way `docs/agents/configuration.md`
+handles other secrets. The OIDC path is only viable for local runs.
+
+## 3. Lifecycle mapping
+
+The contract the provider implements is
+[`HarnessV1SandboxProvider`](https://github.com/vercel/ai/blob/main/packages/harness/src/v1/harness-v1-sandbox-provider.ts#L10-L70):
+`createSession({ sessionId?, identity?, onFirstCreate?, abortSignal? })` and optional
+`resumeSession({ sessionId })`. `sessionId` makes naming deterministic "so a future call to
+`resume` (potentially from a different process) can find the same sandbox"; `identity` is a
+"stable identity for snapshot-based reuse"; `onFirstCreate` is "called exactly once per
+identity, on fresh creation".
+
+| Harness call | `HarnessAgent` / session behavior | Vercel provider call | Vercel Sandbox effect |
+| --- | --- | --- | --- |
+| `agent.createSession()` (fresh) | Computes the bootstrap plan and calls `provider.createSession({ sessionId, identity, onFirstCreate })` ([harness-agent L351-374](https://github.com/vercel/ai/blob/main/packages/harness/src/agent/harness-agent.ts#L351-L374)) | Template: `Sandbox.getOrCreate({ name: 'ai-sdk-harness-<identity>', persistent: true, snapshotExpiration: 0, onCreate: bootstrap })`; if no `currentSnapshotId`, `template.stop()` and read `snapshot.id` (or poll `Sandbox.get({ resume: false })` for up to 30 s). Session: `Sandbox.create({ ...params, source: { type: 'snapshot', snapshotId }, name: 'ai-sdk-harness-session-<sessionId>' })` ([provider L147-243](https://github.com/vercel/ai/blob/main/packages/sandbox-vercel/src/vercel-sandbox.ts#L147-L243)) | One persistent, never-expiring template sandbox per recipe identity (its snapshot is the fork source), plus one persistent session sandbox per harness session. The snapshot ID is cached in a process-global `Map` keyed by template name ([L283-321](https://github.com/vercel/ai/blob/main/packages/sandbox-vercel/src/vercel-sandbox.ts#L283-L321)). |
+| `session.detach()` | Returns resume state with live bridge coordinates; "The runtime and sandbox keep running; this local session handle becomes unusable" ([session L399-427](https://github.com/vercel/ai/blob/main/packages/harness/src/agent/harness-agent-session.ts#L399-L427)) | None | The microVM keeps running and billing until its `timeout` (provider default 30 min) elapses; then Vercel stops the session and, because the sandbox is persistent, snapshots it ([Concepts, Stopping](https://vercel.com/docs/sandbox/concepts#stopping-a-sandbox)). |
+| `session.stop()` | `doStop` waits up to 5 s for the bridge then `proc.kill()`; returns resume state; then `sandboxSession.stop()` when harness-owned ([session L435-461](https://github.com/vercel/ai/blob/main/packages/harness/src/agent/harness-agent-session.ts#L435-L461), [adapter L1925-1945](https://github.com/vercel/ai/blob/main/packages/harness-claude-code/src/claude-code-harness.ts#L1925-L1945)) | `sandbox.stop()` ([network session L114-117](https://github.com/vercel/ai/blob/main/packages/sandbox-vercel/src/vercel-network-sandbox-session.ts#L114-L117)) | Session stops; filesystem auto-snapshotted ("`stop()` … For persistent sandboxes, the resolved value also includes metadata for the snapshot captured during shutdown", [SDK reference](https://vercel.com/docs/sandbox/sdk-reference#sandbox.stop)). |
+| `session.destroy()` | `doDestroy` kills the bridge; then `sandboxSession.destroy()` ([session L468-480](https://github.com/vercel/ai/blob/main/packages/harness/src/agent/harness-agent-session.ts#L468-L480)) | `sandbox.stop()` then `sandbox.delete()` ([L119-123](https://github.com/vercel/ai/blob/main/packages/sandbox-vercel/src/vercel-network-sandbox-session.ts#L119-L123)) | Sandbox and its sessions are deleted. "Its snapshots survive the deletion … and they keep incurring storage charges" until they expire ([Persistence, Delete](https://vercel.com/docs/sandbox/concepts/persistent-sandboxes#delete-a-sandbox)). |
+| `createSession({ sessionId, resumeFrom })` | Requires `provider.resumeSession`; else `HarnessCapabilityUnsupportedError` ([harness-agent L332-350](https://github.com/vercel/ai/blob/main/packages/harness/src/agent/harness-agent.ts#L332-L350)) | `Sandbox.get({ name: 'ai-sdk-harness-session-<sessionId>' })` ([provider L246-270](https://github.com/vercel/ai/blob/main/packages/sandbox-vercel/src/vercel-sandbox.ts#L246-L270)) | "The handle is returned immediately; the SDK starts a new session on the next call that needs a running VM" from the most recent snapshot, with a fresh `timeout` ([Persistence, Resume](https://vercel.com/docs/sandbox/concepts/persistent-sandboxes#resume-where-you-left-off)). The adapter then tries to attach to a still-live bridge, else respawns it in replay or rerun mode (see the feasibility note's restart ladder). |
+| `createSession({ sandboxSession })` | Caller owns the sandbox; harness never stops/destroys it ([HarnessAgent docs](https://github.com/vercel/ai/blob/main/content/docs/03-ai-sdk-harnesses/02-harness-agent.mdx)) | `createVercelSandbox({ sandbox })` → `ownsLifecycle: false` | `stop()`/`destroy()` are no-ops. |
+| Start failure after sandbox acquisition | `cleanupAfterStartFailure` → `sandboxSession.stop()` if harness-owned ([L955-963](https://github.com/vercel/ai/blob/main/packages/harness/src/agent/harness-agent.ts#L955-L963)) | `sandbox.stop()` | Stopped, snapshotted, **not deleted**. |
+
+Points that matter for MyMemo:
+
+- **Session sandboxes are always persistent.** The fork strips `runtime`, `image`, `source`,
+  and `persistent` from the settings before `Sandbox.create`
+  ([L222-228](https://github.com/vercel/ai/blob/main/packages/sandbox-vercel/src/vercel-sandbox.ts#L222-L228)),
+  and `@vercel/sandbox` v2+ defaults `persistent` to `true`
+  ([SDK reference](https://vercel.com/docs/sandbox/sdk-reference#sandbox.create)). Every
+  `stop()` (explicit or by timeout) therefore writes a snapshot. `snapshotExpiration` and
+  `keepLastSnapshots` **are** forwarded, so MyMemo can bound storage (Vercel recommends
+  `keepLastSnapshots: { count: 1 }`,
+  [Persistence](https://vercel.com/docs/sandbox/concepts/persistent-sandboxes#default-snapshot-expiration-and-retention)).
+- **Abandoned sandboxes.** Nothing in the harness deletes a session sandbox except
+  `destroy()`. A detached-then-forgotten session stops at `timeout`, snapshots, and Vercel
+  "removes sandboxes that can't resume from a snapshot after 14 days of inactivity"; a
+  persistent one with a live snapshot stays until its snapshot expires (30 days after last
+  use by default) ([Persistence, Sandbox retention](https://vercel.com/docs/sandbox/concepts/persistent-sandboxes#sandbox-retention)).
+  This is the "cleanup of abandoned sandboxes" item the map defers.
+- **`resumeFrom` is persistence-dependent.** After `stop()` the sandbox is stopped; resume
+  works only because the sandbox is persistent and its snapshot is still available (and in the
+  same region, [Regions and snapshots](https://vercel.com/docs/sandbox/concepts/regions#regions-and-snapshots)).
+- **What survives `stop()`.** The adapter deliberately keeps the installed CLI, bridge, the
+  per-session `.agent-runs/<sessionId>/bridge` state, and the work dir under the sandbox's
+  default working directory (`/vercel/sandbox` on `node24`) so they "survive both detach →
+  attach/replay and stop → snapshot → resume cycles"
+  ([bootstrap comment L5-16](https://github.com/vercel/ai/blob/main/packages/harness-claude-code/src/claude-code-bootstrap.ts#L5-L16),
+  [Runtimes](https://vercel.com/docs/sandbox/concepts/runtimes)).
+- **Per-process snapshot cache.** A new chat-api process re-runs `Sandbox.getOrCreate` on the
+  template name; that "retrieves it without resuming it" and returns the existing
+  `currentSnapshotId`, so no re-bootstrap
+  ([Persistence, Get or create](https://vercel.com/docs/sandbox/concepts/persistent-sandboxes#get-or-create-idempotent)).
+
+## 4. Limits, network policy, and pricing
+
+All figures from Vercel's [pricing and quotas](https://vercel.com/docs/sandbox/pricing)
+(`last_updated: 2026-08-21`) unless noted.
+
+| Dimension | Hobby | Pro / Enterprise |
+| --- | --- | --- |
+| Active CPU (`iad1`) | 5 h/month included | $0.128/hour |
+| Provisioned memory (`iad1`) | 420 GB-h/month included | $0.0212/GB-hour, 1-minute minimum |
+| Sandbox creations | 5,000/month | $0.60 per 1M |
+| Data transfer (egress + exposed-port traffic; downloads free) | 20 GB/month | $0.15/GB |
+| Snapshot storage | 15 GB lifetime | $0.002630137/GB-month (Pro), $0.08/GB-month (Enterprise, as printed) |
+| Concurrent sandboxes | 10 | 10,000 |
+| Max session duration | 45 min | 24 h |
+| Max vCPU / memory | 4 / 8 GB | 8 / 16 GB (Enterprise 32 / 64 GB) |
+| vCPU allocation rate | 20 → 40/min | 150 → 5,000/min (resets after 10 idle min) |
+| Control plane (commands, file ops) | 1,000 req/min | 10,000 req/min (Enterprise 100,000) |
+| Deletions | 20 req/s | 20 req/s |
+
+- **Compute shape.** "You can provision 1 or an even number of vCPUs between 2 and 32 …
+  The default is 2 vCPUs"; "Each vCPU includes 2 GB of memory"; 32 GB ephemeral NVMe; up to
+  15 open ports ([Resource limits](https://vercel.com/docs/sandbox/pricing#resource-limits)).
+  Active CPU excludes time "waiting for I/O (such as network requests, database queries, or AI
+  model calls)", which is most of a Claude turn.
+- **Timeout semantics.** "The default timeout is 5 minutes"; "The maximum duration applies to
+  a single session, not to the sandbox itself. The limit resets every time a sandbox stops and
+  resumes" ([Runtime limits](https://vercel.com/docs/sandbox/pricing#runtime-limits)).
+  `sandbox.extendTimeout(ms)` extends the live deadline up to the plan max
+  ([SDK reference](https://vercel.com/docs/sandbox/sdk-reference#sandbox.extendtimeout)).
+  Vercel's KB confirms the timeout is wall-clock and there is no separate idle timeout
+  ([Duration and persistence guide](https://vercel.com/kb/guide/vercel-sandbox-duration-and-persistence)).
+  The harness never calls `extendTimeout`; a detached Conversation dies at 30 minutes unless
+  MyMemo passes a larger `timeout` or extends it itself.
+- **Pro billing.** "All Sandbox usage on Pro plans is charged against your $20/month credit"
+  then at the rates above; Hobby pauses creation after the allotment
+  ([Billing information](https://vercel.com/docs/sandbox/pricing#billing-information)).
+- **Regions.** `iad1` (default), `sfo1`, `cle1`, `cdg1`; chosen per sandbox via `region` or a
+  project default; failover regions are Pro/Enterprise only. "Snapshots can't be moved between
+  regions", and creating from a snapshot in another region fails with
+  `snapshot_region_mismatch` ([Regions](https://vercel.com/docs/sandbox/concepts/regions)).
+  MyMemo's AWS estate is `us-east-1`-adjacent; `iad1` is the natural choice and must be fixed
+  for the whole template + session set.
+- **Isolation and image.** "Each sandbox runs in its own Firecracker microVM with a dedicated
+  kernel"; `sudo` is available; images boot Ubuntu 26.04, custom VCR images, or snapshots
+  ([Concepts](https://vercel.com/docs/sandbox/concepts)). The legacy `node24` runtime the
+  provider defaults to is Amazon Linux 2023 with Node 24, `npm`, `pnpm`, `git`, user
+  `vercel-sandbox`, cwd `/vercel/sandbox`; runtimes are "deprecated" since 2026-08-07 but "keep
+  working for existing code" ([Runtimes](https://vercel.com/docs/sandbox/concepts/runtimes)).
+  The `vercel/sandbox/universal` image (Node 24 LTS, Python 3.14, "coding agents") is the v3
+  default and is opt-in via `image`
+  ([Images](https://vercel.com/docs/sandbox/concepts/images#vercel-managed-images)).
+- **Network policy.** Three modes: `allow-all` ("Default policy … unrestricted access to the
+  public Internet"), `deny-all` (blocks everything including DNS), and user-defined allowlists
+  of domains (SNI-matched, wildcards per label) and CIDRs with denied CIDRs taking precedence.
+  A domain rule may carry `transform` (credentials brokering) or `forwardURL` (proxying), for
+  which the firewall terminates TLS using a per-sandbox CA that is pre-trusted via
+  `NODE_EXTRA_CA_CERTS`, `SSL_CERT_FILE`, etc. Policies can be set at creation and updated on a
+  running sandbox ([Firewall](https://vercel.com/docs/sandbox/concepts/firewall),
+  [Proxy CA certificates](https://vercel.com/docs/sandbox/concepts#proxy-ca-certificates)).
+  `createVercelSandbox({ networkPolicy })` passes the native shape through, and the harness
+  session exposes `setNetworkPolicy`, `setRequestTransformations`, and
+  `addRequestTransformations` for mid-session changes
+  ([README](https://github.com/vercel/ai/blob/main/packages/sandbox-vercel/README.md)).
+
+## 5. Claude Code bootstrap in a fresh Vercel Sandbox
+
+### The recipe
+
+`getClaudeCodeBootstrap()` returns a `HarnessV1Bootstrap` with `bootstrapDir:
+'.harness-bootstrap/claude-code'`, four files (`package.json`, `pnpm-lock.yaml`,
+`pnpm-workspace.yaml`, `bridge.mjs`), and two commands:
+`pnpm install --frozen-lockfile --store-dir .pnpm-store` then
+`./node_modules/.bin/claude --version`
+([claude-code-bootstrap.ts L17-51](https://github.com/vercel/ai/blob/main/packages/harness-claude-code/src/claude-code-bootstrap.ts#L17-L51)).
+The bridge manifest pins `@anthropic-ai/claude-agent-sdk` **0.3.213**,
+`@anthropic-ai/claude-code` **2.1.213**, `@modelcontextprotocol/sdk` 1.29.0, `ws` 8.21.0,
+`zod` 4.4.3 ([bridge/package.json](https://github.com/vercel/ai/blob/main/packages/harness-claude-code/src/bridge/package.json)).
+The lockfile resolves platform-specific `claude-agent-sdk-linux-x64` binaries, which is what
+the `node24` (AL2023 x64) runtime needs. `pnpm` is present on `node24`
+([Runtimes](https://vercel.com/docs/sandbox/concepts/runtimes)).
+
+The recipe identity is a "deterministic 16-char hex identity derived from the recipe's
+content"; any content change (e.g. a new adapter release bumping the pinned CLI) produces a
+new identity and therefore a new template. After a successful run the framework writes
+`.harness-bootstrap/claude-code/.bootstrap-<identity>.ok`; subsequent `applyBootstrapRecipe`
+calls check the marker and return
+([bootstrap-recipe.ts L12-15, L62-84](https://github.com/vercel/ai/blob/main/packages/harness/src/agent/internal/bootstrap-recipe.ts#L12-L15)).
+`sandboxConfig.onBootstrap` + `bootstrapHash` fold into the same identity when MyMemo needs
+extra template setup ([sandbox-bootstrap.ts L96-108](https://github.com/vercel/ai/blob/main/packages/harness/src/agent/internal/sandbox-bootstrap.ts#L96-L108)).
+
+### Where it runs on Vercel
+
+Because the provider receives `identity` and `onFirstCreate`, the recipe runs inside
+`Sandbox.getOrCreate({ …, onCreate })` for the template sandbox and is captured in its snapshot;
+`onCreate` "runs once when a sandbox is freshly created … awaited before `Sandbox.getOrCreate`
+resolves"
+([Persistence, Lifecycle hooks](https://vercel.com/docs/sandbox/concepts/persistent-sandboxes#lifecycle-hooks)).
+Each harness session then forks from that snapshot and `HarnessAgent` re-applies the recipe as
+"a cheap no-op based on just a marker check"
+([harness-agent L383-407](https://github.com/vercel/ai/blob/main/packages/harness/src/agent/harness-agent.ts#L383-L407)).
+So the `pnpm install` runs once per adapter version per project/region, not per Conversation.
+The feasibility note's concern about "installing packages from the public registry on first
+customer traffic" applies only to the first session after a template invalidation.
+
+`prepareHarnessSandboxTemplate({ harness, sandboxProvider, sandboxConfig })` performs the same
+`createSession({ identity, onFirstCreate })` without a `sessionId`, applies the recipe, and
+stops the temporary session; "the snapshot/template state persists … for Vercel: as the
+`currentSnapshotId` of the named template sandbox"
+([prepare-harness-sandbox-template.ts L12-72](https://github.com/vercel/ai/blob/main/packages/harness/src/agent/prepare-harness-sandbox-template.ts#L12-L72)).
+Vercel documents it as a CI/deploy step
+([HarnessAgent docs, Prepare Reusable Sandboxes](https://github.com/vercel/ai/blob/main/content/docs/03-ai-sdk-harnesses/02-harness-agent.mdx)).
+Note the temporary session is itself a persistent fork with an auto-generated name that is
+stopped (snapshotted) and not deleted.
+
+### Registry egress
+
+Under the default `allow-all` policy `registry.npmjs.org` is reachable, and "Data your sandbox
+downloads from the internet, such as packages … is free"
+([pricing, Network](https://vercel.com/docs/sandbox/pricing#network)). If MyMemo sets a
+restrictive `networkPolicy` at creation, it applies to the template too, so the allowlist must
+include the npm registry (and any `onBootstrap` sources) or template creation fails. Because
+the same settings object feeds both template and forks, a tighter per-session policy is best
+applied after creation via `setNetworkPolicy` rather than in `createVercelSandbox()`.
+
+### First-turn wall-clock
+
+No primary source publishes a number, and the prototype commit did not record one. The
+components are:
+
+1. **Cold (template missing):** `Sandbox.getOrCreate` boot + write four files + `pnpm install`
+   of Claude Code 2.1.213 with its native binary + `claude --version` + `template.stop()`
+   (snapshot publish; the provider polls up to 30 s for the snapshot ID) + fork.
+2. **Warm (template exists):** fork from snapshot ("Resuming from a snapshot is even faster
+   than starting a fresh sandbox", sandboxes "start in milliseconds",
+   [Concepts](https://vercel.com/docs/sandbox/concepts#how-sandboxes-work)) + `mkdir -p` +
+   `spawn node bridge.mjs` + bridge advertises its port (adapter waits up to
+   `startupTimeoutMs`, default 120,000 ms,
+   [adapter L127](https://github.com/vercel/ai/blob/main/packages/harness-claude-code/src/claude-code-harness.ts#L127))
+   + `sandbox.update({ networkPolicy })` for credential brokering + first model round-trip via
+   OpenRouter.
+
+Measuring both paths is a stated deliverable for the
+[#590 spike](https://github.com/X-GPT/mymemo-agent/issues/590).
+
+## 6. How `createClaudeCode({ env })` reaches the Claude CLI
+
+### Resolution on the host
+
+`ClaudeCodeHarnessSettings.env` is "Environment variables for the Claude Code process. These
+values are merged over the sandbox bridge process environment"
+([settings L101-104](https://github.com/vercel/ai/blob/main/packages/harness-claude-code/src/claude-code-harness.ts#L101-L104)).
+On every start the adapter builds
+`claudeEnvironment = { ...resolveClaudeCodeEnv(settings.auth), …, ...settings.env }`
+([L866-879](https://github.com/vercel/ai/blob/main/packages/harness-claude-code/src/claude-code-harness.ts#L866-L879)):
+
+- `auth: 'direct'` → `pickAnthropic` reads `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, and
+  `ANTHROPIC_BASE_URL` from the **host** `process.env` (falling back to the CLI's
+  `apiKeyHelper` from `~/.claude/settings.json`)
+  ([claude-code-auth.ts L185-204](https://github.com/vercel/ai/blob/main/packages/harness-claude-code/src/claude-code-auth.ts#L185-L204)).
+- `auth: 'auto'` (default) → gateway first: `apiKey = AI_GATEWAY_API_KEY || VERCEL_OIDC_TOKEN`
+  ([ai-gateway-auth.ts L11-14](https://github.com/vercel/ai/blob/main/packages/harness/src/utils/ai-gateway-auth.ts#L11-L14));
+  when set, it emits `AI_GATEWAY_API_KEY`, `ANTHROPIC_API_KEY`, `AI_GATEWAY_BASE_URL`, and
+  `ANTHROPIC_BASE_URL` pointing at the Vercel AI Gateway
+  ([L242-259](https://github.com/vercel/ai/blob/main/packages/harness-claude-code/src/claude-code-auth.ts#L242-L259)).
+  Since `VERCEL_OIDC_TOKEN` is the local sandbox credential, `auto` silently reroutes the
+  model call away from OpenRouter; pin `auth: 'direct'`.
+
+### Credential brokering (Vercel path)
+
+Because `VercelNetworkSandboxSession` implements `addRequestTransformations`, the adapter
+takes the brokering branch
+([L880-909](https://github.com/vercel/ai/blob/main/packages/harness-claude-code/src/claude-code-harness.ts#L880-L909)):
+
+1. For each of `AI_GATEWAY_API_KEY`, `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN` present in
+   `claudeEnvironment`, generate a placeholder `aisdkhc_<43 base64url chars>` (or whatever
+   `credentialForwarding` returns for the placeholder)
+   ([credential-forwarding.ts L31-60](https://github.com/vercel/ai/blob/main/packages/harness/src/utils/credential-forwarding.ts#L31-L60),
+   [sandbox-credential-brokering.ts L4-12](https://github.com/vercel/ai/blob/main/packages/harness/src/utils/sandbox-credential-brokering.ts#L4-L12)).
+   The placeholder map is stored in the resume state (`sandboxCredentialEnvironment`) and
+   reused on resume so the same rule re-applies idempotently.
+2. `sandboxClaudeEnvironment = { ...claudeEnvironment, ...placeholders }` — the sandbox never
+   sees the real values.
+3. Build one `HarnessV1RequestTransformation` per credential: `match.host` = hostname of
+   `ANTHROPIC_BASE_URL` (default `api.anthropic.com`), `match.path.startsWith` = the base URL
+   path (`/api` for `https://openrouter.ai/api`), `match.headers` = exact
+   `Authorization: Bearer <placeholder>` (or `x-api-key: <placeholder>`), `transform.headers` =
+   the real header
+   ([claude-code-auth.ts L20-66](https://github.com/vercel/ai/blob/main/packages/harness-claude-code/src/claude-code-auth.ts#L20-L66),
+   [createCredentialRequestTransformation L36-58](https://github.com/vercel/ai/blob/main/packages/harness/src/utils/sandbox-credential-brokering.ts#L36-L58)).
+   The exact-header match is the "harden credential brokering to only apply with correct
+   ephemeral secret" change in harness-claude-code 1.0.93
+   ([CHANGELOG](https://github.com/vercel/ai/blob/main/packages/harness-claude-code/CHANGELOG.md)).
+4. `VercelNetworkPolicyManager.addRequestTransformations` reads the current policy
+   (`allow-all` by default), composes `{ allow: { '*': [], 'openrouter.ai': [ { match, transform } ] } }`
+   (a rule host is active when the allowed pattern `*` contains it), and calls
+   `sandbox.update({ networkPolicy })`
+   ([policy manager L98-200, L302-360, L414-470](https://github.com/vercel/ai/blob/main/packages/sandbox-vercel/src/vercel-network-policy-manager.ts#L302-L360)).
+   Vercel then terminates TLS for that host and rewrites the header
+   ([Firewall, Credentials brokering](https://vercel.com/docs/sandbox/concepts/firewall#credentials-brokering)).
+
+Sandboxes without request-transformation support fall back to forwarding the real values with a
+console warning ([L910-916](https://github.com/vercel/ai/blob/main/packages/harness-claude-code/src/claude-code-harness.ts#L910-L916));
+Vercel's docs state the same rule
+([Claude Code adapter docs, Authentication](https://github.com/vercel/ai/blob/main/content/providers/02-ai-sdk-harnesses/01-claude-code.mdx)).
+
+### Delivery to the bridge and the CLI
+
+The bridge process itself is spawned with only `BRIDGE_CHANNEL_TOKEN`, `BRIDGE_WS_PORT`, and
+`HOME` (when skills are used) over the sandbox's default env
+([L1057-1064, L1098-1101](https://github.com/vercel/ai/blob/main/packages/harness-claude-code/src/claude-code-harness.ts#L1057-L1064)).
+`sandboxClaudeEnvironment` travels in the `start` message over the WebSocket
+(`env: sandboxClaudeEnvironment`, [L1167](https://github.com/vercel/ai/blob/main/packages/harness-claude-code/src/claude-code-harness.ts#L1167)),
+and the bridge passes it to the Agent SDK as
+`query({ options: { env: { ...procEnv, ...start.env } } })`
+([bridge/index.ts L17, L339-344](https://github.com/vercel/ai/blob/main/packages/harness-claude-code/src/bridge/index.ts#L339-L344)).
+The Agent SDK's `env` option "replaces the subprocess environment instead of merging with
+`process.env`", which is why the bridge merges `procEnv` first
+([Agent SDK TypeScript reference](https://code.claude.com/docs/en/agent-sdk/typescript)).
+
+Inside the CLI, `ANTHROPIC_BASE_URL` overrides the API endpoint, `ANTHROPIC_AUTH_TOKEN` is
+sent as `Authorization: Bearer <value>`, and `ANTHROPIC_API_KEY` as `X-Api-Key`
+([Claude Code env vars](https://code.claude.com/docs/en/env-vars),
+[Connect to an LLM gateway](https://code.claude.com/docs/en/llm-gateway-connect)). The
+OpenRouter request therefore leaves the sandbox as
+`POST https://openrouter.ai/api/v1/messages` with `Authorization: Bearer aisdkhc_…`, which
+matches the brokering rule.
+
+### Do Bash-tool children inherit it?
+
+Yes by default. Claude Code documents `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB`: "Set to `1` to strip
+Anthropic and cloud provider credentials from subprocess environments (Bash tool, hooks, MCP
+stdio servers). The parent Claude process keeps these credentials for API calls, but child
+processes cannot read them … On Linux, this also runs Bash subprocesses in an isolated PID
+namespace so they cannot read host process environments via `/proc`"
+([env vars](https://code.claude.com/docs/en/env-vars)); the sandboxing page adds "There is no
+built-in credential deny list"
+([Sandboxed Bash tool](https://code.claude.com/docs/en/sandboxing#protect-credentials)).
+The adapter does not set it.
+
+Consequences for the map's stage-1 trust statement ("the model credential **is** reachable
+from prompt-injected Bash"):
+
+- What Bash can *read* is the placeholder, not the OpenRouter key. Exfiltrating
+  `$ANTHROPIC_AUTH_TOKEN` yields `aisdkhc_…`, which is useless outside this sandbox.
+- What Bash can still *do* is spend the key: a `curl https://openrouter.ai/api/... -H
+  "Authorization: Bearer $ANTHROPIC_AUTH_TOKEN"` from inside the sandbox is rewritten by the
+  same firewall rule. Brokering scopes the credential to one host from one microVM; it does
+  not stop in-sandbox abuse. `createClaudeCode({ env: { CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: '1' } })`
+  removes even the placeholder from Bash, hooks, and MCP children at no cost to the model path.
+
+## 7. Implications for #585
+
+- Configure `createVercelSandbox({ token, teamId, projectId, runtime: 'node24', ports: [n],
+  region: 'iad1', timeout, snapshotExpiration, keepLastSnapshots: { count: 1 } })` and
+  `createClaudeCode({ auth: 'direct', env: { CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: '1' } })`.
+  Set `ANTHROPIC_BASE_URL`/`ANTHROPIC_AUTH_TOKEN` on the chat-api process from
+  `OPENROUTER_BASE_URL`/`OPENROUTER_API_KEY` as the prototype does.
+- Run `prepareHarnessSandboxTemplate()` in the release pipeline so no user turn pays for
+  `pnpm install`; the template is keyed by adapter version, so each dependency bump creates a
+  new template and leaves the old one (never-expiring snapshot) behind until deleted.
+- Decide the sandbox retention policy: `detach()` alone leaves microVMs running to their
+  `timeout`, and `stop()`/timeouts accumulate snapshots. Only `destroy()` deletes a sandbox.
+- The "credential reachable from Bash" risk is narrower than the map states; revise it to
+  "usable from inside the sandbox against the allowed host" and ticket the scrub flag.
+- Snapshot region-binding means the region is a project-level decision, not per Conversation.
+
+## Sources
+
+- `@ai-sdk/sandbox-vercel` 1.0.91: [README](https://github.com/vercel/ai/blob/main/packages/sandbox-vercel/README.md), [package.json](https://github.com/vercel/ai/blob/main/packages/sandbox-vercel/package.json), [vercel-sandbox.ts](https://github.com/vercel/ai/blob/main/packages/sandbox-vercel/src/vercel-sandbox.ts), [vercel-network-sandbox-session.ts](https://github.com/vercel/ai/blob/main/packages/sandbox-vercel/src/vercel-network-sandbox-session.ts), [vercel-sandbox-session.ts](https://github.com/vercel/ai/blob/main/packages/sandbox-vercel/src/vercel-sandbox-session.ts), [vercel-network-policy-manager.ts](https://github.com/vercel/ai/blob/main/packages/sandbox-vercel/src/vercel-network-policy-manager.ts), [CHANGELOG](https://github.com/vercel/ai/blob/main/packages/sandbox-vercel/CHANGELOG.md)
+- `@ai-sdk/harness` 1.0.91: [harness-v1-sandbox-provider.ts](https://github.com/vercel/ai/blob/main/packages/harness/src/v1/harness-v1-sandbox-provider.ts), [harness-agent.ts](https://github.com/vercel/ai/blob/main/packages/harness/src/agent/harness-agent.ts), [harness-agent-session.ts](https://github.com/vercel/ai/blob/main/packages/harness/src/agent/harness-agent-session.ts), [prepare-harness-sandbox-template.ts](https://github.com/vercel/ai/blob/main/packages/harness/src/agent/prepare-harness-sandbox-template.ts), [bootstrap-recipe.ts](https://github.com/vercel/ai/blob/main/packages/harness/src/agent/internal/bootstrap-recipe.ts), [sandbox-bootstrap.ts](https://github.com/vercel/ai/blob/main/packages/harness/src/agent/internal/sandbox-bootstrap.ts), [credential-forwarding.ts](https://github.com/vercel/ai/blob/main/packages/harness/src/utils/credential-forwarding.ts), [sandbox-credential-brokering.ts](https://github.com/vercel/ai/blob/main/packages/harness/src/utils/sandbox-credential-brokering.ts), [ai-gateway-auth.ts](https://github.com/vercel/ai/blob/main/packages/harness/src/utils/ai-gateway-auth.ts), [bridge/index.ts](https://github.com/vercel/ai/blob/main/packages/harness/src/bridge/index.ts)
+- `@ai-sdk/harness-claude-code` 1.0.94: [claude-code-harness.ts](https://github.com/vercel/ai/blob/main/packages/harness-claude-code/src/claude-code-harness.ts), [claude-code-auth.ts](https://github.com/vercel/ai/blob/main/packages/harness-claude-code/src/claude-code-auth.ts), [claude-code-bootstrap.ts](https://github.com/vercel/ai/blob/main/packages/harness-claude-code/src/claude-code-bootstrap.ts), [bridge/package.json](https://github.com/vercel/ai/blob/main/packages/harness-claude-code/src/bridge/package.json), [bridge/index.ts](https://github.com/vercel/ai/blob/main/packages/harness-claude-code/src/bridge/index.ts), [CHANGELOG](https://github.com/vercel/ai/blob/main/packages/harness-claude-code/CHANGELOG.md)
+- AI SDK docs (same commit): [HarnessAgent](https://github.com/vercel/ai/blob/main/content/docs/03-ai-sdk-harnesses/02-harness-agent.mdx) (published at [ai-sdk.dev](https://ai-sdk.dev/docs/ai-sdk-harnesses/harness-agent)), [Claude Code adapter](https://github.com/vercel/ai/blob/main/content/providers/02-ai-sdk-harnesses/01-claude-code.mdx) ([ai-sdk.dev](https://ai-sdk.dev/providers/ai-sdk-harnesses/claude-code))
+- `@vercel/sandbox` 3.1.0: [get-credentials.ts](https://github.com/vercel/sandbox/blob/main/packages/vercel-sandbox/src/utils/get-credentials.ts), [dev-credentials.ts](https://github.com/vercel/sandbox/blob/main/packages/vercel-sandbox/src/utils/dev-credentials.ts), [releases](https://github.com/vercel/sandbox/releases)
+- Vercel Sandbox docs: [overview](https://vercel.com/docs/vercel-sandbox), [authentication](https://vercel.com/docs/sandbox/concepts/authentication), [concepts](https://vercel.com/docs/sandbox/concepts), [persistence](https://vercel.com/docs/sandbox/concepts/persistent-sandboxes), [snapshots](https://vercel.com/docs/sandbox/concepts/snapshots), [firewall](https://vercel.com/docs/sandbox/concepts/firewall), [regions](https://vercel.com/docs/sandbox/concepts/regions), [runtimes](https://vercel.com/docs/sandbox/concepts/runtimes), [images](https://vercel.com/docs/sandbox/concepts/images), [pricing and quotas](https://vercel.com/docs/sandbox/pricing), [JS SDK reference](https://vercel.com/docs/sandbox/sdk-reference), [duration and persistence guide](https://vercel.com/kb/guide/vercel-sandbox-duration-and-persistence)
+- Claude Code docs: [environment variables](https://code.claude.com/docs/en/env-vars), [connect to an LLM gateway](https://code.claude.com/docs/en/llm-gateway-connect), [sandboxed Bash tool](https://code.claude.com/docs/en/sandboxing), [Agent SDK TypeScript reference](https://code.claude.com/docs/en/agent-sdk/typescript)
+- MyMemo: [prototype-harness-agent.ts](https://github.com/X-GPT/mymemo-agent/blob/codex/prototype-harness-agent/apps/agentcore-runtime/prototype-harness-agent.ts) (commit `6cdfc3d`), [#585](https://github.com/X-GPT/mymemo-agent/issues/585), [#590](https://github.com/X-GPT/mymemo-agent/issues/590)


### PR DESCRIPTION
Five research notes under `docs/research/` for [Wayfinder map: HarnessAgent on Vercel Sandbox for /api/chat](https://github.com/X-GPT/mymemo-agent/issues/585). Docs only; no code or config changes.

- `ai-sdk-harness-agent-api-2026.md` — the `HarnessAgent` public surface (previously uncommitted)
- `ai-sdk-harness-agentcore-sandbox-feasibility-2026.md` — bridge vs host-driven, bootstrap/image gaps, upstream PR status (previously uncommitted)
- `ai-sdk-harness-bun-host-compatibility-2026.md` — resolves #586: the host side runs under Bun
- `vercel-sandbox-harness-provider-2026.md` — resolves #587: `@ai-sdk/sandbox-vercel` API, auth, lifecycle, limits, credential brokering
- `claude-code-harness-turn-persistence-2026.md` — resolves #588: continuity lives on the persistent sandbox snapshot, not the S3 blob

The map and the three ticket resolutions link these by `blob/main` path, so merging makes those links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DtcwiPaf15WMywgNPgApx4