### PR TITLE
feat(chat-api): stop and fail a Harness turn cleanly

### DIFF
--- a/apps/chat-api/src/features/ai-chat/ai-chat.route.test.ts
+++ b/apps/chat-api/src/features/ai-chat/ai-chat.route.test.ts
@@ -49,23 +49,36 @@ function fakeAgent() {
 		}) => {
 			events.push({ stream: options, sameSession: session === created });
 			return {
-				toUIMessageStreamResponse: () =>
-					new Response(uiMessageStream, {
-						headers: {
-							"content-type": "text/event-stream",
-							"x-vercel-ai-ui-message-stream": "v1",
-						},
-					}),
+				toUIMessageStreamResponse: (_options: {
+					onError: (error: unknown) => string;
+				}) => streamResponse(uiMessageStream),
 			};
 		},
 	};
 	return { agent: fake as unknown as HarnessChatAgent, events, fake };
 }
 
+function streamResponse(body: ConstructorParameters<typeof Response>[0]) {
+	return new Response(body, {
+		headers: {
+			"content-type": "text/event-stream",
+			"x-vercel-ai-ui-message-stream": "v1",
+		},
+	});
+}
+
+const logged: unknown[] = [];
+const logger = {
+	error: (obj: unknown, msg: string) =>
+		logged.push({ level: "error", obj, msg }),
+	warn: (obj: unknown, msg: string) => logged.push({ level: "warn", obj, msg }),
+};
+
 function makeApp(deps: Partial<AppDeps>) {
 	const app = new Hono<AppEnv>();
 	app.use("*", async (c, next) => {
 		c.set("deps", deps as AppDeps);
+		c.set("logger", logger as never);
 		await next();
 	});
 	app.route("/api/chat", aiChatRoutes);
@@ -133,7 +146,64 @@ it("destroys the session when the client cancels the stream", async () => {
 	expect(events.at(-1)).toBe("destroy");
 });
 
-it("destroys the session when the turn fails to start", async () => {
+it("passes the request's own abort signal to the turn", async () => {
+	const { agent, events } = fakeAgent();
+	const app = makeApp({
+		conversationStore: ownedConversation,
+		exposureGate: { isAgentEnabled: async () => true },
+		harnessChatAgent: agent,
+	});
+	const controller = new AbortController();
+	await app.request(
+		new Request("http://localhost/api/chat", {
+			method: "POST",
+			headers,
+			body: JSON.stringify(requestBody),
+			signal: controller.signal,
+		}),
+	);
+	const streamEvent = events[1] as { stream: { abortSignal?: AbortSignal } };
+	expect(streamEvent.stream.abortSignal).toBe(controller.signal);
+});
+
+it("ends an aborted turn cleanly with the abort part and still destroys the session", async () => {
+	const { agent, events, fake } = fakeAgent();
+	const controller = new AbortController();
+	// Mirrors HarnessAgent: on abort the turn settles with a final `abort` part.
+	fake.stream = async ({ abortSignal }) => ({
+		toUIMessageStreamResponse: () =>
+			streamResponse(
+				new ReadableStream({
+					start(c) {
+						abortSignal?.addEventListener("abort", () => {
+							c.enqueue('data: {"type":"abort"}\n\ndata: [DONE]\n\n');
+							c.close();
+						});
+					},
+				}),
+			),
+	});
+	const app = makeApp({
+		conversationStore: ownedConversation,
+		exposureGate: { isAgentEnabled: async () => true },
+		harnessChatAgent: agent,
+	});
+	const response = await app.request(
+		new Request("http://localhost/api/chat", {
+			method: "POST",
+			headers,
+			body: JSON.stringify(requestBody),
+			signal: controller.signal,
+		}),
+	);
+	expect(response.status).toBe(200);
+	const text = response.text();
+	controller.abort();
+	expect(await text).toContain('{"type":"abort"}');
+	expect(events.at(-1)).toBe("destroy");
+});
+
+it("destroys the session and logs when the turn fails to start", async () => {
 	const { agent, events, fake } = fakeAgent();
 	fake.stream = async () => {
 		throw new Error("bridge unavailable");
@@ -143,13 +213,60 @@ it("destroys the session when the turn fails to start", async () => {
 		exposureGate: { isAgentEnabled: async () => true },
 		harnessChatAgent: agent,
 	});
+	logged.length = 0;
 	const response = await app.request("/api/chat", {
 		method: "POST",
 		headers,
 		body: JSON.stringify(requestBody),
 	});
 	expect(response.status).toBe(500);
+	expect(await response.text()).not.toContain("bridge unavailable");
 	expect(events.at(-1)).toBe("destroy");
+	expect(logged).toEqual([
+		{
+			level: "error",
+			obj: { err: expect.any(Error), conversationId: "conversation-1" },
+			msg: "harness turn failed to start",
+		},
+	]);
+});
+
+it("hides the cause of a mid-stream failure from the client, logs it, and destroys the session", async () => {
+	const { agent, events, fake } = fakeAgent();
+	// Mirrors the AI SDK: a failing turn becomes an `error` part whose text is `onError`'s return.
+	fake.stream = async () => ({
+		toUIMessageStreamResponse: (options: {
+			onError: (error: unknown) => string;
+		}) =>
+			streamResponse(
+				`data: {"type":"error","errorText":${JSON.stringify(
+					options.onError(new Error("model exploded")),
+				)}}\n\ndata: [DONE]\n\n`,
+			),
+	});
+	const app = makeApp({
+		conversationStore: ownedConversation,
+		exposureGate: { isAgentEnabled: async () => true },
+		harnessChatAgent: agent,
+	});
+	logged.length = 0;
+	const response = await app.request("/api/chat", {
+		method: "POST",
+		headers,
+		body: JSON.stringify(requestBody),
+	});
+	expect(response.status).toBe(200);
+	const text = await response.text();
+	expect(text).toContain('"errorText":"An error occurred."');
+	expect(text).not.toContain("model exploded");
+	expect(events.at(-1)).toBe("destroy");
+	expect(logged).toEqual([
+		{
+			level: "error",
+			obj: { err: expect.any(Error), conversationId: "conversation-1" },
+			msg: "harness turn failed while streaming",
+		},
+	]);
 });
 
 it("rejects invalid and exposure-disabled requests before creating a session", async () => {

--- a/apps/chat-api/src/features/ai-chat/ai-chat.route.test.ts
+++ b/apps/chat-api/src/features/ai-chat/ai-chat.route.test.ts
@@ -49,6 +49,7 @@ function fakeAgent() {
 		}) => {
 			events.push({ stream: options, sameSession: session === created });
 			return {
+				// Typed so the mid-stream failure test can override it with a real `onError`.
 				toUIMessageStreamResponse: (_options: {
 					onError: (error: unknown) => string;
 				}) => streamResponse(uiMessageStream),

--- a/apps/chat-api/src/features/ai-chat/ai-chat.route.ts
+++ b/apps/chat-api/src/features/ai-chat/ai-chat.route.ts
@@ -119,10 +119,26 @@ routes.post(
 				abortSignal: c.req.raw.signal,
 			});
 		} catch (error) {
+			c.var.logger.error(
+				{ err: error, conversationId: body.id },
+				"harness turn failed to start",
+			);
 			await destroy();
 			throw error;
 		}
-		return cleanupAfterStream(result.toUIMessageStreamResponse(), destroy);
+		return cleanupAfterStream(
+			result.toUIMessageStreamResponse({
+				// Details stay in the log; the client only ever sees the generic text.
+				onError: (error) => {
+					c.var.logger.error(
+						{ err: error, conversationId: body.id },
+						"harness turn failed while streaming",
+					);
+					return "An error occurred.";
+				},
+			}),
+			destroy,
+		);
 	},
 );
 

--- a/docs/agents/chat-api.md
+++ b/docs/agents/chat-api.md
@@ -27,8 +27,7 @@ generic `500`; a turn that fails while streaming ends with the AI SDK `error`
 part carrying only the generic `"An error occurred."` text. Failure details
 are logged by chat-api and never sent to the client. In every case — drained,
 stopped, cancelled, failed — the session is destroyed so the sandbox does not
-run on to its timeout. The `/v1` Interrupt route is unrelated to this path.
-There is no admission, Run,
+run on to its timeout. There is no admission, Run,
 history, retry, or continuity between messages yet: the fresh-sandbox-per-turn
 lifecycle is the first slice of [#595](https://github.com/X-GPT/mymemo-agent/issues/595)
 and is superseded by ADR-0033's persistent Harness sandbox (resume pointer,

--- a/docs/agents/chat-api.md
+++ b/docs/agents/chat-api.md
@@ -17,9 +17,18 @@ inside a Harness sandbox (see [ADR-0033](../adr/0033-host-the-ai-sdk-chat-loop-i
 Sandbox whose harness `sessionId` is the Conversation id. The response is the
 AI SDK UI message stream (`toUIMessageStreamResponse()`): text arrives as it is
 produced and built-in tool activity appears as `tool-input-available` /
-`tool-output-available` parts. The request abort signal is passed to the turn.
-The session is destroyed once the stream has been drained, cancelled, or
-failed, and also when the turn fails to start. There is no admission, Run,
+`tool-output-available` parts.
+
+Stop is best-effort and has no endpoint or durable record: the request's own
+abort signal is passed to the turn, so `useChat().stop()` or a disconnect
+aborts Claude Code in the sandbox, the stream ends with the AI SDK `abort`
+part, and no error reaches the client. A turn that fails to start returns the
+generic `500`; a turn that fails while streaming ends with the AI SDK `error`
+part carrying only the generic `"An error occurred."` text. Failure details
+are logged by chat-api and never sent to the client. In every case — drained,
+stopped, cancelled, failed — the session is destroyed so the sandbox does not
+run on to its timeout. The `/v1` Interrupt route is unrelated to this path.
+There is no admission, Run,
 history, retry, or continuity between messages yet: the fresh-sandbox-per-turn
 lifecycle is the first slice of [#595](https://github.com/X-GPT/mymemo-agent/issues/595)
 and is superseded by ADR-0033's persistent Harness sandbox (resume pointer,


### PR DESCRIPTION
Closes #598

## Summary

- A user can stop a response mid-way and a failed turn never leaks a running sandbox. The request's own abort signal reaches the harness turn (which settles it with the AI SDK `abort` part — no thrown error), and the session is destroyed on every exit: drained, stopped, cancelled, or failed.
- Failures stay in chat-api logs; the client sees only the existing generic boundary: Hono's `500` when the turn fails to start, the AI SDK `error` part with `"An error occurred."` when it fails mid-stream (`onError` on `toUIMessageStreamResponse` logs and returns the generic text).
- No Stop endpoint and no durable interruption record. `docs/agents/chat-api.md` documents best-effort Stop.

## Tests

Fake-agent route tests in `ai-chat.route.test.ts`:
- the `abortSignal` passed to the turn **is** the request's signal (`toBe(controller.signal)`)
- an aborted turn ends with the `abort` part, status 200, and the session is destroyed afterwards
- a start failure returns 500 without the cause, logs it, and destroys the session
- a mid-stream failure emits only the generic `errorText`, logs the cause, and destroys the session

## Verification

- `bun test src/features/ai-chat` — 9 pass
- `bun run lint` / `bun run format` — clean
- `bunx tsc --noEmit -p apps/chat-api` — only the pre-existing `s3-artifact-download-signer.ts` error on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGFUhQKpiZrHypoXuNVATz