### PR TITLE
fix(chat-api): never persist a resume pointer left by a suspended turn

### DIFF
--- a/apps/chat-api/src/features/ai-chat/ai-chat.route.test.ts
+++ b/apps/chat-api/src/features/ai-chat/ai-chat.route.test.ts
@@ -377,28 +377,17 @@ it("keeps the previous resume pointer when a stopped turn was still running, so 
 		data: { bridge: "dead" },
 		continueFrom: { type: "continue-turn", data: { bridge: "dead" } },
 	};
-	let suspends = true;
 	let resumedSuspended = false;
 	fake.createSession = async ({ resumeFrom }) => {
 		// Mirrors the framework: creating a session from a pointer that carries
 		// `continueFrom` succeeds and yields a *suspended* session.
-		resumedSuspended =
-			(resumeFrom as { continueFrom?: unknown } | undefined)?.continueFrom !==
-			undefined;
-		return {
-			stop: async () => {
-				const state = suspends ? suspendedState : stoppedState;
-				suspends = false;
-				return state;
-			},
-		};
+		resumedSuspended = resumeFrom === suspendedState;
+		return { stop: async () => suspendedState };
 	};
 	fake.stream = async () => {
 		// ...and a suspended session refuses the next prompt, which is the 500.
 		if (resumedSuspended) throw new Error("turn is not promptable");
-		return {
-			toUIMessageStreamResponse: () => streamResponse(uiMessageStream),
-		};
+		return { toUIMessageStreamResponse: () => streamResponse(uiMessageStream) };
 	};
 	const { store, saved } = fakeResumeStore();
 	const app = makeApp({
@@ -418,14 +407,12 @@ it("keeps the previous resume pointer when a stopped turn was still running, so 
 	const first = await post();
 	expect(first.status).toBe(200);
 	await first.body?.cancel();
-	expect(saved).toEqual([]);
 
 	// Second turn on the same Conversation: answers instead of 500ing.
 	const second = await post();
 	expect(second.status).toBe(200);
 	expect(await second.text()).toBe(uiMessageStream);
-	// A pointer from a turn that did stop is still persisted.
-	expect(saved.map((s) => s.state)).toEqual([stoppedState]);
+	expect(saved).toEqual([]);
 });
 
 it("stops the session when the client cancels the stream", async () => {

--- a/apps/chat-api/src/features/ai-chat/ai-chat.route.test.ts
+++ b/apps/chat-api/src/features/ai-chat/ai-chat.route.test.ts
@@ -30,13 +30,17 @@ const uiMessageStream =
 	'data: {"type":"text-delta","id":"t1","delta":"Hi"}\n\ndata: [DONE]\n\n';
 
 /** What the fake session's `stop()` returns; opaque to the route. */
-const stoppedState = { type: "resume-session", data: { after: "turn" } };
+const stoppedState: { type: string; data: unknown; continueFrom?: unknown } = {
+	type: "resume-session",
+	data: { after: "turn" },
+};
 
 /** In-memory resume pointer store, optionally pre-seeded for conversation-1. */
 function fakeResumeStore(initial: unknown = null) {
 	const saved: { ref: unknown; state: unknown }[] = [];
 	const store = {
-		load: async () => initial,
+		// Reads back the last save, so a later turn sees what an earlier one left.
+		load: async () => saved.at(-1)?.state ?? initial,
 		save: async (ref: unknown, state: unknown) => {
 			saved.push({ ref, state });
 		},
@@ -360,6 +364,67 @@ it("starts a fresh session for the same id and logs when resuming throws", async
 		},
 	]);
 	// The stale pointer is replaced by the fresh session's.
+	expect(saved.map((s) => s.state)).toEqual([stoppedState]);
+});
+
+it("keeps the previous resume pointer when a stopped turn was still running, so the Conversation answers the next message", async () => {
+	const { factory, fake } = fakeAgent();
+	// What `stop()` returns when the framework still considers the turn running —
+	// a host tool in flight when the client disconnects. It carries bridge
+	// coordinates for a bridge the same call then kills.
+	const suspendedState = {
+		type: "resume-session",
+		data: { bridge: "dead" },
+		continueFrom: { type: "continue-turn", data: { bridge: "dead" } },
+	};
+	let suspends = true;
+	let resumedSuspended = false;
+	fake.createSession = async ({ resumeFrom }) => {
+		// Mirrors the framework: creating a session from a pointer that carries
+		// `continueFrom` succeeds and yields a *suspended* session.
+		resumedSuspended =
+			(resumeFrom as { continueFrom?: unknown } | undefined)?.continueFrom !==
+			undefined;
+		return {
+			stop: async () => {
+				const state = suspends ? suspendedState : stoppedState;
+				suspends = false;
+				return state;
+			},
+		};
+	};
+	fake.stream = async () => {
+		// ...and a suspended session refuses the next prompt, which is the 500.
+		if (resumedSuspended) throw new Error("turn is not promptable");
+		return {
+			toUIMessageStreamResponse: () => streamResponse(uiMessageStream),
+		};
+	};
+	const { store, saved } = fakeResumeStore();
+	const app = makeApp({
+		conversationStore: ownedConversation,
+		exposureGate: { isAgentEnabled: async () => true },
+		createHarnessChatAgent: factory,
+		harnessResumeStateStore: store,
+	});
+	const post = () =>
+		app.request("/api/chat", {
+			method: "POST",
+			headers,
+			body: JSON.stringify(requestBody),
+		});
+
+	// First turn: the client stops it while a document tool is still running.
+	const first = await post();
+	expect(first.status).toBe(200);
+	await first.body?.cancel();
+	expect(saved).toEqual([]);
+
+	// Second turn on the same Conversation: answers instead of 500ing.
+	const second = await post();
+	expect(second.status).toBe(200);
+	expect(await second.text()).toBe(uiMessageStream);
+	// A pointer from a turn that did stop is still persisted.
 	expect(saved.map((s) => s.state)).toEqual([stoppedState]);
 });
 

--- a/apps/chat-api/src/features/ai-chat/ai-chat.route.ts
+++ b/apps/chat-api/src/features/ai-chat/ai-chat.route.ts
@@ -157,7 +157,16 @@ routes.post(
 		const stop = async () => {
 			try {
 				const state = await session.stop();
-				await c.var.deps.harnessResumeStateStore.save(ref, state);
+				// Except when it carries `continueFrom`: stopping a turn the framework
+				// still considers running suspends it instead, and that pointer
+				// addresses a bridge the same call kills a line later — resuming from
+				// it builds a suspended session that refuses the next prompt, wedging
+				// the Conversation for good. Keeping the previous pointer costs only
+				// the stopped turn's tail: a healthy pointer carries no state, and the
+				// sandbox is found by session id.
+				if (state.continueFrom === undefined) {
+					await c.var.deps.harnessResumeStateStore.save(ref, state);
+				}
 			} catch (error) {
 				c.var.logger.warn(
 					{ err: error, conversationId: body.id },

--- a/apps/chat-api/src/features/ai-chat/ai-chat.route.ts
+++ b/apps/chat-api/src/features/ai-chat/ai-chat.route.ts
@@ -159,8 +159,8 @@ routes.post(
 				const state = await session.stop();
 				// Except when it carries `continueFrom`: `stop()` suspended a turn it
 				// still considered running, and that pointer addresses a bridge the
-				// same call kills. Keep the previous one — a healthy pointer carries no
-				// state, and the sandbox is found by session id.
+				// same call kills. Keep the previous one — it locates the same sandbox
+				// by session id, so only the stopped turn's tail is lost.
 				if (state.continueFrom === undefined) {
 					await c.var.deps.harnessResumeStateStore.save(ref, state);
 				}

--- a/apps/chat-api/src/features/ai-chat/ai-chat.route.ts
+++ b/apps/chat-api/src/features/ai-chat/ai-chat.route.ts
@@ -157,13 +157,10 @@ routes.post(
 		const stop = async () => {
 			try {
 				const state = await session.stop();
-				// Except when it carries `continueFrom`: stopping a turn the framework
-				// still considers running suspends it instead, and that pointer
-				// addresses a bridge the same call kills a line later — resuming from
-				// it builds a suspended session that refuses the next prompt, wedging
-				// the Conversation for good. Keeping the previous pointer costs only
-				// the stopped turn's tail: a healthy pointer carries no state, and the
-				// sandbox is found by session id.
+				// Except when it carries `continueFrom`: `stop()` suspended a turn it
+				// still considered running, and that pointer addresses a bridge the
+				// same call kills. Keep the previous one — a healthy pointer carries no
+				// state, and the sandbox is found by session id.
 				if (state.continueFrom === undefined) {
 					await c.var.deps.harnessResumeStateStore.save(ref, state);
 				}


### PR DESCRIPTION
Closes #642.

## What was broken

Stopping a chat response while a document tool was in flight wedged the Conversation permanently — every later `POST /api/chat` returned 500 with `harness turn failed to start`, with no recovery path.

`HarnessAgentSession.stop()` branches on turn state. When the framework still considers the turn running — which is exactly the case when a host tool is outstanding, the realistic Stop window — it takes `suspendCurrentTurn()` and returns a pointer carrying `continueFrom` (bridge coordinates), then stops the sandbox anyway in its `finally`, because chat-api passes a sandbox provider and owns the lifecycle. The route persisted that pointer verbatim; the next turn resumed into a `turnState: 'suspended'` session, and `agent.stream` → `requirePromptableTurn()` threw. The `createSession` resume fallback does not catch it — `createSession` succeeds; the throw comes later.

## The fix

Skip the save when the pointer carries `continueFrom`:

```ts
const state = await session.stop();
if (state.continueFrom === undefined) {
  await c.var.deps.harnessResumeStateStore.save(ref, state);
}
```

**Not stripping `continueFrom` and saving the rest.** `toResumeStateWithContinuation` copies `data` *out of the continuation*, so `data` is the suspend payload — the same dead bridge coordinates. Removing the field keeps the broken address and deletes the only marker that says so, trading a loud 500 for silent corruption.

**Keeping the previous pointer loses nothing.** A healthy `doStop()` payload is structurally empty: the sandbox is found by `sessionId` (the Conversation id) and the transcript is rehydrated from the workdir in the snapshot. There is no snapshot reference inside the pointer to go stale. If no previous pointer exists, the next message starts a fresh session and the Conversation still works. The check is sound rather than heuristic — bridge coordinates appear only on `doDetach()` / `doSuspendTurn()` payloads.

**On the store's opacity (per #642):** I took the plain inline check, no `carriesUnfinishedTurn(state)` helper. `continueFrom` is an optional *top-level* field on `HarnessV1ResumeSessionState`, beside `harnessId`/`specificationVersion`/`data` — the adapter-defined `data` blob stays untouched, so the payload's opacity is essentially intact and a one-implementation predicate would be over-engineering.

## Test

New case in `ai-chat.route.test.ts`. The fake session's `stop()` returns a pointer carrying `continueFrom`, and the fake agent mirrors the framework: `createSession` from such a pointer *succeeds*, and `stream` then throws. The load-bearing assertion is that a **second** `POST /api/chat` on the same Conversation returns 200 — verified to fail with 500 against the unfixed route. It also asserts the poisoned pointer never reaches the store; that a healthy pointer still does is already covered by the file's first test.

`fakeResumeStore` now reads back its last save; without that the regression test would have been tautological (the second turn would never load the pointer the first one wrote).

## Scope

Fix and test only. No `interrupt()`, no stop endpoint — #635 settled that client disconnect is the mechanism. `POST /api/chat` is not mounted in production, so no production impact.

Verified: `bun test` in `apps/chat-api` — 161 pass, 0 fail; `biome check` clean; `tsc --noEmit` clean for `src/features/ai-chat` (the one remaining error is the pre-existing dual-`@smithy/types` one in `s3-artifact-download-signer.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
