### PR TITLE
docs: ADR-0033 Harness sandbox for the AI SDK chat path

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -187,9 +187,15 @@ _Avoid_: Conversation API, Assistant Cloud
 An additive, AI SDK-compatible data plane through which a client submits a
 message to an existing Conversation and receives that Run's live response. It
 shares the same Run admission and execution authority as the AG-UI agent
-surface rather than defining a second execution path. The staged `/api/chat`
-query verification path is not this surface; it returns raw Claude SDK NDJSON.
+surface rather than defining a second execution path. On the Harness path it is
+served from the Conversation's Harness sandbox rather than by a Run.
 _Avoid_: messaging layer, AI SDK runtime
+
+**Harness sandbox**:
+The persistent Vercel Sandbox, named from the Conversation id, that hosts Claude
+Code and carries the Conversation's model-side memory across turns on the AI SDK
+chat path. It is neither the Workspace nor the Execution runtime.
+_Avoid_: sandbox (ambiguous with E2B), Runtime session, Agent session
 
 **Assistant text delta**:
 A bounded, provisional fragment of Assistant text appended to the Run's Live
@@ -296,10 +302,8 @@ _Avoid_: fetch (the prototype path's word for content-into-context)
 The internal, Runtime-owned Claude SDK transcript that carries a Conversation's
 model-side memory across Runs, including a successfully preserved interrupted
 Run even when its provisional response is absent from Conversation history. It
-is never client-facing or stored in the Workspace. The staged verification path
-keeps its separate opaque Agent session under
-`agent-sessions/<conversationId>` and replaces that detached snapshot after each
-fully drained invocation.
+is never client-facing or stored in the Workspace. On the AI SDK chat path the
+Agent session lives inside the Conversation's Harness sandbox.
 _Avoid_: chat history (that is the user-visible record in run events)
 
 **Session mirror evidence**:

--- a/docs/adr/0033-host-the-ai-sdk-chat-loop-in-a-vercel-sandbox-through-harnessagent.md
+++ b/docs/adr/0033-host-the-ai-sdk-chat-loop-in-a-vercel-sandbox-through-harnessagent.md
@@ -1,0 +1,58 @@
+# Host the AI SDK chat loop in a Vercel Sandbox through HarnessAgent
+
+Status: accepted (2026-08-27). Supersedes the AgentCore-hosted Agent-query
+Runtime design of issue #560 for the AI SDK chat path. Amends ADR-0001 and
+ADR-0031 for that path only; the production Run path is unchanged.
+
+The AI SDK chat route `POST /api/chat` runs Vercel's `@ai-sdk/harness`
+`HarnessAgent` inside the chat-api process, with the upstream `createClaudeCode`
+adapter and `@ai-sdk/sandbox-vercel`. Each Conversation owns one persistent
+Vercel Sandbox — its **Harness sandbox**, named from the Conversation id — that
+hosts Claude Code and carries the Conversation's model-side memory in its
+filesystem snapshot. chat-api stops the sandbox after every turn and keeps
+only a small opaque resume pointer. The Agent-query Runtime on AgentCore, its
+S3 detached-session store, and its infrastructure are retired by hard swap.
+
+The trade this records: on this path the agent loop runs *inside* the sandbox,
+the shape ADR-0001 rejected for production. It is accepted here because the
+sandbox holds no MyMemo secret — the model credential is brokered by the Vercel
+provider and appears inside the sandbox only as a placeholder usable against
+the OpenRouter host — and because the alternative was owning a Claude-to-Harness
+adapter. Stage 1 deliberately runs Claude Code's built-in tools in that
+sandbox. Stage 2 disables them, exposes MyMemo's existing tool catalog as host
+tools, and reattaches the E2B Workspace, at which point the Harness sandbox is
+a trusted host again and the split runtime returns.
+
+## Considered options
+
+- **Custom host-driven `HarnessV1` adapter around the existing direct SDK
+  integration.** Rejected for this path because it means owning the
+  Claude-to-Harness protocol and lifecycle translation (weeks, per the
+  feasibility research) to avoid a boundary the sandbox already provides.
+- **Keep the Agent-query Runtime on AgentCore.** Rejected because it is a
+  second deployed runtime with its own image, IAM, Terraform, and invocation
+  hop for one verification route, and it had no tools.
+- **A fresh sandbox per turn with the transcript copied to S3.** Rejected for
+  stage 1: `resumeFrom` carries no transcript (proven by resuming with the same
+  state into a fresh sandbox — it forgot), so statelessness requires copying
+  Claude Code's internal session files ourselves. It costs 1–3 s more per turn
+  and has no warm path. It remains the natural shape once the Workspace moves
+  to E2B, and a transcript backup can be added to the persistent design later.
+- **`detach()` between turns for ~1.3 s resumes.** Deferred: Vercel's `timeout`
+  is a wall clock on the running session, so attaching late risks the VM
+  dying mid-turn unless it is extended on every attach, and idle VMs consume
+  the plan's concurrency cap.
+
+## Consequences
+
+- chat-api holds the Vercel token triple and the OpenRouter credential for this
+  path; `docs/agents/security.md` is revised with the implementation.
+- Continuity depends on the Vercel snapshot. With default retention a
+  Conversation idle for 30 days starts a fresh thread; an unresumable sandbox
+  is replaced silently and logged.
+- `createClaudeCode({ auth: 'direct' })` is mandatory; `auto` would route the
+  model call to the Vercel AI Gateway using the local OIDC token.
+- Overlapping turns on one Conversation are refused (`409`) rather than raced,
+  because two callers cannot share one running bridge.
+- The *Workspace* and *Execution runtime* glossary entries still describe the
+  production Run path; the AI SDK chat path has neither until stage 2.

--- a/docs/research/vercel-sandbox-harness-provider-2026.md
+++ b/docs/research/vercel-sandbox-harness-provider-2026.md
@@ -91,8 +91,10 @@ Claude Code and Codex require using real network sandbox like `@ai-sdk/sandbox-v
 - `Sandbox.create()` parameters (the SDK type is aliased directly, minus `onResume`), plus
   `name` to override the auto-derived template name. So `runtime`, `image`, `source`, `env`,
   `ports`, `timeout`, `resources.vcpus`, `region`, `failoverRegions`, `networkPolicy`,
-  `persistent`, `snapshotExpiration`, `keepLastSnapshots`, `tags`, `mounts`, `fetch`, and the
+  `persistent`, `snapshotExpiration`, `keepLastSnapshots`, `tags`, `fetch`, and the
   credential fields `token`/`teamId`/`projectId` all pass straight through
+  (there is no `mounts` option in `@vercel/sandbox` 3.1.0; an earlier revision of
+  this note listed one in error)
   ([SDK reference, `Sandbox.create`](https://vercel.com/docs/sandbox/sdk-reference#sandbox.create)).
 
 Provider-imposed defaults


### PR DESCRIPTION
Docs only, from [Wayfinder map: HarnessAgent on Vercel Sandbox for /api/chat](https://github.com/X-GPT/mymemo-agent/issues/585):

- `docs/adr/0033-host-the-ai-sdk-chat-loop-in-a-vercel-sandbox-through-harnessagent.md` — the stage-1 trust trade, considered options, consequences
- `CONTEXT.md` — adds **Harness sandbox**; updates *AI SDK agent surface* and *Agent session* to stop describing the retired staged NDJSON path
- `docs/research/vercel-sandbox-harness-provider-2026.md` — removes the nonexistent `mounts` option

The agent-doc revisions (`security.md`, `chat-api.md`, `architecture.md`, `configuration.md`, `agentcore-runtime.md`) are enumerated in the spec, [Spec: run the AI SDK chat route on HarnessAgent in a Vercel Sandbox](https://github.com/X-GPT/mymemo-agent/issues/595), and land with the implementation so those docs keep describing current behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DtcwiPaf15WMywgNPgApx4