### PR TITLE
feat(chat-api): serve Conversation CRUD on /v2 with v1 semantics

### DIFF
--- a/apps/chat-api/src/app.ts
+++ b/apps/chat-api/src/app.ts
@@ -5,6 +5,7 @@ import type { ApiConfig } from "./config/env";
 import type { AppDeps, AppEnv } from "./deps";
 import artifactRoutes from "./features/artifacts/artifacts.route";
 import conversationHistoryRoutes from "./features/conversation-history/conversation-history.route";
+import conversationLifecycleRoutes from "./features/conversations/conversation-lifecycle.route";
 import conversationsRoutes from "./features/conversations/conversations.route";
 
 /**
@@ -22,9 +23,13 @@ export function createApp(config: ApiConfig, deps: AppDeps) {
 
 	app.get("/", (c) => c.text("Hello Hono!"));
 	app.get("/health", (c) => c.json({ status: "ok" }));
+	app.route("/v1/conversations", conversationLifecycleRoutes);
 	app.route("/v1/conversations", conversationsRoutes);
 	app.route("/v1/conversations", conversationHistoryRoutes);
 	app.route("/v1/conversations", artifactRoutes);
+	// v2 carries the lifecycle routes with v1 semantics (#657); the Run,
+	// history, and artifact routes stay v1-only.
+	app.route("/v2/conversations", conversationLifecycleRoutes);
 
 	return app;
 }

--- a/apps/chat-api/src/features/ai-chat/ai-chat.route.ts
+++ b/apps/chat-api/src/features/ai-chat/ai-chat.route.ts
@@ -1,11 +1,10 @@
 import { sValidator as zValidator } from "@hono/standard-validator";
 import { Hono } from "hono";
-import { bodyLimit } from "hono/body-limit";
 import { z } from "zod";
 import type { AppEnv } from "@/deps";
 import {
 	ConversationIdParam,
-	MAX_REQUEST_BODY_BYTES,
+	conversationBodyLimit,
 	RunIdParam,
 } from "@/features/conversations/conversations.schema";
 import { requireInternalIdentity } from "@/features/conversations/internal-identity";
@@ -83,14 +82,10 @@ function cleanupAfterStream(
 const activeTurns = new Set<string>();
 
 const routes = new Hono<AppEnv>();
-const limit = bodyLimit({
-	maxSize: MAX_REQUEST_BODY_BYTES,
-	onError: (c) => c.json({ error: "Request body too large" }, 413),
-});
 
 routes.post(
 	"/",
-	limit,
+	conversationBodyLimit,
 	zValidator("json", chatBody, (result, c) => {
 		if (!result.success) {
 			return c.json({ error: "Invalid AI SDK chat input" }, 400);

--- a/apps/chat-api/src/features/conversations/conversation-lifecycle.route.test.ts
+++ b/apps/chat-api/src/features/conversations/conversation-lifecycle.route.test.ts
@@ -122,8 +122,7 @@ describe("GET/PATCH/DELETE /v2/conversations", () => {
 		const tdb = await createTestDatabase();
 		try {
 			const store = new PostgresConversationStore(tdb.db);
-			const createApp2 = buildApp(store);
-			const { conversationId } = await createV2Conversation(createApp2);
+			const { conversationId } = await createV2Conversation(buildApp(store));
 			// Reads, renames, archives, and deletes bypass the exposure gate.
 			const app = buildApp(store, gateThatFailsIfConsulted());
 

--- a/apps/chat-api/src/features/conversations/conversation-lifecycle.route.test.ts
+++ b/apps/chat-api/src/features/conversations/conversation-lifecycle.route.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it } from "bun:test";
+import { createTestDatabase } from "@mymemo/agent-db/testing";
+import type { ApiConfig } from "@/config/env";
+import type { AppDeps } from "@/deps";
+import type { ConversationStore } from "@/features/conversation-store/conversation-store";
+import { PostgresConversationStore } from "@/features/conversation-store/postgres-conversation-store";
+import type { ExposureGate } from "@/features/exposure-gate";
+import type { InternalIdentity } from "./conversations.schema";
+
+const { createApp } = await import("@/app");
+
+// The /v2/conversations resource carries v1 semantics (#657): same handlers,
+// mounted a second time. These tests exercise the v2 mount; the shared handler
+// behavior is covered in depth by conversations.route.test.ts.
+
+/** Gate that records the identity it saw and returns a fixed decision. */
+function recordingGate(decision: boolean) {
+	const seen: InternalIdentity[] = [];
+	const gate: ExposureGate = {
+		async isAgentEnabled(identity) {
+			seen.push(identity);
+			return decision;
+		},
+	};
+	return { gate, seen };
+}
+
+function gateThatFailsIfConsulted(): ExposureGate {
+	return {
+		async isAgentEnabled() {
+			throw new Error("exposure gate should not be consulted");
+		},
+	};
+}
+
+function buildApp(
+	conversationStore: ConversationStore,
+	exposureGate: ExposureGate = recordingGate(true).gate,
+) {
+	const deps = { conversationStore, exposureGate } as unknown as AppDeps;
+	return createApp({ logLevel: "silent" } as unknown as ApiConfig, deps);
+}
+
+const identityHeaders = {
+	"content-type": "application/json",
+	"x-member-code": "member-1",
+	"x-partner-code": "partner-1",
+};
+
+interface SummaryBody {
+	conversationId: string;
+	title: string | null;
+	scope: string;
+	createdAt: string;
+	lastActivityAt: string;
+	archivedAt: string | null;
+}
+
+async function createV2Conversation(
+	app: ReturnType<typeof buildApp>,
+	body: Record<string, unknown> = {},
+): Promise<SummaryBody> {
+	const res = await app.request("/v2/conversations", {
+		method: "POST",
+		headers: identityHeaders,
+		body: JSON.stringify(body),
+	});
+	expect(res.status).toBe(201);
+	return (await res.json()) as SummaryBody;
+}
+
+describe("POST /v2/conversations", () => {
+	it("freezes the Scope at creation for all three shapes", async () => {
+		const tdb = await createTestDatabase();
+		try {
+			const store = new PostgresConversationStore(tdb.db);
+			const app = buildApp(store);
+
+			const cases: [Record<string, unknown>, string][] = [
+				[{}, "general"],
+				[{ collectionId: "col-1" }, "collection"],
+				[{ collectionId: "col-1", summaryId: "sum-1" }, "document"],
+			];
+			for (const [body, scope] of cases) {
+				const created = await createV2Conversation(app, body);
+				expect(created).toMatchObject({
+					title: null,
+					scope,
+					archivedAt: null,
+				});
+				expect(
+					await store.get({
+						userId: "member-1",
+						conversationId: created.conversationId,
+					}),
+				).toMatchObject({ scope });
+			}
+		} finally {
+			await tdb.close();
+		}
+	});
+
+	it("is exposure-gated on the trusted identity", async () => {
+		const tdb = await createTestDatabase();
+		try {
+			const { gate, seen } = recordingGate(false);
+			const app = buildApp(new PostgresConversationStore(tdb.db), gate);
+
+			const res = await app.request("/v2/conversations", {
+				method: "POST",
+				headers: identityHeaders,
+				body: JSON.stringify({}),
+			});
+
+			expect(res.status).toBe(403);
+			expect(seen).toEqual([
+				{ memberCode: "member-1", partnerCode: "partner-1" },
+			]);
+		} finally {
+			await tdb.close();
+		}
+	});
+
+	it("rejects missing identity headers with 401", async () => {
+		const tdb = await createTestDatabase();
+		try {
+			const app = buildApp(new PostgresConversationStore(tdb.db));
+			const res = await app.request("/v2/conversations", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({}),
+			});
+			expect(res.status).toBe(401);
+		} finally {
+			await tdb.close();
+		}
+	});
+});
+
+describe("GET/PATCH/DELETE /v2/conversations", () => {
+	it("round-trips Archive: partitioned out of the default list, then back", async () => {
+		const tdb = await createTestDatabase();
+		try {
+			const store = new PostgresConversationStore(tdb.db);
+			const createApp2 = buildApp(store);
+			const { conversationId } = await createV2Conversation(createApp2);
+			// Reads, renames, archives, and deletes bypass the exposure gate.
+			const app = buildApp(store, gateThatFailsIfConsulted());
+
+			const archive = await app.request(`/v2/conversations/${conversationId}`, {
+				method: "PATCH",
+				headers: identityHeaders,
+				body: JSON.stringify({ archived: true }),
+			});
+			expect(archive.status).toBe(200);
+			expect(((await archive.json()) as SummaryBody).archivedAt).not.toBeNull();
+
+			const regular = await app.request("/v2/conversations", {
+				headers: identityHeaders,
+			});
+			expect(
+				((await regular.json()) as { conversations: SummaryBody[] })
+					.conversations,
+			).toHaveLength(0);
+			const archived = await app.request("/v2/conversations?archived=true", {
+				headers: identityHeaders,
+			});
+			expect(
+				((await archived.json()) as { conversations: SummaryBody[] })
+					.conversations,
+			).toHaveLength(1);
+
+			// An archived Conversation still accepts a rename.
+			const rename = await app.request(`/v2/conversations/${conversationId}`, {
+				method: "PATCH",
+				headers: identityHeaders,
+				body: JSON.stringify({ title: "renamed while archived" }),
+			});
+			expect(rename.status).toBe(200);
+
+			const unarchive = await app.request(
+				`/v2/conversations/${conversationId}`,
+				{
+					method: "PATCH",
+					headers: identityHeaders,
+					body: JSON.stringify({ archived: false }),
+				},
+			);
+			expect(unarchive.status).toBe(200);
+			const back = (await unarchive.json()) as SummaryBody;
+			expect(back).toMatchObject({
+				title: "renamed while archived",
+				archivedAt: null,
+			});
+		} finally {
+			await tdb.close();
+		}
+	});
+
+	it("permanently deletes with v1 semantics and stays owner-scoped", async () => {
+		const tdb = await createTestDatabase();
+		try {
+			const store = new PostgresConversationStore(tdb.db);
+			const { conversationId } = await createV2Conversation(buildApp(store));
+			const app = buildApp(store, gateThatFailsIfConsulted());
+
+			const foreign = await app.request(`/v2/conversations/${conversationId}`, {
+				method: "DELETE",
+				headers: { ...identityHeaders, "x-member-code": "member-2" },
+			});
+			expect(foreign.status).toBe(404);
+
+			const deleted = await app.request(`/v2/conversations/${conversationId}`, {
+				method: "DELETE",
+				headers: identityHeaders,
+			});
+			expect(deleted.status).toBe(204);
+			expect(
+				await store.get({ userId: "member-1", conversationId }),
+			).toBeNull();
+
+			const again = await app.request(`/v2/conversations/${conversationId}`, {
+				method: "DELETE",
+				headers: identityHeaders,
+			});
+			expect(again.status).toBe(404);
+		} finally {
+			await tdb.close();
+		}
+	});
+});
+
+describe("v2 surface boundaries", () => {
+	it("does not mount the v1 Run routes under /v2", async () => {
+		const tdb = await createTestDatabase();
+		try {
+			const store = new PostgresConversationStore(tdb.db);
+			const { conversationId } = await createV2Conversation(buildApp(store));
+			const app = buildApp(store, gateThatFailsIfConsulted());
+
+			for (const [method, path] of [
+				["POST", `/v2/conversations/${conversationId}/runs`],
+				["GET", `/v2/conversations/${conversationId}/runs/run-1/events`],
+				["POST", `/v2/conversations/${conversationId}/runs/run-1/interrupt`],
+				["GET", `/v2/conversations/${conversationId}/history`],
+				["GET", `/v2/conversations/${conversationId}/artifacts`],
+			] as const) {
+				const res = await app.request(path, {
+					method,
+					headers: identityHeaders,
+					body: method === "POST" ? JSON.stringify({}) : undefined,
+				});
+				expect(res.status).toBe(404);
+			}
+		} finally {
+			await tdb.close();
+		}
+	});
+
+	it("serves the lifecycle routes identically under /v1", async () => {
+		const tdb = await createTestDatabase();
+		try {
+			const store = new PostgresConversationStore(tdb.db);
+			const app = buildApp(store);
+			const res = await app.request("/v1/conversations", {
+				method: "POST",
+				headers: identityHeaders,
+				body: JSON.stringify({ summaryId: "sum-1" }),
+			});
+			expect(res.status).toBe(201);
+			const created = (await res.json()) as SummaryBody;
+			expect(created.scope).toBe("document");
+
+			const viaV2 = await app.request(
+				`/v2/conversations/${created.conversationId}`,
+				{
+					method: "PATCH",
+					headers: identityHeaders,
+					body: JSON.stringify({ title: "one resource, two prefixes" }),
+				},
+			);
+			expect(viaV2.status).toBe(200);
+		} finally {
+			await tdb.close();
+		}
+	});
+});

--- a/apps/chat-api/src/features/conversations/conversation-lifecycle.route.test.ts
+++ b/apps/chat-api/src/features/conversations/conversation-lifecycle.route.test.ts
@@ -5,6 +5,7 @@ import type { AppDeps } from "@/deps";
 import type { ConversationStore } from "@/features/conversation-store/conversation-store";
 import { PostgresConversationStore } from "@/features/conversation-store/postgres-conversation-store";
 import type { ExposureGate } from "@/features/exposure-gate";
+import type { ConversationSummary } from "./conversations.controller";
 import type { InternalIdentity } from "./conversations.schema";
 
 const { createApp } = await import("@/app");
@@ -50,26 +51,17 @@ const identityHeaders = {
 	"x-partner-code": "partner-1",
 };
 
-interface SummaryBody {
-	conversationId: string;
-	title: string | null;
-	scope: string;
-	createdAt: string;
-	lastActivityAt: string;
-	archivedAt: string | null;
-}
-
 async function createV2Conversation(
 	app: ReturnType<typeof buildApp>,
 	body: Record<string, unknown> = {},
-): Promise<SummaryBody> {
+): Promise<ConversationSummary> {
 	const res = await app.request("/v2/conversations", {
 		method: "POST",
 		headers: identityHeaders,
 		body: JSON.stringify(body),
 	});
 	expect(res.status).toBe(201);
-	return (await res.json()) as SummaryBody;
+	return (await res.json()) as ConversationSummary;
 }
 
 describe("POST /v2/conversations", () => {
@@ -141,20 +133,22 @@ describe("GET/PATCH/DELETE /v2/conversations", () => {
 				body: JSON.stringify({ archived: true }),
 			});
 			expect(archive.status).toBe(200);
-			expect(((await archive.json()) as SummaryBody).archivedAt).not.toBeNull();
+			expect(
+				((await archive.json()) as ConversationSummary).archivedAt,
+			).not.toBeNull();
 
 			const regular = await app.request("/v2/conversations", {
 				headers: identityHeaders,
 			});
 			expect(
-				((await regular.json()) as { conversations: SummaryBody[] })
+				((await regular.json()) as { conversations: ConversationSummary[] })
 					.conversations,
 			).toHaveLength(0);
 			const archived = await app.request("/v2/conversations?archived=true", {
 				headers: identityHeaders,
 			});
 			expect(
-				((await archived.json()) as { conversations: SummaryBody[] })
+				((await archived.json()) as { conversations: ConversationSummary[] })
 					.conversations,
 			).toHaveLength(1);
 
@@ -175,7 +169,7 @@ describe("GET/PATCH/DELETE /v2/conversations", () => {
 				},
 			);
 			expect(unarchive.status).toBe(200);
-			const back = (await unarchive.json()) as SummaryBody;
+			const back = (await unarchive.json()) as ConversationSummary;
 			expect(back).toMatchObject({
 				title: "renamed while archived",
 				archivedAt: null,
@@ -256,7 +250,7 @@ describe("v2 surface boundaries", () => {
 				body: JSON.stringify({ summaryId: "sum-1" }),
 			});
 			expect(res.status).toBe(201);
-			const created = (await res.json()) as SummaryBody;
+			const created = (await res.json()) as ConversationSummary;
 			expect(created.scope).toBe("document");
 
 			const viaV2 = await app.request(

--- a/apps/chat-api/src/features/conversations/conversation-lifecycle.route.test.ts
+++ b/apps/chat-api/src/features/conversations/conversation-lifecycle.route.test.ts
@@ -10,8 +10,11 @@ import type { InternalIdentity } from "./conversations.schema";
 const { createApp } = await import("@/app");
 
 // The /v2/conversations resource carries v1 semantics (#657): same handlers,
-// mounted a second time. These tests exercise the v2 mount; the shared handler
-// behavior is covered in depth by conversations.route.test.ts.
+// mounted a second time. conversations.route.test.ts covers the shared
+// handlers in depth; this file covers only what #657's acceptance criteria
+// require of the v2 mount itself — frozen Scope for the three shapes,
+// exposure-gated creation with gate bypass elsewhere, the Archive round-trip,
+// v1 permanent deletion, and the absence of every other v1 route under /v2.
 
 /** Gate that records the identity it saw and returns a fixed decision. */
 function recordingGate(decision: boolean) {
@@ -116,21 +119,6 @@ describe("POST /v2/conversations", () => {
 			expect(seen).toEqual([
 				{ memberCode: "member-1", partnerCode: "partner-1" },
 			]);
-		} finally {
-			await tdb.close();
-		}
-	});
-
-	it("rejects missing identity headers with 401", async () => {
-		const tdb = await createTestDatabase();
-		try {
-			const app = buildApp(new PostgresConversationStore(tdb.db));
-			const res = await app.request("/v2/conversations", {
-				method: "POST",
-				headers: { "content-type": "application/json" },
-				body: JSON.stringify({}),
-			});
-			expect(res.status).toBe(401);
 		} finally {
 			await tdb.close();
 		}

--- a/apps/chat-api/src/features/conversations/conversation-lifecycle.route.ts
+++ b/apps/chat-api/src/features/conversations/conversation-lifecycle.route.ts
@@ -6,10 +6,10 @@ import {
 	toConversationSummary,
 } from "./conversations.controller";
 import {
-	conversationBodyLimit,
 	ConversationListQuery,
 	ConversationPath,
 	CreateConversationBody,
+	conversationBodyLimit,
 	decodeConversationListCursor,
 	encodeConversationListCursor,
 	UpdateConversationBody,

--- a/apps/chat-api/src/features/conversations/conversation-lifecycle.route.ts
+++ b/apps/chat-api/src/features/conversations/conversation-lifecycle.route.ts
@@ -1,0 +1,161 @@
+import { sValidator as zValidator } from "@hono/standard-validator";
+import { Hono } from "hono";
+import { bodyLimit } from "hono/body-limit";
+import { z } from "zod";
+import type { AppEnv } from "@/deps";
+import {
+	createConversation,
+	toConversationSummary,
+} from "./conversations.controller";
+import {
+	ConversationIdParam,
+	ConversationListQuery,
+	CreateConversationBody,
+	decodeConversationListCursor,
+	encodeConversationListCursor,
+	MAX_REQUEST_BODY_BYTES,
+	UpdateConversationBody,
+} from "./conversations.schema";
+import { requireInternalIdentity } from "./internal-identity";
+
+/**
+ * Conversation lifecycle routes: list, create, rename/Archive, and permanent
+ * deletion. Mounted at both `/v1/conversations` and `/v2/conversations` with
+ * identical semantics (#657); the Run routes stay v1-only.
+ */
+const app = new Hono<AppEnv>();
+
+/** Shared request-body cap for both conversation write endpoints. */
+const conversationBodyLimit = bodyLimit({
+	maxSize: MAX_REQUEST_BODY_BYTES,
+	onError: (c) => c.json({ error: "Request body too large" }, 413),
+});
+const ConversationPath = z.object({ conversationId: ConversationIdParam });
+
+// GET / — list one owned Archive partition using stable activity keyset
+// pagination. Search is evaluated by Postgres before paging.
+app.get(
+	"/",
+	zValidator("query", ConversationListQuery, (result, c) => {
+		if (!result.success) {
+			return c.json({ error: "Invalid query", issues: result.error }, 400);
+		}
+	}),
+	requireInternalIdentity,
+	async (c) => {
+		const query = c.req.valid("query");
+		const after =
+			query.cursor === undefined
+				? undefined
+				: decodeConversationListCursor(query.cursor, query);
+		if (query.cursor !== undefined && after === null) {
+			return c.json({ error: "Invalid cursor" }, 400);
+		}
+
+		const page = await c.var.deps.conversationStore.list({
+			userId: c.var.identity.memberCode,
+			archived: query.archived,
+			search: query.search,
+			after: after ?? undefined,
+			limit: query.limit,
+		});
+		return c.json({
+			conversations: page.conversations.map(toConversationSummary),
+			nextCursor:
+				page.next === null
+					? null
+					: encodeConversationListCursor(query, page.next),
+		});
+	},
+);
+
+// POST / — create a conversation, freezing its document scope.
+app.post(
+	"/",
+	conversationBodyLimit,
+	zValidator("json", CreateConversationBody, (result, c) => {
+		if (!result.success) {
+			return c.json(
+				{ error: "Invalid request body", issues: result.error },
+				400,
+			);
+		}
+	}),
+	requireInternalIdentity,
+	async (c) => {
+		// New-work exposure gate: evaluated on the trusted identity (not the body)
+		// before any conversation write. Fails closed.
+		if (!(await c.var.deps.exposureGate.isAgentEnabled(c.var.identity))) {
+			return c.json({ error: "Agent is not enabled" }, 403);
+		}
+		const result = await createConversation(
+			c.var.deps.conversationStore,
+			c.var.identity,
+			c.req.valid("json"),
+		);
+		return c.json(result, 201);
+	},
+);
+
+// PATCH /:conversationId — rename and/or change Archive state.
+// Existing-resource control deliberately bypasses the exposure gate.
+app.patch(
+	"/:conversationId",
+	conversationBodyLimit,
+	zValidator("param", ConversationPath, (result, c) => {
+		if (!result.success) {
+			return c.json({ error: "Invalid conversation id" }, 400);
+		}
+	}),
+	zValidator("json", UpdateConversationBody, (result, c) => {
+		if (!result.success) {
+			return c.json(
+				{ error: "Invalid request body", issues: result.error },
+				400,
+			);
+		}
+	}),
+	requireInternalIdentity,
+	async (c) => {
+		const result = await c.var.deps.conversationStore.update(
+			{
+				userId: c.var.identity.memberCode,
+				conversationId: c.req.valid("param").conversationId,
+			},
+			c.req.valid("json"),
+		);
+		if (result.outcome !== "updated") {
+			return result.outcome === "not_found"
+				? c.json({ error: "Conversation not found" }, 404)
+				: c.json({ error: "Conversation has an active Run" }, 409);
+		}
+		return c.json(toConversationSummary(result.conversation));
+	},
+);
+
+// DELETE /:conversationId — irreversible user-visible deletion. External
+// workspace/session/object cleanup remains asynchronous.
+app.delete(
+	"/:conversationId",
+	zValidator("param", ConversationPath, (result, c) => {
+		if (!result.success) {
+			return c.json({ error: "Invalid conversation id" }, 400);
+		}
+	}),
+	requireInternalIdentity,
+	async (c) => {
+		const result = await c.var.deps.conversationStore.deletePermanently({
+			userId: c.var.identity.memberCode,
+			conversationId: c.req.valid("param").conversationId,
+		});
+		if (result.outcome === "not_found") {
+			return c.json({ error: "Conversation not found" }, 404);
+		}
+		if (result.outcome === "active_run") {
+			return c.json({ error: "Conversation has an active Run" }, 409);
+		}
+		return c.body(null, 204);
+	},
+);
+
+export default app;

--- a/apps/chat-api/src/features/conversations/conversation-lifecycle.route.ts
+++ b/apps/chat-api/src/features/conversations/conversation-lifecycle.route.ts
@@ -1,19 +1,17 @@
 import { sValidator as zValidator } from "@hono/standard-validator";
 import { Hono } from "hono";
-import { bodyLimit } from "hono/body-limit";
-import { z } from "zod";
 import type { AppEnv } from "@/deps";
 import {
 	createConversation,
 	toConversationSummary,
 } from "./conversations.controller";
 import {
-	ConversationIdParam,
+	conversationBodyLimit,
 	ConversationListQuery,
+	ConversationPath,
 	CreateConversationBody,
 	decodeConversationListCursor,
 	encodeConversationListCursor,
-	MAX_REQUEST_BODY_BYTES,
 	UpdateConversationBody,
 } from "./conversations.schema";
 import { requireInternalIdentity } from "./internal-identity";
@@ -24,13 +22,6 @@ import { requireInternalIdentity } from "./internal-identity";
  * identical semantics (#657); the Run routes stay v1-only.
  */
 const app = new Hono<AppEnv>();
-
-/** Shared request-body cap for both conversation write endpoints. */
-const conversationBodyLimit = bodyLimit({
-	maxSize: MAX_REQUEST_BODY_BYTES,
-	onError: (c) => c.json({ error: "Request body too large" }, 413),
-});
-const ConversationPath = z.object({ conversationId: ConversationIdParam });
 
 // GET / — list one owned Archive partition using stable activity keyset
 // pagination. Search is evaluated by Postgres before paging.

--- a/apps/chat-api/src/features/conversations/conversations.route.ts
+++ b/apps/chat-api/src/features/conversations/conversations.route.ts
@@ -19,27 +19,18 @@ import {
 	ConversationArchivedError,
 	ConversationNotFoundError,
 } from "@/features/run-store/run-store";
-import {
-	admitAgUiRun,
-	createConversation,
-	toConversationSummary,
-} from "./conversations.controller";
+import { admitAgUiRun } from "./conversations.controller";
 import {
 	ConversationIdParam,
-	ConversationListQuery,
-	CreateConversationBody,
-	decodeConversationListCursor,
-	encodeConversationListCursor,
 	MAX_REQUEST_BODY_BYTES,
 	RunAgentInputBody,
 	RunIdParam,
-	UpdateConversationBody,
 } from "./conversations.schema";
 import { requireInternalIdentity } from "./internal-identity";
 
 const app = new Hono<AppEnv>();
 
-/** Shared request-body cap for both conversation endpoints. */
+/** Request-body cap for Run admission. */
 const conversationBodyLimit = bodyLimit({
 	maxSize: MAX_REQUEST_BODY_BYTES,
 	onError: (c) => c.json({ error: "Request body too large" }, 413),
@@ -464,132 +455,6 @@ async function respondWithAgUiRun(c: Context<AppEnv>, run: RunRecord) {
 	if (attached.outcome === "aborted") return c.body(null, 204);
 	return liveStreamReadFailureResponse(c, run, "relay_failed");
 }
-
-// GET /v1/conversations — list one owned Archive partition using stable
-// activity keyset pagination. Search is evaluated by Postgres before paging.
-app.get(
-	"/",
-	zValidator("query", ConversationListQuery, (result, c) => {
-		if (!result.success) {
-			return c.json({ error: "Invalid query", issues: result.error }, 400);
-		}
-	}),
-	requireInternalIdentity,
-	async (c) => {
-		const query = c.req.valid("query");
-		const after =
-			query.cursor === undefined
-				? undefined
-				: decodeConversationListCursor(query.cursor, query);
-		if (query.cursor !== undefined && after === null) {
-			return c.json({ error: "Invalid cursor" }, 400);
-		}
-
-		const page = await c.var.deps.conversationStore.list({
-			userId: c.var.identity.memberCode,
-			archived: query.archived,
-			search: query.search,
-			after: after ?? undefined,
-			limit: query.limit,
-		});
-		return c.json({
-			conversations: page.conversations.map(toConversationSummary),
-			nextCursor:
-				page.next === null
-					? null
-					: encodeConversationListCursor(query, page.next),
-		});
-	},
-);
-
-// POST /v1/conversations — create a conversation, freezing its document scope.
-app.post(
-	"/",
-	conversationBodyLimit,
-	zValidator("json", CreateConversationBody, (result, c) => {
-		if (!result.success) {
-			return c.json(
-				{ error: "Invalid request body", issues: result.error },
-				400,
-			);
-		}
-	}),
-	requireInternalIdentity,
-	async (c) => {
-		// New-work exposure gate: evaluated on the trusted identity (not the body)
-		// before any conversation write. Fails closed.
-		if (!(await c.var.deps.exposureGate.isAgentEnabled(c.var.identity))) {
-			return c.json({ error: "Agent is not enabled" }, 403);
-		}
-		const result = await createConversation(
-			c.var.deps.conversationStore,
-			c.var.identity,
-			c.req.valid("json"),
-		);
-		return c.json(result, 201);
-	},
-);
-
-// PATCH /v1/conversations/:conversationId — rename and/or change Archive
-// state. Existing-resource control deliberately bypasses the exposure gate.
-app.patch(
-	"/:conversationId",
-	conversationBodyLimit,
-	zValidator("param", ConversationPath, (result, c) => {
-		if (!result.success) {
-			return c.json({ error: "Invalid conversation id" }, 400);
-		}
-	}),
-	zValidator("json", UpdateConversationBody, (result, c) => {
-		if (!result.success) {
-			return c.json(
-				{ error: "Invalid request body", issues: result.error },
-				400,
-			);
-		}
-	}),
-	requireInternalIdentity,
-	async (c) => {
-		const result = await c.var.deps.conversationStore.update(
-			{
-				userId: c.var.identity.memberCode,
-				conversationId: c.req.valid("param").conversationId,
-			},
-			c.req.valid("json"),
-		);
-		if (result.outcome !== "updated") {
-			return result.outcome === "not_found"
-				? c.json({ error: "Conversation not found" }, 404)
-				: c.json({ error: "Conversation has an active Run" }, 409);
-		}
-		return c.json(toConversationSummary(result.conversation));
-	},
-);
-
-// DELETE /v1/conversations/:conversationId — irreversible user-visible
-// deletion. External workspace/session/object cleanup remains asynchronous.
-app.delete(
-	"/:conversationId",
-	zValidator("param", ConversationPath, (result, c) => {
-		if (!result.success) {
-			return c.json({ error: "Invalid conversation id" }, 400);
-		}
-	}),
-	requireInternalIdentity,
-	async (c) => {
-		const result = await c.var.deps.conversationStore.deletePermanently({
-			userId: c.var.identity.memberCode,
-			conversationId: c.req.valid("param").conversationId,
-		});
-		if (result.outcome === "not_found") {
-			return c.json({ error: "Conversation not found" }, 404);
-		}
-		if (result.outcome === "active_run") {
-			return c.json({ error: "Conversation has an active Run" }, 409);
-		}
-		return c.body(null, 204);
-	},
-);
 
 // POST /v1/conversations/:conversationId/runs — atomically admit one strict
 // standard AG-UI Run and attach to its producer-buffered Live Stream relay.

--- a/apps/chat-api/src/features/conversations/conversations.route.ts
+++ b/apps/chat-api/src/features/conversations/conversations.route.ts
@@ -20,9 +20,9 @@ import {
 } from "@/features/run-store/run-store";
 import { admitAgUiRun } from "./conversations.controller";
 import {
-	conversationBodyLimit,
 	ConversationIdParam,
 	ConversationPath,
+	conversationBodyLimit,
 	RunAgentInputBody,
 	RunIdParam,
 } from "./conversations.schema";

--- a/apps/chat-api/src/features/conversations/conversations.route.ts
+++ b/apps/chat-api/src/features/conversations/conversations.route.ts
@@ -10,7 +10,6 @@ import {
 	type LiveStreamReason,
 } from "@mymemo/live-text";
 import { type Context, Hono } from "hono";
-import { bodyLimit } from "hono/body-limit";
 import { type SSEStreamingApi, streamSSE } from "hono/streaming";
 import { z } from "zod";
 import type { AppEnv } from "@/deps";
@@ -21,8 +20,9 @@ import {
 } from "@/features/run-store/run-store";
 import { admitAgUiRun } from "./conversations.controller";
 import {
+	conversationBodyLimit,
 	ConversationIdParam,
-	MAX_REQUEST_BODY_BYTES,
+	ConversationPath,
 	RunAgentInputBody,
 	RunIdParam,
 } from "./conversations.schema";
@@ -30,12 +30,6 @@ import { requireInternalIdentity } from "./internal-identity";
 
 const app = new Hono<AppEnv>();
 
-/** Request-body cap for Run admission. */
-const conversationBodyLimit = bodyLimit({
-	maxSize: MAX_REQUEST_BODY_BYTES,
-	onError: (c) => c.json({ error: "Request body too large" }, 413),
-});
-const ConversationPath = z.object({ conversationId: ConversationIdParam });
 const RunPath = z.object({
 	conversationId: ConversationIdParam,
 	runId: RunIdParam,

--- a/apps/chat-api/src/features/conversations/conversations.schema.ts
+++ b/apps/chat-api/src/features/conversations/conversations.schema.ts
@@ -1,4 +1,5 @@
 import { RunAgentInputSchema } from "@ag-ui/core";
+import { bodyLimit } from "hono/body-limit";
 import { z } from "zod";
 import type { ConversationListPosition } from "@/features/conversation-store/conversation-store";
 
@@ -20,6 +21,16 @@ export const ConversationIdParam = z
 	.max(MAX_CONVERSATION_ID_LENGTH)
 	.regex(CONVERSATION_ID_PATTERN);
 export const RunIdParam = ConversationIdParam;
+
+export const ConversationPath = z.object({
+	conversationId: ConversationIdParam,
+});
+
+/** Shared request-body cap for the conversation write endpoints. */
+export const conversationBodyLimit = bodyLimit({
+	maxSize: MAX_REQUEST_BODY_BYTES,
+	onError: (c) => c.json({ error: "Request body too large" }, 413),
+});
 
 const EmptyClientObject = z.object({}).strict();
 const PlainTextUserMessage = z

--- a/docs/agents/chat-api.md
+++ b/docs/agents/chat-api.md
@@ -154,6 +154,8 @@ Return `201 { conversationId, title, scope, createdAt, lastActivityAt, archivedA
 
 All operations are owner-scoped. Missing and foreign Conversations both return `404`. These management routes bypass the new-work exposure gate.
 
+The four lifecycle routes above (create, list, rename/Archive, permanent delete) also serve at `/v2/conversations` with identical semantics: one shared router (`conversation-lifecycle.route.ts`) is mounted under both prefixes. The Run, history, and artifact routes stay v1-only; the v2 data plane and the outbox-based deletion upgrade are separate tickets under spec #654.
+
 ### Admit and stream a Run
 
 `POST /v1/conversations/:conversationId/runs` strictly validates one standard `RunAgentInput` and requires `threadId` to equal the owned Conversation id. Reject client Tools, state, and forwarded authority.


### PR DESCRIPTION
Closes #657 (parent spec #654).

## What

Mounts the `/v2/conversations` resource: `GET` / `POST /v2/conversations`, `PATCH` / `DELETE /v2/conversations/:id`, carrying v1 semantics by reusing the v1 handlers rather than reimplementing them.

## How

- The four Conversation lifecycle routes move verbatim from `conversations.route.ts` into a new `conversation-lifecycle.route.ts`, and `app.ts` mounts that one router at both `/v1/conversations` and `/v2/conversations`. Same handlers, same controller (`createConversation`, `toConversationSummary`), same `PostgresConversationStore` — so list ordering, the archived partition, search, the keyset cursor, exposure-gated creation, frozen Scope, and permanent deletion are v1's by construction.
- The Run, history, and artifact routes stay mounted only under `/v1`; nothing on `/v2` exposes them.
- `docs/agents/chat-api.md` notes the dual mount.

## Out of scope (per the ticket)

- The outbox/VM-cleanup deletion upgrade — DELETE keeps v1 permanent-delete behaviour.
- The v2 data plane (`/messages`, `/interrupt`) — separate tickets under #654.

## Tests

New `conversation-lifecycle.route.test.ts` exercises the `/v2` mount end to end against pglite: frozen Scope for all three shapes (`general`, `collection`, `document`), 403 on gated creation with the gate consulted on trusted identity only, gate bypass on management routes (a gate that throws if consulted), the Archive round-trip (out of the default list, rename while archived, back), owner-scoped 404s, permanent delete, and 404 for every Run/history/artifact path under `/v2`. Existing v1 suites pass unchanged: 167 tests across 21 files green in `apps/chat-api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbY3kbYfSRLAguCKKmhGib