### PR TITLE
feat(chat-api): run each Harness turn on a per-turn HarnessAgent with every built-in off

### DIFF
--- a/apps/chat-api/local/index.ts
+++ b/apps/chat-api/local/index.ts
@@ -5,7 +5,7 @@ import { loadApiConfigFromEnv } from "../src/config/env";
 import { loadHarnessConfigFromEnv } from "../src/config/harness-env";
 import { createDeps } from "../src/deps";
 import aiChatRoutes from "../src/features/ai-chat/ai-chat.route";
-import { createHarnessChatAgent } from "../src/features/ai-chat/harness-chat-agent";
+import { createHarnessChatAgentFactory } from "../src/features/ai-chat/harness-chat-agent";
 import { createS3ArtifactDownloadSigner } from "../src/features/artifacts/s3-artifact-download-signer";
 
 const config = loadApiConfigFromEnv({
@@ -16,7 +16,7 @@ const artifactEndpoint = Bun.env.LOCAL_ARTIFACT_ENDPOINT?.trim();
 const logger = pino({ level: config.logLevel });
 const deps = createDeps(
 	config,
-	createHarnessChatAgent(loadHarnessConfigFromEnv(Bun.env)),
+	createHarnessChatAgentFactory(loadHarnessConfigFromEnv(Bun.env)),
 	createLiveStreamTelemetry("chat-api", logger),
 	{ isAgentEnabled: async () => true },
 	createS3ArtifactDownloadSigner(

--- a/apps/chat-api/src/deps.ts
+++ b/apps/chat-api/src/deps.ts
@@ -30,8 +30,6 @@ import {
 	type RunStore,
 } from "./features/run-store/run-store";
 
-export type { HarnessChatAgentFactory };
-
 /**
  * Application dependencies, built once from a validated `ApiConfig` at the
  * composition root (`createApp`) and injected down the request path instead of

--- a/apps/chat-api/src/deps.ts
+++ b/apps/chat-api/src/deps.ts
@@ -7,7 +7,7 @@ import {
 } from "@mymemo/live-text";
 import type { Env as PinoEnv } from "hono-pino";
 import type { ApiConfig } from "./config/env";
-import type { HarnessChatAgent } from "./features/ai-chat/harness-chat-agent";
+import type { HarnessChatAgentFactory } from "./features/ai-chat/harness-chat-agent";
 import {
 	type HarnessResumeStateStore,
 	PostgresHarnessResumeStateStore,
@@ -30,7 +30,7 @@ import {
 	type RunStore,
 } from "./features/run-store/run-store";
 
-export type { HarnessChatAgent };
+export type { HarnessChatAgentFactory };
 
 /**
  * Application dependencies, built once from a validated `ApiConfig` at the
@@ -40,8 +40,8 @@ export type { HarnessChatAgent };
  */
 export interface AppDeps {
 	config: ApiConfig;
-	/** Harness-hosted AI SDK chat turn (local composition only). */
-	harnessChatAgent: HarnessChatAgent;
+	/** Builds the `HarnessAgent` for one Harness turn (local composition only). */
+	createHarnessChatAgent: HarnessChatAgentFactory;
 	/** Per-Conversation opaque Harness resume pointer (local composition only). */
 	harnessResumeStateStore: HarnessResumeStateStore;
 	/** Authoritative current Downloadable artifact metadata in Postgres. */
@@ -75,7 +75,7 @@ export type AppEnv = PinoEnv & {
 
 export function createDeps(
 	config: ApiConfig,
-	harnessChatAgent: HarnessChatAgent,
+	createHarnessChatAgent: HarnessChatAgentFactory,
 	liveStreamTelemetry: LiveStreamTelemetry = createLiveStreamTelemetry(
 		"chat-api",
 		{
@@ -105,7 +105,7 @@ export function createDeps(
 	});
 	return {
 		config,
-		harnessChatAgent,
+		createHarnessChatAgent,
 		harnessResumeStateStore: new PostgresHarnessResumeStateStore(database),
 		artifactMetadataStore: new PostgresArtifactMetadataStore(database),
 		artifactDownloadSigner,

--- a/apps/chat-api/src/features/ai-chat/ai-chat.route.test.ts
+++ b/apps/chat-api/src/features/ai-chat/ai-chat.route.test.ts
@@ -84,7 +84,7 @@ function fakeAgent() {
 		},
 	};
 	const factory: HarnessChatAgentFactory = (tools) => {
-		toolSets.push(tools ?? {});
+		toolSets.push(tools);
 		return fake as never;
 	};
 	return { factory, events, fake, toolSets };

--- a/apps/chat-api/src/features/ai-chat/ai-chat.route.test.ts
+++ b/apps/chat-api/src/features/ai-chat/ai-chat.route.test.ts
@@ -84,7 +84,7 @@ function fakeAgent() {
 		},
 	};
 	const factory: HarnessChatAgentFactory = (tools) => {
-		toolSets.push(tools);
+		toolSets.push(tools ?? {});
 		return fake as never;
 	};
 	return { factory, events, fake, toolSets };
@@ -250,7 +250,6 @@ it("forwards the stream unchanged: reasoning parts pass, and no built-in tool pa
 	});
 	const received = streamParts(await response.text());
 	expect(received).toEqual(parts);
-	expect(received.map((p) => p.type)).toContain("reasoning-delta");
 	// The built-in invariant: a provider-executed tool part is only ever one
 	// of the two synthetic dynamic parts.
 	const providerExecuted = received.filter(

--- a/apps/chat-api/src/features/ai-chat/ai-chat.route.test.ts
+++ b/apps/chat-api/src/features/ai-chat/ai-chat.route.test.ts
@@ -2,7 +2,8 @@ import { expect, it } from "bun:test";
 import { Hono } from "hono";
 import type { AppDeps, AppEnv } from "@/deps";
 import aiChatRoutes from "./ai-chat.route";
-import type { HarnessChatAgent } from "./harness-chat-agent";
+import type { HarnessChatAgentFactory } from "./harness-chat-agent";
+import { HARNESS_TOOL_NAMES } from "./tools/harness-tools";
 
 const headers = {
 	"content-type": "application/json",
@@ -44,9 +45,13 @@ function fakeResumeStore(initial: unknown = null) {
 	};
 }
 
-/** Fake agent that records the lifecycle and streams a canned UI message stream. */
+/**
+ * Fake agent factory: records the tool set of every agent it builds, and the
+ * agent records the lifecycle and streams a canned UI message stream.
+ */
 function fakeAgent() {
 	const events: unknown[] = [];
+	const toolSets: object[] = [];
 	const created = {
 		stop: async () => {
 			events.push("stop");
@@ -78,7 +83,19 @@ function fakeAgent() {
 			};
 		},
 	};
-	return { agent: fake as unknown as HarnessChatAgent, events, fake };
+	const factory: HarnessChatAgentFactory = (tools) => {
+		toolSets.push(tools);
+		return fake as never;
+	};
+	return { factory, events, fake, toolSets };
+}
+
+/** The JSON parts of a UI message stream body, `[DONE]` excluded. */
+function streamParts(body: string): Record<string, unknown>[] {
+	return body
+		.split("\n\n")
+		.filter((line) => line.startsWith("data: {"))
+		.map((line) => JSON.parse(line.slice("data: ".length)));
 }
 
 function streamResponse(body: ConstructorParameters<typeof Response>[0]) {
@@ -116,7 +133,7 @@ const ownedConversation = {
 } as unknown as AppDeps["conversationStore"];
 
 it("runs one Harness turn in a session named after the Conversation and stops it after the stream", async () => {
-	const { agent, events } = fakeAgent();
+	const { factory, events } = fakeAgent();
 	const { store, saved } = fakeResumeStore();
 	const lookups: unknown[] = [];
 	const app = makeApp({
@@ -127,7 +144,7 @@ it("runs one Harness turn in a session named after the Conversation and stops it
 			},
 		} as unknown as AppDeps["conversationStore"],
 		exposureGate: { isAgentEnabled: async () => true },
-		harnessChatAgent: agent,
+		createHarnessChatAgent: factory,
 		harnessResumeStateStore: store,
 	});
 
@@ -164,13 +181,95 @@ it("runs one Harness turn in a session named after the Conversation and stops it
 	]);
 });
 
+it("builds one agent per turn from the factory with the turn's tool set", async () => {
+	const { factory, toolSets } = fakeAgent();
+	const app = makeApp({
+		conversationStore: ownedConversation,
+		exposureGate: { isAgentEnabled: async () => true },
+		createHarnessChatAgent: factory,
+	});
+	for (const id of ["conversation-1", "conversation-2"]) {
+		const response = await app.request("/api/chat", {
+			method: "POST",
+			headers,
+			body: JSON.stringify({ ...requestBody, id }),
+		});
+		expect(response.status).toBe(200);
+		await response.text();
+	}
+	// Every user tool the turn offers is in the exported name list; the factory
+	// activates exactly those names, so no built-in is ever callable.
+	expect(toolSets.map((tools) => Object.keys(tools))).toEqual([
+		[...HARNESS_TOOL_NAMES],
+		[...HARNESS_TOOL_NAMES],
+	]);
+});
+
+it("forwards the stream unchanged: reasoning parts pass, and no built-in tool part can reach the client", async () => {
+	const { factory, fake } = fakeAgent();
+	// What the configured harness emits: reasoning, text, and the two synthetic
+	// dynamic parts the bridge reports itself. A user tool arrives with
+	// `providerExecuted: false`; nothing else carries `providerExecuted: true`.
+	const parts = [
+		{ type: "reasoning-start", id: "r1" },
+		{ type: "reasoning-delta", id: "r1", delta: "thinking" },
+		{ type: "reasoning-end", id: "r1" },
+		{
+			type: "tool-input-available",
+			toolCallId: "c1",
+			toolName: "compaction",
+			dynamic: true,
+			providerExecuted: true,
+			input: {},
+		},
+		{
+			type: "tool-input-available",
+			toolCallId: "f1",
+			toolName: "fileChange",
+			dynamic: true,
+			providerExecuted: true,
+			input: { path: "notes.md" },
+		},
+		{ type: "text-delta", id: "t1", delta: "I cannot run commands." },
+	];
+	fake.stream = async () => ({
+		toUIMessageStreamResponse: () =>
+			streamResponse(
+				`${parts.map((p) => `data: ${JSON.stringify(p)}\n\n`).join("")}data: [DONE]\n\n`,
+			),
+	});
+	const app = makeApp({
+		conversationStore: ownedConversation,
+		exposureGate: { isAgentEnabled: async () => true },
+		createHarnessChatAgent: factory,
+	});
+	const response = await app.request("/api/chat", {
+		method: "POST",
+		headers,
+		body: JSON.stringify(requestBody),
+	});
+	const received = streamParts(await response.text());
+	expect(received).toEqual(parts);
+	expect(received.map((p) => p.type)).toContain("reasoning-delta");
+	// The built-in invariant: a provider-executed tool part is only ever one
+	// of the two synthetic dynamic parts.
+	const providerExecuted = received.filter(
+		(p) => String(p.type).startsWith("tool-") && p.providerExecuted === true,
+	);
+	expect(providerExecuted).toHaveLength(2);
+	for (const part of providerExecuted) {
+		expect(part.dynamic).toBe(true);
+		expect(["compaction", "fileChange"]).toContain(String(part.toolName));
+	}
+});
+
 it("resumes the Conversation's session from the stored pointer", async () => {
-	const { agent, events } = fakeAgent();
+	const { factory, events } = fakeAgent();
 	const pointer = { type: "resume-session", data: { from: "before" } };
 	const app = makeApp({
 		conversationStore: ownedConversation,
 		exposureGate: { isAgentEnabled: async () => true },
-		harnessChatAgent: agent,
+		createHarnessChatAgent: factory,
 		harnessResumeStateStore: fakeResumeStore(pointer).store,
 	});
 	const response = await app.request("/api/chat", {
@@ -186,7 +285,7 @@ it("resumes the Conversation's session from the stored pointer", async () => {
 });
 
 it("starts a fresh session for the same id and logs when resuming throws", async () => {
-	const { agent, events, fake } = fakeAgent();
+	const { factory, events, fake } = fakeAgent();
 	const createSession = fake.createSession;
 	fake.createSession = async (options) => {
 		if (options.resumeFrom) throw new Error("snapshot expired");
@@ -199,7 +298,7 @@ it("starts a fresh session for the same id and logs when resuming throws", async
 	const app = makeApp({
 		conversationStore: ownedConversation,
 		exposureGate: { isAgentEnabled: async () => true },
-		harnessChatAgent: agent,
+		createHarnessChatAgent: factory,
 		harnessResumeStateStore: store,
 	});
 	logged.length = 0;
@@ -223,11 +322,11 @@ it("starts a fresh session for the same id and logs when resuming throws", async
 });
 
 it("stops the session when the client cancels the stream", async () => {
-	const { agent, events } = fakeAgent();
+	const { factory, events } = fakeAgent();
 	const app = makeApp({
 		conversationStore: ownedConversation,
 		exposureGate: { isAgentEnabled: async () => true },
-		harnessChatAgent: agent,
+		createHarnessChatAgent: factory,
 	});
 	const response = await app.request("/api/chat", {
 		method: "POST",
@@ -240,11 +339,11 @@ it("stops the session when the client cancels the stream", async () => {
 });
 
 it("passes the request's own abort signal to the turn", async () => {
-	const { agent, events } = fakeAgent();
+	const { factory, events } = fakeAgent();
 	const app = makeApp({
 		conversationStore: ownedConversation,
 		exposureGate: { isAgentEnabled: async () => true },
-		harnessChatAgent: agent,
+		createHarnessChatAgent: factory,
 	});
 	const controller = new AbortController();
 	const response = await app.request(
@@ -261,7 +360,7 @@ it("passes the request's own abort signal to the turn", async () => {
 });
 
 it("ends an aborted turn cleanly with the abort part and still stops the session", async () => {
-	const { agent, events, fake } = fakeAgent();
+	const { factory, events, fake } = fakeAgent();
 	const controller = new AbortController();
 	// Mirrors HarnessAgent: on abort the turn settles with a final `abort` part.
 	fake.stream = async ({ abortSignal }) => ({
@@ -280,7 +379,7 @@ it("ends an aborted turn cleanly with the abort part and still stops the session
 	const app = makeApp({
 		conversationStore: ownedConversation,
 		exposureGate: { isAgentEnabled: async () => true },
-		harnessChatAgent: agent,
+		createHarnessChatAgent: factory,
 	});
 	const response = await app.request(
 		new Request("http://localhost/api/chat", {
@@ -298,14 +397,14 @@ it("ends an aborted turn cleanly with the abort part and still stops the session
 });
 
 it("stops the session and logs when the turn fails to start", async () => {
-	const { agent, events, fake } = fakeAgent();
+	const { factory, events, fake } = fakeAgent();
 	fake.stream = async () => {
 		throw new Error("bridge unavailable");
 	};
 	const app = makeApp({
 		conversationStore: ownedConversation,
 		exposureGate: { isAgentEnabled: async () => true },
-		harnessChatAgent: agent,
+		createHarnessChatAgent: factory,
 	});
 	logged.length = 0;
 	const response = await app.request("/api/chat", {
@@ -326,7 +425,7 @@ it("stops the session and logs when the turn fails to start", async () => {
 });
 
 it("hides the cause of a mid-stream failure from the client, logs it, and stops the session", async () => {
-	const { agent, events, fake } = fakeAgent();
+	const { factory, events, fake } = fakeAgent();
 	// Mirrors the AI SDK: a failing turn becomes an `error` part whose text is `onError`'s return.
 	fake.stream = async () => ({
 		toUIMessageStreamResponse: (options: {
@@ -341,7 +440,7 @@ it("hides the cause of a mid-stream failure from the client, logs it, and stops 
 	const app = makeApp({
 		conversationStore: ownedConversation,
 		exposureGate: { isAgentEnabled: async () => true },
-		harnessChatAgent: agent,
+		createHarnessChatAgent: factory,
 	});
 	logged.length = 0;
 	const response = await app.request("/api/chat", {
@@ -364,7 +463,7 @@ it("hides the cause of a mid-stream failure from the client, logs it, and stops 
 });
 
 it("refuses a second turn on the same Conversation until the first has been stopped", async () => {
-	const { agent, events, fake } = fakeAgent();
+	const { factory, events, fake } = fakeAgent();
 	// conversation-1's stop() hangs until released; other sessions stop at once.
 	const releases: (() => void)[] = [];
 	const releaseStop = () => releases.shift()?.();
@@ -381,7 +480,7 @@ it("refuses a second turn on the same Conversation until the first has been stop
 	const app = makeApp({
 		conversationStore: ownedConversation,
 		exposureGate: { isAgentEnabled: async () => true },
-		harnessChatAgent: agent,
+		createHarnessChatAgent: factory,
 	});
 	const post = (id = requestBody.id) =>
 		app.request("/api/chat", {
@@ -421,14 +520,14 @@ it("refuses a second turn on the same Conversation until the first has been stop
 });
 
 it("releases the slot when the session cannot be created", async () => {
-	const { agent, fake } = fakeAgent();
+	const { factory, fake } = fakeAgent();
 	fake.createSession = async () => {
 		throw new Error("sandbox unavailable");
 	};
 	const app = makeApp({
 		conversationStore: ownedConversation,
 		exposureGate: { isAgentEnabled: async () => true },
-		harnessChatAgent: agent,
+		createHarnessChatAgent: factory,
 	});
 	const post = () =>
 		app.request("/api/chat", {
@@ -441,11 +540,11 @@ it("releases the slot when the session cannot be created", async () => {
 });
 
 it("rejects invalid and exposure-disabled requests before creating a session", async () => {
-	const { agent, events } = fakeAgent();
+	const { factory, events } = fakeAgent();
 	const app = makeApp({
 		conversationStore: ownedConversation,
 		exposureGate: { isAgentEnabled: async () => false },
-		harnessChatAgent: agent,
+		createHarnessChatAgent: factory,
 	});
 
 	expect(
@@ -473,7 +572,7 @@ it.each([
 	[null, 404, "Conversation not found"],
 	[{ archivedAt: new Date() }, 409, "Conversation is archived"],
 ] as const)("rejects a missing or archived Conversation before creating a session", async (conversation, status, error) => {
-	const { agent, events } = fakeAgent();
+	const { factory, events } = fakeAgent();
 	let gateChecks = 0;
 	const app = makeApp({
 		conversationStore: {
@@ -485,7 +584,7 @@ it.each([
 				return true;
 			},
 		},
-		harnessChatAgent: agent,
+		createHarnessChatAgent: factory,
 	});
 
 	const response = await app.request("/api/chat", {

--- a/apps/chat-api/src/features/ai-chat/ai-chat.route.ts
+++ b/apps/chat-api/src/features/ai-chat/ai-chat.route.ts
@@ -112,11 +112,14 @@ routes.post(
 		if (!(await c.var.deps.exposureGate.isAgentEnabled(c.var.identity))) {
 			return c.json({ error: "Agent is not enabled" }, 403);
 		}
+		// One agent per turn over the composition-time providers, closing over
+		// this turn's user-tool set (none yet). Pure and synchronous: nothing
+		// touches the sandbox until `createSession`, and a throw here holds no slot.
+		const agent = c.var.deps.createHarnessChatAgent({});
 		if (activeTurns.has(body.id)) {
 			return c.json({ error: "Conversation has an active response" }, 409);
 		}
 		activeTurns.add(body.id);
-		const agent = c.var.deps.harnessChatAgent;
 		const ref = { userId: c.var.identity.memberCode, conversationId: body.id };
 		const createSession = async () => {
 			const resumeFrom = await c.var.deps.harnessResumeStateStore.load(ref);

--- a/apps/chat-api/src/features/ai-chat/ai-chat.route.ts
+++ b/apps/chat-api/src/features/ai-chat/ai-chat.route.ts
@@ -112,9 +112,8 @@ routes.post(
 		if (!(await c.var.deps.exposureGate.isAgentEnabled(c.var.identity))) {
 			return c.json({ error: "Agent is not enabled" }, 403);
 		}
-		// One agent per turn over the composition-time providers, closing over
-		// this turn's user-tool set (none yet). Pure and synchronous: nothing
-		// touches the sandbox until `createSession`, and a throw here holds no slot.
+		// One agent per turn, built before the slot is taken: a constructor throw
+		// holds no slot, and the sandbox is untouched until `createSession`.
 		const agent = c.var.deps.createHarnessChatAgent({});
 		if (activeTurns.has(body.id)) {
 			return c.json({ error: "Conversation has an active response" }, 409);

--- a/apps/chat-api/src/features/ai-chat/harness-chat-agent.test.ts
+++ b/apps/chat-api/src/features/ai-chat/harness-chat-agent.test.ts
@@ -1,0 +1,72 @@
+import { afterAll, expect, it, spyOn } from "bun:test";
+import * as claudeCode from "@ai-sdk/harness-claude-code";
+import type { HarnessConfig } from "@/config/harness-env";
+import {
+	createHarnessChatAgentFactory,
+	HARNESS_INSTRUCTIONS,
+} from "./harness-chat-agent";
+import { HARNESS_TOOL_NAMES } from "./tools/harness-tools";
+
+const config: HarnessConfig = {
+	VERCEL_TOKEN: "test-vercel-token",
+	VERCEL_TEAM_ID: "team_test",
+	VERCEL_PROJECT_ID: "prj_test",
+	OPENROUTER_API_KEY: "test-openrouter-key",
+	OPENROUTER_BASE_URL: "https://openrouter.example",
+	OPENROUTER_DEFAULT_MODEL: "anthropic/claude-sonnet-5",
+	HARNESS_SANDBOX_TIMEOUT_MS: 600_000,
+	HARNESS_SANDBOX_REGION: "iad1",
+};
+
+// Pass-through spy on the adapter constructor; restored with the env below.
+const createClaudeCode = spyOn(claudeCode, "createClaudeCode");
+
+// The factory sets the adapter's credentials on this process; put them back.
+const savedEnv = {
+	ANTHROPIC_BASE_URL: process.env.ANTHROPIC_BASE_URL,
+	ANTHROPIC_AUTH_TOKEN: process.env.ANTHROPIC_AUTH_TOKEN,
+	ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+};
+afterAll(() => {
+	createClaudeCode.mockRestore();
+	for (const [name, value] of Object.entries(savedEnv)) {
+		if (value === undefined) delete process.env[name];
+		else process.env[name] = value;
+	}
+});
+
+/** `HarnessAgent` keeps its settings private; read them for the pin. */
+function inspect(agent: object) {
+	return agent as unknown as {
+		settings: Record<string, unknown>;
+		builtinToolFiltering: unknown;
+	};
+}
+
+it("configures the Claude Code adapter once, with built-ins off and tool search disabled", () => {
+	const createAgent = createHarnessChatAgentFactory(config);
+	const tools = {};
+	const first = inspect(createAgent(tools));
+	const second = inspect(createAgent({}));
+
+	// Built once at composition, shared by every turn's agent.
+	expect(createClaudeCode).toHaveBeenCalledTimes(1);
+	expect(createClaudeCode.mock.calls[0]).toEqual([
+		{
+			auth: "direct",
+			model: "anthropic/claude-sonnet-5",
+			env: { ENABLE_TOOL_SEARCH: "false" },
+		},
+	]);
+	expect(second.settings.harness).toBe(first.settings.harness);
+	expect(second.settings.sandbox).toBe(first.settings.sandbox);
+
+	// Per turn: this turn's tools, and only their names are active — the
+	// framework turns that into an empty allow-list for every built-in.
+	expect(first.settings.tools).toBe(tools);
+	expect(first.settings.activeTools).toBe(HARNESS_TOOL_NAMES);
+	expect(first.builtinToolFiltering).toEqual({ mode: "allow", toolNames: [] });
+	expect(first.settings.permissionMode).toBe("allow-all");
+	expect(first.settings.instructions).toBe(HARNESS_INSTRUCTIONS);
+	expect(process.env.ANTHROPIC_API_KEY).toBe("");
+});

--- a/apps/chat-api/src/features/ai-chat/harness-chat-agent.test.ts
+++ b/apps/chat-api/src/features/ai-chat/harness-chat-agent.test.ts
@@ -36,18 +36,16 @@ afterAll(() => {
 });
 
 /** `HarnessAgent` keeps its settings private; read them for the pin. */
-function inspect(agent: object) {
-	return agent as unknown as {
-		settings: Record<string, unknown>;
-		builtinToolFiltering: unknown;
-	};
-}
+type Inspected = {
+	settings: Record<string, unknown>;
+	builtinToolFiltering: unknown;
+};
 
 it("configures the Claude Code adapter once, with built-ins off and tool search disabled", () => {
 	const createAgent = createHarnessChatAgentFactory(config);
 	const tools = {};
-	const first = inspect(createAgent(tools));
-	const second = inspect(createAgent({}));
+	const first = createAgent(tools) as unknown as Inspected;
+	const second = createAgent({}) as unknown as Inspected;
 
 	// Built once at composition, shared by every turn's agent.
 	expect(createClaudeCode).toHaveBeenCalledTimes(1);
@@ -66,7 +64,6 @@ it("configures the Claude Code adapter once, with built-ins off and tool search 
 	expect(first.settings.tools).toBe(tools);
 	expect(first.settings.activeTools).toBe(HARNESS_TOOL_NAMES);
 	expect(first.builtinToolFiltering).toEqual({ mode: "allow", toolNames: [] });
-	expect(first.settings.permissionMode).toBe("allow-all");
 	expect(first.settings.instructions).toBe(HARNESS_INSTRUCTIONS);
 	expect(process.env.ANTHROPIC_API_KEY).toBe("");
 });

--- a/apps/chat-api/src/features/ai-chat/harness-chat-agent.ts
+++ b/apps/chat-api/src/features/ai-chat/harness-chat-agent.ts
@@ -11,15 +11,19 @@ export type HarnessChatAgentFactory = ReturnType<
 
 /**
  * Appended to Claude Code's native system prompt (the bridge hardcodes the
- * `claude_code` preset, so this path can only append — ADR-0033). The model
- * must not reach for a filesystem, a memory directory, or a built-in tool:
- * none exists on this path. The tool guidance lands with the tools.
+ * `claude_code` preset, so this path can only append — ADR-0033). That preset
+ * still describes Claude Code's own tools, so the model must be told that only
+ * its tool list is real: seen live, with no tool listed it otherwise writes a
+ * tool call out as text and invents the result. The tool guidance lands with
+ * the tools.
  */
 export const HARNESS_INSTRUCTIONS =
 	"You are MyMemo's agent. You answer the user's questions and do file-backed work on their behalf.\n\n" +
-	"You have no filesystem, memory directory, or built-in tools of your own — never try to run a " +
-	"command, read or write a file, or save a memory except through the tools offered to you, which " +
-	"you refer to by their short names. If no offered tool can do what is asked, say so.\n\n" +
+	"You have no filesystem, memory directory, or built-in tools of your own. The only tools that exist " +
+	"are the ones in your tool list, which you call by their short names; any shell, file reader, or " +
+	"memory file your other instructions mention is not available. Never write a tool call out as text " +
+	"and never invent a tool's output. If no listed tool can do what is asked, say plainly that you " +
+	"cannot do it in this session.\n\n" +
 	"Keep responses concise.";
 
 /** Port inside the sandbox the Claude Code bridge listens on (adapter uses `ports[0]`; any free port works). */

--- a/apps/chat-api/src/features/ai-chat/harness-chat-agent.ts
+++ b/apps/chat-api/src/features/ai-chat/harness-chat-agent.ts
@@ -8,11 +8,6 @@ import { HARNESS_TOOL_NAMES } from "./tools/harness-tools";
 export type HarnessChatAgentFactory = ReturnType<
 	typeof createHarnessChatAgentFactory
 >;
-/** The `HarnessAgent` the route drives for one turn. */
-export type HarnessChatAgent = ReturnType<HarnessChatAgentFactory>;
-
-/** The turn's user-tool set, keyed by `HARNESS_TOOL_NAMES`. */
-type HarnessToolSet = NonNullable<HarnessAgentSettings["tools"]>;
 
 /**
  * Appended to Claude Code's native system prompt (the bridge hardcodes the
@@ -49,11 +44,8 @@ export function createHarnessChatAgentFactory(config: HarnessConfig) {
 	const harness = createClaudeCode({
 		auth: "direct",
 		model: config.OPENROUTER_DEFAULT_MODEL,
-		// Thinking stays at the adapter default (adaptive, summarized): the
-		// model's reasoning reaches the client as `reasoning-*` parts.
-		// Route-independent guarantee that no user tool is deferred toward the
-		// CLI's ToolSearch, even though the OpenRouter base URL already
-		// suppresses deferred tools.
+		// Adapter-default thinking: reasoning reaches the client as `reasoning-*`
+		// parts. Tool search off so no user tool is deferred to the CLI's ToolSearch.
 		env: { ENABLE_TOOL_SEARCH: "false" },
 	});
 	const sandbox = createVercelSandbox({
@@ -66,7 +58,8 @@ export function createHarnessChatAgentFactory(config: HarnessConfig) {
 		region: config.HARNESS_SANDBOX_REGION,
 		keepLastSnapshots: { count: 1 },
 	});
-	return (tools: HarnessToolSet) =>
+	// `tools` is this turn's user-tool set, keyed by `HARNESS_TOOL_NAMES`.
+	return (tools: HarnessAgentSettings["tools"]) =>
 		new HarnessAgent({
 			harness,
 			sandbox,

--- a/apps/chat-api/src/features/ai-chat/harness-chat-agent.ts
+++ b/apps/chat-api/src/features/ai-chat/harness-chat-agent.ts
@@ -1,45 +1,83 @@
-import { HarnessAgent } from "@ai-sdk/harness/agent";
+import { HarnessAgent, type HarnessAgentSettings } from "@ai-sdk/harness/agent";
 import { createClaudeCode } from "@ai-sdk/harness-claude-code";
 import { createVercelSandbox } from "@ai-sdk/sandbox-vercel";
 import type { HarnessConfig } from "@/config/harness-env";
+import { HARNESS_TOOL_NAMES } from "./tools/harness-tools";
 
-/** The `HarnessAgent` the route drives; tests inject a cast fake. */
-export type HarnessChatAgent = ReturnType<typeof createHarnessChatAgent>;
+/** Builds the `HarnessAgent` for one turn over that turn's user-tool set; tests inject a cast fake. */
+export type HarnessChatAgentFactory = ReturnType<
+	typeof createHarnessChatAgentFactory
+>;
+/** The `HarnessAgent` the route drives for one turn. */
+export type HarnessChatAgent = ReturnType<HarnessChatAgentFactory>;
+
+/** The turn's user-tool set, keyed by `HARNESS_TOOL_NAMES`. */
+type HarnessToolSet = NonNullable<HarnessAgentSettings["tools"]>;
+
+/**
+ * Appended to Claude Code's native system prompt (the bridge hardcodes the
+ * `claude_code` preset, so this path can only append — ADR-0033). The model
+ * must not reach for a filesystem, a memory directory, or a built-in tool:
+ * none exists on this path. The tool guidance lands with the tools.
+ */
+export const HARNESS_INSTRUCTIONS =
+	"You are MyMemo's agent. You answer the user's questions and do file-backed work on their behalf.\n\n" +
+	"You have no filesystem, memory directory, or built-in tools of your own — never try to run a " +
+	"command, read or write a file, or save a memory except through the tools offered to you, which " +
+	"you refer to by their short names. If no offered tool can do what is asked, say so.\n\n" +
+	"Keep responses concise.";
 
 /** Port inside the sandbox the Claude Code bridge listens on (adapter uses `ports[0]`; any free port works). */
 const BRIDGE_PORT = 4000;
 
 /**
- * Real `HarnessAgent` over a Vercel Sandbox. The Claude Code adapter with
- * `auth: 'direct'` reads `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN` from
- * this process and brokers them: the sandbox only ever sees a placeholder that
- * the Vercel firewall swaps for the real bearer on requests to that host.
- * `auto` would instead route the model call to the AI Gateway via the local
- * `VERCEL_OIDC_TOKEN`.
+ * Composition-time Claude Code adapter and Vercel Sandbox provider, shared by
+ * every turn; the returned factory builds one `HarnessAgent` per turn over
+ * that turn's tools. The adapter with `auth: 'direct'` reads
+ * `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN` from this process and brokers
+ * them: the sandbox only ever sees a placeholder that the Vercel firewall
+ * swaps for the real bearer on requests to that host. `auto` would instead
+ * route the model call to the AI Gateway via the local `VERCEL_OIDC_TOKEN`.
  */
-export function createHarnessChatAgent(config: HarnessConfig) {
+export function createHarnessChatAgentFactory(config: HarnessConfig) {
 	process.env.ANTHROPIC_BASE_URL = config.OPENROUTER_BASE_URL;
 	process.env.ANTHROPIC_AUTH_TOKEN = config.OPENROUTER_API_KEY;
 	// Load-bearing: the adapter forwards a non-empty `ANTHROPIC_API_KEY` from
 	// this process alongside the auth token, so a real key exported in the shell
 	// would be brokered into the sandbox too. Empty means "none".
 	process.env.ANTHROPIC_API_KEY = "";
-	return new HarnessAgent({
-		harness: createClaudeCode({
-			auth: "direct",
-			model: config.OPENROUTER_DEFAULT_MODEL,
-			// First slice runs without extended thinking; revisit with stage 2.
-			thinking: { type: "disabled" },
-		}),
-		sandbox: createVercelSandbox({
-			token: config.VERCEL_TOKEN,
-			teamId: config.VERCEL_TEAM_ID,
-			projectId: config.VERCEL_PROJECT_ID,
-			runtime: "node24",
-			ports: [BRIDGE_PORT],
-			timeout: config.HARNESS_SANDBOX_TIMEOUT_MS,
-			region: config.HARNESS_SANDBOX_REGION,
-			keepLastSnapshots: { count: 1 },
-		}),
+	const harness = createClaudeCode({
+		auth: "direct",
+		model: config.OPENROUTER_DEFAULT_MODEL,
+		// Thinking stays at the adapter default (adaptive, summarized): the
+		// model's reasoning reaches the client as `reasoning-*` parts.
+		// Route-independent guarantee that no user tool is deferred toward the
+		// CLI's ToolSearch, even though the OpenRouter base URL already
+		// suppresses deferred tools.
+		env: { ENABLE_TOOL_SEARCH: "false" },
 	});
+	const sandbox = createVercelSandbox({
+		token: config.VERCEL_TOKEN,
+		teamId: config.VERCEL_TEAM_ID,
+		projectId: config.VERCEL_PROJECT_ID,
+		runtime: "node24",
+		ports: [BRIDGE_PORT],
+		timeout: config.HARNESS_SANDBOX_TIMEOUT_MS,
+		region: config.HARNESS_SANDBOX_REGION,
+		keepLastSnapshots: { count: 1 },
+	});
+	return (tools: HarnessToolSet) =>
+		new HarnessAgent({
+			harness,
+			sandbox,
+			tools,
+			// User-tool names only: the bridge turns this into Agent SDK
+			// `tools: []` plus `disallowedTools` for every native name, and the
+			// agent auto-denies any approval request outside the list.
+			activeTools: HARNESS_TOOL_NAMES,
+			// Changes nothing for user tools; a stricter mode would only add
+			// ask-rules for built-ins that are already absent.
+			permissionMode: "allow-all",
+			instructions: HARNESS_INSTRUCTIONS,
+		});
 }

--- a/apps/chat-api/src/features/ai-chat/harness-chat-agent.ts
+++ b/apps/chat-api/src/features/ai-chat/harness-chat-agent.ts
@@ -13,9 +13,9 @@ export type HarnessChatAgentFactory = ReturnType<
  * Appended to Claude Code's native system prompt (the bridge hardcodes the
  * `claude_code` preset, so this path can only append — ADR-0033). That preset
  * still describes Claude Code's own tools, so the model must be told that only
- * its tool list is real: seen live, with no tool listed it otherwise writes a
- * tool call out as text and invents the result. The tool guidance lands with
- * the tools.
+ * its tool list is real: seen live, with no tool listed it can write a tool
+ * call out as text and invent the result, and this reduces but does not
+ * remove that. The tool guidance lands with the tools.
  */
 export const HARNESS_INSTRUCTIONS =
 	"You are MyMemo's agent. You answer the user's questions and do file-backed work on their behalf.\n\n" +
@@ -23,7 +23,7 @@ export const HARNESS_INSTRUCTIONS =
 	"are the ones in your tool list, which you call by their short names; any shell, file reader, or " +
 	"memory file your other instructions mention is not available. Never write a tool call out as text " +
 	"and never invent a tool's output. If no listed tool can do what is asked, say plainly that you " +
-	"cannot do it in this session.\n\n" +
+	"cannot do it in this conversation.\n\n" +
 	"Keep responses concise.";
 
 /** Port inside the sandbox the Claude Code bridge listens on (adapter uses `ports[0]`; any free port works). */

--- a/apps/chat-api/src/features/ai-chat/harness-chat-agent.ts
+++ b/apps/chat-api/src/features/ai-chat/harness-chat-agent.ts
@@ -59,7 +59,7 @@ export function createHarnessChatAgentFactory(config: HarnessConfig) {
 		keepLastSnapshots: { count: 1 },
 	});
 	// `tools` is this turn's user-tool set, keyed by `HARNESS_TOOL_NAMES`.
-	return (tools: HarnessAgentSettings["tools"]) =>
+	return (tools: NonNullable<HarnessAgentSettings["tools"]>) =>
 		new HarnessAgent({
 			harness,
 			sandbox,
@@ -68,9 +68,8 @@ export function createHarnessChatAgentFactory(config: HarnessConfig) {
 			// `tools: []` plus `disallowedTools` for every native name, and the
 			// agent auto-denies any approval request outside the list.
 			activeTools: HARNESS_TOOL_NAMES,
-			// Changes nothing for user tools; a stricter mode would only add
-			// ask-rules for built-ins that are already absent.
-			permissionMode: "allow-all",
+			// `permissionMode` stays at the default `allow-all`: a stricter mode
+			// would only add ask-rules for built-ins that are already absent.
 			instructions: HARNESS_INSTRUCTIONS,
 		});
 }

--- a/apps/chat-api/src/features/ai-chat/harness-chat-agent.ts
+++ b/apps/chat-api/src/features/ai-chat/harness-chat-agent.ts
@@ -68,8 +68,7 @@ export function createHarnessChatAgentFactory(config: HarnessConfig) {
 			// `tools: []` plus `disallowedTools` for every native name, and the
 			// agent auto-denies any approval request outside the list.
 			activeTools: HARNESS_TOOL_NAMES,
-			// `permissionMode` stays at the default `allow-all`: a stricter mode
-			// would only add ask-rules for built-ins that are already absent.
+			// Default permissionMode; ask-rules would only cover built-ins that are already absent.
 			instructions: HARNESS_INSTRUCTIONS,
 		});
 }

--- a/apps/chat-api/src/features/ai-chat/tools/harness-tools.ts
+++ b/apps/chat-api/src/features/ai-chat/tools/harness-tools.ts
@@ -1,0 +1,7 @@
+/**
+ * Short names of the Harness user tools — the only tools Claude Code can call
+ * on the AI SDK chat path. `activeTools` derives from this list, so every
+ * built-in stays off and a new tool is enabled by adding its name here.
+ * Empty until the first Harness tool lands.
+ */
+export const HARNESS_TOOL_NAMES = [] as const;

--- a/apps/chat-api/src/index.ts
+++ b/apps/chat-api/src/index.ts
@@ -2,7 +2,7 @@ import { createLiveStreamTelemetry } from "@mymemo/live-text";
 import pino from "pino";
 import { createApp } from "./app";
 import { loadApiConfigFromEnv } from "./config/env";
-import { createDeps, type HarnessChatAgent } from "./deps";
+import { createDeps } from "./deps";
 
 export { createApp } from "./app";
 
@@ -11,15 +11,11 @@ export { createApp } from "./app";
 // is required at boot, while runtime reachability remains outside health.
 const productionConfig = loadApiConfigFromEnv(Bun.env);
 const productionLogger = pino({ level: productionConfig.logLevel });
-const harnessDisabled = async (): Promise<never> => {
-	throw new Error("Harness chat is not enabled in production");
-};
 const productionDeps = createDeps(
 	productionConfig,
-	{
-		createSession: harnessDisabled,
-		stream: harnessDisabled,
-	} as unknown as HarnessChatAgent,
+	() => {
+		throw new Error("Harness chat is not enabled in production");
+	},
 	createLiveStreamTelemetry("chat-api", productionLogger),
 );
 const productionApp = createApp(productionConfig, productionDeps);

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -55,8 +55,7 @@ Workspace persistence, Agent session continuity, Searchable document loading, an
 | `apps/agentcore-runtime/src/run-serving.ts` | Serving behavior for an already-running Run |
 | `apps/agentcore-runtime/src/sdk/` | SDK query wiring, transcript mirroring, tools, and AG-UI event projection |
 | `apps/agentcore-runtime/src/artifacts/` | Artifact discovery, upload, and publication for Runs with a `done` Outcome |
-| `apps/chat-api/src/features/ai-chat/` | Harness-hosted AI SDK chat route (`POST /api/chat`, local composition only): one Claude Code turn per message on a per-turn `HarnessAgent` with every built-in off, in a persistent Vercel Sandbox per Conversation, streamed as the UI message stream |
-| `apps/chat-api/src/features/ai-chat/tools/` | The Harness tool-name list the agent's `activeTools` derives from (the chat-api-hosted Harness tool set lands here) |
+| `apps/chat-api/src/features/ai-chat/` | Harness-hosted AI SDK chat route (`POST /api/chat`, local composition only): one Claude Code turn per message on a per-turn `HarnessAgent` whose `activeTools` is the Harness tool-name list in `tools/` (so every built-in is off), in a persistent Vercel Sandbox per Conversation, streamed as the UI message stream |
 | `packages/agentcore-dispatch/src/` | Shared AgentCore Dispatch publisher policy, envelope serialization, and isolated SQS/SSM adapters |
 | `packages/agent-db/src/conversation-ownership.ts` | Live Ownership renew, release, and mutation fence |
 | `packages/agent-db/src/run-store.ts` | Fenced Run state and Run event transactions |

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -55,7 +55,8 @@ Workspace persistence, Agent session continuity, Searchable document loading, an
 | `apps/agentcore-runtime/src/run-serving.ts` | Serving behavior for an already-running Run |
 | `apps/agentcore-runtime/src/sdk/` | SDK query wiring, transcript mirroring, tools, and AG-UI event projection |
 | `apps/agentcore-runtime/src/artifacts/` | Artifact discovery, upload, and publication for Runs with a `done` Outcome |
-| `apps/chat-api/src/features/ai-chat/` | Harness-hosted AI SDK chat route (`POST /api/chat`, local composition only): one Claude Code turn per message in a persistent Vercel Sandbox per Conversation, streamed as the UI message stream |
+| `apps/chat-api/src/features/ai-chat/` | Harness-hosted AI SDK chat route (`POST /api/chat`, local composition only): one Claude Code turn per message on a per-turn `HarnessAgent` with every built-in off, in a persistent Vercel Sandbox per Conversation, streamed as the UI message stream |
+| `apps/chat-api/src/features/ai-chat/tools/` | The Harness tool-name list the agent's `activeTools` derives from (the chat-api-hosted Harness tool set lands here) |
 | `packages/agentcore-dispatch/src/` | Shared AgentCore Dispatch publisher policy, envelope serialization, and isolated SQS/SSM adapters |
 | `packages/agent-db/src/conversation-ownership.ts` | Live Ownership renew, release, and mutation fence |
 | `packages/agent-db/src/run-store.ts` | Fenced Run state and Run event transactions |

--- a/docs/agents/chat-api.md
+++ b/docs/agents/chat-api.md
@@ -11,13 +11,28 @@ A Conversation is the durable container, a Run serves one submitted message, and
 The local-only composition mounts `POST /api/chat`. It accepts the strict
 `useChat` body (`id`, one User message with one text part, `model`, `trigger`)
 and, after identity, Conversation ownership (`404`), Archive (`409`), and
-exposure (`403`) checks, runs one turn of Claude Code with its built-in tools
-inside a Harness sandbox (see [ADR-0033](../adr/0033-host-the-ai-sdk-chat-loop-in-a-vercel-sandbox-through-harnessagent.md)).
+exposure (`403`) checks, runs one turn of Claude Code with every built-in tool
+disabled inside a Harness sandbox (see [ADR-0033](../adr/0033-host-the-ai-sdk-chat-loop-in-a-vercel-sandbox-through-harnessagent.md)).
 `HarnessAgent` runs in the chat-api process; each Conversation owns one
 persistent Vercel Sandbox whose harness `sessionId` is the Conversation id. The
-response is the AI SDK UI message stream (`toUIMessageStreamResponse()`): text
-arrives as it is produced and built-in tool activity appears as
-`tool-input-available` / `tool-output-available` parts.
+response is the AI SDK UI message stream (`toUIMessageStreamResponse()`),
+forwarded unchanged: text arrives as it is produced and the model's reasoning
+as `reasoning-start` / `reasoning-delta` / `reasoning-end` parts.
+
+The route builds one `HarnessAgent` per turn through
+`deps.createHarnessChatAgent(tools)`, a factory the local composition creates
+once over the Claude Code adapter (`auth: 'direct'`, `ENABLE_TOOL_SEARCH=false`,
+thinking at the adapter default) and the Vercel sandbox provider. The agent's
+`activeTools` is `HARNESS_TOOL_NAMES` (`ai-chat/tools/harness-tools.ts`) — the
+short names of the chat-api-hosted Harness tools, and nothing else — so no
+Claude built-in is callable in the sandbox; the list is empty until the first
+Harness tool lands. Asked to run a command or read a file, the model refuses
+in text. The only `tool-*` parts with `providerExecuted: true` are the bridge's
+own synthetic `compaction` and `fileChange` parts (`dynamic: true`). The
+appended `instructions` (`HARNESS_INSTRUCTIONS`) tell the model it has no
+filesystem, memory directory, or built-in tools of its own; the bridge
+hardcodes the `claude_code` preset, so this path appends to Claude Code's
+native prompt rather than replacing it.
 
 Continuity between messages is the sandbox snapshot: after every turn —
 drained, cancelled, or failed — the route calls `session.stop()` and stores the
@@ -49,7 +64,7 @@ There is no admission, Run, history, or retry yet: those are follow-up slices
 of [#595](https://github.com/X-GPT/mymemo-agent/issues/595).
 The adapter runs the configured `OPENROUTER_DEFAULT_MODEL`; the request `model`
 literal is validated, not forwarded. Production composition does not mount this
-path; its `harnessChatAgent` throws.
+path; its `createHarnessChatAgent` throws.
 
 Local two-turn recall check (real harness; needs the Compose stack with the
 Vercel triple and `OPENROUTER_API_KEY` exported):
@@ -61,6 +76,16 @@ turn() { curl -sN -X POST localhost:3000/api/chat $H -d "{\"id\":\"$ID\",\"model
 turn "Remember the word pelican." 11111111-1111-4111-8111-111111111111
 docker compose restart chat-api
 turn "Which word did I ask you to remember?" 22222222-2222-4222-8222-222222222222   # answer mentions pelican
+```
+
+Local built-ins-off check (same stack and `turn` helper): a request for shell
+or file work yields a text refusal with no `tool-*` part of any kind, and the
+model's reasoning arrives as `reasoning-*` parts:
+
+```sh
+turn "Run ls -la in your shell and show me the output, then read /etc/hostname." 33333333-3333-4333-8333-333333333333 | tee /tmp/turn.sse
+grep -c '"type":"tool-' /tmp/turn.sse        # 0
+grep -o '"type":"reasoning-[a-z]*"' /tmp/turn.sse | sort -u   # reasoning-start, reasoning-delta, reasoning-end
 ```
 
 ### Create a Conversation

--- a/docs/agents/chat-api.md
+++ b/docs/agents/chat-api.md
@@ -26,8 +26,10 @@ thinking at the adapter default) and the Vercel sandbox provider. The agent's
 `activeTools` is `HARNESS_TOOL_NAMES` (`ai-chat/tools/harness-tools.ts`) — the
 short names of the chat-api-hosted Harness tools, and nothing else — so no
 Claude built-in is callable in the sandbox; the list is empty until the first
-Harness tool lands. Asked to run a command or read a file, the model refuses
-in text. The only `tool-*` parts with `providerExecuted: true` are the bridge's
+Harness tool lands. Asked to run a command or read a file, the model produces
+text only: nothing executes and no tool part is streamed (see the built-ins-off
+check below for what that text looks like). The only `tool-*` parts with
+`providerExecuted: true` are the bridge's
 own synthetic `compaction` and `fileChange` parts (`dynamic: true`). The
 appended `instructions` (`HARNESS_INSTRUCTIONS`) tell the model it has no
 filesystem, memory directory, or built-in tools of its own; the bridge
@@ -88,9 +90,9 @@ grep -c '"type":"tool-' /tmp/turn.sse        # 0
 grep -o '"type":"reasoning-[a-z]*"' /tmp/turn.sse | sort -u   # reasoning-start, reasoning-delta, reasoning-end
 ```
 
-The text is usually a refusal ("I don't have access to shell commands … in
-this session"), but not always: with no tool listed, the `claude_code` preset's
-own tool guidance sometimes leads the model to narrate a tool call as text
+The text is a refusal ("I don't have access to shell commands … here") in some
+runs but not all: with no tool listed, the `claude_code` preset's own tool
+guidance can lead the model to narrate a tool call as text
 (`<bash>ls -la</bash>`) and invent its output — seen in one of two runs even
 with `HARNESS_INSTRUCTIONS` forbidding it. That is model text, not a tool part,
 and the pinned guarantee is the stream shape above; the refusal is expected to

--- a/docs/agents/chat-api.md
+++ b/docs/agents/chat-api.md
@@ -79,7 +79,7 @@ turn "Which word did I ask you to remember?" 22222222-2222-4222-8222-22222222222
 ```
 
 Local built-ins-off check (same stack and `turn` helper): a request for shell
-or file work yields a text refusal with no `tool-*` part of any kind, and the
+or file work produces no `tool-*` part of any kind, nothing executes, and the
 model's reasoning arrives as `reasoning-*` parts:
 
 ```sh
@@ -87,6 +87,14 @@ turn "Run ls -la in your shell and show me the output, then read /etc/hostname."
 grep -c '"type":"tool-' /tmp/turn.sse        # 0
 grep -o '"type":"reasoning-[a-z]*"' /tmp/turn.sse | sort -u   # reasoning-start, reasoning-delta, reasoning-end
 ```
+
+The text is usually a refusal ("I don't have access to shell commands … in
+this session"), but not always: with no tool listed, the `claude_code` preset's
+own tool guidance sometimes leads the model to narrate a tool call as text
+(`<bash>ls -la</bash>`) and invent its output — seen in one of two runs even
+with `HARNESS_INSTRUCTIONS` forbidding it. That is model text, not a tool part,
+and the pinned guarantee is the stream shape above; the refusal is expected to
+settle once a real Harness tool is listed, as it did on the #612 spike.
 
 ### Create a Conversation
 

--- a/docs/agents/security.md
+++ b/docs/agents/security.md
@@ -28,12 +28,16 @@ chat-api must not hold KB or E2B credentials. It admits Runs, serves history and
 The production AgentCore Runtime alone owns product Run model traffic, scoped
 Searchable document access, E2B execution, relay production, and Downloadable
 artifact publication. On the AI SDK chat path (`POST /api/chat`, local
-composition only) the Harness sandbox is the trust boundary: Claude Code and
-its built-in tools run inside a Vercel Sandbox that holds no MyMemo secret. The
-model credential is brokered — the adapter replaces it with a placeholder
-before it reaches the sandbox and the Vercel firewall injects the real bearer
-only on requests to the OpenRouter host — so prompt-injected Bash can spend
-model credit against that host but cannot read the key. The sandbox receives no
+composition only) the Harness sandbox is the trust boundary: Claude Code runs
+inside a Vercel Sandbox with every built-in tool disabled (`activeTools` names
+only the chat-api-hosted Harness tools), and the sandbox holds no MyMemo
+secret. The model credential is brokered — the adapter replaces it with a
+placeholder before it reaches the sandbox and the Vercel firewall injects the
+real bearer only on requests to the OpenRouter host. With no built-in tool
+there is no model-directed route to the sandbox's environment or filesystem;
+the placeholder is present in the sandbox's process environment and in the
+bridge's on-disk start config, readable by Vercel project members and by
+nothing the model can call. The sandbox receives no
 database, E2B, Searchable document, Redis, or Downloadable artifact authority.
 The AgentCore Runtime's KB credential is read-only and separate from the
 writable `mymemo_agent` credential. The maintenance service receives only writable agent DB, E2B


### PR DESCRIPTION
## Summary

Closes #617 (parent spec #615, ADR-0033 stage-2 amendment).

The prefactor the stage-2 tool tickets build on. `POST /api/chat` still runs one Claude Code turn per message in the Conversation's Harness sandbox, but the model now has **no built-in tool** and its reasoning is visible:

- `createHarnessChatAgentFactory(config)` builds the Claude Code adapter (`auth: 'direct'`, `env: { ENABLE_TOOL_SEARCH: 'false' }`, thinking at the adapter default `adaptive` / `summarized`; the stage-1 "thinking deferred" comment is gone) and the Vercel sandbox provider **once at composition**, and returns `(tools) => HarnessAgent`.
- The route builds **one `HarnessAgent` per turn** from `deps.createHarnessChatAgent(tools)` with `instructions: HARNESS_INSTRUCTIONS` and `activeTools: HARNESS_TOOL_NAMES` — the exported name list in `ai-chat/tools/harness-tools.ts`, empty in this ticket, so `@ai-sdk/harness` turns it into an empty built-in allow-list (`builtinToolFiltering: { mode: 'allow', toolNames: [] }`) and later tickets only add names. `permissionMode` is left at the library default `allow-all` (spec #615's choice; a one-line comment says why a stricter mode buys nothing).
- `HARNESS_INSTRUCTIONS` is appended to the `claude_code` preset (the bridge hardcodes it; this path can only append): the model has no filesystem, memory directory, or built-in tools of its own and refers to offered tools by short name. The per-tool guidance from `MYMEMO_SYSTEM_PROMPT` lands with the tools in #619, which owns the full text — a prompt describing tools the model does not yet have would be wrong at this commit.
- Production `createDeps` receives a throwing factory instead of a throwing agent.
- No `ai` dependency: `Tool` is not resolvable from chat-api today, so the factory's tool-set parameter is typed `NonNullable<HarnessAgentSettings["tools"]>` (resolves to `{}` for now); #619 types the real set when it adds tools.

## Acceptance criteria

- [x] `POST /api/chat` streams a turn end to end exactly as before — every stage-1 route test (resume pointer, stop after the stream, `409` on overlap, resume-failure fallback) is unchanged apart from injecting the factory.
- [x] Agent built once per turn by `deps.createHarnessChatAgent(tools)`; the route test fake is that factory and asserts one factory call per turn with the tool keys equal to `HARNESS_TOOL_NAMES`; the factory test asserts `activeTools` **is** `HARNESS_TOOL_NAMES` and `instructions` is `HARNESS_INSTRUCTIONS` on the real `HarnessAgent` (a factory-shaped fake cannot see either, so those two pins live in `harness-chat-agent.test.ts`).
- [x] Adapter configured once with `auth: 'direct'`, `env: { ENABLE_TOOL_SEARCH: 'false' }`, thinking at the adapter default — pinned by a pass-through spy on `createClaudeCode` (one call, exact settings, both agents share the adapter and provider).
- [x] Route-level invariant test with the fake harness: the stream is forwarded unchanged, `reasoning-*` parts pass, and no `tool-*` part with `providerExecuted: true` reaches the client except `compaction` / `fileChange` with `dynamic: true`. (Per the spec there is no runtime interception — the guarantee is the configuration, which the factory test pins as the empty built-in allow-list.)
- [x] Live, stream shape (Compose stack, real Vercel sandbox + OpenRouter, 3 runs on fresh Conversations, ~10 s each): every run streamed `200` with **0** `tool-*` parts, `reasoning-start` / `reasoning-delta` / `reasoning-end` present, nothing executed, `stop()` and the pointer save clean.
- [ ] Live, text refusal — **partial, inherited by #619.** The text was a refusal in 1 of 3 runs; in the other two the model narrated a fake tool call as text (`<function_calls>…` / `<bash>ls -la</bash>`) and invented the output — its reasoning cited the `claude_code` preset's own tool guidance ("I should use PowerShell for shell operations and the Read tool"), which this path can only append to. `HARNESS_INSTRUCTIONS` now says only the tool list is real and forbids text tool calls / invented output (the clean refusal came after that change); the behaviour is documented next to the check in `chat-api.md` and handed to #619, which owns the final prompt and adds the real `Bash`. The refusal cannot be made deterministic at zero tools by prompt alone.

## Changes

- `apps/chat-api/src/features/ai-chat/harness-chat-agent.ts`: `createHarnessChatAgentFactory` over composition-time providers; `HARNESS_INSTRUCTIONS`; `HarnessChatAgentFactory` type (the stage-1 `HarnessChatAgent` type is gone — nothing consumed it).
- `apps/chat-api/src/features/ai-chat/tools/harness-tools.ts` (new): `HARNESS_TOOL_NAMES = []`.
- `apps/chat-api/src/features/ai-chat/ai-chat.route.ts`: one agent per turn, built before the overlap check so a constructor throw holds no slot.
- `apps/chat-api/src/deps.ts`, `src/index.ts`, `local/index.ts`: `harnessChatAgent` → `createHarnessChatAgent`.
- `apps/chat-api/src/features/ai-chat/harness-chat-agent.test.ts` (new): the factory pin.
- `apps/chat-api/src/features/ai-chat/ai-chat.route.test.ts`: factory-shaped fake; per-turn agent test; stream-invariant test.
- `docs/agents/chat-api.md`, `security.md`, `architecture.md`: built-ins off, per-turn agent, reasoning parts, the live check.

## Review trail

- Ponytail (`/ponytail-review`), four fresh passes: `a1c305f` → 6 findings (dead `HarnessChatAgent` type and `deps.ts` re-export, one-use alias, redundant assertion, long comment) fixed in `37c8584`; → 5 findings (explicit default `permissionMode`, `inspect()` helper, `tools ?? {}`, premature docs row) fixed in `4c9fdbc`; → 2 comment trims fixed in `44f3386`; → **NO FINDINGS** on `44f3386`.
- `/code-review` (Standards + Spec) on `44f3386`: **APPROVED FOR MERGE**, 9 non-blocking notes (see the review comment). The `{}`-typed factory parameter and the tools/name-list agreement pin are #619's to close when it adds real tools.

## Verification

- `apps/chat-api`: `bun test` — 136 pass (includes `local/index.test.ts`, which boots the local composition).
- `tsc --noEmit -p apps/chat-api` — clean apart from the pre-existing `@smithy/types` mismatch in `s3-artifact-download-signer.ts`.
- `biome check` — clean.
- CI on `44f3386`: test, infrastructure, integration — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fm4wPcnWvNj2zUy1E8TqAu


