### PR TITLE
feat(infra): MicroVM image skeleton + authenticated boot pipeline (#661)

### DIFF
--- a/.github/workflows/microvm-image.yml
+++ b/.github/workflows/microvm-image.yml
@@ -59,9 +59,7 @@ jobs:
       - name: Load deploy config
         run: |
           set -euo pipefail
-          set -a
           source infra/deploy/prod.env
-          set +a
           {
             printf 'AWS_REGION=%s\n' "${AWS_REGION}"
             printf 'AWS_ACCOUNT_ID=%s\n' "${AWS_ACCOUNT_ID}"

--- a/.github/workflows/microvm-image.yml
+++ b/.github/workflows/microvm-image.yml
@@ -1,0 +1,75 @@
+name: MicroVM image
+
+# The production MicroVM image pipeline (ticket #661, spec #654).
+#
+# Pull requests get the offline contract check: an ARM64 docker build of the
+# image directory plus scripts/smoke/microvm-image-check.sh (pinned versions,
+# root-owned managed settings, non-root user). Pushes to main register the
+# image with Lambda MicroVMs via create/update-microvm-image and wait for the
+# build to land — the deploy role's OIDC trust is pinned to refs/heads/main.
+#
+# First-run prerequisites, applied by a human before this can register:
+# the bootstrap-iam policy (MicrovmImageRegistration + artifact objects) and
+# the infra/terraform build role (microvm-image.tf) via release-deploy.
+
+on:
+  pull_request:
+    paths:
+      - infra/microvm-image/**
+      - scripts/smoke/microvm-image-check.sh
+      - .github/workflows/microvm-image.yml
+  push:
+    branches: [main]
+    paths:
+      - infra/microvm-image/**
+      - scripts/deploy/register_microvm_image.sh
+      - .github/workflows/microvm-image.yml
+
+# Registration runs must not cancel one another; PR contract checks may.
+concurrency:
+  group: microvm-image-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  image-contract:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+      - name: Build ARM64 MicroVM image
+        uses: docker/build-push-action@v6
+        with:
+          context: infra/microvm-image
+          platforms: linux/arm64
+          load: true
+          tags: mymemo-microvm:image-check
+      - name: Verify image contract offline
+        run: scripts/smoke/microvm-image-check.sh mymemo-microvm:image-check
+
+  register:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v7
+      - name: Load deploy config
+        run: |
+          set -euo pipefail
+          set -a
+          source infra/deploy/prod.env
+          set +a
+          {
+            printf 'AWS_REGION=%s\n' "${AWS_REGION}"
+            printf 'AWS_ACCOUNT_ID=%s\n' "${AWS_ACCOUNT_ID}"
+          } >> "${GITHUB_ENV}"
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/mymemo-agent-github-actions-deploy
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Register MicroVM image
+        run: scripts/deploy/register_microvm_image.sh

--- a/infra/bootstrap-iam/main.tf
+++ b/infra/bootstrap-iam/main.tf
@@ -409,6 +409,29 @@ data "aws_iam_policy_document" "github_actions_deploy" {
     ]
   }
 
+  # MicroVM image registration (ticket #661): the main-push workflow zips the
+  # image directory into the artifact bucket and drives create/update/get on
+  # the MicroVM image. iam:PassRole for the build role is already granted by
+  # AgentIamManagement (mymemo-agent-* roles).
+  statement {
+    sid = "MicrovmImageRegistration"
+    actions = [
+      "lambda:CreateMicrovmImage",
+      "lambda:GetMicrovmImage",
+      "lambda:UpdateMicrovmImage",
+    ]
+    resources = ["arn:aws:lambda:${var.aws_region}:${var.aws_account_id}:microvm-image:mymemo-agent-*"]
+  }
+
+  statement {
+    sid = "MicrovmImageArtifactObjects"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+    ]
+    resources = ["arn:aws:s3:::${var.artifact_bucket_name}/microvm-images/*"]
+  }
+
   statement {
     sid       = "CreateServiceLinkedRoles"
     actions   = ["iam:CreateServiceLinkedRole"]

--- a/infra/microvm-image/Dockerfile
+++ b/infra/microvm-image/Dockerfile
@@ -1,0 +1,36 @@
+# Production MicroVM image for the per-Conversation VM (ticket #661, spec #654).
+# Derived from the #646 probe kit (docs/research/microvm-probe on the
+# research/microvm-probe branch), which proved this recipe live: AL2023 base at
+# DEFAULT capabilities — bubblewrap creates namespaces with no ALL flag.
+# server.mjs is a placeholder; #666 swaps in the real In-VM server.
+FROM public.ecr.aws/lambda/microvms:al2023-minimal
+
+# bubblewrap backs sandbox-mode Bash; socat relays the egress proxy; nodejs22
+# runs the SDK; shadow-utils provides useradd. dnf installs are all-or-nothing:
+# one unavailable package fails the whole line (ripgrep is absent from AL2023
+# repos and must stay off this list — Claude Code ships its own rg).
+RUN dnf install -y bash git nodejs22 nodejs22-npm shadow-utils bubblewrap socat util-linux \
+ && dnf clean all
+
+# The versions the spec pins. The runtime resolves the global SDK install via
+# NODE_PATH="$(npm root -g)".
+RUN npm install -g @anthropic-ai/claude-agent-sdk@0.3.251 @anthropic-ai/claude-code@2.1.251
+
+# Managed policy tier: root-owned so the non-root runtime user can neither
+# replace it nor merge drop-ins in (the directory matters as much as the file).
+# Deny rules use Edit(...) — Write(...) entries are inert (the CLI warns they
+# are "not matched by file permission checks — only Edit").
+RUN mkdir -p /etc/claude-code && chown root:root /etc/claude-code && chmod 0755 /etc/claude-code
+COPY --chown=root:root --chmod=0644 managed-settings.json /etc/claude-code/managed-settings.json
+
+# Non-root runtime user: the policy tier's protection assumes the agent cannot
+# write /etc.
+RUN useradd -m -u 1000 developer
+COPY --chown=root:root --chmod=0755 server.mjs /opt/microvm/server.mjs
+COPY --chown=root:root --chmod=0755 smoke.sh /opt/microvm/smoke.sh
+
+ENV CLAUDE_CODE_DISABLE_AUTO_MEMORY=1
+EXPOSE 8080
+USER developer
+WORKDIR /home/developer/workspace
+ENTRYPOINT ["node", "/opt/microvm/server.mjs"]

--- a/infra/microvm-image/Dockerfile
+++ b/infra/microvm-image/Dockerfile
@@ -26,8 +26,8 @@ COPY --chown=root:root --chmod=0644 managed-settings.json /etc/claude-code/manag
 # Non-root runtime user: the policy tier's protection assumes the agent cannot
 # write /etc.
 RUN useradd -m -u 1000 developer
-COPY --chown=root:root --chmod=0755 server.mjs /opt/microvm/server.mjs
-COPY --chown=root:root --chmod=0755 smoke.sh /opt/microvm/smoke.sh
+COPY --chown=root:root --chmod=0644 server.mjs /opt/microvm/server.mjs
+COPY --chown=root:root --chmod=0644 smoke.sh /opt/microvm/smoke.sh
 
 ENV CLAUDE_CODE_DISABLE_AUTO_MEMORY=1
 USER developer

--- a/infra/microvm-image/Dockerfile
+++ b/infra/microvm-image/Dockerfile
@@ -17,10 +17,10 @@ RUN dnf install -y bash git nodejs22 nodejs22-npm shadow-utils bubblewrap socat 
 RUN npm install -g @anthropic-ai/claude-agent-sdk@0.3.251 @anthropic-ai/claude-code@2.1.251
 
 # Managed policy tier: root-owned so the non-root runtime user can neither
-# replace it nor merge drop-ins in (the directory matters as much as the file).
-# Deny rules use Edit(...) — Write(...) entries are inert (the CLI warns they
-# are "not matched by file permission checks — only Edit").
-RUN mkdir -p /etc/claude-code && chown root:root /etc/claude-code && chmod 0755 /etc/claude-code
+# replace it nor merge drop-ins in (the directory matters as much as the file;
+# COPY creates it root:root 0755). Deny rules use Edit(...) — Write(...)
+# entries are inert (the CLI warns they are "not matched by file permission
+# checks — only Edit").
 COPY --chown=root:root --chmod=0644 managed-settings.json /etc/claude-code/managed-settings.json
 
 # Non-root runtime user: the policy tier's protection assumes the agent cannot

--- a/infra/microvm-image/Dockerfile
+++ b/infra/microvm-image/Dockerfile
@@ -30,7 +30,6 @@ COPY --chown=root:root --chmod=0755 server.mjs /opt/microvm/server.mjs
 COPY --chown=root:root --chmod=0755 smoke.sh /opt/microvm/smoke.sh
 
 ENV CLAUDE_CODE_DISABLE_AUTO_MEMORY=1
-EXPOSE 8080
 USER developer
 WORKDIR /home/developer/workspace
 ENTRYPOINT ["node", "/opt/microvm/server.mjs"]

--- a/infra/microvm-image/Dockerfile
+++ b/infra/microvm-image/Dockerfile
@@ -16,11 +16,15 @@ RUN dnf install -y bash git nodejs22 nodejs22-npm shadow-utils bubblewrap socat 
 # NODE_PATH="$(npm root -g)".
 RUN npm install -g @anthropic-ai/claude-agent-sdk@0.3.251 @anthropic-ai/claude-code@2.1.251
 
+# Create the COPY target directories explicitly: newer BuildKit applies
+# --chmod to parent directories it creates, which would leave them 0644 —
+# untraversable by the non-root user.
+RUN mkdir -p /etc/claude-code /opt/microvm
+
 # Managed policy tier: root-owned so the non-root runtime user can neither
-# replace it nor merge drop-ins in (the directory matters as much as the file;
-# COPY creates it root:root 0755). Deny rules use Edit(...) — Write(...)
-# entries are inert (the CLI warns they are "not matched by file permission
-# checks — only Edit").
+# replace it nor merge drop-ins in (the directory matters as much as the
+# file). Deny rules use Edit(...) — Write(...) entries are inert (the CLI
+# warns they are "not matched by file permission checks — only Edit").
 COPY --chown=root:root --chmod=0644 managed-settings.json /etc/claude-code/managed-settings.json
 
 # Non-root runtime user: the policy tier's protection assumes the agent cannot

--- a/infra/microvm-image/README.md
+++ b/infra/microvm-image/README.md
@@ -1,0 +1,54 @@
+# MicroVM image skeleton — ticket #661
+
+The production MicroVM image for the per-Conversation VM ([spec #654](https://github.com/X-GPT/mymemo-agent/issues/654)), proven with a placeholder server (`server.mjs`) so the platform risk retires before the real In-VM server (#666) exists. Derived from the #646 probe kit (`docs/research/microvm-probe` on the `research/microvm-probe` branch), whose live run proved the recipe: bubblewrap creates namespaces at DEFAULT capabilities — no `--additional-os-capabilities ALL`.
+
+## Pipeline
+
+- **PR**: `.github/workflows/microvm-image.yml` builds this directory for ARM64 and runs `scripts/smoke/microvm-image-check.sh` (pinned SDK `0.3.251` / CLI `2.1.251`, root-owned managed settings, non-root `developer` user).
+- **Main push**: the same workflow assumes the deploy role and runs `scripts/deploy/register_microvm_image.sh` — zip → S3 (`mymemo-agent-prod-artifacts/microvm-images/`) → `create-microvm-image` (first run) or `update-microvm-image` (after) → poll to `CREATED`/`UPDATED`. Build role: `mymemo-agent-prod-microvm-image-build` (`infra/terraform/microvm-image.tf`).
+
+First-run prerequisites (human-applied, in order): bootstrap-iam apply (deploy-role `MicrovmImageRegistration` + artifact-object grants), then a release-deploy Terraform apply (build role).
+
+## Hand-launch verification (acceptance spot-checks)
+
+Needs AWS CLI ≥ 2.35.10 (`lambda-microvms` service); run operator commands with the `mymemo` profile (`export AWS_PROFILE=mymemo`). Platform corrections, verified live on #646: `get-microvm-image` wants the full **ARN**, build logs live under **`/aws/lambda-microvms/<name>`** (hyphen), `list-microvms` returns `items[]`, and `run-microvm` can throw a transient 502 — retry.
+
+```bash
+REGION=us-west-2
+IMAGE_ARN=arn:aws:lambda:$REGION:637423444544:microvm-image:mymemo-agent-prod-microvm
+
+# 1. Launch (managed ingress/egress; short idle policy so suspend fires quickly)
+aws lambda-microvms run-microvm --region $REGION \
+  --image-identifier "$IMAGE_ARN" \
+  --ingress-network-connectors "arn:aws:lambda:$REGION:aws:network-connector:aws-network-connector:ALL_INGRESS" \
+  --egress-network-connectors "arn:aws:lambda:$REGION:aws:network-connector:aws-network-connector:INTERNET_EGRESS" \
+  --idle-policy '{"autoResumeEnabled":true,"maxIdleDurationSeconds":120,"suspendedDurationSeconds":1800}' \
+  --maximum-duration-in-seconds 3600
+# capture microvmId + endpoint; poll get-microvm until RUNNING
+
+# 2. Health through the JWE-authenticated per-VM endpoint
+TOKEN=$(aws lambda-microvms create-microvm-auth-token --region $REGION \
+  --microvm-identifier "$VM" --expiration-in-minutes 30 \
+  --allowed-ports '[{"port":8080}]' \
+  --query 'authToken."X-aws-proxy-auth"' --output text)
+curl -sS "https://$ENDPOINT/healthz" -H "X-aws-proxy-auth: $TOKEN" -H "X-aws-proxy-port: 8080"
+
+# 3. In-VM smoke: bwrap namespaces, pinned versions, root-owned settings
+curl -sS "https://$ENDPOINT/smoke" -H "X-aws-proxy-auth: $TOKEN" -H "X-aws-proxy-port: 8080"
+# expect every RESULT line PASS and EXIT 0
+
+# 4. Lifecycle: suspend → resume → health again (hooks are ENABLED on the
+#    image; a hook that failed to answer would break this cycle)
+aws lambda-microvms suspend-microvm --region $REGION --microvm-identifier "$VM"
+aws lambda-microvms resume-microvm  --region $REGION --microvm-identifier "$VM"
+curl -sS "https://$ENDPOINT/healthz" -H "X-aws-proxy-auth: $TOKEN" -H "X-aws-proxy-port: 8080"
+
+# 5. Always terminate
+aws lambda-microvms terminate-microvm --region $REGION --microvm-identifier "$VM"
+```
+
+## What stays out (by design)
+
+- Egress lockdown (VPC connector, no-NAT subnets, SGs) — #660; this image launches with managed egress for verification only.
+- The real In-VM server, gateway token, model turns — #666/#659; nothing here holds a credential.
+- `--additional-os-capabilities` — deliberately omitted; default caps are proven sufficient.

--- a/infra/microvm-image/managed-settings.json
+++ b/infra/microvm-image/managed-settings.json
@@ -1,0 +1,20 @@
+{
+	"permissions": {
+		"deny": [
+			"Read(~/.claude/.credentials.json)",
+			"Edit(~/.claude/**)",
+			"Edit(~/.claude.json)",
+			"Edit(~/.claude.json.backup)",
+			"Edit(.claude/**)",
+			"Edit(.mcp.json)",
+			"Edit(//etc/claude-code/**)"
+		],
+		"disableBypassPermissionsMode": "disable"
+	},
+	"allowManagedMcpServersOnly": true,
+	"sandbox": {
+		"enabled": true,
+		"failIfUnavailable": true,
+		"allowUnsandboxedCommands": false
+	}
+}

--- a/infra/microvm-image/server.mjs
+++ b/infra/microvm-image/server.mjs
@@ -1,0 +1,43 @@
+// Placeholder in-VM server for the production MicroVM image (ticket #661).
+// It retires the platform risk before the real In-VM server (#666) exists:
+//  - answers the build and lifecycle hooks so the image build snapshots and
+//    boot/suspend/resume/terminate cycle cleanly,
+//  - GET /healthz answers through the platform's JWE-authenticated endpoint,
+//  - GET /smoke streams the in-VM acceptance checks (bubblewrap namespaces,
+//    pinned versions, root-owned managed settings).
+import { spawn } from "node:child_process";
+import { createServer } from "node:http";
+
+const PORT = process.env.PORT || 8080;
+const HOOKS = "/aws/lambda-microvms/runtime/v1"; // ready|validate|run|resume|suspend|terminate
+
+createServer((req, res) => {
+	const { url } = req;
+
+	// 200 = proceed. /ready gates the image-build snapshot; /suspend runs
+	// before the platform snapshots the VM. The real server (#666/#670) turns
+	// /suspend into the graceful-drain + checkpoint gate.
+	if (url.startsWith(HOOKS)) {
+		res.writeHead(200).end("ok");
+		return;
+	}
+
+	if (url === "/healthz") {
+		res.writeHead(200).end("ok");
+		return;
+	}
+
+	if (url === "/smoke") {
+		res.writeHead(200, {
+			"content-type": "text/plain",
+			"cache-control": "no-cache",
+		});
+		const p = spawn("bash", ["/opt/microvm/smoke.sh"]);
+		p.stdout.pipe(res, { end: false });
+		p.stderr.pipe(res, { end: false });
+		p.on("close", (code) => res.end(`\nEXIT ${code}\n`));
+		return;
+	}
+
+	res.writeHead(404).end("not found");
+}).listen(PORT, () => console.log(`microvm placeholder server on :${PORT}`));

--- a/infra/microvm-image/smoke.sh
+++ b/infra/microvm-image/smoke.sh
@@ -47,5 +47,4 @@ else
 	r policy-dir PASS "/etc/claude-code not writable by $(whoami)"
 fi
 
-if [ "$fail" = 0 ]; then r done PASS "smoke complete"; else r done FAIL "smoke complete"; fi
 exit "$fail"

--- a/infra/microvm-image/smoke.sh
+++ b/infra/microvm-image/smoke.sh
@@ -14,7 +14,12 @@ r() {
 
 # bubblewrap namespace smoke — sandbox-mode Bash rides on this. Proven at
 # DEFAULT capabilities by the #646 probe; re-proven here on every image.
-if bwrap --unshare-all --ro-bind / / --dev /dev true 2>/dev/null; then
+# SKIP_BWRAP=1: CI runs this in a Docker container whose seccomp blocks
+# namespace creation — presence is still checkable, the real namespace check
+# runs in-VM.
+if [ "${SKIP_BWRAP:-0}" = 1 ]; then
+	if command -v bwrap >/dev/null; then r bwrap-present PASS; else r bwrap-present FAIL "bubblewrap missing"; fi
+elif bwrap --unshare-all --ro-bind / / --dev /dev true 2>/dev/null; then
 	r bwrap PASS "bubblewrap can create namespaces"
 else
 	r bwrap FAIL "bwrap failed — sandbox-mode Bash unavailable"

--- a/infra/microvm-image/smoke.sh
+++ b/infra/microvm-image/smoke.sh
@@ -26,9 +26,7 @@ else
 fi
 
 # Pinned versions (the spec's exact pins, not ranges).
-# Read the manifest with fs — the SDK's exports map refuses
-# require("…/package.json").
-v=$(node -e 'console.log(JSON.parse(require("fs").readFileSync(process.argv[1], "utf8")).version)' "$(npm root -g)/@anthropic-ai/claude-agent-sdk/package.json" 2>/dev/null)
+v=$(node -p 'require(process.argv[1]).version' "$(npm root -g)/@anthropic-ai/claude-agent-sdk/package.json" 2>/dev/null)
 if [ "$v" = "$SDK_VERSION" ]; then r sdk-pinned PASS "$v"; else r sdk-pinned FAIL "want $SDK_VERSION got ${v:-none}"; fi
 c=$(claude --version 2>/dev/null | head -1)
 case "$c" in

--- a/infra/microvm-image/smoke.sh
+++ b/infra/microvm-image/smoke.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# In-VM acceptance checks for the image skeleton (#661), served by GET /smoke.
+# One `RESULT <check> <PASS|FAIL> <detail>` line per check; exits non-zero if
+# any check failed. Runs as the non-root runtime user.
+set -uo pipefail
+
+SDK_VERSION="0.3.251"
+CLI_VERSION="2.1.251"
+fail=0
+r() {
+	echo "RESULT $1 $2 ${3:-}"
+	if [ "$2" = FAIL ]; then fail=1; fi
+}
+
+# bubblewrap namespace smoke — sandbox-mode Bash rides on this. Proven at
+# DEFAULT capabilities by the #646 probe; re-proven here on every image.
+if bwrap --unshare-all --ro-bind / / --dev /dev true 2>/dev/null; then
+	r bwrap PASS "bubblewrap can create namespaces"
+else
+	r bwrap FAIL "bwrap failed — sandbox-mode Bash unavailable"
+fi
+
+# Pinned versions (the spec's exact pins, not ranges).
+v=$(NODE_PATH="$(npm root -g)" node -e 'console.log(require("@anthropic-ai/claude-agent-sdk/package.json").version)' 2>/dev/null)
+if [ "$v" = "$SDK_VERSION" ]; then r sdk-pinned PASS "$v"; else r sdk-pinned FAIL "want $SDK_VERSION got ${v:-none}"; fi
+c=$(claude --version 2>/dev/null | head -1)
+case "$c" in
+"$CLI_VERSION"*) r cli-pinned PASS "$c" ;;
+*) r cli-pinned FAIL "want $CLI_VERSION got ${c:-none}" ;;
+esac
+
+# Managed settings must be root-owned and non-writable by the runtime user —
+# the directory too, or drop-ins merge in.
+own=$(stat -c '%U:%G %a' /etc/claude-code/managed-settings.json 2>/dev/null)
+if [ "$own" = "root:root 644" ]; then r policy-owner PASS "$own"; else r policy-owner FAIL "${own:-missing}"; fi
+if echo x >/etc/claude-code/managed-settings.json 2>/dev/null; then
+	r policy-immutable FAIL "runtime user overwrote the policy file"
+else
+	r policy-immutable PASS "policy file not writable by $(whoami)"
+fi
+if touch /etc/claude-code/drop-in.json 2>/dev/null; then
+	rm -f /etc/claude-code/drop-in.json
+	r policy-dir FAIL "runtime user can add drop-ins to /etc/claude-code"
+else
+	r policy-dir PASS "/etc/claude-code not writable by $(whoami)"
+fi
+
+if [ "$fail" = 0 ]; then r done PASS "smoke complete"; else r done FAIL "smoke complete"; fi
+exit "$fail"

--- a/infra/microvm-image/smoke.sh
+++ b/infra/microvm-image/smoke.sh
@@ -21,7 +21,9 @@ else
 fi
 
 # Pinned versions (the spec's exact pins, not ranges).
-v=$(NODE_PATH="$(npm root -g)" node -e 'console.log(require("@anthropic-ai/claude-agent-sdk/package.json").version)' 2>/dev/null)
+# Read the manifest with fs — the SDK's exports map refuses
+# require("…/package.json").
+v=$(node -e 'console.log(JSON.parse(require("fs").readFileSync(process.argv[1], "utf8")).version)' "$(npm root -g)/@anthropic-ai/claude-agent-sdk/package.json" 2>/dev/null)
 if [ "$v" = "$SDK_VERSION" ]; then r sdk-pinned PASS "$v"; else r sdk-pinned FAIL "want $SDK_VERSION got ${v:-none}"; fi
 c=$(claude --version 2>/dev/null | head -1)
 case "$c" in
@@ -33,7 +35,7 @@ esac
 # the directory too, or drop-ins merge in.
 own=$(stat -c '%U:%G %a' /etc/claude-code/managed-settings.json 2>/dev/null)
 if [ "$own" = "root:root 644" ]; then r policy-owner PASS "$own"; else r policy-owner FAIL "${own:-missing}"; fi
-if echo x >/etc/claude-code/managed-settings.json 2>/dev/null; then
+if (echo x >/etc/claude-code/managed-settings.json) 2>/dev/null; then
 	r policy-immutable FAIL "runtime user overwrote the policy file"
 else
 	r policy-immutable PASS "policy file not writable by $(whoami)"

--- a/infra/terraform/microvm-image.tf
+++ b/infra/terraform/microvm-image.tf
@@ -32,7 +32,7 @@ data "aws_iam_policy_document" "microvm_image_build" {
 
   # Build logs land under /aws/lambda-microvms/<image-name> (hyphenated —
   # verified live on the #646 probe; the tutorial's /aws/lambda/microvms/...
-  # spelling is kept as a fallback in case the platform changes it back).
+  # spelling is wrong).
   statement {
     sid = "BuildLogs"
     actions = [
@@ -43,8 +43,6 @@ data "aws_iam_policy_document" "microvm_image_build" {
     resources = [
       "arn:aws:logs:${var.aws_region}:${var.aws_account_id}:log-group:/aws/lambda-microvms/${local.microvm_image_name}*",
       "arn:aws:logs:${var.aws_region}:${var.aws_account_id}:log-group:/aws/lambda-microvms/${local.microvm_image_name}*:*",
-      "arn:aws:logs:${var.aws_region}:${var.aws_account_id}:log-group:/aws/lambda/microvms/${local.microvm_image_name}*",
-      "arn:aws:logs:${var.aws_region}:${var.aws_account_id}:log-group:/aws/lambda/microvms/${local.microvm_image_name}*:*",
     ]
   }
 }

--- a/infra/terraform/microvm-image.tf
+++ b/infra/terraform/microvm-image.tf
@@ -3,10 +3,8 @@
 # owns the build role Lambda assumes during that build (code-artifact read +
 # build logs, per the Lambda MicroVMs security guide).
 
-locals {
-  microvm_image_name = "${local.common_name}-microvm"
-}
-
+# The image carries the same name as the VM infra prefix (local.microvm_name,
+# microvm.tf); register_microvm_image.sh hardcodes the same value.
 data "aws_iam_policy_document" "microvm_image_build_assume" {
   statement {
     actions = ["sts:AssumeRole", "sts:TagSession"]
@@ -41,8 +39,8 @@ data "aws_iam_policy_document" "microvm_image_build" {
       "logs:PutLogEvents",
     ]
     resources = [
-      "arn:aws:logs:${var.aws_region}:${var.aws_account_id}:log-group:/aws/lambda-microvms/${local.microvm_image_name}*",
-      "arn:aws:logs:${var.aws_region}:${var.aws_account_id}:log-group:/aws/lambda-microvms/${local.microvm_image_name}*:*",
+      "arn:aws:logs:${var.aws_region}:${var.aws_account_id}:log-group:/aws/lambda-microvms/${local.microvm_name}*",
+      "arn:aws:logs:${var.aws_region}:${var.aws_account_id}:log-group:/aws/lambda-microvms/${local.microvm_name}*:*",
     ]
   }
 }

--- a/infra/terraform/microvm-image.tf
+++ b/infra/terraform/microvm-image.tf
@@ -1,0 +1,56 @@
+# MicroVM image build pipeline (ticket #661, spec #654). The image itself is
+# registered by .github/workflows/microvm-image.yml on main pushes; Terraform
+# owns the build role Lambda assumes during that build (code-artifact read +
+# build logs, per the Lambda MicroVMs security guide).
+
+locals {
+  microvm_image_name = "${local.common_name}-microvm"
+}
+
+data "aws_iam_policy_document" "microvm_image_build_assume" {
+  statement {
+    actions = ["sts:AssumeRole", "sts:TagSession"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "microvm_image_build" {
+  name               = "${local.common_name}-microvm-image-build"
+  assume_role_policy = data.aws_iam_policy_document.microvm_image_build_assume.json
+}
+
+data "aws_iam_policy_document" "microvm_image_build" {
+  statement {
+    sid       = "CodeArtifactRead"
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.artifacts.arn}/microvm-images/*"]
+  }
+
+  # Build logs land under /aws/lambda-microvms/<image-name> (hyphenated —
+  # verified live on the #646 probe; the tutorial's /aws/lambda/microvms/...
+  # spelling is kept as a fallback in case the platform changes it back).
+  statement {
+    sid = "BuildLogs"
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+    resources = [
+      "arn:aws:logs:${var.aws_region}:${var.aws_account_id}:log-group:/aws/lambda-microvms/${local.microvm_image_name}*",
+      "arn:aws:logs:${var.aws_region}:${var.aws_account_id}:log-group:/aws/lambda-microvms/${local.microvm_image_name}*:*",
+      "arn:aws:logs:${var.aws_region}:${var.aws_account_id}:log-group:/aws/lambda/microvms/${local.microvm_image_name}*",
+      "arn:aws:logs:${var.aws_region}:${var.aws_account_id}:log-group:/aws/lambda/microvms/${local.microvm_image_name}*:*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "microvm_image_build" {
+  name   = "${local.common_name}-microvm-image-build-policy"
+  role   = aws_iam_role.microvm_image_build.id
+  policy = data.aws_iam_policy_document.microvm_image_build.json
+}

--- a/scripts/deploy/register_microvm_image.sh
+++ b/scripts/deploy/register_microvm_image.sh
@@ -21,8 +21,8 @@ load_deploy_config
 : "${AWS_REGION:?AWS_REGION is required}"
 : "${AWS_ACCOUNT_ID:?AWS_ACCOUNT_ID is required}"
 
-image_name="${MICROVM_IMAGE_NAME:-mymemo-agent-prod-microvm}"
-bucket="${MICROVM_ARTIFACT_BUCKET:-mymemo-agent-prod-artifacts}"
+image_name="mymemo-agent-prod-microvm"
+bucket="mymemo-agent-prod-artifacts"
 build_role_arn="arn:aws:iam::${AWS_ACCOUNT_ID}:role/mymemo-agent-prod-microvm-image-build"
 base_image_arn="arn:aws:lambda:${AWS_REGION}:aws:microvm-image:al2023-1"
 image_arn="arn:aws:lambda:${AWS_REGION}:${AWS_ACCOUNT_ID}:microvm-image:${image_name}"

--- a/scripts/deploy/register_microvm_image.sh
+++ b/scripts/deploy/register_microvm_image.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Register the production MicroVM image (ticket #661, spec #654).
+#
+# Zips infra/microvm-image, uploads it to the artifacts bucket, then creates
+# (first run) or updates (every later run) the MicroVM image and polls until
+# the build lands. Run on main by .github/workflows/microvm-image.yml with the
+# deploy role; hand-runnable with an operator profile:
+#   AWS_PROFILE=mymemo scripts/deploy/register_microvm_image.sh
+#
+# Platform corrections baked in (verified live on the #646 probe):
+#  - get-microvm-image needs the full image ARN, not the bare name;
+#  - build logs land under /aws/lambda-microvms/<name> (hyphenated);
+#  - run/create can throw a transient 502 — retried once.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+set -a
+# shellcheck source=/dev/null
+source "${repo_root}/infra/deploy/prod.env"
+set +a
+: "${AWS_REGION:?AWS_REGION is required}"
+: "${AWS_ACCOUNT_ID:?AWS_ACCOUNT_ID is required}"
+
+image_name="${MICROVM_IMAGE_NAME:-mymemo-agent-prod-microvm}"
+bucket="${MICROVM_ARTIFACT_BUCKET:-mymemo-agent-prod-artifacts}"
+build_role_arn="arn:aws:iam::${AWS_ACCOUNT_ID}:role/mymemo-agent-prod-microvm-image-build"
+base_image_arn="arn:aws:lambda:${AWS_REGION}:aws:microvm-image:al2023-1"
+image_arn="arn:aws:lambda:${AWS_REGION}:${AWS_ACCOUNT_ID}:microvm-image:${image_name}"
+build_log_group="/aws/lambda-microvms/${image_name}"
+
+sha="$(git -C "${repo_root}" rev-parse --short HEAD)"
+key="microvm-images/app-${sha}.zip"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+(cd "${repo_root}/infra/microvm-image" && zip -q "${workdir}/app.zip" Dockerfile managed-settings.json server.mjs smoke.sh)
+aws s3 cp --region "${AWS_REGION}" "${workdir}/app.zip" "s3://${bucket}/${key}"
+
+# Both create and update take the same build inputs; update refuses to build
+# without --base-image-arn and --build-role-arn even when only the code
+# artifact changed (ValidationException).
+build_args=(
+	--region "${AWS_REGION}"
+	--code-artifact "uri=s3://${bucket}/${key}"
+	--base-image-arn "${base_image_arn}"
+	--build-role-arn "${build_role_arn}"
+	--cpu-configurations architecture=ARM_64
+	--hooks 'port=8080,microvmHooks={run=ENABLED,resume=ENABLED,suspend=ENABLED,terminate=ENABLED},microvmImageHooks={ready=ENABLED,readyTimeoutInSeconds=300}'
+	--description "mymemo-agent ${sha} (#661 image skeleton)"
+)
+
+register() {
+	if aws lambda-microvms get-microvm-image --region "${AWS_REGION}" \
+		--image-identifier "${image_arn}" >/dev/null 2>&1; then
+		echo "Updating ${image_name} from s3://${bucket}/${key}"
+		aws lambda-microvms update-microvm-image --image-identifier "${image_arn}" "${build_args[@]}"
+	else
+		echo "Creating ${image_name} from s3://${bucket}/${key}"
+		aws lambda-microvms create-microvm-image --name "${image_name}" "${build_args[@]}"
+	fi
+}
+
+if ! register; then
+	echo "Registration failed once (transient 502s are a known platform behavior); retrying." >&2
+	sleep 5
+	register
+fi
+
+echo "Polling ${image_arn} until the build lands (logs: ${build_log_group})"
+for _ in $(seq 1 60); do
+	state="$(aws lambda-microvms get-microvm-image --region "${AWS_REGION}" \
+		--image-identifier "${image_arn}" --query state --output text)"
+	case "${state}" in
+	CREATED | UPDATED)
+		echo "MicroVM image ${image_name} is ${state}."
+		exit 0
+		;;
+	CREATING | UPDATING)
+		sleep 20
+		;;
+	*)
+		echo "MicroVM image build ended in ${state}. Check CloudWatch log group ${build_log_group}." >&2
+		exit 1
+		;;
+	esac
+done
+
+echo "Timed out waiting for ${image_name} to finish building. Check ${build_log_group}." >&2
+exit 1

--- a/scripts/deploy/register_microvm_image.sh
+++ b/scripts/deploy/register_microvm_image.sh
@@ -13,12 +13,11 @@
 #  - run/create can throw a transient 502 — retried once.
 set -euo pipefail
 
-repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-
-set -a
-# shellcheck source=/dev/null
-source "${repo_root}/infra/deploy/prod.env"
-set +a
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+# shellcheck source=scripts/deploy/lib/load_config.sh
+source "${script_dir}/lib/load_config.sh"
+load_deploy_config
 : "${AWS_REGION:?AWS_REGION is required}"
 : "${AWS_ACCOUNT_ID:?AWS_ACCOUNT_ID is required}"
 

--- a/scripts/smoke/microvm-image-check.sh
+++ b/scripts/smoke/microvm-image-check.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-# Offline contract check for the MicroVM image skeleton (#661): the assertions
-# from the ticket's acceptance criteria that need no live VM. Namespace
-# creation (bwrap) cannot run under the CI runner's Docker seccomp/AppArmor —
-# that check lives in the in-VM smoke (infra/microvm-image/smoke.sh).
+# Offline contract check for the MicroVM image skeleton (#661). The version
+# pins, policy-tier ownership, and writability assertions live in the image's
+# own /opt/microvm/smoke.sh — run here with SKIP_BWRAP=1 because the CI
+# runner's Docker seccomp blocks namespace creation (the real bwrap check runs
+# in-VM). Only the CI-specific assertions live inline.
 set -euo pipefail
 
 if [[ $# -ne 1 ]]; then
@@ -18,32 +19,16 @@ if [[ "$architecture" != "arm64" ]]; then
 	exit 1
 fi
 
-# One emulated container run for every in-image assertion. Runs as the image's
-# default (non-root) user with networking off.
-docker run --rm --platform linux/arm64 --network none --entrypoint bash "$image" -euo pipefail -c '
+# One emulated container run, as the image's default (non-root) user with
+# networking off.
+docker run --rm --platform linux/arm64 --network none -e SKIP_BWRAP=1 \
+	--entrypoint bash "$image" -euo pipefail -c '
 	[ "$(whoami)" = developer ] || { echo "runtime user is $(whoami), want developer"; exit 1; }
-
 	node --version | grep -q "^v22\." || { echo "node is $(node --version), want v22"; exit 1; }
-
-	sdk="$(node -e "console.log(JSON.parse(require(\"fs\").readFileSync(process.argv[1], \"utf8\")).version)" "$(npm root -g)/@anthropic-ai/claude-agent-sdk/package.json")"
-	[ "$sdk" = "0.3.251" ] || { echo "SDK pinned to $sdk, want 0.3.251"; exit 1; }
-
-	cli="$(claude --version | head -1)"
-	case "$cli" in 2.1.251*) ;; *) echo "CLI pinned to $cli, want 2.1.251"; exit 1 ;; esac
-
-	command -v bwrap >/dev/null || { echo "bubblewrap missing"; exit 1; }
 	command -v socat >/dev/null || { echo "socat missing"; exit 1; }
 	command -v git >/dev/null || { echo "git missing"; exit 1; }
-
 	node --check /opt/microvm/server.mjs
-
-	own="$(stat -c "%U:%G %a" /etc/claude-code/managed-settings.json)"
-	[ "$own" = "root:root 644" ] || { echo "managed settings are $own, want root:root 644"; exit 1; }
-	dirown="$(stat -c "%U:%G %a" /etc/claude-code)"
-	[ "$dirown" = "root:root 755" ] || { echo "/etc/claude-code is $dirown, want root:root 755"; exit 1; }
-	if (echo x > /etc/claude-code/managed-settings.json) 2>/dev/null; then
-		echo "runtime user overwrote the managed settings"; exit 1
-	fi
-
-	echo "microvm image contract holds"
+	bash /opt/microvm/smoke.sh
 '
+
+echo "microvm image contract holds"

--- a/scripts/smoke/microvm-image-check.sh
+++ b/scripts/smoke/microvm-image-check.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Offline contract check for the MicroVM image skeleton (#661): the assertions
+# from the ticket's acceptance criteria that need no live VM. Namespace
+# creation (bwrap) cannot run under the CI runner's Docker seccomp/AppArmor —
+# that check lives in the in-VM smoke (infra/microvm-image/smoke.sh).
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+	echo "Usage: scripts/smoke/microvm-image-check.sh <image>" >&2
+	exit 2
+fi
+
+image="$1"
+
+architecture="$(docker image inspect --format '{{ .Architecture }}' "$image")"
+if [[ "$architecture" != "arm64" ]]; then
+	echo "MicroVM image architecture must be arm64, got $architecture" >&2
+	exit 1
+fi
+
+# One emulated container run for every in-image assertion. Runs as the image's
+# default (non-root) user with networking off.
+docker run --rm --platform linux/arm64 --network none --entrypoint bash "$image" -euo pipefail -c '
+	[ "$(whoami)" = developer ] || { echo "runtime user is $(whoami), want developer"; exit 1; }
+
+	node --version | grep -q "^v22\." || { echo "node is $(node --version), want v22"; exit 1; }
+
+	sdk="$(NODE_PATH="$(npm root -g)" node -e "console.log(require(\"@anthropic-ai/claude-agent-sdk/package.json\").version)")"
+	[ "$sdk" = "0.3.251" ] || { echo "SDK pinned to $sdk, want 0.3.251"; exit 1; }
+
+	cli="$(claude --version | head -1)"
+	case "$cli" in 2.1.251*) ;; *) echo "CLI pinned to $cli, want 2.1.251"; exit 1 ;; esac
+
+	command -v bwrap >/dev/null || { echo "bubblewrap missing"; exit 1; }
+	command -v socat >/dev/null || { echo "socat missing"; exit 1; }
+	command -v git >/dev/null || { echo "git missing"; exit 1; }
+
+	node --check /opt/microvm/server.mjs
+
+	own="$(stat -c "%U:%G %a" /etc/claude-code/managed-settings.json)"
+	[ "$own" = "root:root 644" ] || { echo "managed settings are $own, want root:root 644"; exit 1; }
+	dirown="$(stat -c "%U:%G %a" /etc/claude-code)"
+	[ "$dirown" = "root:root 755" ] || { echo "/etc/claude-code is $dirown, want root:root 755"; exit 1; }
+	if echo x > /etc/claude-code/managed-settings.json 2>/dev/null; then
+		echo "runtime user overwrote the managed settings"; exit 1
+	fi
+
+	echo "microvm image contract holds"
+'

--- a/scripts/smoke/microvm-image-check.sh
+++ b/scripts/smoke/microvm-image-check.sh
@@ -25,7 +25,7 @@ docker run --rm --platform linux/arm64 --network none --entrypoint bash "$image"
 
 	node --version | grep -q "^v22\." || { echo "node is $(node --version), want v22"; exit 1; }
 
-	sdk="$(NODE_PATH="$(npm root -g)" node -e "console.log(require(\"@anthropic-ai/claude-agent-sdk/package.json\").version)")"
+	sdk="$(node -e "console.log(JSON.parse(require(\"fs\").readFileSync(process.argv[1], \"utf8\")).version)" "$(npm root -g)/@anthropic-ai/claude-agent-sdk/package.json")"
 	[ "$sdk" = "0.3.251" ] || { echo "SDK pinned to $sdk, want 0.3.251"; exit 1; }
 
 	cli="$(claude --version | head -1)"
@@ -41,7 +41,7 @@ docker run --rm --platform linux/arm64 --network none --entrypoint bash "$image"
 	[ "$own" = "root:root 644" ] || { echo "managed settings are $own, want root:root 644"; exit 1; }
 	dirown="$(stat -c "%U:%G %a" /etc/claude-code)"
 	[ "$dirown" = "root:root 755" ] || { echo "/etc/claude-code is $dirown, want root:root 755"; exit 1; }
-	if echo x > /etc/claude-code/managed-settings.json 2>/dev/null; then
+	if (echo x > /etc/claude-code/managed-settings.json) 2>/dev/null; then
 		echo "runtime user overwrote the managed settings"; exit 1
 	fi
 


### PR DESCRIPTION
Closes #661 on [Spec #654](https://github.com/X-GPT/mymemo-agent/issues/654): the production MicroVM image pipeline, proven with a placeholder server so the platform risk retires before the real In-VM server (#666) exists. Starts from the #646 probe kit (`research/microvm-probe`) with every recorded platform correction applied.

- **`infra/microvm-image/`** — the image: AL2023 base at **default capabilities** (bwrap needs no `ALL` flag, proven live), nodejs22 + bubblewrap + socat + shadow-utils, pinned `@anthropic-ai/claude-agent-sdk@0.3.251` + CLI `2.1.251`, root-owned `/etc/claude-code/managed-settings.json` with `Edit(...)` deny rules (`Write(...)` entries omitted — the CLI warns they are inert), non-root `developer` user. `server.mjs` answers the build/lifecycle hooks, `/healthz`, and `/smoke` (streams the in-VM acceptance checks: bwrap namespaces, version pins, policy immutability). README carries the hand-launch verification runbook.
- **`.github/workflows/microvm-image.yml`** — PR: ARM64 docker build + `scripts/smoke/microvm-image-check.sh` (offline contract: arch, pins, root-owned settings, non-root user, server syntax). Main push: OIDC to the deploy role, then `scripts/deploy/register_microvm_image.sh` — zip → S3 → `create-microvm-image` (or `update-`, which requires re-passing `--base-image-arn`/`--build-role-arn`) with `--cpu-configurations architecture=ARM_64` and all hooks ENABLED → poll to `CREATED`/`UPDATED`. Probe corrections baked in: full-ARN `get-microvm-image`, hyphenated `/aws/lambda-microvms/<name>` log group, transient-502 retry, all-or-nothing `dnf` comment.
- **Terraform** — `infra/terraform/microvm-image.tf`: the build role Lambda assumes (`s3:GetObject` on `artifacts/microvm-images/*` + build logs). `infra/bootstrap-iam`: deploy-role grants (`lambda:Create/Update/GetMicrovmImage` on `mymemo-agent-*` images, artifact-object read/write); `iam:PassRole` already covered by `AgentIamManagement`.

**Verified locally**: ARM64 docker build; offline contract check green; `smoke.sh` exercised in-container (all PASS except `bwrap`, blocked by Docker's seccomp by design — the #646 probe proved it PASSes in the real MicroVM at default caps); placeholder server answers `/healthz`, the hook paths, and 404s the rest. `terraform fmt`/`validate` green on both stacks; `bun run test` green.

**Apply order for the first registration run** (human steps, as with prior IAM changes): bootstrap-iam apply → release-deploy Terraform apply (build role) → merge lands here and the main-push job registers the image. The remaining acceptance boxes (hand-launched VM ready/health/lifecycle/smoke through the JWE endpoint) run post-apply via the README runbook — the same sequence the probe already executed successfully against this recipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZVJwUjxzm2fxitfNbw8e1
