### PR TITLE
fix(deploy): tolerate transient 502s in the MicroVM image poll loop

### DIFF
--- a/scripts/deploy/register_microvm_image.sh
+++ b/scripts/deploy/register_microvm_image.sh
@@ -77,14 +77,16 @@ fi
 
 echo "Polling ${image_arn} until the build lands (logs: ${build_log_group})"
 for _ in $(seq 1 60); do
+	# The platform's transient 502s hit reads too (bit the poll live on #666
+	# after a successful update) — treat a failed poll as "still building".
 	state="$(aws lambda-microvms get-microvm-image --region "${AWS_REGION}" \
-		--image-identifier "${image_arn}" --query state --output text)"
+		--image-identifier "${image_arn}" --query state --output text 2>/dev/null || echo TRANSIENT)"
 	case "${state}" in
 	CREATED | UPDATED)
 		echo "MicroVM image ${image_name} is ${state}."
 		exit 0
 		;;
-	CREATING | UPDATING)
+	CREATING | UPDATING | TRANSIENT)
 		sleep 20
 		;;
 	*)


### PR DESCRIPTION
Observed live on #666's re-registration: `update-microvm-image` succeeded (version 3.0 accepted), then a transient 502 on `get-microvm-image` inside the poll loop killed the workflow under `set -e` while the build proceeded server-side. The register call already had a retry (the #646-documented platform quirk); the poll didn't. A failed poll now counts as "still building".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBtkhfv1sRxGbXF9G8xz37