### PR TITLE
docs: add coding standards note

### DIFF
--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -1,0 +1,1 @@
+Tautological tests considered harmful.


### PR DESCRIPTION
## Summary

- add a root coding standards note discouraging tautological tests

## Testing

- not run (documentation-only change)