### PR TITLE
feat(chat-api): refuse overlapping Harness turns

### DIFF
--- a/apps/chat-api/src/features/ai-chat/ai-chat.route.test.ts
+++ b/apps/chat-api/src/features/ai-chat/ai-chat.route.test.ts
@@ -247,7 +247,7 @@ it("passes the request's own abort signal to the turn", async () => {
 		harnessChatAgent: agent,
 	});
 	const controller = new AbortController();
-	await app.request(
+	const response = await app.request(
 		new Request("http://localhost/api/chat", {
 			method: "POST",
 			headers,
@@ -257,6 +257,7 @@ it("passes the request's own abort signal to the turn", async () => {
 	);
 	const streamEvent = events[1] as { stream: { abortSignal?: AbortSignal } };
 	expect(streamEvent.stream.abortSignal).toBe(controller.signal);
+	await response.body?.cancel();
 });
 
 it("ends an aborted turn cleanly with the abort part and still stops the session", async () => {
@@ -360,6 +361,83 @@ it("hides the cause of a mid-stream failure from the client, logs it, and stops 
 			msg: "harness turn failed while streaming",
 		},
 	]);
+});
+
+it("refuses a second turn on the same Conversation until the first has been stopped", async () => {
+	const { agent, events, fake } = fakeAgent();
+	// conversation-1's stop() hangs until released; other sessions stop at once.
+	const releases: (() => void)[] = [];
+	const releaseStop = () => releases.shift()?.();
+	let gated = true;
+	fake.createSession = async ({ sessionId }) => ({
+		stop: async () => {
+			if (gated && sessionId === requestBody.id) {
+				await new Promise<void>((resolve) => releases.push(resolve));
+			}
+			events.push("stop");
+			return stoppedState;
+		},
+	});
+	const app = makeApp({
+		conversationStore: ownedConversation,
+		exposureGate: { isAgentEnabled: async () => true },
+		harnessChatAgent: agent,
+	});
+	const post = (id = requestBody.id) =>
+		app.request("/api/chat", {
+			method: "POST",
+			headers,
+			body: JSON.stringify({ ...requestBody, id }),
+		});
+
+	const first = await post();
+	expect(first.status).toBe(200);
+	const second = await post();
+	expect(second.status).toBe(409);
+	expect(await second.json()).toEqual({
+		error: "Conversation has an active response",
+	});
+	// Other Conversations are unaffected.
+	const other = await post("conversation-2");
+	expect(other.status).toBe(200);
+	await other.body?.cancel();
+	// Rejected before any sandbox work: one session per admitted turn.
+	expect(
+		events.filter((e) => typeof e === "object" && "stream" in (e as object)),
+	).toHaveLength(2);
+
+	// Draining the stream is not enough: the slot is held until stop() settles.
+	const drained = first.text();
+	await Bun.sleep(0);
+	expect(releases).toHaveLength(1); // stop() is pending
+	expect((await post()).status).toBe(409);
+	releaseStop();
+	await drained;
+	expect(events.at(-1)).toBe("stop");
+	gated = false;
+	const third = await post();
+	expect(third.status).toBe(200);
+	await third.body?.cancel();
+});
+
+it("releases the slot when the session cannot be created", async () => {
+	const { agent, fake } = fakeAgent();
+	fake.createSession = async () => {
+		throw new Error("sandbox unavailable");
+	};
+	const app = makeApp({
+		conversationStore: ownedConversation,
+		exposureGate: { isAgentEnabled: async () => true },
+		harnessChatAgent: agent,
+	});
+	const post = () =>
+		app.request("/api/chat", {
+			method: "POST",
+			headers,
+			body: JSON.stringify(requestBody),
+		});
+	expect((await post()).status).toBe(500);
+	expect((await post()).status).toBe(500);
 });
 
 it("rejects invalid and exposure-disabled requests before creating a session", async () => {

--- a/apps/chat-api/src/features/ai-chat/ai-chat.route.ts
+++ b/apps/chat-api/src/features/ai-chat/ai-chat.route.ts
@@ -71,6 +71,16 @@ function cleanupAfterStream(
 	return new Response(body, response);
 }
 
+/**
+ * Conversation ids with a Harness turn in flight. Checked and set in one
+ * synchronous step so two requests can never share a sandbox; released only
+ * after `session.stop()` settles. In-process by design for the single-process
+ * local composition.
+ * ponytail: process-local set; a leased marker on conversation_runtime once
+ * chat-api runs more than one process.
+ */
+const activeTurns = new Set<string>();
+
 const routes = new Hono<AppEnv>();
 const limit = bodyLimit({
 	maxSize: MAX_REQUEST_BODY_BYTES,
@@ -102,26 +112,37 @@ routes.post(
 		if (!(await c.var.deps.exposureGate.isAgentEnabled(c.var.identity))) {
 			return c.json({ error: "Agent is not enabled" }, 403);
 		}
+		if (activeTurns.has(body.id)) {
+			return c.json({ error: "Conversation has an active response" }, 409);
+		}
+		activeTurns.add(body.id);
 		const agent = c.var.deps.harnessChatAgent;
 		const ref = { userId: c.var.identity.memberCode, conversationId: body.id };
-		const resumeFrom = await c.var.deps.harnessResumeStateStore.load(ref);
 		let session: Awaited<ReturnType<typeof agent.createSession>>;
 		try {
-			session = await agent.createSession({
-				sessionId: body.id,
-				resumeFrom: resumeFrom ?? undefined,
-			});
+			const resumeFrom = await c.var.deps.harnessResumeStateStore.load(ref);
+			try {
+				session = await agent.createSession({
+					sessionId: body.id,
+					resumeFrom: resumeFrom ?? undefined,
+				});
+			} catch (error) {
+				if (!resumeFrom) throw error;
+				// Snapshot expired or sandbox gone: start a fresh thread under the same
+				// id rather than block the user. The stale pointer is overwritten below.
+				c.var.logger.warn(
+					{ err: error, conversationId: body.id },
+					"harness session resume failed; starting a fresh session",
+				);
+				session = await agent.createSession({ sessionId: body.id });
+			}
 		} catch (error) {
-			if (!resumeFrom) throw error;
-			// Snapshot expired or sandbox gone: start a fresh thread under the same
-			// id rather than block the user. The stale pointer is overwritten below.
-			c.var.logger.warn(
-				{ err: error, conversationId: body.id },
-				"harness session resume failed; starting a fresh session",
-			);
-			session = await agent.createSession({ sessionId: body.id });
+			activeTurns.delete(body.id);
+			throw error;
 		}
 		// Snapshot the sandbox and remember how to resume it; the pointer is opaque.
+		// The slot is released only once the stop has settled, so a resume can
+		// never overlap it.
 		const stop = async () => {
 			try {
 				const state = await session.stop();
@@ -131,6 +152,8 @@ routes.post(
 					{ err: error, conversationId: body.id },
 					"harness session stop failed",
 				);
+			} finally {
+				activeTurns.delete(body.id);
 			}
 		};
 		let result: Awaited<ReturnType<typeof agent.stream>>;

--- a/apps/chat-api/src/features/ai-chat/ai-chat.route.ts
+++ b/apps/chat-api/src/features/ai-chat/ai-chat.route.ts
@@ -118,11 +118,10 @@ routes.post(
 		activeTurns.add(body.id);
 		const agent = c.var.deps.harnessChatAgent;
 		const ref = { userId: c.var.identity.memberCode, conversationId: body.id };
-		let session: Awaited<ReturnType<typeof agent.createSession>>;
-		try {
+		const createSession = async () => {
 			const resumeFrom = await c.var.deps.harnessResumeStateStore.load(ref);
 			try {
-				session = await agent.createSession({
+				return await agent.createSession({
 					sessionId: body.id,
 					resumeFrom: resumeFrom ?? undefined,
 				});
@@ -134,15 +133,14 @@ routes.post(
 					{ err: error, conversationId: body.id },
 					"harness session resume failed; starting a fresh session",
 				);
-				session = await agent.createSession({ sessionId: body.id });
+				return agent.createSession({ sessionId: body.id });
 			}
-		} catch (error) {
+		};
+		const session = await createSession().catch((error) => {
 			activeTurns.delete(body.id);
 			throw error;
-		}
+		});
 		// Snapshot the sandbox and remember how to resume it; the pointer is opaque.
-		// The slot is released only once the stop has settled, so a resume can
-		// never overlap it.
 		const stop = async () => {
 			try {
 				const state = await session.stop();

--- a/docs/agents/chat-api.md
+++ b/docs/agents/chat-api.md
@@ -33,9 +33,20 @@ aborts Claude Code in the sandbox, the stream ends with the AI SDK `abort`
 part, and no error reaches the client. A turn that fails to start returns the
 generic `500`; a turn that fails while streaming ends with the AI SDK `error`
 part carrying only the generic `"An error occurred."` text. Failure details
-are logged by chat-api and never sent to the client. There is no admission,
-Run, history, or retry yet, and overlapping turns are not rejected: those are
-follow-up slices of [#595](https://github.com/X-GPT/mymemo-agent/issues/595).
+are logged by chat-api and never sent to the client.
+
+Two messages cannot drive one Conversation's sandbox at once. While a turn is
+in flight, a second `POST /api/chat` for the same Conversation returns
+`409 { error: "Conversation has an active response" }` and the first turn is
+unaffected; other Conversations are unaffected. The guard is a process-local set
+of Conversation ids in `ai-chat.route.ts`, checked and set in one synchronous
+step before any sandbox work and released only after `session.stop()` has
+settled — also on abort and on failure — so a resume can never overlap a stop.
+It is correct only for the single-process local composition; the production
+replacement (a leased marker on `conversation_runtime`) is deferred.
+
+There is no admission, Run, history, or retry yet: those are follow-up slices
+of [#595](https://github.com/X-GPT/mymemo-agent/issues/595).
 The adapter runs the configured `OPENROUTER_DEFAULT_MODEL`; the request `model`
 literal is validated, not forwarded. Production composition does not mount this
 path; its `harnessChatAgent` throws.


### PR DESCRIPTION
## Summary

Closes #600 (parent spec #595, ADR-0033).

Two messages cannot drive one Conversation's sandbox at once:

- `ai-chat.route.ts` keeps a process-local `Set` of Conversation ids with a Harness turn in flight. It is checked and set in one synchronous step after the ownership / archive / exposure checks and before any sandbox work (`load` pointer, `createSession`).
- A concurrent second `POST /api/chat` on the same Conversation returns `409 { error: "Conversation has an active response" }`; the first turn and other Conversations are unaffected.
- The slot is released in `stop()`'s `finally` — i.e. only after `session.stop()` (and the pointer save) has settled — on drain, cancel, abort, start failure, and mid-stream failure. A `createSession` failure releases it too.
- This is the in-process guard for the single-process local composition; the leased marker on `conversation_runtime` is deferred (documented, `ponytail:` comment names the upgrade path).

## Changes

- `apps/chat-api/src/features/ai-chat/ai-chat.route.ts`: `activeTurns` set, 409 branch, release in `stop()` `finally` and on `createSession` failure.
- `apps/chat-api/src/features/ai-chat/ai-chat.route.test.ts`: overlap test (409 while in flight, other Conversation 200, one session per admitted turn, slot still held after the stream is drained while `stop()` is pending, free once it settles); slot released when `createSession` throws; the abort-signal test now cancels its response so it releases its slot.
- `docs/agents/chat-api.md`: documents the 409 and the deferred production replacement.

## Verification

- `apps/chat-api`: `bun test` — 148 pass.
- `biome check .` — clean apart from the pre-existing `biome.json` `useBiomeIgnoreFolder` warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wch4fJapr54aHtuXFAPZzd
