### PR TITLE
fix(infra): set runTimeoutInSeconds=60 on the MicroVM run hook (#666)

### DIFF
--- a/apps/in-vm-server/src/index.ts
+++ b/apps/in-vm-server/src/index.ts
@@ -94,6 +94,10 @@ const app = createApp({
 			logger.warn({ microvmId }, "run hook repeated; already configured");
 			return;
 		}
+		// Log before configuring: the platform's runTimeoutInSeconds terminates
+		// the VM if configure outlasts it, and this line is then the only
+		// in-VM evidence the hook arrived (learned live on #666).
+		logger.info({ microvmId }, "run hook received; configuring");
 		// A configure failure throws into Hono's 500 — the non-200 run hook
 		// keeps the platform from ever routing traffic to this VM.
 		await configure({

--- a/scripts/deploy/register_microvm_image.sh
+++ b/scripts/deploy/register_microvm_image.sh
@@ -50,7 +50,11 @@ build_args=(
 	--base-image-arn "${base_image_arn}"
 	--build-role-arn "${build_role_arn}"
 	--cpu-configurations architecture=ARM_64
-	--hooks 'port=8080,microvmHooks={run=ENABLED,resume=ENABLED,suspend=ENABLED,terminate=ENABLED},microvmImageHooks={ready=ENABLED,readyTimeoutInSeconds=300}'
+	# runTimeoutInSeconds=60 (the platform max): the default is a few seconds,
+	# and the /run hook deliberately configures before answering 200 — CLI
+	# exec-verify + boot sweep through a cold connector ENI. Proven necessary
+	# live: an unset timeout terminated the VM ~3s after launch (#666).
+	--hooks 'port=8080,microvmHooks={run=ENABLED,runTimeoutInSeconds=60,resume=ENABLED,suspend=ENABLED,terminate=ENABLED},microvmImageHooks={ready=ENABLED,readyTimeoutInSeconds=300}'
 	--description "mymemo-agent ${sha} (In-VM server)"
 )
 


### PR DESCRIPTION
Live-launch finding from the #666 verification runbook: with no `runTimeoutInSeconds` in the registration's `--hooks`, the platform default (a few seconds) terminated the first real VM ~3s after launch — `stateReason: Run lifecycle hook timed out` — while `/run` was still configuring (CLI exec-verify + boot sweep through a cold connector ENI). The parameter's documented range is 1–60s; this pins the maximum.

Also adds one log line at run-hook entry: the VM's log stream showed only the server banner, so there was no in-VM evidence the hook had even arrived — this line is that evidence next time.

Merging re-triggers the image workflow (the register script is in its push paths), which re-registers the image with the new hook config; the #666 runbook then relaunches the VM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBtkhfv1sRxGbXF9G8xz37