### PR TITLE
fix(infra): grant deploy role MicroVM permissions

### DIFF
--- a/infra/bootstrap-iam/main.tf
+++ b/infra/bootstrap-iam/main.tf
@@ -54,7 +54,7 @@ data "aws_iam_policy_document" "github_actions_deploy" {
   }
 
   statement {
-    sid = "ArtifactBucketManagement"
+    sid = "AgentBucketManagement"
     actions = [
       "s3:CreateBucket",
       "s3:DeleteBucket",
@@ -73,7 +73,10 @@ data "aws_iam_policy_document" "github_actions_deploy" {
       "s3:PutEncryptionConfiguration",
       "s3:PutLifecycleConfiguration",
     ]
-    resources = ["arn:aws:s3:::${var.artifact_bucket_name}"]
+    resources = [
+      "arn:aws:s3:::${var.artifact_bucket_name}",
+      "arn:aws:s3:::${var.checkpoint_bucket_name}",
+    ]
   }
 
   statement {
@@ -106,28 +109,36 @@ data "aws_iam_policy_document" "github_actions_deploy" {
       "autoscaling:*",
       "cloudwatch:*",
       "ec2:AllocateAddress",
+      "ec2:AssociateRouteTable",
       "ec2:AuthorizeSecurityGroupEgress",
       "ec2:AuthorizeSecurityGroupIngress",
       "ec2:CreateInstanceConnectEndpoint",
       "ec2:CreateLaunchTemplate",
       "ec2:CreateLaunchTemplateVersion",
       "ec2:CreateNetworkInterface",
+      "ec2:CreateRouteTable",
       "ec2:CreateSecurityGroup",
+      "ec2:CreateSubnet",
       "ec2:CreateTags",
       "ec2:DeleteInstanceConnectEndpoint",
       "ec2:DeleteLaunchTemplate",
       "ec2:DeleteLaunchTemplateVersions",
       "ec2:DeleteNatGateway",
       "ec2:DeleteNetworkInterface",
+      "ec2:DeleteRouteTable",
       "ec2:DeleteSecurityGroup",
+      "ec2:DeleteSubnet",
       "ec2:DeleteTags",
       "ec2:Describe*",
       "ec2:DisassociateAddress",
+      "ec2:DisassociateRouteTable",
       "ec2:ModifyInstanceAttribute",
       "ec2:ModifyInstanceConnectEndpoint",
       "ec2:ModifyNetworkInterfaceAttribute",
+      "ec2:ModifySubnetAttribute",
       "ec2:ReleaseAddress",
       "ec2:ReplaceRoute",
+      "ec2:ReplaceRouteTableAssociation",
       "ec2:RevokeSecurityGroupEgress",
       "ec2:RevokeSecurityGroupIngress",
       "ec2:RunInstances",
@@ -148,6 +159,21 @@ data "aws_iam_policy_document" "github_actions_deploy" {
       "secretsmanager:PutSecretValue",
       "secretsmanager:TagResource",
       "secretsmanager:UpdateSecret",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "MicrovmNetworkConnectorManagement"
+    actions = [
+      "lambda:CreateNetworkConnector",
+      "lambda:DeleteNetworkConnector",
+      "lambda:GetNetworkConnector",
+      "lambda:ListNetworkConnectors",
+      "lambda:ListTags",
+      "lambda:TagResource",
+      "lambda:UntagResource",
+      "lambda:UpdateNetworkConnector",
     ]
     resources = ["*"]
   }

--- a/infra/bootstrap-iam/prod.tfvars
+++ b/infra/bootstrap-iam/prod.tfvars
@@ -1,3 +1,4 @@
-aws_region           = "us-west-2"
-aws_account_id       = "637423444544"
-artifact_bucket_name = "mymemo-agent-prod-artifacts"
+aws_region             = "us-west-2"
+aws_account_id         = "637423444544"
+artifact_bucket_name   = "mymemo-agent-prod-artifacts"
+checkpoint_bucket_name = "mymemo-agent-prod-microvm-checkpoints"

--- a/infra/bootstrap-iam/variables.tf
+++ b/infra/bootstrap-iam/variables.tf
@@ -46,6 +46,12 @@ variable "artifact_bucket_name" {
   default     = "mymemo-agent-prod-artifacts"
 }
 
+variable "checkpoint_bucket_name" {
+  description = "S3 bucket managed by the deploy role for MicroVM Checkpoints."
+  type        = string
+  default     = "mymemo-agent-prod-microvm-checkpoints"
+}
+
 variable "tags" {
   description = "Tags applied to bootstrap IAM resources."
   type        = map(string)

--- a/scripts/deploy-config.test.ts
+++ b/scripts/deploy-config.test.ts
@@ -9,6 +9,29 @@ import { loadApiConfigFromEnv } from "../apps/chat-api/src/config/env";
 const root = process.cwd();
 
 describe("agent deployment behavior", () => {
+	it("grants the deploy role control-plane access for MicroVM infrastructure", () => {
+		const policy = readFileSync("infra/bootstrap-iam/main.tf", "utf8");
+
+		for (const required of [
+			"ec2:AssociateRouteTable",
+			"ec2:CreateRouteTable",
+			"ec2:CreateSubnet",
+			"ec2:DeleteRouteTable",
+			"ec2:DeleteSubnet",
+			"ec2:DisassociateRouteTable",
+			"ec2:ModifySubnetAttribute",
+			"ec2:ReplaceRouteTableAssociation",
+			"lambda:CreateNetworkConnector",
+			"lambda:DeleteNetworkConnector",
+			"lambda:GetNetworkConnector",
+			"lambda:ListNetworkConnectors",
+			"lambda:UpdateNetworkConnector",
+			"var.checkpoint_bucket_name",
+		]) {
+			expect(policy).toContain(required);
+		}
+	});
+
 	it("writes a Terraform-formatted generated image overlay", () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "mymemo-deploy-tfvars-"));
 		const generatedTfvars = join(tempDir, "generated.auto.tfvars");


### PR DESCRIPTION
## Summary

- grant the GitHub Actions deploy role EC2 subnet and route-table lifecycle permissions
- scope S3 bucket management to the MicroVM checkpoint bucket and add Lambda network-connector lifecycle permissions
- add regression coverage for the deploy-role contract

## Root cause

PR #677 added the v2 MicroVM Terraform inventory without updating the separately bootstrapped deploy-role policy. Release deploy run #33454260471 therefore failed with explicit denies for ec2:CreateSubnet, ec2:CreateRouteTable, and s3:CreateBucket before it could reach network-connector creation.

## Verification

- bun test scripts/deploy-config.test.ts
- terraform -chdir=infra/bootstrap-iam validate
- terraform -chdir=infra/terraform validate
- AWS IAM simulation: required EC2, S3, and Lambda connector actions allowed
- production Release deploy rerun succeeded: https://github.com/X-GPT/mymemo-agent/actions/runs/33454260471

## Production state

The exact bootstrap IAM plan was applied in place: 0 added, 1 changed, 0 destroyed.