### PR TITLE
feat(chat-api): continue a Conversation across Harness turns

### DIFF
--- a/apps/chat-api/src/deps.ts
+++ b/apps/chat-api/src/deps.ts
@@ -8,6 +8,10 @@ import {
 import type { Env as PinoEnv } from "hono-pino";
 import type { ApiConfig } from "./config/env";
 import type { HarnessChatAgent } from "./features/ai-chat/harness-chat-agent";
+import {
+	type HarnessResumeStateStore,
+	PostgresHarnessResumeStateStore,
+} from "./features/ai-chat/harness-resume-state-store";
 import type { ArtifactDownloadSigner } from "./features/artifacts/artifact-download-signer";
 import type { ArtifactMetadataStore } from "./features/artifacts/artifact-metadata-store";
 import { PostgresArtifactMetadataStore } from "./features/artifacts/postgres-artifact-metadata-store";
@@ -38,6 +42,8 @@ export interface AppDeps {
 	config: ApiConfig;
 	/** Harness-hosted AI SDK chat turn (local composition only). */
 	harnessChatAgent: HarnessChatAgent;
+	/** Per-Conversation opaque Harness resume pointer (local composition only). */
+	harnessResumeStateStore: HarnessResumeStateStore;
 	/** Authoritative current Downloadable artifact metadata in Postgres. */
 	artifactMetadataStore: ArtifactMetadataStore;
 	/** Creates short-lived direct-download URLs after ownership authorization. */
@@ -100,6 +106,7 @@ export function createDeps(
 	return {
 		config,
 		harnessChatAgent,
+		harnessResumeStateStore: new PostgresHarnessResumeStateStore(database),
 		artifactMetadataStore: new PostgresArtifactMetadataStore(database),
 		artifactDownloadSigner,
 		conversationStore,

--- a/apps/chat-api/src/features/ai-chat/ai-chat.route.test.ts
+++ b/apps/chat-api/src/features/ai-chat/ai-chat.route.test.ts
@@ -26,16 +26,38 @@ const requestBody = {
 const uiMessageStream =
 	'data: {"type":"text-delta","id":"t1","delta":"Hi"}\n\ndata: [DONE]\n\n';
 
+/** What the fake session's `stop()` returns; opaque to the route. */
+const stoppedState = { type: "resume-session", data: { after: "turn" } };
+
+/** In-memory resume pointer store, optionally pre-seeded for conversation-1. */
+function fakeResumeStore(initial: unknown = null) {
+	const saved: unknown[] = [];
+	const store = {
+		load: async () => initial,
+		save: async (ref: unknown, state: unknown) => {
+			saved.push({ ref, state });
+		},
+	};
+	return {
+		store: store as unknown as AppDeps["harnessResumeStateStore"],
+		saved,
+	};
+}
+
 /** Fake agent that records the lifecycle and streams a canned UI message stream. */
 function fakeAgent() {
 	const events: unknown[] = [];
 	const created = {
-		destroy: async () => {
-			events.push("destroy");
+		stop: async () => {
+			events.push("stop");
+			return stoppedState;
 		},
 	};
 	const fake = {
-		createSession: async (options: { sessionId: string }) => {
+		createSession: async (options: {
+			sessionId: string;
+			resumeFrom?: unknown;
+		}) => {
 			events.push({ createSession: options });
 			return created;
 		},
@@ -78,7 +100,10 @@ const logger = {
 function makeApp(deps: Partial<AppDeps>) {
 	const app = new Hono<AppEnv>();
 	app.use("*", async (c, next) => {
-		c.set("deps", deps as AppDeps);
+		c.set("deps", {
+			harnessResumeStateStore: fakeResumeStore().store,
+			...deps,
+		} as AppDeps);
 		c.set("logger", logger as never);
 		await next();
 	});
@@ -90,8 +115,9 @@ const ownedConversation = {
 	get: async () => ({ archivedAt: null }) as never,
 } as unknown as AppDeps["conversationStore"];
 
-it("runs one Harness turn in a session named after the Conversation and destroys it after the stream", async () => {
+it("runs one Harness turn in a session named after the Conversation and stops it after the stream", async () => {
 	const { agent, events } = fakeAgent();
+	const { store, saved } = fakeResumeStore();
 	const lookups: unknown[] = [];
 	const app = makeApp({
 		conversationStore: {
@@ -102,6 +128,7 @@ it("runs one Harness turn in a session named after the Conversation and destroys
 		} as unknown as AppDeps["conversationStore"],
 		exposureGate: { isAgentEnabled: async () => true },
 		harnessChatAgent: agent,
+		harnessResumeStateStore: store,
 	});
 
 	const response = await app.request("/api/chat", {
@@ -116,7 +143,7 @@ it("runs one Harness turn in a session named after the Conversation and destroys
 	expect(lookups).toEqual([
 		{ userId: "member-1", conversationId: "conversation-1" },
 	]);
-	// The session is not destroyed until the client has drained the stream.
+	// The session is not stopped until the client has drained the stream.
 	expect(events).toEqual([
 		{
 			createSession: { sessionId: "conversation-1" },
@@ -126,11 +153,78 @@ it("runs one Harness turn in a session named after the Conversation and destroys
 			sameSession: true,
 		},
 	]);
+	// The pointer never appears in the stream; it is stored after `stop()`.
 	expect(await response.text()).toBe(uiMessageStream);
-	expect(events.at(-1)).toBe("destroy");
+	expect(events.at(-1)).toBe("stop");
+	expect(saved).toEqual([
+		{
+			ref: { userId: "member-1", conversationId: "conversation-1" },
+			state: stoppedState,
+		},
+	]);
 });
 
-it("destroys the session when the client cancels the stream", async () => {
+it("resumes the Conversation's session from the stored pointer", async () => {
+	const { agent, events } = fakeAgent();
+	const pointer = { type: "resume-session", data: { from: "before" } };
+	const app = makeApp({
+		conversationStore: ownedConversation,
+		exposureGate: { isAgentEnabled: async () => true },
+		harnessChatAgent: agent,
+		harnessResumeStateStore: fakeResumeStore(pointer).store,
+	});
+	const response = await app.request("/api/chat", {
+		method: "POST",
+		headers,
+		body: JSON.stringify(requestBody),
+	});
+	expect(response.status).toBe(200);
+	expect(events[0]).toEqual({
+		createSession: { sessionId: "conversation-1", resumeFrom: pointer },
+	});
+	expect(await response.text()).not.toContain("before");
+});
+
+it("starts a fresh session for the same id and logs when resuming throws", async () => {
+	const { agent, events, fake } = fakeAgent();
+	const createSession = fake.createSession;
+	fake.createSession = async (options) => {
+		if (options.resumeFrom) throw new Error("snapshot expired");
+		return createSession(options);
+	};
+	const { store, saved } = fakeResumeStore({
+		type: "resume-session",
+		data: {},
+	});
+	const app = makeApp({
+		conversationStore: ownedConversation,
+		exposureGate: { isAgentEnabled: async () => true },
+		harnessChatAgent: agent,
+		harnessResumeStateStore: store,
+	});
+	logged.length = 0;
+	const response = await app.request("/api/chat", {
+		method: "POST",
+		headers,
+		body: JSON.stringify(requestBody),
+	});
+	expect(response.status).toBe(200);
+	expect(await response.text()).toBe(uiMessageStream);
+	expect(events[0]).toEqual({ createSession: { sessionId: "conversation-1" } });
+	expect(logged).toEqual([
+		{
+			level: "warn",
+			obj: { err: expect.any(Error), conversationId: "conversation-1" },
+			msg: "harness session resume failed; starting a fresh session",
+		},
+	]);
+	// The stale pointer is replaced by the fresh session's.
+	expect(saved.map((s) => (s as { state: unknown }).state)).toEqual([
+		stoppedState,
+	]);
+});
+
+it("stops the session when the client cancels the stream", async () => {
 	const { agent, events } = fakeAgent();
 	const app = makeApp({
 		conversationStore: ownedConversation,
@@ -142,9 +236,9 @@ it("destroys the session when the client cancels the stream", async () => {
 		headers,
 		body: JSON.stringify(requestBody),
 	});
-	expect(events).not.toContain("destroy");
+	expect(events).not.toContain("stop");
 	await response.body?.cancel();
-	expect(events.at(-1)).toBe("destroy");
+	expect(events.at(-1)).toBe("stop");
 });
 
 it("passes the request's own abort signal to the turn", async () => {
@@ -167,7 +261,7 @@ it("passes the request's own abort signal to the turn", async () => {
 	expect(streamEvent.stream.abortSignal).toBe(controller.signal);
 });
 
-it("ends an aborted turn cleanly with the abort part and still destroys the session", async () => {
+it("ends an aborted turn cleanly with the abort part and still stops the session", async () => {
 	const { agent, events, fake } = fakeAgent();
 	const controller = new AbortController();
 	// Mirrors HarnessAgent: on abort the turn settles with a final `abort` part.
@@ -201,10 +295,10 @@ it("ends an aborted turn cleanly with the abort part and still destroys the sess
 	const text = response.text();
 	controller.abort();
 	expect(await text).toContain('{"type":"abort"}');
-	expect(events.at(-1)).toBe("destroy");
+	expect(events.at(-1)).toBe("stop");
 });
 
-it("destroys the session and logs when the turn fails to start", async () => {
+it("stops the session and logs when the turn fails to start", async () => {
 	const { agent, events, fake } = fakeAgent();
 	fake.stream = async () => {
 		throw new Error("bridge unavailable");
@@ -222,7 +316,7 @@ it("destroys the session and logs when the turn fails to start", async () => {
 	});
 	expect(response.status).toBe(500);
 	expect(await response.text()).not.toContain("bridge unavailable");
-	expect(events.at(-1)).toBe("destroy");
+	expect(events.at(-1)).toBe("stop");
 	expect(logged).toEqual([
 		{
 			level: "error",
@@ -232,7 +326,7 @@ it("destroys the session and logs when the turn fails to start", async () => {
 	]);
 });
 
-it("hides the cause of a mid-stream failure from the client, logs it, and destroys the session", async () => {
+it("hides the cause of a mid-stream failure from the client, logs it, and stops the session", async () => {
 	const { agent, events, fake } = fakeAgent();
 	// Mirrors the AI SDK: a failing turn becomes an `error` part whose text is `onError`'s return.
 	fake.stream = async () => ({
@@ -260,7 +354,7 @@ it("hides the cause of a mid-stream failure from the client, logs it, and destro
 	const text = await response.text();
 	expect(text).toContain('"errorText":"An error occurred."');
 	expect(text).not.toContain("model exploded");
-	expect(events.at(-1)).toBe("destroy");
+	expect(events.at(-1)).toBe("stop");
 	expect(logged).toEqual([
 		{
 			level: "error",

--- a/apps/chat-api/src/features/ai-chat/ai-chat.route.test.ts
+++ b/apps/chat-api/src/features/ai-chat/ai-chat.route.test.ts
@@ -31,7 +31,7 @@ const stoppedState = { type: "resume-session", data: { after: "turn" } };
 
 /** In-memory resume pointer store, optionally pre-seeded for conversation-1. */
 function fakeResumeStore(initial: unknown = null) {
-	const saved: unknown[] = [];
+	const saved: { ref: unknown; state: unknown }[] = [];
 	const store = {
 		load: async () => initial,
 		save: async (ref: unknown, state: unknown) => {
@@ -219,9 +219,7 @@ it("starts a fresh session for the same id and logs when resuming throws", async
 		},
 	]);
 	// The stale pointer is replaced by the fresh session's.
-	expect(saved.map((s) => (s as { state: unknown }).state)).toEqual([
-		stoppedState,
-	]);
+	expect(saved.map((s) => s.state)).toEqual([stoppedState]);
 });
 
 it("stops the session when the client cancels the stream", async () => {

--- a/apps/chat-api/src/features/ai-chat/ai-chat.route.ts
+++ b/apps/chat-api/src/features/ai-chat/ai-chat.route.ts
@@ -107,11 +107,10 @@ routes.post(
 		const resumeFrom = await c.var.deps.harnessResumeStateStore.load(ref);
 		let session: Awaited<ReturnType<typeof agent.createSession>>;
 		try {
-			session = await agent.createSession(
-				resumeFrom
-					? { sessionId: body.id, resumeFrom }
-					: { sessionId: body.id },
-			);
+			session = await agent.createSession({
+				sessionId: body.id,
+				resumeFrom: resumeFrom ?? undefined,
+			});
 		} catch (error) {
 			if (!resumeFrom) throw error;
 			// Snapshot expired or sandbox gone: start a fresh thread under the same

--- a/apps/chat-api/src/features/ai-chat/ai-chat.route.ts
+++ b/apps/chat-api/src/features/ai-chat/ai-chat.route.ts
@@ -30,7 +30,7 @@ const chatBody = z.strictObject({
 
 /**
  * Forward `response` unchanged and run `cleanup` once its body has been fully
- * read, cancelled, or failed — the Harness sandbox must not outlive the turn.
+ * read, cancelled, or failed — the Harness sandbox must not run on past the turn.
  * Hand-rolled because Bun 1.3 honours neither `TransformStream.cancel` nor
  * `finally` in an async-generator body when the client cancels.
  */
@@ -103,14 +103,37 @@ routes.post(
 			return c.json({ error: "Agent is not enabled" }, 403);
 		}
 		const agent = c.var.deps.harnessChatAgent;
-		const session = await agent.createSession({ sessionId: body.id });
-		const destroy = () =>
-			session.destroy().catch((error: unknown) => {
+		const ref = { userId: c.var.identity.memberCode, conversationId: body.id };
+		const resumeFrom = await c.var.deps.harnessResumeStateStore.load(ref);
+		let session: Awaited<ReturnType<typeof agent.createSession>>;
+		try {
+			session = await agent.createSession(
+				resumeFrom
+					? { sessionId: body.id, resumeFrom }
+					: { sessionId: body.id },
+			);
+		} catch (error) {
+			if (!resumeFrom) throw error;
+			// Snapshot expired or sandbox gone: start a fresh thread under the same
+			// id rather than block the user. The stale pointer is overwritten below.
+			c.var.logger.warn(
+				{ err: error, conversationId: body.id },
+				"harness session resume failed; starting a fresh session",
+			);
+			session = await agent.createSession({ sessionId: body.id });
+		}
+		// Snapshot the sandbox and remember how to resume it; the pointer is opaque.
+		const stop = async () => {
+			try {
+				const state = await session.stop();
+				await c.var.deps.harnessResumeStateStore.save(ref, state);
+			} catch (error) {
 				c.var.logger.warn(
 					{ err: error, conversationId: body.id },
-					"harness session destroy failed",
+					"harness session stop failed",
 				);
-			});
+			}
+		};
 		let result: Awaited<ReturnType<typeof agent.stream>>;
 		try {
 			result = await agent.stream({
@@ -123,7 +146,7 @@ routes.post(
 				{ err: error, conversationId: body.id },
 				"harness turn failed to start",
 			);
-			await destroy();
+			await stop();
 			throw error;
 		}
 		return cleanupAfterStream(
@@ -137,7 +160,7 @@ routes.post(
 					return "An error occurred.";
 				},
 			}),
-			destroy,
+			stop,
 		);
 	},
 );

--- a/apps/chat-api/src/features/ai-chat/harness-resume-state-store.test.ts
+++ b/apps/chat-api/src/features/ai-chat/harness-resume-state-store.test.ts
@@ -1,0 +1,32 @@
+import { afterAll, beforeAll, expect, it } from "bun:test";
+import type { HarnessAgentResumeSessionState } from "@ai-sdk/harness/agent";
+import { conversationRuntime } from "@mymemo/agent-db/schema";
+import { createTestDatabase, type TestDb } from "@mymemo/agent-db/testing";
+import { PostgresHarnessResumeStateStore } from "./harness-resume-state-store";
+
+let tdb: TestDb;
+let store: PostgresHarnessResumeStateStore;
+
+beforeAll(async () => {
+	tdb = await createTestDatabase();
+	store = new PostgresHarnessResumeStateStore(tdb.db);
+});
+
+afterAll(() => tdb.close());
+
+const ref = { userId: "user-1", conversationId: "conv-1" };
+const state = (n: number): HarnessAgentResumeSessionState =>
+	({ type: "resume-session", data: { turn: n } }) as never;
+
+it("round-trips the pointer verbatim, creating the runtime row on first save", async () => {
+	expect(await store.load(ref)).toBeNull();
+	await store.save(ref, state(1));
+	expect(await store.load(ref)).toEqual(state(1));
+	// A later turn replaces the pointer on the existing row.
+	await store.save(ref, state(2));
+	expect(await store.load(ref)).toEqual(state(2));
+	expect(await tdb.db.select().from(conversationRuntime)).toHaveLength(1);
+	expect(
+		await store.load({ userId: "user-2", conversationId: "conv-1" }),
+	).toBeNull();
+});

--- a/apps/chat-api/src/features/ai-chat/harness-resume-state-store.ts
+++ b/apps/chat-api/src/features/ai-chat/harness-resume-state-store.ts
@@ -39,8 +39,7 @@ export class PostgresHarnessResumeStateStore
 					eq(conversationRuntime.userId, ref.userId),
 					eq(conversationRuntime.conversationId, ref.conversationId),
 				),
-			)
-			.limit(1);
+			);
 		return (row?.state as HarnessAgentResumeSessionState | undefined) ?? null;
 	}
 

--- a/apps/chat-api/src/features/ai-chat/harness-resume-state-store.ts
+++ b/apps/chat-api/src/features/ai-chat/harness-resume-state-store.ts
@@ -1,0 +1,62 @@
+import type { HarnessAgentResumeSessionState } from "@ai-sdk/harness/agent";
+import type { Database } from "@mymemo/agent-db/client";
+import { conversationRuntime } from "@mymemo/agent-db/schema";
+import { and, eq } from "drizzle-orm";
+import type { ConversationRef } from "@/features/conversation-store/conversation-store";
+
+/**
+ * The Conversation's opaque Harness resume pointer (ADR-0033): whatever
+ * `session.stop()` returned after the last turn, handed back verbatim as
+ * `createSession({ resumeFrom })`. chat-api never reads inside it — the
+ * Conversation's memory is the sandbox snapshot, not this value.
+ */
+export interface HarnessResumeStateStore {
+	load(ref: ConversationRef): Promise<HarnessAgentResumeSessionState | null>;
+	save(
+		ref: ConversationRef,
+		state: HarnessAgentResumeSessionState,
+	): Promise<void>;
+}
+
+/**
+ * Stores the pointer on `conversation_runtime`. Unfenced on purpose: the AI SDK
+ * chat path has no Run and no Conversation Ownership, so there is no epoch to
+ * fence on; the `(user_id, conversation_id)` key is the only guard.
+ */
+export class PostgresHarnessResumeStateStore
+	implements HarnessResumeStateStore
+{
+	constructor(private readonly db: Database) {}
+
+	async load(
+		ref: ConversationRef,
+	): Promise<HarnessAgentResumeSessionState | null> {
+		const [row] = await this.db
+			.select({ state: conversationRuntime.harnessResumeState })
+			.from(conversationRuntime)
+			.where(
+				and(
+					eq(conversationRuntime.userId, ref.userId),
+					eq(conversationRuntime.conversationId, ref.conversationId),
+				),
+			)
+			.limit(1);
+		return (row?.state as HarnessAgentResumeSessionState | undefined) ?? null;
+	}
+
+	async save(
+		ref: ConversationRef,
+		state: HarnessAgentResumeSessionState,
+	): Promise<void> {
+		await this.db
+			.insert(conversationRuntime)
+			.values({ ...ref, harnessResumeState: state })
+			.onConflictDoUpdate({
+				target: [
+					conversationRuntime.userId,
+					conversationRuntime.conversationId,
+				],
+				set: { harnessResumeState: state, updatedAt: new Date() },
+			});
+	}
+}

--- a/apps/chat-api/src/features/conversation-store/postgres-conversation-store.test.ts
+++ b/apps/chat-api/src/features/conversation-store/postgres-conversation-store.test.ts
@@ -181,6 +181,7 @@ describe("PostgresConversationStore", () => {
 			userId: "user-1",
 			conversationId: "conv-1",
 			sandboxId: "sandbox-1",
+			harnessResumeState: { type: "resume-session", data: {} },
 		});
 		await tdb.db.insert(agentSessions).values({
 			conversationId: "conv-1",
@@ -232,7 +233,13 @@ describe("PostgresConversationStore", () => {
 		expect(await tdb.db.select().from(runs)).toHaveLength(0);
 		expect(await tdb.db.select().from(runEvents)).toHaveLength(0);
 		expect(await tdb.db.select().from(conversationArtifacts)).toHaveLength(0);
-		expect(await tdb.db.select().from(conversationRuntime)).toHaveLength(1);
+		// The runtime row survives for E2B cleanup; the Harness pointer does not.
+		expect(await tdb.db.select().from(conversationRuntime)).toEqual([
+			expect.objectContaining({
+				sandboxId: "sandbox-1",
+				harnessResumeState: null,
+			}),
+		]);
 		expect(await tdb.db.select().from(agentSessions)).toHaveLength(1);
 		expect(await tdb.db.select().from(artifactObjects)).toHaveLength(1);
 	});

--- a/apps/chat-api/src/features/conversation-store/postgres-conversation-store.ts
+++ b/apps/chat-api/src/features/conversation-store/postgres-conversation-store.ts
@@ -1,6 +1,7 @@
 import type { Database } from "@mymemo/agent-db/client";
 import {
 	ACTIVE_RUN_STATUSES,
+	conversationRuntime,
 	conversations,
 	runs,
 } from "@mymemo/agent-db/schema";
@@ -199,6 +200,17 @@ export class PostgresConversationStore implements ConversationStore {
 			if (!conversation) return { outcome: "not_found" };
 			if (await hasActiveRun(tx, ref)) return { outcome: "active_run" };
 
+			// The runtime row outlives the Conversation so cleanup can still find
+			// its E2B sandbox; only the Harness resume pointer dies with it here.
+			await tx
+				.update(conversationRuntime)
+				.set({ harnessResumeState: null })
+				.where(
+					and(
+						eq(conversationRuntime.userId, ref.userId),
+						eq(conversationRuntime.conversationId, ref.conversationId),
+					),
+				);
 			await tx
 				.delete(conversations)
 				.where(

--- a/docs/agents/chat-api.md
+++ b/docs/agents/chat-api.md
@@ -13,11 +13,25 @@ The local-only composition mounts `POST /api/chat`. It accepts the strict
 and, after identity, Conversation ownership (`404`), Archive (`409`), and
 exposure (`403`) checks, runs one turn of Claude Code with its built-in tools
 inside a Harness sandbox (see [ADR-0033](../adr/0033-host-the-ai-sdk-chat-loop-in-a-vercel-sandbox-through-harnessagent.md)).
-`HarnessAgent` runs in the chat-api process; the sandbox is a fresh Vercel
-Sandbox whose harness `sessionId` is the Conversation id. The response is the
-AI SDK UI message stream (`toUIMessageStreamResponse()`): text arrives as it is
-produced and built-in tool activity appears as `tool-input-available` /
-`tool-output-available` parts.
+`HarnessAgent` runs in the chat-api process; each Conversation owns one
+persistent Vercel Sandbox whose harness `sessionId` is the Conversation id. The
+response is the AI SDK UI message stream (`toUIMessageStreamResponse()`): text
+arrives as it is produced and built-in tool activity appears as
+`tool-input-available` / `tool-output-available` parts.
+
+Continuity between messages is the sandbox snapshot. A turn loads the
+Conversation's **resume pointer** (`conversation_runtime.harness_resume_state`,
+the opaque value the previous turn's `session.stop()` returned) and calls
+`createSession({ sessionId, resumeFrom })`; without one it creates a fresh
+session for the same id. After every turn — drained, stopped, cancelled, or
+failed — the route calls `session.stop()` so Vercel snapshots the sandbox, and
+stores the returned pointer. chat-api never interprets the pointer and it never
+appears in the stream. If resuming throws (snapshot expired or sandbox gone),
+the route logs `harness session resume failed; starting a fresh session` and
+creates a fresh session for the same id: the user gets a response on a new
+thread. Retention is Vercel's default (30-day snapshot expiry, one snapshot
+kept); there is no deletion hook or sweep. Permanent deletion of a Conversation
+nulls its pointer and leaves the sandbox to expire.
 
 Stop is best-effort and has no endpoint or durable record: the request's own
 abort signal is passed to the turn, so `useChat().stop()` or a disconnect
@@ -25,16 +39,24 @@ aborts Claude Code in the sandbox, the stream ends with the AI SDK `abort`
 part, and no error reaches the client. A turn that fails to start returns the
 generic `500`; a turn that fails while streaming ends with the AI SDK `error`
 part carrying only the generic `"An error occurred."` text. Failure details
-are logged by chat-api and never sent to the client. In every case — drained,
-stopped, cancelled, failed — the session is destroyed so the sandbox does not
-run on to its timeout. There is no admission, Run,
-history, retry, or continuity between messages yet: the fresh-sandbox-per-turn
-lifecycle is the first slice of [#595](https://github.com/X-GPT/mymemo-agent/issues/595)
-and is superseded by ADR-0033's persistent Harness sandbox (resume pointer,
-`stop()` per turn, `409` on overlapping turns) in the follow-up tickets. The
-adapter runs the configured `OPENROUTER_DEFAULT_MODEL`; the request `model`
+are logged by chat-api and never sent to the client. There is no admission,
+Run, history, or retry yet, and overlapping turns are not rejected: those are
+follow-up slices of [#595](https://github.com/X-GPT/mymemo-agent/issues/595).
+The adapter runs the configured `OPENROUTER_DEFAULT_MODEL`; the request `model`
 literal is validated, not forwarded. Production composition does not mount this
 path; its `harnessChatAgent` throws.
+
+Local two-turn recall check (real harness; needs the Compose stack with the
+Vercel triple and `OPENROUTER_API_KEY` exported):
+
+```sh
+H='-H content-type:application/json -H x-member-code:m1 -H x-partner-code:p1'
+ID=$(curl -s -X POST localhost:3000/v1/conversations $H -d '{}' | jq -r .conversationId)
+turn() { curl -sN -X POST localhost:3000/api/chat $H -d "{\"id\":\"$ID\",\"model\":\"anthropic/claude-sonnet-5\",\"trigger\":\"submit-message\",\"messages\":[{\"id\":\"$2\",\"role\":\"user\",\"parts\":[{\"type\":\"text\",\"text\":\"$1\"}]}]}"; }
+turn "Remember the word pelican." 11111111-1111-4111-8111-111111111111
+docker compose restart chat-api
+turn "Which word did I ask you to remember?" 22222222-2222-4222-8222-222222222222   # answer mentions pelican
+```
 
 ### Create a Conversation
 

--- a/docs/agents/chat-api.md
+++ b/docs/agents/chat-api.md
@@ -19,19 +19,13 @@ response is the AI SDK UI message stream (`toUIMessageStreamResponse()`): text
 arrives as it is produced and built-in tool activity appears as
 `tool-input-available` / `tool-output-available` parts.
 
-Continuity between messages is the sandbox snapshot. A turn loads the
-Conversation's **resume pointer** (`conversation_runtime.harness_resume_state`,
-the opaque value the previous turn's `session.stop()` returned) and calls
-`createSession({ sessionId, resumeFrom })`; without one it creates a fresh
-session for the same id. After every turn — drained, stopped, cancelled, or
-failed — the route calls `session.stop()` so Vercel snapshots the sandbox, and
-stores the returned pointer. chat-api never interprets the pointer and it never
-appears in the stream. If resuming throws (snapshot expired or sandbox gone),
-the route logs `harness session resume failed; starting a fresh session` and
-creates a fresh session for the same id: the user gets a response on a new
-thread. Retention is Vercel's default (30-day snapshot expiry, one snapshot
-kept); there is no deletion hook or sweep. Permanent deletion of a Conversation
-nulls its pointer and leaves the sandbox to expire.
+Continuity between messages is the sandbox snapshot: after every turn —
+drained, cancelled, or failed — the route calls `session.stop()` and stores the
+returned opaque pointer in `conversation_runtime.harness_resume_state`; the
+next turn passes it back as `createSession({ sessionId, resumeFrom })`. If
+resuming throws, the route logs `harness session resume failed; starting a
+fresh session` and starts a fresh session for the same id. Permanent deletion
+nulls the pointer; retention and the rest of the lifecycle are ADR-0033's.
 
 Stop is best-effort and has no endpoint or durable record: the request's own
 abort signal is passed to the turn, so `useChat().stop()` or a disconnect

--- a/packages/agent-db/drizzle/0028_medical_jubilee.sql
+++ b/packages/agent-db/drizzle/0028_medical_jubilee.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "conversation_runtime" ADD COLUMN "harness_resume_state" jsonb;

--- a/packages/agent-db/drizzle/meta/0028_snapshot.json
+++ b/packages/agent-db/drizzle/meta/0028_snapshot.json
@@ -1,0 +1,1280 @@
+{
+  "id": "3547190a-f0dc-4b0d-a5ff-95321de6d478",
+  "prevId": "4177f629-8038-4c1b-8298-70f5cc8b23b6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agentcore_dispatch_outbox": {
+      "name": "agentcore_dispatch_outbox",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admitted_at": {
+          "name": "admitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_claimed_by": {
+          "name": "publish_claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_claim_until": {
+          "name": "publish_claim_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_attempts": {
+          "name": "publish_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "replay_requested_at": {
+          "name": "replay_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_requested_by": {
+          "name": "replay_requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agentcore_dispatch_outbox_pending_idx": {
+          "name": "agentcore_dispatch_outbox_pending_idx",
+          "columns": [
+            {
+              "expression": "admitted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"agentcore_dispatch_outbox\".\"published_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agentcore_dispatch_outbox_publish_claim_idx": {
+          "name": "agentcore_dispatch_outbox_publish_claim_idx",
+          "columns": [
+            {
+              "expression": "publish_claim_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_sessions": {
+      "name": "agent_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subpath": {
+          "name": "subpath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry": {
+          "name": "entry",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "epoch": {
+          "name": "epoch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_sessions_dedup_idx": {
+          "name": "agent_sessions_dedup_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subpath",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_sessions_transcript_idx": {
+          "name": "agent_sessions_transcript_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subpath",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_sessions_conversation_idx": {
+          "name": "agent_sessions_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artifact_objects": {
+      "name": "artifact_objects",
+      "schema": "",
+      "columns": {
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "artifact_objects_run_idx": {
+          "name": "artifact_objects_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifact_objects_status_idx": {
+          "name": "artifact_objects_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "artifact_objects_status_check": {
+          "name": "artifact_objects_status_check",
+          "value": "\"artifact_objects\".\"status\" in ('pending', 'current', 'superseded')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversation_artifacts": {
+      "name": "conversation_artifacts",
+      "schema": "",
+      "columns": {
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_artifacts_owner_conversation_path_idx": {
+          "name": "conversation_artifacts_owner_conversation_path_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_artifacts_conversation_fk": {
+          "name": "conversation_artifacts_conversation_fk",
+          "tableFrom": "conversation_artifacts",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "user_id",
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "user_id",
+            "conversation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "conversation_artifacts_size_bytes_check": {
+          "name": "conversation_artifacts_size_bytes_check",
+          "value": "\"conversation_artifacts\".\"size_bytes\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversation_messages": {
+      "name": "conversation_messages",
+      "schema": "",
+      "columns": {
+        "sequence": {
+          "name": "sequence",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_messages_order_idx": {
+          "name": "conversation_messages_order_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_messages_conversation_fk": {
+          "name": "conversation_messages_conversation_fk",
+          "tableFrom": "conversation_messages",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "user_id",
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "user_id",
+            "conversation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_messages_user_id_conversation_id_message_id_pk": {
+          "name": "conversation_messages_user_id_conversation_id_message_id_pk",
+          "columns": [
+            "user_id",
+            "conversation_id",
+            "message_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "conversation_messages_sequence_unique": {
+          "name": "conversation_messages_sequence_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sequence"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "conversation_messages_role_check": {
+          "name": "conversation_messages_role_check",
+          "value": "\"conversation_messages\".\"role\" in ('user', 'assistant')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversation_runtime": {
+      "name": "conversation_runtime",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_tainted": {
+          "name": "sandbox_tainted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "harness_resume_state": {
+          "name": "harness_resume_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "conversation_runtime_user_id_conversation_id_pk": {
+          "name": "conversation_runtime_user_id_conversation_id_pk",
+          "columns": [
+            "user_id",
+            "conversation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_id": {
+          "name": "summary_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_worker_id": {
+          "name": "owner_worker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_until": {
+          "name": "owner_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "epoch": {
+          "name": "epoch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "conversations_regular_activity_idx": {
+          "name": "conversations_regular_activity_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversations\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_archived_activity_idx": {
+          "name": "conversations_archived_activity_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversations\".\"archived_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_reclamation_idx": {
+          "name": "conversations_reclamation_idx",
+          "columns": [
+            {
+              "expression": "owner_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversations\".\"owner_until\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "conversations_user_id_conversation_id_pk": {
+          "name": "conversations_user_id_conversation_id_pk",
+          "columns": [
+            "user_id",
+            "conversation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "conversations_scope_check": {
+          "name": "conversations_scope_check",
+          "value": "\"conversations\".\"scope\" in ('general', 'collection', 'document')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.document_access_events": {
+      "name": "document_access_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_ids": {
+          "name": "document_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_count": {
+          "name": "result_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_access_events_run_id_idx": {
+          "name": "document_access_events_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_access_events_created_at_idx": {
+          "name": "document_access_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "document_access_events_operation_check": {
+          "name": "document_access_events_operation_check",
+          "value": "\"document_access_events\".\"operation\" in ('search', 'list', 'load')"
+        },
+        "document_access_events_scope_type_check": {
+          "name": "document_access_events_scope_type_check",
+          "value": "\"document_access_events\".\"scope_type\" in ('general', 'collection', 'document')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.orphan_sandboxes": {
+      "name": "orphan_sandboxes",
+      "schema": "",
+      "columns": {
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_worker_id": {
+          "name": "created_by_worker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_events": {
+      "name": "run_events",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "run_events_run_id_runs_run_id_fk": {
+          "name": "run_events_run_id_runs_run_id_fk",
+          "tableFrom": "run_events",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "run_events_run_id_seq_pk": {
+          "name": "run_events_run_id_seq_pk",
+          "columns": [
+            "run_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runs": {
+      "name": "runs",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_input": {
+          "name": "normalized_input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executed_by_worker_id": {
+          "name": "executed_by_worker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interrupt_requested_at": {
+          "name": "interrupt_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_stream_failed_at": {
+          "name": "live_stream_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_event_seq": {
+          "name": "next_event_seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "runs_conversation_active_idx": {
+          "name": "runs_conversation_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runs\".\"status\" in ('queued', 'running', 'interrupt_requested')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_cleanup_idx": {
+          "name": "runs_cleanup_idx",
+          "columns": [
+            {
+              "expression": "terminal_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runs\".\"status\" in ('done', 'error', 'interrupted')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_history_paging_idx": {
+          "name": "runs_history_paging_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runs\".\"status\" in ('done', 'error', 'interrupted')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runs_conversation_fk": {
+          "name": "runs_conversation_fk",
+          "tableFrom": "runs",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "user_id",
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "user_id",
+            "conversation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runs_status_check": {
+          "name": "runs_status_check",
+          "value": "\"runs\".\"status\" in ('queued', 'running', 'interrupt_requested', 'done', 'error', 'interrupted')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/agent-db/drizzle/meta/_journal.json
+++ b/packages/agent-db/drizzle/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1787609618911,
       "tag": "0027_petite_major_mapleleaf",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1787811489673,
+      "tag": "0028_medical_jubilee",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/agent-db/src/runtime-store.test.ts
+++ b/packages/agent-db/src/runtime-store.test.ts
@@ -95,6 +95,14 @@ describe("migration", () => {
 			await columnExists("conversation_runtime", "workspace_checkpoint_status"),
 		).toBe(false);
 	});
+
+	it("adds the nullable Harness resume pointer to conversation_runtime", async () => {
+		// ADR-0033: the AI SDK chat path stores `session.stop()`'s opaque return
+		// value per Conversation; the sandbox snapshot holds the memory itself.
+		expect(
+			await columnExists("conversation_runtime", "harness_resume_state"),
+		).toBe(true);
+	});
 });
 
 /** The identity every fenced helper is keyed by in these tests. */

--- a/packages/agent-db/src/schema.ts
+++ b/packages/agent-db/src/schema.ts
@@ -59,6 +59,13 @@ export const conversationRuntime = pgTable(
 		 * leave it unchanged.
 		 */
 		agentSessionId: text("agent_session_id"),
+		/**
+		 * Opaque Harness resume pointer (ADR-0033): the value `session.stop()`
+		 * returned after the Conversation's last AI SDK chat turn, replayed as
+		 * `createSession({ resumeFrom })` on the next. Never interpreted here;
+		 * NULL until the first turn stops, and after Permanent deletion.
+		 */
+		harnessResumeState: jsonb("harness_resume_state"),
 		createdAt: timestamp("created_at", { withTimezone: true })
 			.notNull()
 			.defaultNow(),


### PR DESCRIPTION
## Summary

Closes #599 (parent spec #595, ADR-0033).

Each Conversation now owns one persistent Harness sandbox named from its id:

- A turn loads the Conversation's opaque resume pointer and calls `createSession({ sessionId, resumeFrom })`; without one it creates a fresh session for the same id.
- After the stream is drained, cancelled, or fails, the route calls `session.stop()` (Vercel snapshots the sandbox) and stores the returned state as the pointer. The pointer is never interpreted and never appears in the stream.
- If resuming throws (snapshot expired, sandbox gone), the route logs `harness session resume failed; starting a fresh session` and starts a fresh session for the same id — the user gets a response on a new thread.
- Retention is Vercel's default (30-day expiry, one snapshot kept); no deletion hook or sweep.

## Changes

- `packages/agent-db`: nullable jsonb `conversation_runtime.harness_resume_state` (migration `0028_medical_jubilee`), covered by the PGlite migration test.
- `apps/chat-api`: `HarnessResumeStateStore` + `PostgresHarnessResumeStateStore` (unfenced upsert — this path has no Run or Ownership epoch), wired into `AppDeps`; route resume / stop / fallback; Permanent deletion nulls the pointer.
- Docs: `docs/agents/chat-api.md` describes continuity and retention and adds the local two-turn recall check across a `docker compose restart chat-api`.

## Deviation from the acceptance criteria

"Deleting a Conversation deletes its row, and with it the pointer": the `conversation_runtime` row deliberately survives Permanent deletion today so the agent-worker cleanup sweep can still find and kill the E2B sandbox (`cleanup.ts` "Remove `conversation_runtime` rows whose conversation no longer exists"; existing test "leaves external cleanup state recoverable"). Deleting the row here would break that. So deletion nulls `harness_resume_state` in the same transaction; the sweep later removes the row. Net effect on the pointer is the same.

## Verification

- `apps/chat-api`: `bun test` — 146 pass (route tests: pointer stored after `stop()`, resume passes the stored pointer, resume failure → 200 + warn + replaced pointer; store round-trip on PGlite; delete nulls the pointer).
- `packages/agent-db`: `bun test` — 228 pass (new column exists after migrations).
- `biome check .` clean.
- The real-harness two-turn check is documented but not run here (needs Vercel + OpenRouter credentials).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
