### PR TITLE
feat(agent-db): Turn queue — schema and race-safe drain primitives (#656)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,9 @@ jobs:
       # The AgentCore publisher/acquisition races use the same migrated
       # real-Postgres service as the surrounding integration suites.
       - run: bun test packages/agent-db/src/agentcore-dispatch.postgres.test.ts
+      # Turn-queue one-in-flight claim and at-most-once terminalization need
+      # concurrent real-Postgres sessions.
+      - run: bun test packages/agent-db/src/turn-store.postgres.test.ts
       # The dedicated publisher task's session lock must exclude a rolling-
       # deploy overlap and release when its database backend dies.
       - run: RUN_AGENTCORE_PUBLISHER_POSTGRES_TESTS=true bun test apps/agentcore-dispatch-publisher/src/publisher-loop.postgres.test.ts

--- a/docs/agents/database.md
+++ b/docs/agents/database.md
@@ -19,6 +19,7 @@ chat-api imports the shared client and schema directly. Its migration entrypoint
 - `src/runtime-store.ts`: fenced Run sandbox/taint mutations, in-transaction Agent session pointer updates, Reclamation tainting, and the orphan-sandbox ledger
 - `src/session-store.ts`: Ownership-fenced production Run append/delete operations, transcript reads, and administrative Conversation transcript deletion
 - `src/artifact-store.ts`: pre-upload object ledger and fence-first atomic artifact-pointer/current-metadata/`run_done` commit
+- `src/turn-store.ts`: /v2 Turn-queue primitives on `conversation_messages` (enqueue, one-in-flight claim, at-most-once terminalization, boot sweep, queued-cancel)
 - `src/testing.ts`: PGlite harness and shared seed helpers
 
 chat-api's `PostgresRunStore` composes shared admission inside the Conversation lifecycle lock. The new Run, its `run_started` event, and its Run-keyed dispatch outbox row share that transaction; exact retries insert nothing. Run-store operations compose runtime pointer publication into qualifying terminal transactions through the same live Ownership fence.
@@ -31,7 +32,7 @@ PGlite tests cover transaction behavior that one in-process backend can express.
 - Reclamation skipping a Conversation row held by another session
 - queued-Run expiration racing Reclamation
 
-AgentCore outbox/acquisition races live in `packages/agent-db/src/agentcore-dispatch.postgres.test.ts`. The dedicated publisher task's deployment-overlap exclusion and backend-termination release live in `apps/agentcore-dispatch-publisher/src/publisher-loop.postgres.test.ts`; it additionally requires `RUN_AGENTCORE_PUBLISHER_POSTGRES_TESTS=true` so the publisher app's local `.env` cannot accidentally target a database during its ordinary unit suite. These tests require `AGENT_DATABASE_URL` and run in the CI `integration` job against the Postgres major used in production.
+Turn-queue races (concurrent claimers, racing terminalizers) live in `packages/agent-db/src/turn-store.postgres.test.ts`. AgentCore outbox/acquisition races live in `packages/agent-db/src/agentcore-dispatch.postgres.test.ts`. The dedicated publisher task's deployment-overlap exclusion and backend-termination release live in `apps/agentcore-dispatch-publisher/src/publisher-loop.postgres.test.ts`; it additionally requires `RUN_AGENTCORE_PUBLISHER_POSTGRES_TESTS=true` so the publisher app's local `.env` cannot accidentally target a database during its ordinary unit suite. These tests require `AGENT_DATABASE_URL` and run in the CI `integration` job against the Postgres major used in production.
 
 ## Drizzle dependency identity
 

--- a/packages/agent-db/drizzle/0029_turn_queue.sql
+++ b/packages/agent-db/drizzle/0029_turn_queue.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "conversation_messages" ADD COLUMN "status" text;--> statement-breakpoint
+ALTER TABLE "conversation_messages" ADD COLUMN "started_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "conversation_messages" ADD COLUMN "finished_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "conversation_messages" ADD CONSTRAINT "conversation_messages_turn_status_check" CHECK (("conversation_messages"."role" = 'user' and "conversation_messages"."status" is not null and "conversation_messages"."status" in ('queued', 'processing', 'done', 'error', 'interrupted')) or ("conversation_messages"."role" <> 'user' and "conversation_messages"."status" is null));

--- a/packages/agent-db/drizzle/meta/0029_snapshot.json
+++ b/packages/agent-db/drizzle/meta/0029_snapshot.json
@@ -1,0 +1,1302 @@
+{
+  "id": "c3c14236-c4b2-4285-b4e2-47a76fe9b4f5",
+  "prevId": "3547190a-f0dc-4b0d-a5ff-95321de6d478",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agentcore_dispatch_outbox": {
+      "name": "agentcore_dispatch_outbox",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admitted_at": {
+          "name": "admitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_claimed_by": {
+          "name": "publish_claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_claim_until": {
+          "name": "publish_claim_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_attempts": {
+          "name": "publish_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "replay_requested_at": {
+          "name": "replay_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_requested_by": {
+          "name": "replay_requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agentcore_dispatch_outbox_pending_idx": {
+          "name": "agentcore_dispatch_outbox_pending_idx",
+          "columns": [
+            {
+              "expression": "admitted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"agentcore_dispatch_outbox\".\"published_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agentcore_dispatch_outbox_publish_claim_idx": {
+          "name": "agentcore_dispatch_outbox_publish_claim_idx",
+          "columns": [
+            {
+              "expression": "publish_claim_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_sessions": {
+      "name": "agent_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subpath": {
+          "name": "subpath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry": {
+          "name": "entry",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "epoch": {
+          "name": "epoch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_sessions_dedup_idx": {
+          "name": "agent_sessions_dedup_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subpath",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_sessions_transcript_idx": {
+          "name": "agent_sessions_transcript_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subpath",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_sessions_conversation_idx": {
+          "name": "agent_sessions_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artifact_objects": {
+      "name": "artifact_objects",
+      "schema": "",
+      "columns": {
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "artifact_objects_run_idx": {
+          "name": "artifact_objects_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifact_objects_status_idx": {
+          "name": "artifact_objects_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "artifact_objects_status_check": {
+          "name": "artifact_objects_status_check",
+          "value": "\"artifact_objects\".\"status\" in ('pending', 'current', 'superseded')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversation_artifacts": {
+      "name": "conversation_artifacts",
+      "schema": "",
+      "columns": {
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_artifacts_owner_conversation_path_idx": {
+          "name": "conversation_artifacts_owner_conversation_path_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_artifacts_conversation_fk": {
+          "name": "conversation_artifacts_conversation_fk",
+          "tableFrom": "conversation_artifacts",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "user_id",
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "user_id",
+            "conversation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "conversation_artifacts_size_bytes_check": {
+          "name": "conversation_artifacts_size_bytes_check",
+          "value": "\"conversation_artifacts\".\"size_bytes\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversation_messages": {
+      "name": "conversation_messages",
+      "schema": "",
+      "columns": {
+        "sequence": {
+          "name": "sequence",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_messages_order_idx": {
+          "name": "conversation_messages_order_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_messages_conversation_fk": {
+          "name": "conversation_messages_conversation_fk",
+          "tableFrom": "conversation_messages",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "user_id",
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "user_id",
+            "conversation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_messages_user_id_conversation_id_message_id_pk": {
+          "name": "conversation_messages_user_id_conversation_id_message_id_pk",
+          "columns": [
+            "user_id",
+            "conversation_id",
+            "message_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "conversation_messages_sequence_unique": {
+          "name": "conversation_messages_sequence_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sequence"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "conversation_messages_role_check": {
+          "name": "conversation_messages_role_check",
+          "value": "\"conversation_messages\".\"role\" in ('user', 'assistant')"
+        },
+        "conversation_messages_turn_status_check": {
+          "name": "conversation_messages_turn_status_check",
+          "value": "(\"conversation_messages\".\"role\" = 'user' and \"conversation_messages\".\"status\" is not null and \"conversation_messages\".\"status\" in ('queued', 'processing', 'done', 'error', 'interrupted')) or (\"conversation_messages\".\"role\" <> 'user' and \"conversation_messages\".\"status\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversation_runtime": {
+      "name": "conversation_runtime",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_tainted": {
+          "name": "sandbox_tainted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "harness_resume_state": {
+          "name": "harness_resume_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "conversation_runtime_user_id_conversation_id_pk": {
+          "name": "conversation_runtime_user_id_conversation_id_pk",
+          "columns": [
+            "user_id",
+            "conversation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_id": {
+          "name": "summary_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_worker_id": {
+          "name": "owner_worker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_until": {
+          "name": "owner_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "epoch": {
+          "name": "epoch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "conversations_regular_activity_idx": {
+          "name": "conversations_regular_activity_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversations\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_archived_activity_idx": {
+          "name": "conversations_archived_activity_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversations\".\"archived_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_reclamation_idx": {
+          "name": "conversations_reclamation_idx",
+          "columns": [
+            {
+              "expression": "owner_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversations\".\"owner_until\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "conversations_user_id_conversation_id_pk": {
+          "name": "conversations_user_id_conversation_id_pk",
+          "columns": [
+            "user_id",
+            "conversation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "conversations_scope_check": {
+          "name": "conversations_scope_check",
+          "value": "\"conversations\".\"scope\" in ('general', 'collection', 'document')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.document_access_events": {
+      "name": "document_access_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_ids": {
+          "name": "document_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_count": {
+          "name": "result_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_access_events_run_id_idx": {
+          "name": "document_access_events_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_access_events_created_at_idx": {
+          "name": "document_access_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "document_access_events_operation_check": {
+          "name": "document_access_events_operation_check",
+          "value": "\"document_access_events\".\"operation\" in ('search', 'list', 'load')"
+        },
+        "document_access_events_scope_type_check": {
+          "name": "document_access_events_scope_type_check",
+          "value": "\"document_access_events\".\"scope_type\" in ('general', 'collection', 'document')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.orphan_sandboxes": {
+      "name": "orphan_sandboxes",
+      "schema": "",
+      "columns": {
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_worker_id": {
+          "name": "created_by_worker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_events": {
+      "name": "run_events",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "run_events_run_id_runs_run_id_fk": {
+          "name": "run_events_run_id_runs_run_id_fk",
+          "tableFrom": "run_events",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "run_events_run_id_seq_pk": {
+          "name": "run_events_run_id_seq_pk",
+          "columns": [
+            "run_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runs": {
+      "name": "runs",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_input": {
+          "name": "normalized_input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executed_by_worker_id": {
+          "name": "executed_by_worker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interrupt_requested_at": {
+          "name": "interrupt_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_stream_failed_at": {
+          "name": "live_stream_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_event_seq": {
+          "name": "next_event_seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "runs_conversation_active_idx": {
+          "name": "runs_conversation_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runs\".\"status\" in ('queued', 'running', 'interrupt_requested')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_cleanup_idx": {
+          "name": "runs_cleanup_idx",
+          "columns": [
+            {
+              "expression": "terminal_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runs\".\"status\" in ('done', 'error', 'interrupted')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_history_paging_idx": {
+          "name": "runs_history_paging_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runs\".\"status\" in ('done', 'error', 'interrupted')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runs_conversation_fk": {
+          "name": "runs_conversation_fk",
+          "tableFrom": "runs",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "user_id",
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "user_id",
+            "conversation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runs_status_check": {
+          "name": "runs_status_check",
+          "value": "\"runs\".\"status\" in ('queued', 'running', 'interrupt_requested', 'done', 'error', 'interrupted')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/agent-db/drizzle/meta/_journal.json
+++ b/packages/agent-db/drizzle/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1787811489673,
       "tag": "0028_medical_jubilee",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1788162856475,
+      "tag": "0029_turn_queue",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/agent-db/package.json
+++ b/packages/agent-db/package.json
@@ -13,6 +13,7 @@
 		"./run-events": "./src/run-events.ts",
 		"./tool-event-projection": "./src/tool-event-projection.ts",
 		"./runtime-store": "./src/runtime-store.ts",
+		"./turn-store": "./src/turn-store.ts",
 		"./session-store": "./src/session-store.ts",
 		"./testing": "./src/testing.ts",
 		"./migrations": "./src/migrations.ts"

--- a/packages/agent-db/src/schema.ts
+++ b/packages/agent-db/src/schema.ts
@@ -176,10 +176,30 @@ export const conversations = pgTable(
 );
 
 /**
- * Canonical AI SDK messages for the direct-response expansion path. The
- * browser-facing representation is stored intact as role plus parts; the
- * monotonically increasing sequence supplies deterministic Conversation order.
- * This table is not read by the production Run/AG-UI path before cutover.
+ * The Turn statuses that are an Outcome — the Turn is finished and will never
+ * change again (spec #654's at-most-once invariant). Deliberately separate from
+ * {@link TERMINAL_RUN_STATUSES} even though the words match: the Run machinery
+ * retires wholesale after v2 cutover and the Turn queue must not couple to it.
+ */
+export const TERMINAL_TURN_STATUSES = ["done", "error", "interrupted"] as const;
+
+/** Every legal `conversation_messages.status` for a user-role (Turn) row. */
+export const ALL_TURN_STATUSES = [
+	"queued",
+	"processing",
+	...TERMINAL_TURN_STATUSES,
+] as const;
+
+/**
+ * Canonical AI SDK messages, doubling as the /v2 Turn queue (ADR-0034,
+ * spec #654). The browser-facing representation is stored intact as role plus
+ * parts; the monotonically increasing sequence supplies deterministic
+ * Conversation order. A user-role row IS the Turn record: its status carries
+ * the `queued → processing → done|error|interrupted` lifecycle and the primary
+ * key is the enqueue idempotency key. Assistant rows carry no Turn semantics —
+ * the status check pins their lifecycle columns to NULL at the database so no
+ * writer can forge a Turn out of an assistant message. Turn mutations go
+ * through `turn-store.ts`. Not read by the production Run/AG-UI path.
  */
 export const conversationMessages = pgTable(
 	"conversation_messages",
@@ -190,6 +210,12 @@ export const conversationMessages = pgTable(
 		messageId: text("message_id").notNull(),
 		role: text("role").notNull(),
 		parts: jsonb("parts").notNull(),
+		/** Turn lifecycle; NULL exactly when the row is not a Turn (assistant). */
+		status: text("status"),
+		/** Stamped by the queued→processing claim; NULL until then. */
+		startedAt: timestamp("started_at", { withTimezone: true }),
+		/** Stamped once by terminalization (or queued-cancel); never cleared. */
+		finishedAt: timestamp("finished_at", { withTimezone: true }),
 		createdAt: timestamp("created_at", { withTimezone: true })
 			.notNull()
 			.defaultNow(),
@@ -204,6 +230,15 @@ export const conversationMessages = pgTable(
 		check(
 			"conversation_messages_role_check",
 			sql`${t.role} in ('user', 'assistant')`,
+		),
+		// "Turn semantics apply to user-role rows only" as a database invariant:
+		// a user row always has a legal Turn status, any other row never has one.
+		check(
+			"conversation_messages_turn_status_check",
+			// The explicit `is not null` matters: `null in (...)` is NULL, and a
+			// NULL check verdict passes, which would let a user row slip in with no
+			// Turn status at all.
+			sql`(${t.role} = 'user' and ${t.status} is not null and ${t.status} in (${statusList(ALL_TURN_STATUSES)})) or (${t.role} <> 'user' and ${t.status} is null)`,
 		),
 		index("conversation_messages_order_idx").on(
 			t.userId,

--- a/packages/agent-db/src/turn-store.postgres.test.ts
+++ b/packages/agent-db/src/turn-store.postgres.test.ts
@@ -1,0 +1,133 @@
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	setDefaultTimeout,
+} from "bun:test";
+import { and, eq } from "drizzle-orm";
+import { createDatabase, type Database } from "./client";
+import { conversationMessages, conversations } from "./schema";
+import {
+	claimNextTurnTx,
+	enqueueTurnTx,
+	type TurnOutcome,
+	terminalizeTurnTx,
+} from "./turn-store";
+
+/**
+ * Turn-queue concurrency (spec #654, ticket #656) against real PostgreSQL.
+ * PGlite has one backend, so it cannot prove that concurrent claimers get at
+ * most one winner or that racing terminalizers publish exactly one Outcome.
+ */
+
+const DB_URL = process.env.AGENT_DATABASE_URL ?? "";
+const RUN = DB_URL !== "";
+const USER_ID = `turn-queue-${crypto.randomUUID()}`;
+const CONVERSATION_ID = "turn-race-conversation";
+
+if (RUN) setDefaultTimeout(30_000);
+
+let db: Database;
+
+async function deleteOwnRows(): Promise<void> {
+	await db.delete(conversations).where(eq(conversations.userId, USER_ID));
+}
+
+async function enqueue(messageId: string): Promise<void> {
+	await enqueueTurnTx(db, {
+		userId: USER_ID,
+		conversationId: CONVERSATION_ID,
+		messageId,
+		parts: [],
+	});
+}
+
+async function ownTurnStatuses(): Promise<Array<[string, string | null]>> {
+	const rows = await db
+		.select({
+			messageId: conversationMessages.messageId,
+			status: conversationMessages.status,
+		})
+		.from(conversationMessages)
+		.where(
+			and(
+				eq(conversationMessages.userId, USER_ID),
+				eq(conversationMessages.conversationId, CONVERSATION_ID),
+			),
+		);
+	return rows.map(({ messageId, status }): [string, string | null] => [
+		messageId,
+		status,
+	]);
+}
+
+describe.skipIf(!RUN)("Turn queue against real Postgres", () => {
+	beforeAll(() => {
+		db = createDatabase(DB_URL);
+	});
+
+	beforeEach(async () => {
+		await deleteOwnRows();
+		await db.insert(conversations).values({
+			userId: USER_ID,
+			conversationId: CONVERSATION_ID,
+			scope: "general",
+		});
+	});
+
+	afterAll(async () => {
+		await deleteOwnRows();
+		await db.$client.end();
+	});
+
+	it("concurrent claimers get at most one winner, and it is the lowest sequence", async () => {
+		await enqueue("m1");
+		await enqueue("m2");
+		await enqueue("m3");
+
+		const claims = await Promise.all(
+			Array.from({ length: 6 }, () =>
+				claimNextTurnTx(db, {
+					userId: USER_ID,
+					conversationId: CONVERSATION_ID,
+				}),
+			),
+		);
+
+		const winners = claims.filter((claim) => claim !== null);
+		expect(winners.map(({ messageId }) => messageId)).toEqual(["m1"]);
+		expect((await ownTurnStatuses()).sort()).toEqual([
+			["m1", "processing"],
+			["m2", "queued"],
+			["m3", "queued"],
+		]);
+	});
+
+	it("racing terminalizers publish exactly one Outcome", async () => {
+		await enqueue("m1");
+		await claimNextTurnTx(db, {
+			userId: USER_ID,
+			conversationId: CONVERSATION_ID,
+		});
+
+		const outcomes: TurnOutcome[] = ["done", "error", "interrupted"];
+		const results = await Promise.all(
+			outcomes.map((outcome) =>
+				terminalizeTurnTx(db, {
+					userId: USER_ID,
+					conversationId: CONVERSATION_ID,
+					messageId: "m1",
+					outcome,
+				}),
+			),
+		);
+
+		expect(results.filter(Boolean)).toHaveLength(1);
+		const winner = outcomes[results.indexOf(true)];
+		if (!winner) throw new Error("no terminalizer won");
+		expect((await ownTurnStatuses()).sort()).toEqual([["m1", winner]]);
+	});
+});

--- a/packages/agent-db/src/turn-store.postgres.test.ts
+++ b/packages/agent-db/src/turn-store.postgres.test.ts
@@ -58,10 +58,7 @@ async function ownTurnStatuses(): Promise<Array<[string, string | null]>> {
 				eq(conversationMessages.conversationId, CONVERSATION_ID),
 			),
 		);
-	return rows.map(({ messageId, status }): [string, string | null] => [
-		messageId,
-		status,
-	]);
+	return rows.map((r) => [r.messageId, r.status] as [string, string | null]);
 }
 
 describe.skipIf(!RUN)("Turn queue against real Postgres", () => {

--- a/packages/agent-db/src/turn-store.test.ts
+++ b/packages/agent-db/src/turn-store.test.ts
@@ -47,6 +47,13 @@ function turnIdentity(messageId: string) {
 	return { userId: USER_ID, conversationId: CONVERSATION_ID, messageId };
 }
 
+async function claim() {
+	return await claimNextTurnTx(db, {
+		userId: USER_ID,
+		conversationId: CONVERSATION_ID,
+	});
+}
+
 async function enqueue(messageId: string) {
 	return await enqueueTurnTx(db, {
 		...turnIdentity(messageId),
@@ -82,10 +89,7 @@ describe("enqueueTurnTx", () => {
 
 	it("reports a duplicate client message id as a no-op and leaves the row untouched", async () => {
 		await enqueue("m1");
-		await claimNextTurnTx(db, {
-			userId: USER_ID,
-			conversationId: CONVERSATION_ID,
-		});
+		await claim();
 
 		const duplicate = await enqueueTurnTx(db, {
 			...turnIdentity("m1"),
@@ -101,22 +105,14 @@ describe("enqueueTurnTx", () => {
 
 describe("claimNextTurnTx", () => {
 	it("returns null when nothing is queued", async () => {
-		expect(
-			await claimNextTurnTx(db, {
-				userId: USER_ID,
-				conversationId: CONVERSATION_ID,
-			}),
-		).toBeNull();
+		expect(await claim()).toBeNull();
 	});
 
 	it("claims the lowest-sequence queued Turn and stamps started_at", async () => {
 		await enqueue("m1");
 		await enqueue("m2");
 
-		const claimed = await claimNextTurnTx(db, {
-			userId: USER_ID,
-			conversationId: CONVERSATION_ID,
-		});
+		const claimed = await claim();
 
 		expect(claimed?.messageId).toBe("m1");
 		expect(claimed?.status).toBe("processing");
@@ -127,32 +123,18 @@ describe("claimNextTurnTx", () => {
 	it("claims nothing while a Turn is processing", async () => {
 		await enqueue("m1");
 		await enqueue("m2");
-		await claimNextTurnTx(db, {
-			userId: USER_ID,
-			conversationId: CONVERSATION_ID,
-		});
+		await claim();
 
-		expect(
-			await claimNextTurnTx(db, {
-				userId: USER_ID,
-				conversationId: CONVERSATION_ID,
-			}),
-		).toBeNull();
+		expect(await claim()).toBeNull();
 	});
 
 	it("claims the next Turn once the previous one terminalizes", async () => {
 		await enqueue("m1");
 		await enqueue("m2");
-		await claimNextTurnTx(db, {
-			userId: USER_ID,
-			conversationId: CONVERSATION_ID,
-		});
+		await claim();
 		await terminalizeTurnTx(db, { ...turnIdentity("m1"), outcome: "done" });
 
-		const claimed = await claimNextTurnTx(db, {
-			userId: USER_ID,
-			conversationId: CONVERSATION_ID,
-		});
+		const claimed = await claim();
 		expect(claimed?.messageId).toBe("m2");
 	});
 
@@ -161,10 +143,7 @@ describe("claimNextTurnTx", () => {
 		await enqueue("m2");
 		await cancelQueuedTurnTx(db, turnIdentity("m1"));
 
-		const claimed = await claimNextTurnTx(db, {
-			userId: USER_ID,
-			conversationId: CONVERSATION_ID,
-		});
+		const claimed = await claim();
 		expect(claimed?.messageId).toBe("m2");
 	});
 });
@@ -176,10 +155,7 @@ describe("terminalizeTurnTx", () => {
 		"interrupted",
 	] as TurnOutcome[])("moves a processing Turn to %s with finished_at", async (outcome) => {
 		await enqueue("m1");
-		await claimNextTurnTx(db, {
-			userId: USER_ID,
-			conversationId: CONVERSATION_ID,
-		});
+		await claim();
 
 		expect(
 			await terminalizeTurnTx(db, { ...turnIdentity("m1"), outcome }),
@@ -191,10 +167,7 @@ describe("terminalizeTurnTx", () => {
 
 	it("never transitions a terminal Turn again", async () => {
 		await enqueue("m1");
-		await claimNextTurnTx(db, {
-			userId: USER_ID,
-			conversationId: CONVERSATION_ID,
-		});
+		await claim();
 		await terminalizeTurnTx(db, { ...turnIdentity("m1"), outcome: "done" });
 
 		expect(
@@ -217,10 +190,7 @@ describe("sweepStaleProcessingTurnsTx", () => {
 	it("terminalizes stale processing Turns as interrupted and leaves queued ones", async () => {
 		await enqueue("m1");
 		await enqueue("m2");
-		await claimNextTurnTx(db, {
-			userId: USER_ID,
-			conversationId: CONVERSATION_ID,
-		});
+		await claim();
 
 		const swept = await sweepStaleProcessingTurnsTx(db, {
 			userId: USER_ID,
@@ -235,10 +205,7 @@ describe("sweepStaleProcessingTurnsTx", () => {
 
 	it("sweeps nothing on a repeat pass — interrupted Turns are terminal", async () => {
 		await enqueue("m1");
-		await claimNextTurnTx(db, {
-			userId: USER_ID,
-			conversationId: CONVERSATION_ID,
-		});
+		await claim();
 		await sweepStaleProcessingTurnsTx(db, {
 			userId: USER_ID,
 			conversationId: CONVERSATION_ID,
@@ -267,10 +234,7 @@ describe("cancelQueuedTurnTx", () => {
 
 	it("refuses a processing Turn", async () => {
 		await enqueue("m1");
-		await claimNextTurnTx(db, {
-			userId: USER_ID,
-			conversationId: CONVERSATION_ID,
-		});
+		await claim();
 
 		expect(await cancelQueuedTurnTx(db, turnIdentity("m1"))).toBe(false);
 		expect((await loadTurn("m1")).status).toBe("processing");

--- a/packages/agent-db/src/turn-store.test.ts
+++ b/packages/agent-db/src/turn-store.test.ts
@@ -71,7 +71,7 @@ async function loadTurn(messageId: string) {
 
 describe("enqueueTurnTx", () => {
 	it("admits a user message as a queued Turn", async () => {
-		expect(await enqueue("m1")).toEqual({ enqueued: true });
+		expect(await enqueue("m1")).toBe(true);
 
 		const turn = await loadTurn("m1");
 		expect(turn.role).toBe("user");
@@ -92,7 +92,7 @@ describe("enqueueTurnTx", () => {
 			parts: [{ type: "text", text: "replacement" }],
 		});
 
-		expect(duplicate).toEqual({ enqueued: false });
+		expect(duplicate).toBe(false);
 		const turn = await loadTurn("m1");
 		expect(turn.status).toBe("processing");
 		expect(turn.parts).toEqual([{ type: "text", text: "m1" }]);

--- a/packages/agent-db/src/turn-store.test.ts
+++ b/packages/agent-db/src/turn-store.test.ts
@@ -1,0 +1,314 @@
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+} from "bun:test";
+import { and, eq } from "drizzle-orm";
+import type { Database } from "./client";
+import { conversationMessages, conversations } from "./schema";
+import { createTestDatabase, type TestDb } from "./testing";
+import {
+	cancelQueuedTurnTx,
+	claimNextTurnTx,
+	enqueueTurnTx,
+	sweepStaleProcessingTurnsTx,
+	type TurnOutcome,
+	terminalizeTurnTx,
+} from "./turn-store";
+
+const USER_ID = "turn-user";
+const CONVERSATION_ID = "turn-conversation";
+
+let tdb: TestDb;
+let db: Database;
+
+beforeAll(async () => {
+	tdb = await createTestDatabase();
+	db = tdb.db;
+});
+
+afterAll(async () => {
+	await tdb.close();
+});
+
+beforeEach(async () => {
+	await db.delete(conversations);
+	await db.insert(conversations).values({
+		userId: USER_ID,
+		conversationId: CONVERSATION_ID,
+		scope: "general",
+	});
+});
+
+function turnIdentity(messageId: string) {
+	return { userId: USER_ID, conversationId: CONVERSATION_ID, messageId };
+}
+
+async function enqueue(messageId: string) {
+	return await enqueueTurnTx(db, {
+		...turnIdentity(messageId),
+		parts: [{ type: "text", text: messageId }],
+	});
+}
+
+async function loadTurn(messageId: string) {
+	const [row] = await db
+		.select()
+		.from(conversationMessages)
+		.where(
+			and(
+				eq(conversationMessages.userId, USER_ID),
+				eq(conversationMessages.conversationId, CONVERSATION_ID),
+				eq(conversationMessages.messageId, messageId),
+			),
+		);
+	if (!row) throw new Error(`turn ${messageId} not found`);
+	return row;
+}
+
+describe("enqueueTurnTx", () => {
+	it("admits a user message as a queued Turn", async () => {
+		expect(await enqueue("m1")).toEqual({ enqueued: true });
+
+		const turn = await loadTurn("m1");
+		expect(turn.role).toBe("user");
+		expect(turn.status).toBe("queued");
+		expect(turn.startedAt).toBeNull();
+		expect(turn.finishedAt).toBeNull();
+	});
+
+	it("reports a duplicate client message id as a no-op and leaves the row untouched", async () => {
+		await enqueue("m1");
+		await claimNextTurnTx(db, {
+			userId: USER_ID,
+			conversationId: CONVERSATION_ID,
+		});
+
+		const duplicate = await enqueueTurnTx(db, {
+			...turnIdentity("m1"),
+			parts: [{ type: "text", text: "replacement" }],
+		});
+
+		expect(duplicate).toEqual({ enqueued: false });
+		const turn = await loadTurn("m1");
+		expect(turn.status).toBe("processing");
+		expect(turn.parts).toEqual([{ type: "text", text: "m1" }]);
+	});
+});
+
+describe("claimNextTurnTx", () => {
+	it("returns null when nothing is queued", async () => {
+		expect(
+			await claimNextTurnTx(db, {
+				userId: USER_ID,
+				conversationId: CONVERSATION_ID,
+			}),
+		).toBeNull();
+	});
+
+	it("claims the lowest-sequence queued Turn and stamps started_at", async () => {
+		await enqueue("m1");
+		await enqueue("m2");
+
+		const claimed = await claimNextTurnTx(db, {
+			userId: USER_ID,
+			conversationId: CONVERSATION_ID,
+		});
+
+		expect(claimed?.messageId).toBe("m1");
+		expect(claimed?.status).toBe("processing");
+		expect(claimed?.startedAt).toBeInstanceOf(Date);
+		expect((await loadTurn("m2")).status).toBe("queued");
+	});
+
+	it("claims nothing while a Turn is processing", async () => {
+		await enqueue("m1");
+		await enqueue("m2");
+		await claimNextTurnTx(db, {
+			userId: USER_ID,
+			conversationId: CONVERSATION_ID,
+		});
+
+		expect(
+			await claimNextTurnTx(db, {
+				userId: USER_ID,
+				conversationId: CONVERSATION_ID,
+			}),
+		).toBeNull();
+	});
+
+	it("claims the next Turn once the previous one terminalizes", async () => {
+		await enqueue("m1");
+		await enqueue("m2");
+		await claimNextTurnTx(db, {
+			userId: USER_ID,
+			conversationId: CONVERSATION_ID,
+		});
+		await terminalizeTurnTx(db, { ...turnIdentity("m1"), outcome: "done" });
+
+		const claimed = await claimNextTurnTx(db, {
+			userId: USER_ID,
+			conversationId: CONVERSATION_ID,
+		});
+		expect(claimed?.messageId).toBe("m2");
+	});
+
+	it("skips a cancelled Turn and claims the next queued one", async () => {
+		await enqueue("m1");
+		await enqueue("m2");
+		await cancelQueuedTurnTx(db, turnIdentity("m1"));
+
+		const claimed = await claimNextTurnTx(db, {
+			userId: USER_ID,
+			conversationId: CONVERSATION_ID,
+		});
+		expect(claimed?.messageId).toBe("m2");
+	});
+});
+
+describe("terminalizeTurnTx", () => {
+	it.each([
+		"done",
+		"error",
+		"interrupted",
+	] as TurnOutcome[])("moves a processing Turn to %s with finished_at", async (outcome) => {
+		await enqueue("m1");
+		await claimNextTurnTx(db, {
+			userId: USER_ID,
+			conversationId: CONVERSATION_ID,
+		});
+
+		expect(
+			await terminalizeTurnTx(db, { ...turnIdentity("m1"), outcome }),
+		).toBe(true);
+		const turn = await loadTurn("m1");
+		expect(turn.status).toBe(outcome);
+		expect(turn.finishedAt).toBeInstanceOf(Date);
+	});
+
+	it("never transitions a terminal Turn again", async () => {
+		await enqueue("m1");
+		await claimNextTurnTx(db, {
+			userId: USER_ID,
+			conversationId: CONVERSATION_ID,
+		});
+		await terminalizeTurnTx(db, { ...turnIdentity("m1"), outcome: "done" });
+
+		expect(
+			await terminalizeTurnTx(db, { ...turnIdentity("m1"), outcome: "error" }),
+		).toBe(false);
+		expect((await loadTurn("m1")).status).toBe("done");
+	});
+
+	it("refuses a Turn that is still queued", async () => {
+		await enqueue("m1");
+
+		expect(
+			await terminalizeTurnTx(db, { ...turnIdentity("m1"), outcome: "done" }),
+		).toBe(false);
+		expect((await loadTurn("m1")).status).toBe("queued");
+	});
+});
+
+describe("sweepStaleProcessingTurnsTx", () => {
+	it("terminalizes stale processing Turns as interrupted and leaves queued ones", async () => {
+		await enqueue("m1");
+		await enqueue("m2");
+		await claimNextTurnTx(db, {
+			userId: USER_ID,
+			conversationId: CONVERSATION_ID,
+		});
+
+		const swept = await sweepStaleProcessingTurnsTx(db, {
+			userId: USER_ID,
+			conversationId: CONVERSATION_ID,
+		});
+
+		expect(swept).toEqual(["m1"]);
+		expect((await loadTurn("m1")).status).toBe("interrupted");
+		expect((await loadTurn("m1")).finishedAt).toBeInstanceOf(Date);
+		expect((await loadTurn("m2")).status).toBe("queued");
+	});
+
+	it("sweeps nothing on a repeat pass — interrupted Turns are terminal", async () => {
+		await enqueue("m1");
+		await claimNextTurnTx(db, {
+			userId: USER_ID,
+			conversationId: CONVERSATION_ID,
+		});
+		await sweepStaleProcessingTurnsTx(db, {
+			userId: USER_ID,
+			conversationId: CONVERSATION_ID,
+		});
+
+		expect(
+			await sweepStaleProcessingTurnsTx(db, {
+				userId: USER_ID,
+				conversationId: CONVERSATION_ID,
+			}),
+		).toEqual([]);
+		expect((await loadTurn("m1")).status).toBe("interrupted");
+	});
+});
+
+describe("cancelQueuedTurnTx", () => {
+	it("terminalizes a queued Turn directly to interrupted without starting it", async () => {
+		await enqueue("m1");
+
+		expect(await cancelQueuedTurnTx(db, turnIdentity("m1"))).toBe(true);
+		const turn = await loadTurn("m1");
+		expect(turn.status).toBe("interrupted");
+		expect(turn.startedAt).toBeNull();
+		expect(turn.finishedAt).toBeInstanceOf(Date);
+	});
+
+	it("refuses a processing Turn", async () => {
+		await enqueue("m1");
+		await claimNextTurnTx(db, {
+			userId: USER_ID,
+			conversationId: CONVERSATION_ID,
+		});
+
+		expect(await cancelQueuedTurnTx(db, turnIdentity("m1"))).toBe(false);
+		expect((await loadTurn("m1")).status).toBe("processing");
+	});
+});
+
+describe("turn status database invariant", () => {
+	it("rejects a user row without a legal Turn status", async () => {
+		await expect(
+			db
+				.insert(conversationMessages)
+				.values({
+					...turnIdentity("bad"),
+					role: "user",
+					parts: [],
+					status: "sideways",
+				})
+				.execute(),
+		).rejects.toThrow();
+		await expect(
+			db
+				.insert(conversationMessages)
+				.values({ ...turnIdentity("bad"), role: "user", parts: [] })
+				.execute(),
+		).rejects.toThrow();
+	});
+
+	it("rejects an assistant row carrying a Turn status", async () => {
+		await expect(
+			db
+				.insert(conversationMessages)
+				.values({
+					...turnIdentity("bad"),
+					role: "assistant",
+					parts: [],
+					status: "queued",
+				})
+				.execute(),
+		).rejects.toThrow();
+	});
+});

--- a/packages/agent-db/src/turn-store.ts
+++ b/packages/agent-db/src/turn-store.ts
@@ -1,0 +1,224 @@
+import { and, asc, eq } from "drizzle-orm";
+import type { Database } from "./client";
+import {
+	type ALL_TURN_STATUSES,
+	conversationMessages,
+	conversations,
+	type TERMINAL_TURN_STATUSES,
+} from "./schema";
+
+/**
+ * Race-safe Turn-queue primitives over `conversation_messages` (ADR-0034,
+ * spec #654, ticket #656). The user-message row is the Turn record; the
+ * database itself gates one-in-flight per Conversation and makes
+ * terminalization at-most-once: every status transition here is guarded by the
+ * status it moves from, so a Turn that reached the Outcome triad can never
+ * transition again. chat-api only enqueues and reads; the In-VM server drives
+ * claim, terminalize, boot sweep, and queued-cancel.
+ */
+
+export type TurnStatus = (typeof ALL_TURN_STATUSES)[number];
+export type TurnOutcome = (typeof TERMINAL_TURN_STATUSES)[number];
+
+export interface TurnRecord {
+	sequence: number;
+	userId: string;
+	conversationId: string;
+	messageId: string;
+	parts: unknown;
+	status: TurnStatus;
+	startedAt: Date | null;
+	finishedAt: Date | null;
+	createdAt: Date;
+}
+
+type TurnRow = typeof conversationMessages.$inferSelect;
+
+function toTurnRecord(row: TurnRow): TurnRecord {
+	return {
+		sequence: row.sequence,
+		userId: row.userId,
+		conversationId: row.conversationId,
+		messageId: row.messageId,
+		parts: row.parts,
+		// The turn-status check constrains user rows to the Turn lifecycle, so a
+		// user-role row's status is a TurnStatus by database invariant.
+		status: row.status as TurnStatus,
+		startedAt: row.startedAt,
+		finishedAt: row.finishedAt,
+		createdAt: row.createdAt,
+	};
+}
+
+function turnKey(input: {
+	userId: string;
+	conversationId: string;
+	messageId: string;
+}) {
+	return and(
+		eq(conversationMessages.userId, input.userId),
+		eq(conversationMessages.conversationId, input.conversationId),
+		eq(conversationMessages.messageId, input.messageId),
+	);
+}
+
+function conversationTurns(input: { userId: string; conversationId: string }) {
+	return and(
+		eq(conversationMessages.userId, input.userId),
+		eq(conversationMessages.conversationId, input.conversationId),
+		eq(conversationMessages.role, "user"),
+	);
+}
+
+/**
+ * Admit a user message as a `queued` Turn. Re-inserting the same client
+ * message id is a reported no-op — the table's primary key is the idempotency
+ * authority, and the duplicate leaves the existing row (parts and Turn status
+ * alike) untouched.
+ */
+export async function enqueueTurnTx(
+	db: Database,
+	input: {
+		userId: string;
+		conversationId: string;
+		messageId: string;
+		parts: unknown;
+	},
+): Promise<{ enqueued: boolean }> {
+	const inserted = await db
+		.insert(conversationMessages)
+		.values({ ...input, role: "user", status: "queued" })
+		.onConflictDoNothing()
+		.returning({ sequence: conversationMessages.sequence });
+	return { enqueued: inserted.length > 0 };
+}
+
+/**
+ * Atomically move the Conversation's next Turn (lowest sequence `queued`) to
+ * `processing`, only when nothing is `processing` — the one-in-flight gate the
+ * spec puts in the database. Claimers serialize on the Conversation row lock
+ * (the repo's global Conversation-first lock order), so concurrent claimers
+ * get at most one winner; the queued-status guard on the update means a
+ * concurrent queued-cancel costs this claim its Turn rather than resurrecting
+ * a cancelled one. Returns the claimed Turn, or null when there is nothing to
+ * claim, a Turn is already in flight, or the Conversation does not exist.
+ */
+export async function claimNextTurnTx(
+	db: Database,
+	input: { userId: string; conversationId: string; now?: Date },
+): Promise<TurnRecord | null> {
+	return await db.transaction(async (tx) => {
+		const [conversation] = await tx
+			.select({ conversationId: conversations.conversationId })
+			.from(conversations)
+			.where(
+				and(
+					eq(conversations.userId, input.userId),
+					eq(conversations.conversationId, input.conversationId),
+				),
+			)
+			.for("update");
+		if (!conversation) return null;
+
+		const [processing] = await tx
+			.select({ messageId: conversationMessages.messageId })
+			.from(conversationMessages)
+			.where(
+				and(
+					conversationTurns(input),
+					eq(conversationMessages.status, "processing"),
+				),
+			)
+			.limit(1);
+		if (processing) return null;
+
+		const [next] = await tx
+			.select()
+			.from(conversationMessages)
+			.where(
+				and(
+					conversationTurns(input),
+					eq(conversationMessages.status, "queued"),
+				),
+			)
+			.orderBy(asc(conversationMessages.sequence))
+			.limit(1);
+		if (!next) return null;
+
+		const [claimed] = await tx
+			.update(conversationMessages)
+			.set({ status: "processing", startedAt: input.now ?? new Date() })
+			.where(and(turnKey(next), eq(conversationMessages.status, "queued")))
+			.returning();
+		return claimed ? toTurnRecord(claimed) : null;
+	});
+}
+
+/**
+ * Move one `processing` Turn to its Outcome. The from-status guard is the
+ * at-most-once authority: a Turn already at an Outcome (or still queued)
+ * matches nothing and the call reports false, so no Outcome is ever
+ * overwritten.
+ */
+export async function terminalizeTurnTx(
+	db: Database,
+	input: {
+		userId: string;
+		conversationId: string;
+		messageId: string;
+		outcome: TurnOutcome;
+		now?: Date;
+	},
+): Promise<boolean> {
+	const terminalized = await db
+		.update(conversationMessages)
+		.set({ status: input.outcome, finishedAt: input.now ?? new Date() })
+		.where(and(turnKey(input), eq(conversationMessages.status, "processing")))
+		.returning({ messageId: conversationMessages.messageId });
+	return terminalized.length > 0;
+}
+
+/**
+ * Boot sweep: terminalize the Conversation's stale `processing` Turns as
+ * `interrupted` — a Turn is never re-run. `queued` Turns are untouched, and a
+ * repeat sweep finds nothing (the interrupted Turns are terminal). Returns the
+ * swept message ids.
+ */
+export async function sweepStaleProcessingTurnsTx(
+	db: Database,
+	input: { userId: string; conversationId: string; now?: Date },
+): Promise<string[]> {
+	const swept = await db
+		.update(conversationMessages)
+		.set({ status: "interrupted", finishedAt: input.now ?? new Date() })
+		.where(
+			and(
+				conversationTurns(input),
+				eq(conversationMessages.status, "processing"),
+			),
+		)
+		.returning({ messageId: conversationMessages.messageId });
+	return swept.map(({ messageId }) => messageId);
+}
+
+/**
+ * Cancel a `queued` Turn directly to `interrupted` without it ever running —
+ * `started_at` stays NULL. A Turn already claimed (or already terminal)
+ * matches nothing and the call reports false.
+ */
+export async function cancelQueuedTurnTx(
+	db: Database,
+	input: {
+		userId: string;
+		conversationId: string;
+		messageId: string;
+		now?: Date;
+	},
+): Promise<boolean> {
+	const cancelled = await db
+		.update(conversationMessages)
+		.set({ status: "interrupted", finishedAt: input.now ?? new Date() })
+		.where(and(turnKey(input), eq(conversationMessages.status, "queued")))
+		.returning({ messageId: conversationMessages.messageId });
+	return cancelled.length > 0;
+}

--- a/packages/agent-db/src/turn-store.ts
+++ b/packages/agent-db/src/turn-store.ts
@@ -20,35 +20,15 @@ import {
 export type TurnStatus = (typeof ALL_TURN_STATUSES)[number];
 export type TurnOutcome = (typeof TERMINAL_TURN_STATUSES)[number];
 
-export interface TurnRecord {
-	sequence: number;
-	userId: string;
-	conversationId: string;
-	messageId: string;
-	parts: unknown;
-	status: TurnStatus;
-	startedAt: Date | null;
-	finishedAt: Date | null;
-	createdAt: Date;
-}
-
-type TurnRow = typeof conversationMessages.$inferSelect;
-
-function toTurnRecord(row: TurnRow): TurnRecord {
-	return {
-		sequence: row.sequence,
-		userId: row.userId,
-		conversationId: row.conversationId,
-		messageId: row.messageId,
-		parts: row.parts,
-		// The turn-status check constrains user rows to the Turn lifecycle, so a
-		// user-role row's status is a TurnStatus by database invariant.
-		status: row.status as TurnStatus,
-		startedAt: row.startedAt,
-		finishedAt: row.finishedAt,
-		createdAt: row.createdAt,
-	};
-}
+/**
+ * A user-role row narrowed to the Turn lifecycle: the turn-status check
+ * constrains user rows to a legal Turn status, so the narrowing holds by
+ * database invariant.
+ */
+export type TurnRecord = Omit<
+	typeof conversationMessages.$inferSelect,
+	"status"
+> & { status: TurnStatus };
 
 function turnKey(input: {
 	userId: string;
@@ -71,8 +51,8 @@ function conversationTurns(input: { userId: string; conversationId: string }) {
 }
 
 /**
- * Admit a user message as a `queued` Turn. Re-inserting the same client
- * message id is a reported no-op — the table's primary key is the idempotency
+ * Admit a user message as a `queued` Turn. Returns false for a re-insert of
+ * the same client message id — the table's primary key is the idempotency
  * authority, and the duplicate leaves the existing row (parts and Turn status
  * alike) untouched.
  */
@@ -84,13 +64,13 @@ export async function enqueueTurnTx(
 		messageId: string;
 		parts: unknown;
 	},
-): Promise<{ enqueued: boolean }> {
+): Promise<boolean> {
 	const inserted = await db
 		.insert(conversationMessages)
 		.values({ ...input, role: "user", status: "queued" })
 		.onConflictDoNothing()
 		.returning({ sequence: conversationMessages.sequence });
-	return { enqueued: inserted.length > 0 };
+	return inserted.length > 0;
 }
 
 /**
@@ -105,7 +85,7 @@ export async function enqueueTurnTx(
  */
 export async function claimNextTurnTx(
 	db: Database,
-	input: { userId: string; conversationId: string; now?: Date },
+	input: { userId: string; conversationId: string },
 ): Promise<TurnRecord | null> {
 	return await db.transaction(async (tx) => {
 		const [conversation] = await tx
@@ -147,10 +127,12 @@ export async function claimNextTurnTx(
 
 		const [claimed] = await tx
 			.update(conversationMessages)
-			.set({ status: "processing", startedAt: input.now ?? new Date() })
+			.set({ status: "processing", startedAt: new Date() })
 			.where(and(turnKey(next), eq(conversationMessages.status, "queued")))
 			.returning();
-		return claimed ? toTurnRecord(claimed) : null;
+		return claimed
+			? { ...claimed, status: claimed.status as TurnStatus }
+			: null;
 	});
 }
 
@@ -167,12 +149,11 @@ export async function terminalizeTurnTx(
 		conversationId: string;
 		messageId: string;
 		outcome: TurnOutcome;
-		now?: Date;
 	},
 ): Promise<boolean> {
 	const terminalized = await db
 		.update(conversationMessages)
-		.set({ status: input.outcome, finishedAt: input.now ?? new Date() })
+		.set({ status: input.outcome, finishedAt: new Date() })
 		.where(and(turnKey(input), eq(conversationMessages.status, "processing")))
 		.returning({ messageId: conversationMessages.messageId });
 	return terminalized.length > 0;
@@ -186,11 +167,11 @@ export async function terminalizeTurnTx(
  */
 export async function sweepStaleProcessingTurnsTx(
 	db: Database,
-	input: { userId: string; conversationId: string; now?: Date },
+	input: { userId: string; conversationId: string },
 ): Promise<string[]> {
 	const swept = await db
 		.update(conversationMessages)
-		.set({ status: "interrupted", finishedAt: input.now ?? new Date() })
+		.set({ status: "interrupted", finishedAt: new Date() })
 		.where(
 			and(
 				conversationTurns(input),
@@ -208,16 +189,11 @@ export async function sweepStaleProcessingTurnsTx(
  */
 export async function cancelQueuedTurnTx(
 	db: Database,
-	input: {
-		userId: string;
-		conversationId: string;
-		messageId: string;
-		now?: Date;
-	},
+	input: { userId: string; conversationId: string; messageId: string },
 ): Promise<boolean> {
 	const cancelled = await db
 		.update(conversationMessages)
-		.set({ status: "interrupted", finishedAt: input.now ?? new Date() })
+		.set({ status: "interrupted", finishedAt: new Date() })
 		.where(and(turnKey(input), eq(conversationMessages.status, "queued")))
 		.returning({ messageId: conversationMessages.messageId });
 	return cancelled.length > 0;


### PR DESCRIPTION
Closes #656 (spec #654, ADR-0034).

## What

The user-message row of `conversation_messages` becomes the /v2 Turn record, and `@mymemo/agent-db` gains the race-safe primitives the In-VM server drains through.

- **Migration `0029_turn_queue`**: adds `status`, `started_at`, `finished_at` to `conversation_messages`, plus a check constraint making "Turn semantics apply to user-role rows only" a database invariant — a user row always carries a legal Turn status (`queued|processing|done|error|interrupted`), any other row never does. The table has zero production readers/writers, so the alter is free.
- **`src/turn-store.ts`**:
  - `enqueueTurnTx` — INSERT as `queued`; a duplicate client message id is a reported no-op via the existing PK, leaving the original row untouched.
  - `claimNextTurnTx` — atomically moves the lowest-sequence `queued` Turn to `processing` only when nothing is `processing` for the Conversation. Claimers serialize on the Conversation row lock (the repo's global Conversation-first lock order), so concurrent claimers get at most one winner.
  - `terminalizeTurnTx` — `processing → done|error|interrupted` with `finished_at`; the from-status guard makes terminalization at-most-once, so a terminal Turn can never transition again.
  - `sweepStaleProcessingTurnsTx` — boot sweep: stale `processing` Turns terminalize as `interrupted`; `queued` Turns untouched; a repeat sweep finds nothing.
  - `cancelQueuedTurnTx` — a `queued` Turn terminalizes directly to `interrupted` (`started_at` stays NULL).

## Tests

- PGlite suite (`turn-store.test.ts`, 18 tests): every primitive's happy path and refusal path, terminal immutability, and the role/status check constraint.
- Real-Postgres race lane (`turn-store.postgres.test.ts`, new CI step): 6 concurrent claimers get exactly one winner (the lowest sequence); 3 racing terminalizers publish exactly one Outcome.

## Verification

- `packages/agent-db`: 250 pass / 0 fail (PGlite lane), `tsc --noEmit` clean, Biome clean.
- Race lane run locally against a throwaway `postgres:16` with all migrations applied: 2 pass. `conversation-ownership` and `agentcore-dispatch` postgres suites also re-run green against the migrated DB.
- `apps/chat-api`: 160 pass / 0 fail (replays the shared migrations, covering `0029`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177Cgcr3bWGbf46w1CUVYUa