### PR TITLE
fix(infra): CreateMicrovmImage authorizes against resource * (#661 follow-up)

### DIFF
--- a/infra/bootstrap-iam/main.tf
+++ b/infra/bootstrap-iam/main.tf
@@ -416,11 +416,19 @@ data "aws_iam_policy_document" "github_actions_deploy" {
   statement {
     sid = "MicrovmImageRegistration"
     actions = [
-      "lambda:CreateMicrovmImage",
       "lambda:GetMicrovmImage",
       "lambda:UpdateMicrovmImage",
     ]
     resources = ["arn:aws:lambda:${var.aws_region}:${var.aws_account_id}:microvm-image:mymemo-agent-*"]
+  }
+
+  # CreateMicrovmImage authorizes against resource "*" — the image does not
+  # exist yet at create time (proven live: the ARN-scoped grant was denied
+  # with "on resource: *").
+  statement {
+    sid       = "MicrovmImageCreation"
+    actions   = ["lambda:CreateMicrovmImage"]
+    resources = ["*"]
   }
 
   statement {


### PR DESCRIPTION
First live register run on main ([job](https://github.com/X-GPT/mymemo-agent/actions/runs/33461619930)) was denied: `lambda:CreateMicrovmImage` evaluates against resource `*` (no image resource exists yet at create time), so the `mymemo-agent-*`-scoped grant from #679 never matches. Split create into its own `*`-scoped statement — matching #681's connector-management pattern — and keep Get/Update ARN-scoped.

`terraform fmt`/`validate` green; deploy-role contract test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZVJwUjxzm2fxitfNbw8e1