### PR TITLE
feat(chat-api): v2 Conversation history GET — UIMessages over conversation_messages (#663)

### DIFF
--- a/apps/chat-api/src/app.ts
+++ b/apps/chat-api/src/app.ts
@@ -5,6 +5,7 @@ import type { ApiConfig } from "./config/env";
 import type { AppDeps, AppEnv } from "./deps";
 import artifactRoutes from "./features/artifacts/artifacts.route";
 import conversationHistoryRoutes from "./features/conversation-history/conversation-history.route";
+import conversationMessagesRoutes from "./features/conversation-messages/conversation-messages.route";
 import conversationLifecycleRoutes from "./features/conversations/conversation-lifecycle.route";
 import conversationsRoutes from "./features/conversations/conversations.route";
 import gatewayRoutes from "./features/gateway/gateway.route";
@@ -28,9 +29,10 @@ export function createApp(config: ApiConfig, deps: AppDeps) {
 	app.route("/v1/conversations", conversationsRoutes);
 	app.route("/v1/conversations", conversationHistoryRoutes);
 	app.route("/v1/conversations", artifactRoutes);
-	// v2 carries the lifecycle routes with v1 semantics (#657); the Run,
-	// history, and artifact routes stay v1-only.
+	// v2 carries the lifecycle routes with v1 semantics (#657); the Run and
+	// artifact routes stay v1-only. v2 history is its own UIMessage read (#663).
 	app.route("/v2/conversations", conversationLifecycleRoutes);
+	app.route("/v2/conversations", conversationMessagesRoutes);
 	app.route("/v2/gateway", gatewayRoutes);
 
 	return app;

--- a/apps/chat-api/src/deps.ts
+++ b/apps/chat-api/src/deps.ts
@@ -22,6 +22,8 @@ import { PostgresArtifactMetadataStore } from "./features/artifacts/postgres-art
 import { createS3ArtifactDownloadSigner } from "./features/artifacts/s3-artifact-download-signer";
 import type { ConversationHistoryStore } from "./features/conversation-history/conversation-history-store";
 import { PostgresConversationHistoryStore } from "./features/conversation-history/postgres-conversation-history-store";
+import type { ConversationMessagesStore } from "./features/conversation-messages/conversation-messages-store";
+import { PostgresConversationMessagesStore } from "./features/conversation-messages/postgres-conversation-messages-store";
 import type { ConversationStore } from "./features/conversation-store/conversation-store";
 import { PostgresConversationStore } from "./features/conversation-store/postgres-conversation-store";
 import type { InternalIdentity } from "./features/conversations/conversations.schema";
@@ -56,6 +58,8 @@ export interface AppDeps {
 	conversationStore: ConversationStore;
 	/** Permanent AG-UI Conversation-history projection over Postgres Runs. */
 	conversationHistoryStore: ConversationHistoryStore;
+	/** /v2 UIMessage history over `conversation_messages` (read-only here; the In-VM server is the sole writer). */
+	conversationMessagesStore: ConversationMessagesStore;
 	/** Durable split-runtime run queue and event log. */
 	runStore: RunStore;
 	/** Producer-buffered per-Run relay used by initial and reconnect SSE. */
@@ -122,6 +126,7 @@ export function createDeps(
 		artifactDownloadSigner,
 		conversationStore,
 		conversationHistoryStore,
+		conversationMessagesStore: new PostgresConversationMessagesStore(database),
 		runStore,
 		liveStreamRelay,
 		liveStreamTelemetry,

--- a/apps/chat-api/src/features/conversation-messages/conversation-messages-store.ts
+++ b/apps/chat-api/src/features/conversation-messages/conversation-messages-store.ts
@@ -1,0 +1,57 @@
+import type { TurnStatus } from "@mymemo/agent-db/turn-store";
+
+/**
+ * The /v2 Conversation history read contract (spec #654, ticket #663): the
+ * durable UIMessages of one Conversation in ascending `sequence` order.
+ * chat-api only reads this projection — the In-VM server is the sole writer —
+ * so a page shows exactly what durably committed: an interrupted or error Turn
+ * carries its completed Steps and never provisional text, by the writer's
+ * commit-before-publish invariant, not by any filtering here.
+ */
+
+/**
+ * Turn lifecycle riding a user message as UIMessage metadata. Column names
+ * (`status`/`started_at`/`finished_at`) surface in the API's camelCase, like
+ * every other route.
+ */
+export interface TurnMetadata {
+	status: TurnStatus;
+	startedAt: Date | null;
+	finishedAt: Date | null;
+}
+
+export interface ConversationUiMessage {
+	id: string;
+	role: "user" | "assistant";
+	/** Stored UIMessage parts, returned verbatim (step and tool parts included). */
+	parts: unknown;
+	/** Present exactly on user messages — a user row IS the Turn record. */
+	metadata?: TurnMetadata;
+}
+
+export interface ConversationMessagesPage {
+	/** One page in ascending `sequence`; the newest page when `before` is null. */
+	messages: ConversationUiMessage[];
+	/** `?before` value for the next older page, or null at the beginning. */
+	nextCursor: number | null;
+}
+
+export interface ConversationMessagesPageInput {
+	userId: string;
+	conversationId: string;
+	limit: number;
+	/** Exclusive upper `sequence` bound; null asks for the newest page. */
+	before: number | null;
+}
+
+export interface ConversationMessagesStore {
+	/**
+	 * Null when the owner has no such Conversation (missing and foreign look
+	 * identical); an empty page — not null — when the Conversation exists with
+	 * no v2 rows, which is every pre-v2 Conversation. Archived Conversations
+	 * read normally.
+	 */
+	getPage(
+		input: ConversationMessagesPageInput,
+	): Promise<ConversationMessagesPage | null>;
+}

--- a/apps/chat-api/src/features/conversation-messages/conversation-messages.route.test.ts
+++ b/apps/chat-api/src/features/conversation-messages/conversation-messages.route.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "bun:test";
+import type { ApiConfig } from "@/config/env";
+import type { AppDeps } from "@/deps";
+import type {
+	ConversationMessagesPageInput,
+	ConversationMessagesStore,
+} from "./conversation-messages-store";
+
+const { createApp } = await import("@/app");
+
+const identityHeaders = {
+	"x-member-code": "member-1",
+	"x-partner-code": "partner-1",
+};
+
+function appWith(store: ConversationMessagesStore) {
+	const deps = {
+		conversationMessagesStore: store,
+		exposureGate: {
+			async isAgentEnabled() {
+				throw new Error("history reads must not consult exposure");
+			},
+		},
+	} as unknown as AppDeps;
+	return createApp({ logLevel: "silent" } as ApiConfig, deps);
+}
+
+describe("GET /v2/conversations/:conversationId/messages", () => {
+	it("serves the store page with defaulted query, camelCase Turn metadata, and no exposure check", async () => {
+		const calls: ConversationMessagesPageInput[] = [];
+		const app = appWith({
+			async getPage(input) {
+				calls.push(input);
+				return {
+					messages: [
+						{
+							id: "message-1",
+							role: "user",
+							parts: [{ type: "text", text: "hi" }],
+							metadata: {
+								status: "done",
+								startedAt: new Date("2026-08-31T01:00:00.000Z"),
+								finishedAt: new Date("2026-08-31T01:00:05.000Z"),
+							},
+						},
+						{
+							id: "message-2",
+							role: "assistant",
+							parts: [{ type: "step-start" }, { type: "text", text: "hello" }],
+						},
+						{
+							id: "message-3",
+							role: "user",
+							parts: [{ type: "text", text: "more" }],
+							metadata: { status: "queued", startedAt: null, finishedAt: null },
+						},
+					],
+					nextCursor: 41,
+				};
+			},
+		});
+
+		const response = await app.request(
+			"/v2/conversations/conversation-1/messages",
+			{ headers: identityHeaders },
+		);
+
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe(
+			'{"messages":[' +
+				'{"id":"message-1","role":"user","parts":[{"type":"text","text":"hi"}],"metadata":{"status":"done","startedAt":"2026-08-31T01:00:00.000Z","finishedAt":"2026-08-31T01:00:05.000Z"}},' +
+				'{"id":"message-2","role":"assistant","parts":[{"type":"step-start"},{"type":"text","text":"hello"}]},' +
+				'{"id":"message-3","role":"user","parts":[{"type":"text","text":"more"}],"metadata":{"status":"queued","startedAt":null,"finishedAt":null}}' +
+				'],"nextCursor":41}',
+		);
+		expect(calls).toEqual([
+			{
+				userId: "member-1",
+				conversationId: "conversation-1",
+				limit: 50,
+				before: null,
+			},
+		]);
+	});
+
+	it("clamps an over-large limit to the cap and forwards the before cursor", async () => {
+		const calls: ConversationMessagesPageInput[] = [];
+		const app = appWith({
+			async getPage(input) {
+				calls.push(input);
+				return { messages: [], nextCursor: null };
+			},
+		});
+
+		const response = await app.request(
+			"/v2/conversations/conversation-1/messages?limit=1000&before=17",
+			{ headers: identityHeaders },
+		);
+
+		expect(response.status).toBe(200);
+		expect(calls).toEqual([
+			{
+				userId: "member-1",
+				conversationId: "conversation-1",
+				limit: 100,
+				before: 17,
+			},
+		]);
+	});
+
+	it("rejects malformed paging input before touching the store", async () => {
+		const app = appWith({
+			async getPage() {
+				throw new Error("store must not be reached");
+			},
+		});
+
+		for (const query of [
+			"limit=0",
+			"limit=abc",
+			"limit=1.5",
+			"before=-1",
+			"before=abc",
+			"unknown=1",
+		]) {
+			const response = await app.request(
+				`/v2/conversations/conversation-1/messages?${query}`,
+				{ headers: identityHeaders },
+			);
+			expect(response.status).toBe(400);
+		}
+	});
+
+	it("returns owner-safe 404 when the store reports no such Conversation", async () => {
+		const app = appWith({
+			async getPage() {
+				return null;
+			},
+		});
+
+		const response = await app.request(
+			"/v2/conversations/conversation-1/messages",
+			{ headers: identityHeaders },
+		);
+
+		expect(response.status).toBe(404);
+		expect(await response.json()).toEqual({ error: "Conversation not found" });
+	});
+});

--- a/apps/chat-api/src/features/conversation-messages/conversation-messages.route.ts
+++ b/apps/chat-api/src/features/conversation-messages/conversation-messages.route.ts
@@ -1,0 +1,71 @@
+import { sValidator as zValidator } from "@hono/standard-validator";
+import { Hono } from "hono";
+import { z } from "zod";
+import type { AppEnv } from "@/deps";
+import { ConversationIdParam } from "@/features/conversations/conversations.schema";
+import { requireInternalIdentity } from "@/features/conversations/internal-identity";
+
+const DEFAULT_MESSAGES_LIMIT = 50;
+const MAX_MESSAGES_LIMIT = 100;
+
+// An over-large limit clamps to the cap instead of erroring (the #663 read
+// contract); everything non-numeric, negative, zero, or fractional is a 400.
+const MessagesLimit = z
+	.string()
+	.regex(/^\d+$/)
+	.transform(Number)
+	.pipe(z.number().int().min(1))
+	.transform((limit) => Math.min(limit, MAX_MESSAGES_LIMIT));
+
+// The cursor is a raw `sequence` value handed back as `nextCursor`.
+const BeforeSequence = z
+	.string()
+	.regex(/^\d+$/)
+	.transform(Number)
+	.pipe(z.number().int());
+
+const MessagesQuery = z
+	.object({
+		limit: MessagesLimit.default(DEFAULT_MESSAGES_LIMIT),
+		before: BeforeSequence.optional(),
+	})
+	.strict();
+
+/**
+ * `GET /:conversationId/messages` (mounted at `/v2/conversations`) — the
+ * durable UIMessage history (spec #654, ticket #663). Owner-scoped via
+ * internal identity; reads bypass the new-work exposure gate (v1 precedent).
+ */
+const app = new Hono<AppEnv>();
+
+app.get(
+	"/:conversationId/messages",
+	zValidator(
+		"param",
+		z.object({ conversationId: ConversationIdParam }),
+		(result, c) => {
+			if (!result.success) {
+				return c.json({ error: "Invalid conversation id" }, 400);
+			}
+		},
+	),
+	zValidator("query", MessagesQuery, (result, c) => {
+		if (!result.success) {
+			return c.json({ error: "Invalid messages query" }, 400);
+		}
+	}),
+	requireInternalIdentity,
+	async (c) => {
+		const query = c.req.valid("query");
+		const page = await c.var.deps.conversationMessagesStore.getPage({
+			userId: c.var.identity.memberCode,
+			conversationId: c.req.valid("param").conversationId,
+			limit: query.limit,
+			before: query.before ?? null,
+		});
+		if (!page) return c.json({ error: "Conversation not found" }, 404);
+		return c.json(page);
+	},
+);
+
+export default app;

--- a/apps/chat-api/src/features/conversation-messages/postgres-conversation-messages-store.test.ts
+++ b/apps/chat-api/src/features/conversation-messages/postgres-conversation-messages-store.test.ts
@@ -1,0 +1,188 @@
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+} from "bun:test";
+import { conversationMessages, conversations } from "@mymemo/agent-db/schema";
+import { createTestDatabase, type TestDb } from "@mymemo/agent-db/testing";
+import { PostgresConversationMessagesStore } from "./postgres-conversation-messages-store";
+
+let tdb: TestDb;
+let store: PostgresConversationMessagesStore;
+
+beforeAll(async () => {
+	tdb = await createTestDatabase();
+	store = new PostgresConversationMessagesStore(tdb.db);
+});
+
+afterAll(async () => {
+	await tdb.close();
+});
+
+beforeEach(async () => {
+	await tdb.db.delete(conversations);
+	await tdb.db.insert(conversations).values({
+		userId: "member-1",
+		conversationId: "conversation-1",
+		scope: "general",
+	});
+});
+
+function userRow(
+	sequence: number,
+	messageId: string,
+	turn: Partial<{
+		status: string;
+		startedAt: Date;
+		finishedAt: Date;
+	}> = {},
+) {
+	return {
+		sequence,
+		userId: "member-1",
+		conversationId: "conversation-1",
+		messageId,
+		role: "user",
+		parts: [{ type: "text", text: messageId }],
+		status: turn.status ?? "done",
+		startedAt: turn.startedAt ?? null,
+		finishedAt: turn.finishedAt ?? null,
+	};
+}
+
+function assistantRow(sequence: number, messageId: string, parts: unknown) {
+	return {
+		sequence,
+		userId: "member-1",
+		conversationId: "conversation-1",
+		messageId,
+		role: "assistant",
+		parts,
+	};
+}
+
+function getPage(input: Partial<Parameters<typeof store.getPage>[0]> = {}) {
+	return store.getPage({
+		userId: "member-1",
+		conversationId: "conversation-1",
+		limit: 50,
+		before: null,
+		...input,
+	});
+}
+
+describe("PostgresConversationMessagesStore", () => {
+	it("serves Turns ascending: user rows carry Turn metadata, assistant parts return verbatim", async () => {
+		const startedAt = new Date("2026-08-31T01:00:00.000Z");
+		const finishedAt = new Date("2026-08-31T01:00:09.000Z");
+		const assistantParts = [
+			{ type: "step-start" },
+			{
+				type: "tool-Bash",
+				toolCallId: "call-1",
+				state: "output-available",
+				input: { command: "ls" },
+				output: "notes.md",
+			},
+			{ type: "text", text: "Listed your files." },
+		];
+		await tdb.db
+			.insert(conversationMessages)
+			.values([
+				userRow(1, "user-1", { status: "done", startedAt, finishedAt }),
+				assistantRow(2, "assistant-1", assistantParts),
+				userRow(3, "user-2", { status: "interrupted", startedAt }),
+			]);
+
+		const page = await getPage();
+
+		expect(page).toEqual({
+			messages: [
+				{
+					id: "user-1",
+					role: "user",
+					parts: [{ type: "text", text: "user-1" }],
+					metadata: { status: "done", startedAt, finishedAt },
+				},
+				{ id: "assistant-1", role: "assistant", parts: assistantParts },
+				{
+					id: "user-2",
+					role: "user",
+					parts: [{ type: "text", text: "user-2" }],
+					metadata: { status: "interrupted", startedAt, finishedAt: null },
+				},
+			],
+			nextCursor: null,
+		});
+		// toEqual treats an undefined value as a missing key, so absence needs
+		// its own assertion: assistant messages must not serialize a metadata key.
+		expect(Object.keys(page?.messages[1] ?? {})).not.toContain("metadata");
+	});
+
+	it("pages backwards on a before cursor that later appends cannot destabilize", async () => {
+		await tdb.db
+			.insert(conversationMessages)
+			.values([1, 2, 3, 4, 5].map((n) => userRow(n, `user-${n}`)));
+
+		const newest = await getPage({ limit: 2 });
+		expect(newest?.messages.map((m) => m.id)).toEqual(["user-4", "user-5"]);
+		expect(newest?.nextCursor).toBe(4);
+
+		// The append lands after the cursor was handed out; older pages must not
+		// shift under the client mid-walk.
+		await tdb.db.insert(conversationMessages).values(userRow(6, "user-6"));
+
+		const older = await getPage({ limit: 2, before: 4 });
+		expect(older?.messages.map((m) => m.id)).toEqual(["user-2", "user-3"]);
+		expect(older?.nextCursor).toBe(2);
+
+		const oldest = await getPage({ limit: 2, before: 2 });
+		expect(oldest?.messages.map((m) => m.id)).toEqual(["user-1"]);
+		expect(oldest?.nextCursor).toBeNull();
+	});
+
+	it("returns an empty page — not null — for a Conversation with no v2 rows (the pre-v2 case)", async () => {
+		expect(await getPage()).toEqual({ messages: [], nextCursor: null });
+	});
+
+	it("returns null for a missing or foreign Conversation", async () => {
+		await tdb.db.insert(conversations).values({
+			userId: "member-2",
+			conversationId: "conversation-2",
+			scope: "general",
+		});
+		await tdb.db.insert(conversationMessages).values({
+			...userRow(10, "foreign-1"),
+			userId: "member-2",
+			conversationId: "conversation-2",
+		});
+
+		expect(await getPage({ conversationId: "missing" })).toBeNull();
+		expect(await getPage({ conversationId: "conversation-2" })).toBeNull();
+	});
+
+	it("reads an archived Conversation normally", async () => {
+		await tdb.db.insert(conversations).values({
+			userId: "member-1",
+			conversationId: "conversation-archived",
+			scope: "general",
+			archivedAt: new Date("2026-08-30T00:00:00.000Z"),
+		});
+		await tdb.db.insert(conversationMessages).values({
+			...userRow(20, "archived-1"),
+			conversationId: "conversation-archived",
+		});
+
+		const page = await getPage({ conversationId: "conversation-archived" });
+		expect(page?.messages.map((m) => m.id)).toEqual(["archived-1"]);
+	});
+
+	it("rejects a non-positive limit before querying", async () => {
+		await expect(getPage({ limit: 0 })).rejects.toThrow(
+			"Messages page limit must be a positive integer",
+		);
+	});
+});

--- a/apps/chat-api/src/features/conversation-messages/postgres-conversation-messages-store.ts
+++ b/apps/chat-api/src/features/conversation-messages/postgres-conversation-messages-store.ts
@@ -1,0 +1,82 @@
+import type { Database } from "@mymemo/agent-db/client";
+import { conversationMessages, conversations } from "@mymemo/agent-db/schema";
+import type { TurnStatus } from "@mymemo/agent-db/turn-store";
+import { and, desc, eq, lt } from "drizzle-orm";
+import type {
+	ConversationMessagesPage,
+	ConversationMessagesPageInput,
+	ConversationMessagesStore,
+	ConversationUiMessage,
+} from "./conversation-messages-store";
+
+export class PostgresConversationMessagesStore
+	implements ConversationMessagesStore
+{
+	constructor(private readonly db: Database) {}
+
+	async getPage(
+		input: ConversationMessagesPageInput,
+	): Promise<ConversationMessagesPage | null> {
+		if (!Number.isSafeInteger(input.limit) || input.limit < 1) {
+			throw new Error("Messages page limit must be a positive integer");
+		}
+		const [conversation] = await this.db
+			.select({ conversationId: conversations.conversationId })
+			.from(conversations)
+			.where(
+				and(
+					eq(conversations.userId, input.userId),
+					eq(conversations.conversationId, input.conversationId),
+				),
+			);
+		if (!conversation) return null;
+
+		// Newest-first keyset page on the (user, conversation, sequence) index,
+		// one row past the limit to learn whether an older page exists; served
+		// ascending. `sequence` makes the cursor stable: later appends only ever
+		// take higher values.
+		const rows = await this.db
+			.select()
+			.from(conversationMessages)
+			.where(
+				and(
+					eq(conversationMessages.userId, input.userId),
+					eq(conversationMessages.conversationId, input.conversationId),
+					input.before === null
+						? undefined
+						: lt(conversationMessages.sequence, input.before),
+				),
+			)
+			.orderBy(desc(conversationMessages.sequence))
+			.limit(input.limit + 1);
+
+		const hasOlder = rows.length > input.limit;
+		const page = rows.slice(0, input.limit).reverse();
+		return {
+			messages: page.map(toUiMessage),
+			nextCursor: hasOlder ? (page[0]?.sequence ?? null) : null,
+		};
+	}
+}
+
+function toUiMessage(
+	row: typeof conversationMessages.$inferSelect,
+): ConversationUiMessage {
+	const message = {
+		id: row.messageId,
+		// The role check constrains rows to these two values at the database.
+		role: row.role as "user" | "assistant",
+		parts: row.parts,
+	};
+	if (row.role !== "user") return message;
+	return {
+		...message,
+		metadata: {
+			// The turn-status check makes a user row's status a non-null
+			// TurnStatus by database invariant.
+			status: row.status as TurnStatus,
+			startedAt: row.startedAt,
+			finishedAt: row.finishedAt,
+		},
+	};
+}

--- a/docs/agents/chat-api.md
+++ b/docs/agents/chat-api.md
@@ -154,7 +154,11 @@ Return `201 { conversationId, title, scope, createdAt, lastActivityAt, archivedA
 
 All operations are owner-scoped. Missing and foreign Conversations both return `404`. These management routes bypass the new-work exposure gate.
 
-The four lifecycle routes above (create, list, rename/Archive, permanent delete) also serve at `/v2/conversations` with identical semantics: one shared router (`conversation-lifecycle.route.ts`) is mounted under both prefixes. The Run, history, and artifact routes stay v1-only; the v2 data plane and the outbox-based deletion upgrade are separate tickets under spec #654.
+The four lifecycle routes above (create, list, rename/Archive, permanent delete) also serve at `/v2/conversations` with identical semantics: one shared router (`conversation-lifecycle.route.ts`) is mounted under both prefixes. The Run and artifact routes stay v1-only; the rest of the v2 data plane and the outbox-based deletion upgrade are separate tickets under spec #654.
+
+### Read v2 history
+
+`GET /v2/conversations/:conversationId/messages` returns the durable UIMessage history over `conversation_messages` in ascending `sequence`, paged backwards from the newest page as `{ messages, nextCursor }` (`?limit` defaults to 50 and clamps to 100; `?before=<sequence>` is the cursor `nextCursor` hands back). A user message carries its Turn `status`/`startedAt`/`finishedAt` as UIMessage `metadata`; a Turn's single assistant message returns its stored parts verbatim (step and tool parts included) — an interrupted or error Turn shows exactly its completed Steps by the In-VM writer's commit-before-publish invariant. chat-api only reads here. Owner-scoped: missing and foreign Conversations return `404`; an empty history — every pre-v2 Conversation included — is an empty page; archived Conversations stay readable; the read bypasses the new-work exposure gate (v1 precedent).
 
 ### Admit and stream a Run
 


### PR DESCRIPTION
Closes #663 (spec #654, amended 2026-08-31: one assistant UIMessage per Turn).

## What

`GET /v2/conversations/:conversationId/messages` — the durable /v2 Conversation history, read straight off `conversation_messages`:

- **Ascending `sequence`, backwards cursor paging**: the default request returns the newest page; `nextCursor` is the page's oldest `sequence`, handed back as `?before=<sequence>` for the next older page (`null` at the beginning). Sequence-based, so later appends never shift an older page mid-walk.
- **`?limit`** defaults to 50 (the spec's table) and **clamps** to 100; non-numeric/zero/fractional input is a 400.
- **User rows are Turn records**: each carries `status` / `startedAt` / `finishedAt` as UIMessage `metadata` (the `status`/`started_at`/`finished_at` columns, surfaced in the API's camelCase like every other route). Assistant rows return their stored parts verbatim — step and tool parts included — and no `metadata` key.
- **Interrupted/error Turns show exactly their completed Steps**: guaranteed by the In-VM writer's per-Step commit-before-publish invariant (#662); the read is a pure pass-through and never sees provisional text.
- **Owner-scoped 404** on missing and foreign Conversations (identical responses); **empty page, not 404**, for an empty history — which is every pre-v2 Conversation; **archived Conversations stay readable**; reads **bypass the new-work exposure gate** (v1 precedent).
- chat-api only reads this projection — the In-VM server (#662) is the sole writer — so the route is fully exercised with seeded rows.

## Where

- `apps/chat-api/src/features/conversation-messages/` — store contract, Postgres impl, route.
- Wired into `AppDeps` and mounted at `/v2/conversations`; v1 history stays untouched (it dies with the Run path at teardown).
- `docs/agents/chat-api.md` gains the v2 history read contract.

## Acceptance criteria → tests

| AC | Test |
| --- | --- |
| ascending `sequence`, stable `?before`, `?limit` defaulted and clamped | `postgres-conversation-messages-store.test.ts` ("pages backwards…", with an append after the cursor was handed out), route test ("clamps an over-large limit…", default-50 assertion) |
| user-row metadata `status`/`started_at`/`finished_at`; assistant row's stored parts (step-start + tool parts) | store test ("serves Turns ascending…"), route serialization test |
| empty history (incl. pre-v2 Conversation) → empty page, not 404 | store test ("returns an empty page — not null…") |
| 404 on missing/foreign; archived readable | store tests ("returns null for a missing or foreign…", "reads an archived…"), route 404 test |

## Verification

- `bun test` in `apps/chat-api`: 194 pass, 0 fail (10 new).
- `bun run check` (Biome): clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Nce1uVZvDiEMDyyChxNb5
