### PR TITLE
docs(adr): amend ADR-0033 for stage 2 and add the Harness turn term

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -197,6 +197,14 @@ Code and carries the Conversation's model-side memory across turns on the AI SDK
 chat path. It is neither the Workspace nor the Execution runtime.
 _Avoid_: sandbox (ambiguous with E2B), Runtime session, Agent session
 
+**Harness turn**:
+One request-scoped execution of Claude Code in the Conversation's Harness
+sandbox serving one user message on the AI SDK chat path. It is not a Run:
+never admitted, ordered, persisted, reclaimed, or given an Outcome. Each turn
+mints a UUID that appears in logs, in the Harness tool binding, and as
+`document_access_events.run_id`; there is no table for it.
+_Avoid_: Run, Agent session, request (ambiguous with the HTTP request)
+
 **Assistant text delta**:
 A bounded, provisional fragment of Assistant text appended to the Run's Live
 Stream before the provider response completes. It is never copied into Postgres

--- a/docs/adr/0033-host-the-ai-sdk-chat-loop-in-a-vercel-sandbox-through-harnessagent.md
+++ b/docs/adr/0033-host-the-ai-sdk-chat-loop-in-a-vercel-sandbox-through-harnessagent.md
@@ -1,8 +1,10 @@
 # Host the AI SDK chat loop in a Vercel Sandbox through HarnessAgent
 
-Status: accepted (2026-08-27). Supersedes the AgentCore-hosted Agent-query
-Runtime design of issue #560 for the AI SDK chat path. Amends ADR-0001 and
-ADR-0031 for that path only; the production Run path is unchanged.
+Status: accepted (2026-08-27); amended for stage 2 (2026-08-27, see
+[Stage 2 amendment](#stage-2-amendment-2026-08-27)). Supersedes the
+AgentCore-hosted Agent-query Runtime design of issue #560 for the AI SDK chat
+path. Amends ADR-0001 and ADR-0031 for that path only; the production Run path
+is unchanged.
 
 The AI SDK chat route `POST /api/chat` runs Vercel's `@ai-sdk/harness`
 `HarnessAgent` inside the chat-api process, with the upstream `createClaudeCode`
@@ -21,7 +23,8 @@ the OpenRouter host — and because the alternative was owning a Claude-to-Harne
 adapter. Stage 1 deliberately runs Claude Code's built-in tools in that
 sandbox. Stage 2 disables them, exposes MyMemo's existing tool catalog as host
 tools, and reattaches the E2B Workspace, at which point the Harness sandbox is
-a trusted host again and the split runtime returns.
+a trusted host again and the split runtime returns. Stage 2 is decided in the
+amendment below.
 
 ## Considered options
 
@@ -55,4 +58,50 @@ a trusted host again and the split runtime returns.
 - Overlapping turns on one Conversation are refused (`409`) rather than raced,
   because two callers cannot share one running bridge.
 - The *Workspace* and *Execution runtime* glossary entries still describe the
-  production Run path; the AI SDK chat path has neither until stage 2.
+  production Run path. After stage 2 the AI SDK chat path shares the
+  Conversation's Workspace but still has no Execution runtime — a *Harness
+  turn* is not a Run; rewording the glossary is deferred to production
+  readiness.
+
+## Stage 2 amendment (2026-08-27)
+
+Decided on issue #607 (Wayfinder map: stage 2 — MyMemo tools on the Harness
+chat path), specified in issue #615, and verified live on issue #612.
+
+- **Every Claude Code built-in tool is disabled in the Harness sandbox.**
+  `HarnessAgent` receives `activeTools` = the user-tool names only, which the
+  Claude Code bridge turns into Agent SDK `tools: []` plus `disallowedTools`
+  for every native name, and `ENABLE_TOOL_SEARCH=false` in the Claude process
+  environment. The sandbox holds only the Claude process, the bridge, and the
+  transcript. No model-directed route reaches its environment or filesystem;
+  the brokered placeholder remains the one credential-shaped value there (in
+  the process environment and the bridge's on-disk start config), readable by
+  Vercel project members and by nothing the model can call.
+- **MyMemo's tools execute in chat-api.** The Workspace tools (`Read`,
+  `Write`, `Edit`, `Grep`, `Bash`) and document tools (`ListDocuments`,
+  `SearchDocuments`, `LoadDocuments`) are `HarnessAgent` user tools whose
+  `execute()` runs in the chat-api process against the Conversation's existing
+  E2B Workspace (`conversation_runtime.sandbox_id`) and the read-only KB, with
+  the Run path's bounds. chat-api's local-only `HarnessConfig` therefore holds
+  `E2B_API_KEY` and `KB_DATABASE_URL` next to the Vercel triple and the
+  OpenRouter credential; the production `ApiConfig` still reads none of them,
+  and a test pins that.
+- **A fresh, Harness-only tool implementation.** The tools live under
+  `apps/chat-api/src/features/ai-chat/tools/`; `apps/agentcore-runtime` is
+  untouched. Two implementations of the same security boundaries (path escape,
+  caps, timeouts, scope) now exist, and a fix must land in both while both
+  paths live. A shared package was weighed and rejected as more code than the
+  duplication it removed.
+- **The Workspace is attached without a Run.** Connect-or-create against the
+  `e2b` SDK, the pointer written with the same unfenced
+  `(user_id, conversation_id)` upsert as the resume pointer: no Conversation
+  Ownership, no orphan ledger, no renewal timer, no taint. One request-scoped
+  **Harness turn** serves each message; overlap with a Run on the same
+  Conversation is refused symmetrically (`409`) in-process, as stage 1 already
+  assumed for the single-process local composition.
+
+Why an amendment rather than a new ADR: this record already named stage 2 as
+its second half, and stage 2 confirms that shape — it adds one consequence,
+chat-api gaining E2B and KB read authority for one local-only path, and
+reverses nothing decided here. ADR-0001 and ADR-0031 remain amended for this
+path only.

--- a/docs/adr/0033-host-the-ai-sdk-chat-loop-in-a-vercel-sandbox-through-harnessagent.md
+++ b/docs/adr/0033-host-the-ai-sdk-chat-loop-in-a-vercel-sandbox-through-harnessagent.md
@@ -76,7 +76,10 @@ chat path), specified in issue #615, and verified live on issue #612.
   transcript. No model-directed route reaches its environment or filesystem;
   the brokered placeholder remains the one credential-shaped value there (in
   the process environment and the bridge's on-disk start config), readable by
-  Vercel project members and by nothing the model can call.
+  Vercel project members and by nothing the model can call. Unlike the Run
+  path, which replaces the `claude_code` system-prompt preset (ADR-0006),
+  this path can only append to it — the bridge hardcodes the preset — so
+  MyMemo's instructions ride behind Claude Code's native prompt.
 - **MyMemo's tools execute in chat-api.** The Workspace tools (`Read`,
   `Write`, `Edit`, `Grep`, `Bash`) and document tools (`ListDocuments`,
   `SearchDocuments`, `LoadDocuments`) are `HarnessAgent` user tools whose


### PR DESCRIPTION
Records the stage-2 decisions from [Wayfinder map: stage 2 — MyMemo tools on the Harness chat path](https://github.com/X-GPT/mymemo-agent/issues/607) as an amendment to ADR-0033 and adds the *Harness turn* glossary term to `CONTEXT.md`.

- Every Claude built-in tool off in the Harness sandbox (`activeTools` = user tools only, `ENABLE_TOOL_SEARCH=false`).
- MyMemo's Workspace and document tools execute in chat-api against the Conversation's existing E2B Workspace and the read-only KB; local-only `HarnessConfig` gains `E2B_API_KEY` / `KB_DATABASE_URL`.
- Fresh Harness-only tool implementation; `apps/agentcore-runtime` untouched; drift accepted.
- Workspace attached without a Run (unfenced pointer, no renewal/taint/Ownership); *Harness turn* coined.

Amendment rather than a new ADR because ADR-0033 already named stage 2 as its second half and nothing decided there is reversed. Spec: #615. Live verification: #612.

Docs only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fm4wPcnWvNj2zUy1E8TqAu