### PR TITLE
fix(infra): PassNetworkConnector for MicroVM image builds (#661 follow-up)

### DIFF
--- a/infra/bootstrap-iam/main.tf
+++ b/infra/bootstrap-iam/main.tf
@@ -431,6 +431,15 @@ data "aws_iam_policy_document" "github_actions_deploy" {
     resources = ["*"]
   }
 
+  # The image build runs on the AWS-managed INTERNET_EGRESS connector (dnf/npm
+  # need egress) and CreateMicrovmImage passes it implicitly — denied live
+  # without PassNetworkConnector on the aws-owned connector namespace.
+  statement {
+    sid       = "MicrovmImagePassManagedConnector"
+    actions   = ["lambda:PassNetworkConnector"]
+    resources = ["arn:aws:lambda:${var.aws_region}:aws:network-connector:*"]
+  }
+
   statement {
     sid = "MicrovmImageArtifactObjects"
     actions = [


### PR DESCRIPTION
Second live register run ([job rerun](https://github.com/X-GPT/mymemo-agent/actions/runs/33461619930)) got past CreateMicrovmImage (#682) and was then denied `lambda:PassNetworkConnector` on `arn:aws:lambda:us-west-2:aws:network-connector:aws-network-connector:INTERNET_EGRESS` — the image build passes the AWS-managed egress connector implicitly (dnf/npm need egress during the build). Grant PassNetworkConnector on the aws-owned connector namespace, region-scoped.

`terraform fmt`/`validate` green; deploy-role contract test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZVJwUjxzm2fxitfNbw8e1