### PR TITLE
feat(chat-api): v2 message POST + own-Turn UIMessage SSE (#667)

### DIFF
--- a/apps/chat-api/package.json
+++ b/apps/chat-api/package.json
@@ -20,6 +20,7 @@
 		"@mymemo/document-tools": "workspace:*",
 		"@mymemo/live-text": "workspace:*",
 		"@statsig/statsig-node-core": "^0.19.8",
+		"ai": "7.0.83",
 		"drizzle-orm": "^0.45.2",
 		"hono": "^4.10.1",
 		"hono-pino": "^0.10.3",

--- a/apps/chat-api/src/config/env.test.ts
+++ b/apps/chat-api/src/config/env.test.ts
@@ -83,9 +83,10 @@ describe("loadApiConfigFromEnv — ADR-0034 gateway credential rule", () => {
 		expect(loadApiConfigFromEnv(baseEnv()).inVmServerUrl).toBeUndefined();
 		const env = baseEnv();
 		env.IN_VM_SERVER_URL = "http://127.0.0.1:8080";
-		expect(loadApiConfigFromEnv(env).inVmServerUrl).toBe(
-			"http://127.0.0.1:8080",
-		);
+		env.IN_VM_SERVER_AUTH_TOKEN = "per-vm-token";
+		const config = loadApiConfigFromEnv(env);
+		expect(config.inVmServerUrl).toBe("http://127.0.0.1:8080");
+		expect(config.inVmServerAuthToken).toBe("per-vm-token");
 	});
 
 	it("still never reads the remaining worker-only secrets (KB, E2B)", () => {

--- a/apps/chat-api/src/config/env.test.ts
+++ b/apps/chat-api/src/config/env.test.ts
@@ -79,10 +79,10 @@ describe("loadApiConfigFromEnv — ADR-0034 gateway credential rule", () => {
 		expect(config.gatewayTokenSecret).toBe("gateway-signing-secret");
 	});
 
-	it("reads the dev-mode In-VM server URL for the v2 message POST, trailing slash dropped", () => {
+	it("reads the dev-mode In-VM server URL for the v2 message POST", () => {
 		expect(loadApiConfigFromEnv(baseEnv()).inVmServerUrl).toBeUndefined();
 		const env = baseEnv();
-		env.IN_VM_SERVER_URL = "http://127.0.0.1:8080/";
+		env.IN_VM_SERVER_URL = "http://127.0.0.1:8080";
 		expect(loadApiConfigFromEnv(env).inVmServerUrl).toBe(
 			"http://127.0.0.1:8080",
 		);

--- a/apps/chat-api/src/config/env.test.ts
+++ b/apps/chat-api/src/config/env.test.ts
@@ -79,6 +79,15 @@ describe("loadApiConfigFromEnv — ADR-0034 gateway credential rule", () => {
 		expect(config.gatewayTokenSecret).toBe("gateway-signing-secret");
 	});
 
+	it("reads the dev-mode In-VM server URL for the v2 message POST, trailing slash dropped", () => {
+		expect(loadApiConfigFromEnv(baseEnv()).inVmServerUrl).toBeUndefined();
+		const env = baseEnv();
+		env.IN_VM_SERVER_URL = "http://127.0.0.1:8080/";
+		expect(loadApiConfigFromEnv(env).inVmServerUrl).toBe(
+			"http://127.0.0.1:8080",
+		);
+	});
+
 	it("still never reads the remaining worker-only secrets (KB, E2B)", () => {
 		const env = baseEnv();
 		env.KB_DATABASE_URL = "postgresql://kb:kb@localhost:5432/mymemo_kb";

--- a/apps/chat-api/src/config/env.ts
+++ b/apps/chat-api/src/config/env.ts
@@ -120,7 +120,6 @@ export function loadApiConfigFromEnv(env: Env): ApiConfig {
 		openrouterBaseUrl:
 			env.OPENROUTER_BASE_URL?.trim() || "https://openrouter.ai/api",
 		gatewayTokenSecret: env.GATEWAY_TOKEN_SECRET?.trim() || undefined,
-		inVmServerUrl:
-			env.IN_VM_SERVER_URL?.trim().replace(/\/+$/, "") || undefined,
+		inVmServerUrl: env.IN_VM_SERVER_URL?.trim() || undefined,
 	};
 }

--- a/apps/chat-api/src/config/env.ts
+++ b/apps/chat-api/src/config/env.ts
@@ -69,6 +69,13 @@ export interface ApiConfig {
 	 * never leaves this process. Optional alongside `openrouterApiKey`.
 	 */
 	gatewayTokenSecret?: string;
+	/**
+	 * Dev-mode Ensure-VM stub (ticket #667): the base URL of one locally
+	 * running In-VM server that `POST /v2/conversations/:id/messages` nudges.
+	 * The orchestration ticket replaces it with per-Conversation MicroVM
+	 * launch. While unset the v2 message POST answers 503.
+	 */
+	inVmServerUrl?: string;
 }
 
 /**
@@ -113,5 +120,7 @@ export function loadApiConfigFromEnv(env: Env): ApiConfig {
 		openrouterBaseUrl:
 			env.OPENROUTER_BASE_URL?.trim() || "https://openrouter.ai/api",
 		gatewayTokenSecret: env.GATEWAY_TOKEN_SECRET?.trim() || undefined,
+		inVmServerUrl:
+			env.IN_VM_SERVER_URL?.trim().replace(/\/+$/, "") || undefined,
 	};
 }

--- a/apps/chat-api/src/config/env.ts
+++ b/apps/chat-api/src/config/env.ts
@@ -76,6 +76,12 @@ export interface ApiConfig {
 	 * launch. While unset the v2 message POST answers 503.
 	 */
 	inVmServerUrl?: string;
+	/**
+	 * With `inVmServerUrl` pointing at a real MicroVM endpoint: the platform's
+	 * per-VM auth token (`CreateMicrovmAuthToken`), sent as `X-aws-proxy-auth`
+	 * on the nudge. Unset for a plain local In-VM server.
+	 */
+	inVmServerAuthToken?: string;
 }
 
 /**
@@ -121,5 +127,6 @@ export function loadApiConfigFromEnv(env: Env): ApiConfig {
 			env.OPENROUTER_BASE_URL?.trim() || "https://openrouter.ai/api",
 		gatewayTokenSecret: env.GATEWAY_TOKEN_SECRET?.trim() || undefined,
 		inVmServerUrl: env.IN_VM_SERVER_URL?.trim() || undefined,
+		inVmServerAuthToken: env.IN_VM_SERVER_AUTH_TOKEN?.trim() || undefined,
 	};
 }

--- a/apps/chat-api/src/deps.ts
+++ b/apps/chat-api/src/deps.ts
@@ -24,10 +24,7 @@ import { PostgresArtifactMetadataStore } from "./features/artifacts/postgres-art
 import { createS3ArtifactDownloadSigner } from "./features/artifacts/s3-artifact-download-signer";
 import type { ConversationHistoryStore } from "./features/conversation-history/conversation-history-store";
 import { PostgresConversationHistoryStore } from "./features/conversation-history/postgres-conversation-history-store";
-import type {
-	ConversationMessagesStore,
-	TurnSubmissionStore,
-} from "./features/conversation-messages/conversation-messages-store";
+import type { ConversationMessagesStore } from "./features/conversation-messages/conversation-messages-store";
 import { PostgresConversationMessagesStore } from "./features/conversation-messages/postgres-conversation-messages-store";
 import type { ConversationStore } from "./features/conversation-store/conversation-store";
 import { PostgresConversationStore } from "./features/conversation-store/postgres-conversation-store";
@@ -64,7 +61,7 @@ export interface AppDeps {
 	/** Permanent AG-UI Conversation-history projection over Postgres Runs. */
 	conversationHistoryStore: ConversationHistoryStore;
 	/** /v2 UIMessage history over `conversation_messages` plus the `queued` Turn INSERT — chat-api's only write; the In-VM server owns every status transition. */
-	conversationMessagesStore: ConversationMessagesStore & TurnSubmissionStore;
+	conversationMessagesStore: ConversationMessagesStore;
 	/** Durable split-runtime run queue and event log. */
 	runStore: RunStore;
 	/** Producer-buffered per-Run relay used by initial and reconnect SSE. */
@@ -151,9 +148,12 @@ export function createDeps(
 		// orchestration ticket swaps in per-Conversation MicroVM launch here.
 		nudgeInVmServer: config.inVmServerUrl
 			? async () => {
-					const response = await fetch(`${config.inVmServerUrl}/nudge`, {
-						method: "POST",
-					});
+					const response = await fetch(
+						new URL("/nudge", config.inVmServerUrl),
+						{
+							method: "POST",
+						},
+					);
 					if (!response.ok) {
 						throw new Error(`nudge answered ${response.status}`);
 					}

--- a/apps/chat-api/src/deps.ts
+++ b/apps/chat-api/src/deps.ts
@@ -6,8 +6,10 @@ import {
 import {
 	createLiveStreamTelemetry,
 	createRedisLiveStreamRelay,
+	createRedisTurnLiveStreamRelay,
 	type LiveStreamRelay,
 	type LiveStreamTelemetry,
+	type TurnLiveStreamRelay,
 } from "@mymemo/live-text";
 import type { Env as PinoEnv } from "hono-pino";
 import type { ApiConfig } from "./config/env";
@@ -22,7 +24,10 @@ import { PostgresArtifactMetadataStore } from "./features/artifacts/postgres-art
 import { createS3ArtifactDownloadSigner } from "./features/artifacts/s3-artifact-download-signer";
 import type { ConversationHistoryStore } from "./features/conversation-history/conversation-history-store";
 import { PostgresConversationHistoryStore } from "./features/conversation-history/postgres-conversation-history-store";
-import type { ConversationMessagesStore } from "./features/conversation-messages/conversation-messages-store";
+import type {
+	ConversationMessagesStore,
+	TurnSubmissionStore,
+} from "./features/conversation-messages/conversation-messages-store";
 import { PostgresConversationMessagesStore } from "./features/conversation-messages/postgres-conversation-messages-store";
 import type { ConversationStore } from "./features/conversation-store/conversation-store";
 import { PostgresConversationStore } from "./features/conversation-store/postgres-conversation-store";
@@ -58,12 +63,23 @@ export interface AppDeps {
 	conversationStore: ConversationStore;
 	/** Permanent AG-UI Conversation-history projection over Postgres Runs. */
 	conversationHistoryStore: ConversationHistoryStore;
-	/** /v2 UIMessage history over `conversation_messages` (read-only here; the In-VM server is the sole writer). */
-	conversationMessagesStore: ConversationMessagesStore;
+	/** /v2 UIMessage history over `conversation_messages` plus the `queued` Turn INSERT — chat-api's only write; the In-VM server owns every status transition. */
+	conversationMessagesStore: ConversationMessagesStore & TurnSubmissionStore;
 	/** Durable split-runtime run queue and event log. */
 	runStore: RunStore;
 	/** Producer-buffered per-Run relay used by initial and reconnect SSE. */
 	liveStreamRelay: LiveStreamRelay;
+	/** The v2 per-Turn UIMessage lane (#658) the message POST subscribes to. */
+	turnLiveStreamRelay: TurnLiveStreamRelay;
+	/**
+	 * Ensure-VM + nudge for one Conversation (#667). Undefined = not configured,
+	 * so the v2 message POST answers 503. Today a dev-mode stub over
+	 * `IN_VM_SERVER_URL`; the orchestration ticket replaces it.
+	 */
+	nudgeInVmServer?: (ref: {
+		userId: string;
+		conversationId: string;
+	}) => Promise<void>;
 	/** Cardinality-safe, payload-free Live Stream relay observability. */
 	liveStreamTelemetry: LiveStreamTelemetry;
 	/** Close the lazy Redis relay clients during service shutdown. */
@@ -117,6 +133,11 @@ export function createDeps(
 		deployment: "current",
 		telemetry: liveStreamTelemetry,
 	});
+	const turnLiveStreamRelay = createRedisTurnLiveStreamRelay({
+		url: config.redisUrl,
+		deployment: "current",
+	});
+	const inVmServerUrl = config.inVmServerUrl;
 	return {
 		config,
 		createHarnessChatAgent,
@@ -129,8 +150,23 @@ export function createDeps(
 		conversationMessagesStore: new PostgresConversationMessagesStore(database),
 		runStore,
 		liveStreamRelay,
+		turnLiveStreamRelay,
+		// ponytail: one config-provided In-VM server, nudged by URL; the
+		// orchestration ticket swaps in per-Conversation MicroVM launch here.
+		nudgeInVmServer: inVmServerUrl
+			? async () => {
+					const response = await fetch(`${inVmServerUrl}/nudge`, {
+						method: "POST",
+					});
+					if (!response.ok) {
+						throw new Error(`nudge answered ${response.status}`);
+					}
+				}
+			: undefined,
 		liveStreamTelemetry,
-		closeLiveResources: () => liveStreamRelay.close(),
+		closeLiveResources: async () => {
+			await Promise.all([liveStreamRelay.close(), turnLiveStreamRelay.close()]);
+		},
 		exposureGate,
 		gatewayUpstreamFetch: fetch,
 	};

--- a/apps/chat-api/src/deps.ts
+++ b/apps/chat-api/src/deps.ts
@@ -152,6 +152,7 @@ export function createDeps(
 						new URL("/nudge", config.inVmServerUrl),
 						{
 							method: "POST",
+							signal: AbortSignal.timeout(5_000),
 						},
 					);
 					if (!response.ok) {

--- a/apps/chat-api/src/deps.ts
+++ b/apps/chat-api/src/deps.ts
@@ -76,10 +76,7 @@ export interface AppDeps {
 	 * so the v2 message POST answers 503. Today a dev-mode stub over
 	 * `IN_VM_SERVER_URL`; the orchestration ticket replaces it.
 	 */
-	nudgeInVmServer?: (ref: {
-		userId: string;
-		conversationId: string;
-	}) => Promise<void>;
+	nudgeInVmServer?: () => Promise<void>;
 	/** Cardinality-safe, payload-free Live Stream relay observability. */
 	liveStreamTelemetry: LiveStreamTelemetry;
 	/** Close the lazy Redis relay clients during service shutdown. */
@@ -137,7 +134,6 @@ export function createDeps(
 		url: config.redisUrl,
 		deployment: "current",
 	});
-	const inVmServerUrl = config.inVmServerUrl;
 	return {
 		config,
 		createHarnessChatAgent,
@@ -153,9 +149,9 @@ export function createDeps(
 		turnLiveStreamRelay,
 		// ponytail: one config-provided In-VM server, nudged by URL; the
 		// orchestration ticket swaps in per-Conversation MicroVM launch here.
-		nudgeInVmServer: inVmServerUrl
+		nudgeInVmServer: config.inVmServerUrl
 			? async () => {
-					const response = await fetch(`${inVmServerUrl}/nudge`, {
+					const response = await fetch(`${config.inVmServerUrl}/nudge`, {
 						method: "POST",
 					});
 					if (!response.ok) {

--- a/apps/chat-api/src/deps.ts
+++ b/apps/chat-api/src/deps.ts
@@ -152,6 +152,14 @@ export function createDeps(
 						new URL("/nudge", config.inVmServerUrl),
 						{
 							method: "POST",
+							// A real MicroVM endpoint authenticates with the platform's
+							// per-VM token and routes by port (the image listens on 8080).
+							headers: config.inVmServerAuthToken
+								? {
+										"x-aws-proxy-auth": config.inVmServerAuthToken,
+										"x-aws-proxy-port": "8080",
+									}
+								: {},
 							signal: AbortSignal.timeout(5_000),
 						},
 					);

--- a/apps/chat-api/src/features/conversation-messages/conversation-messages-store.ts
+++ b/apps/chat-api/src/features/conversation-messages/conversation-messages-store.ts
@@ -55,3 +55,34 @@ export interface ConversationMessagesStore {
 		input: ConversationMessagesPageInput,
 	): Promise<ConversationMessagesPage | null>;
 }
+
+export interface TurnRef {
+	userId: string;
+	conversationId: string;
+	messageId: string;
+}
+
+export type EnqueueTurnResult =
+	/** The row was inserted as a `queued` Turn. */
+	| { outcome: "queued" }
+	/** The client message id already names a Turn; nothing changed. */
+	| { outcome: "duplicate"; status: TurnStatus }
+	| { outcome: "not_found" }
+	| { outcome: "archived" };
+
+/**
+ * The /v2 submission contract (ticket #667): chat-api's only write to
+ * `conversation_messages` is the `queued` INSERT; the In-VM server owns every
+ * status transition.
+ */
+export interface TurnSubmissionStore {
+	/**
+	 * Admit a user message as a `queued` Turn under the Conversation row lock,
+	 * so an Archive cannot slip between the check and the insert (the row lock
+	 * is the one `PATCH` takes). Missing and foreign Conversations look
+	 * identical.
+	 */
+	enqueueTurn(input: TurnRef & { parts: unknown }): Promise<EnqueueTurnResult>;
+	/** The Turn's current status, or null when no such Turn exists. */
+	getTurnStatus(ref: TurnRef): Promise<TurnStatus | null>;
+}

--- a/apps/chat-api/src/features/conversation-messages/conversation-messages-store.ts
+++ b/apps/chat-api/src/features/conversation-messages/conversation-messages-store.ts
@@ -54,6 +54,17 @@ export interface ConversationMessagesStore {
 	getPage(
 		input: ConversationMessagesPageInput,
 	): Promise<ConversationMessagesPage | null>;
+	/**
+	 * The /v2 submission write (ticket #667) — chat-api's only write to
+	 * `conversation_messages`; the In-VM server owns every status transition.
+	 * Admits a user message as a `queued` Turn under the Conversation row lock,
+	 * so an Archive cannot slip between the check and the insert (the row lock
+	 * is the one `PATCH` takes). Missing and foreign Conversations look
+	 * identical.
+	 */
+	enqueueTurn(input: TurnRef & { parts: unknown }): Promise<EnqueueTurnResult>;
+	/** The Turn's current status, or null when no such Turn exists. */
+	getTurnStatus(ref: TurnRef): Promise<TurnStatus | null>;
 }
 
 export interface TurnRef {
@@ -69,20 +80,3 @@ export type EnqueueTurnResult =
 	| { outcome: "duplicate"; status: TurnStatus }
 	| { outcome: "not_found" }
 	| { outcome: "archived" };
-
-/**
- * The /v2 submission contract (ticket #667): chat-api's only write to
- * `conversation_messages` is the `queued` INSERT; the In-VM server owns every
- * status transition.
- */
-export interface TurnSubmissionStore {
-	/**
-	 * Admit a user message as a `queued` Turn under the Conversation row lock,
-	 * so an Archive cannot slip between the check and the insert (the row lock
-	 * is the one `PATCH` takes). Missing and foreign Conversations look
-	 * identical.
-	 */
-	enqueueTurn(input: TurnRef & { parts: unknown }): Promise<EnqueueTurnResult>;
-	/** The Turn's current status, or null when no such Turn exists. */
-	getTurnStatus(ref: TurnRef): Promise<TurnStatus | null>;
-}

--- a/apps/chat-api/src/features/conversation-messages/conversation-messages-store.ts
+++ b/apps/chat-api/src/features/conversation-messages/conversation-messages-store.ts
@@ -78,5 +78,7 @@ export type EnqueueTurnResult =
 	| { outcome: "queued" }
 	/** The client message id already names a Turn; nothing changed. */
 	| { outcome: "duplicate"; status: TurnStatus }
+	/** The client message id already names an assistant message (ids are visible in history). */
+	| { outcome: "not_a_turn" }
 	| { outcome: "not_found" }
 	| { outcome: "archived" };

--- a/apps/chat-api/src/features/conversation-messages/conversation-messages.route.test.ts
+++ b/apps/chat-api/src/features/conversation-messages/conversation-messages.route.test.ts
@@ -186,6 +186,9 @@ class FakeTurnStore implements ConversationMessagesStore {
 			return { outcome: "not_found" };
 		}
 		if (this.archived) return { outcome: "archived" };
+		if (input.messageId.startsWith("assistant-")) {
+			return { outcome: "not_a_turn" };
+		}
 		const existing = this.rows.get(input.messageId);
 		if (existing) return { outcome: "duplicate", status: existing.status };
 		this.rows.set(input.messageId, { status: "queued", parts: input.parts });
@@ -468,6 +471,17 @@ describe("POST /v2/conversations/:conversationId/messages", () => {
 		]);
 		expect(store.rows.size).toBe(2);
 		expect(vm.nudges).toBe(1);
+
+		// An id copied from an assistant message in history is a 409, not a 500.
+		const taken = await app.request(
+			MESSAGES_URL,
+			submitBody(userMessage("assistant-turn-done")),
+		);
+		expect(taken.status).toBe(409);
+		expect(await taken.json()).toEqual({
+			error: "Message id names an assistant message",
+		});
+		expect(vm.nudges).toBe(1);
 	});
 
 	it("client disconnect mid-stream leaves the Turn running to its Outcome", async () => {
@@ -511,7 +525,7 @@ describe("POST /v2/conversations/:conversationId/messages", () => {
 		if (row) row.status = "interrupted";
 
 		const { data, pings } = parseSse(await response.text());
-		expect(pings).toBeGreaterThanOrEqual(1);
+		expect(pings).toBeGreaterThanOrEqual(2);
 		expect(data).toEqual(["[DONE]"]);
 	});
 

--- a/apps/chat-api/src/features/conversation-messages/conversation-messages.route.test.ts
+++ b/apps/chat-api/src/features/conversation-messages/conversation-messages.route.test.ts
@@ -1,9 +1,24 @@
 import { describe, expect, it } from "bun:test";
+import { setTimeout as delay } from "node:timers/promises";
+import type { TurnStatus } from "@mymemo/agent-db/turn-store";
+import {
+	createInMemoryTurnLiveStreamRelay,
+	type TurnLiveStreamRelay,
+} from "@mymemo/live-text";
+import {
+	DefaultChatTransport,
+	readUIMessageStream,
+	type UIMessage,
+	type UIMessageChunk,
+} from "ai";
 import type { ApiConfig } from "@/config/env";
 import type { AppDeps } from "@/deps";
 import type {
 	ConversationMessagesPageInput,
 	ConversationMessagesStore,
+	EnqueueTurnResult,
+	TurnRef,
+	TurnSubmissionStore,
 } from "./conversation-messages-store";
 
 const { createApp } = await import("@/app");
@@ -145,5 +160,449 @@ describe("GET /v2/conversations/:conversationId/messages", () => {
 
 		expect(response.status).toBe(404);
 		expect(await response.json()).toEqual({ error: "Conversation not found" });
+	});
+});
+
+// ---------------------------------------------------------------------------
+// POST — submit a UIMessage and stream its own Turn (#667)
+// ---------------------------------------------------------------------------
+
+const CONVERSATION_ID = "conversation-1";
+const MESSAGES_URL = `/v2/conversations/${CONVERSATION_ID}/messages`;
+
+/** The queue as chat-api sees it: rows keyed by message id, insertion-ordered. */
+class FakeTurnStore implements ConversationMessagesStore, TurnSubmissionStore {
+	readonly rows = new Map<string, { status: TurnStatus; parts: unknown }>();
+	archived = false;
+	exists = true;
+
+	async getPage(): Promise<never> {
+		throw new Error("not under test");
+	}
+
+	async enqueueTurn(
+		input: TurnRef & { parts: unknown },
+	): Promise<EnqueueTurnResult> {
+		if (!this.exists || input.conversationId !== CONVERSATION_ID) {
+			return { outcome: "not_found" };
+		}
+		if (this.archived) return { outcome: "archived" };
+		const existing = this.rows.get(input.messageId);
+		if (existing) return { outcome: "duplicate", status: existing.status };
+		this.rows.set(input.messageId, { status: "queued", parts: input.parts });
+		return { outcome: "queued" };
+	}
+
+	async getTurnStatus(ref: TurnRef): Promise<TurnStatus | null> {
+		return this.rows.get(ref.messageId)?.status ?? null;
+	}
+
+	/** The In-VM server's claim: lowest queued row while nothing is processing. */
+	claimNext(): string | null {
+		for (const row of this.rows.values()) {
+			if (row.status === "processing") return null;
+		}
+		for (const [id, row] of this.rows) {
+			if (row.status === "queued") {
+				row.status = "processing";
+				return id;
+			}
+		}
+		return null;
+	}
+}
+
+function scriptedChunks(turnId: string): UIMessageChunk[] {
+	return [
+		{ type: "start", messageId: `assistant-${turnId}` },
+		{ type: "start-step" },
+		{ type: "text-start", id: "t1" },
+		{ type: "text-delta", id: "t1", delta: `hello from ${turnId}` },
+		{ type: "text-end", id: "t1" },
+		{ type: "finish-step" },
+	];
+}
+
+/**
+ * A stand-in for the In-VM server's drain loop: a nudge drains queued Turns
+ * in order, publishing each Turn's chunks on its own channel with the real
+ * commit-before-publish ordering (status flips before the terminal chunk).
+ */
+function fakeInVmServer(
+	relay: TurnLiveStreamRelay,
+	store: FakeTurnStore,
+	options: { chunkDelayMs?: number; sync?: boolean } = {},
+) {
+	const served: string[] = [];
+	let nudges = 0;
+	let draining: Promise<void> | null = null;
+	const drain = async () => {
+		let turnId = store.claimNext();
+		while (turnId) {
+			const publisher = relay.openPublisher(turnId);
+			for (const chunk of scriptedChunks(turnId)) {
+				await publisher.publish(chunk);
+				if (options.chunkDelayMs) await delay(options.chunkDelayMs);
+			}
+			const row = store.rows.get(turnId);
+			if (row) row.status = "done";
+			await publisher.publish({ type: "finish" });
+			await publisher.close();
+			served.push(turnId);
+			turnId = store.claimNext();
+		}
+	};
+	return {
+		served,
+		get nudges() {
+			return nudges;
+		},
+		async nudge() {
+			nudges += 1;
+			if (options.sync) {
+				await drain();
+				return;
+			}
+			if (!draining) {
+				draining = drain().finally(() => {
+					draining = null;
+				});
+			}
+		},
+		async idle() {
+			while (draining) await draining;
+		},
+	};
+}
+
+function submitApp(
+	overrides: Partial<AppDeps> & { store?: FakeTurnStore } = {},
+) {
+	const store = overrides.store ?? new FakeTurnStore();
+	const relay = createInMemoryTurnLiveStreamRelay();
+	const vm = fakeInVmServer(relay, store);
+	const deps = {
+		conversationMessagesStore: store,
+		turnLiveStreamRelay: relay,
+		nudgeInVmServer: () => vm.nudge(),
+		exposureGate: { isAgentEnabled: async () => true },
+		...overrides,
+	} as unknown as AppDeps;
+	const app = createApp({ logLevel: "silent" } as ApiConfig, deps);
+	return { app, store, relay, vm };
+}
+
+function userMessage(id: string, text = `message ${id}`): UIMessage {
+	return { id, role: "user", parts: [{ type: "text", text }] };
+}
+
+function submitBody(message: UIMessage, id = CONVERSATION_ID) {
+	return {
+		method: "POST",
+		headers: { ...identityHeaders, "content-type": "application/json" },
+		body: JSON.stringify({
+			id,
+			trigger: "submit-message",
+			messages: [message],
+		}),
+	};
+}
+
+/** Every SSE `data:` payload in order, `[DONE]` included, plus the pings. */
+function parseSse(text: string): { data: string[]; pings: number } {
+	const frames = text.split("\n\n").filter((frame) => frame.length > 0);
+	return {
+		data: frames
+			.filter((frame) => frame.startsWith("data: "))
+			.map((frame) => frame.slice("data: ".length)),
+		pings: frames.filter((frame) => frame === ": ping").length,
+	};
+}
+
+function chunksOf(data: string[]): unknown[] {
+	return data.filter((d) => d !== "[DONE]").map((d) => JSON.parse(d));
+}
+
+describe("POST /v2/conversations/:conversationId/messages", () => {
+	it("persists the message queued, streams its Turn as the stock UI Message Stream, and ends with [DONE]", async () => {
+		const { app, store, vm } = submitApp();
+
+		const response = await app.request(
+			MESSAGES_URL,
+			submitBody(userMessage("turn-1", "hi")),
+		);
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("content-type")).toContain("text/event-stream");
+		expect(response.headers.get("x-vercel-ai-ui-message-stream")).toBe("v1");
+		const { data } = parseSse(await response.text());
+		expect(chunksOf(data)).toEqual([
+			...scriptedChunks("turn-1"),
+			{ type: "finish" },
+		]);
+		expect(data.at(-1)).toBe("[DONE]");
+		expect(store.rows.get("turn-1")).toEqual({
+			status: "done",
+			parts: [{ type: "text", text: "hi" }],
+		});
+		expect(vm.nudges).toBe(1);
+	});
+
+	it("is consumable by the stock DefaultChatTransport as one assistant message", async () => {
+		const { app } = submitApp();
+		const transport = new DefaultChatTransport({
+			api: MESSAGES_URL,
+			headers: identityHeaders,
+			fetch: (input, init) => app.request(input, init),
+		});
+
+		const stream = await transport.sendMessages({
+			chatId: CONVERSATION_ID,
+			messages: [userMessage("turn-1")],
+			trigger: "submit-message",
+			messageId: undefined,
+			abortSignal: undefined,
+		});
+		let last: UIMessage | undefined;
+		for await (const message of readUIMessageStream({ stream })) {
+			last = message;
+		}
+
+		expect(last).toEqual({
+			id: "assistant-turn-1",
+			role: "assistant",
+			parts: [
+				{ type: "step-start" },
+				{ type: "text", text: "hello from turn-1", state: "done" },
+			],
+		});
+	});
+
+	it("subscribes before nudging, so chunks published during the nudge itself are not lost", async () => {
+		const store = new FakeTurnStore();
+		const relay = createInMemoryTurnLiveStreamRelay();
+		const vm = fakeInVmServer(relay, store, { sync: true });
+		const { app } = submitApp({
+			store,
+			turnLiveStreamRelay: relay,
+			nudgeInVmServer: () => vm.nudge(),
+		});
+
+		const response = await app.request(
+			MESSAGES_URL,
+			submitBody(userMessage("turn-1")),
+		);
+
+		expect(response.status).toBe(200);
+		const { data } = parseSse(await response.text());
+		expect(chunksOf(data)).toEqual([
+			...scriptedChunks("turn-1"),
+			{ type: "finish" },
+		]);
+	});
+
+	it("two rapid POSTs: no 409; the second holds with silent keepalives, then streams only its own Turn", async () => {
+		const store = new FakeTurnStore();
+		const relay = createInMemoryTurnLiveStreamRelay();
+		// The first Turn outlasts one keepalive interval.
+		const vm = fakeInVmServer(relay, store, { chunkDelayMs: 900 });
+		const { app } = submitApp({
+			store,
+			turnLiveStreamRelay: relay,
+			nudgeInVmServer: () => vm.nudge(),
+		});
+
+		const first = await app.request(
+			MESSAGES_URL,
+			submitBody(userMessage("turn-1")),
+		);
+		const second = await app.request(
+			MESSAGES_URL,
+			submitBody(userMessage("turn-2")),
+		);
+		expect(first.status).toBe(200);
+		expect(second.status).toBe(200);
+
+		const [firstSse, secondSse] = await Promise.all([
+			first.text().then(parseSse),
+			second.text().then(parseSse),
+		]);
+		expect(chunksOf(firstSse.data)).toEqual([
+			...scriptedChunks("turn-1"),
+			{ type: "finish" },
+		]);
+		expect(chunksOf(secondSse.data)).toEqual([
+			...scriptedChunks("turn-2"),
+			{ type: "finish" },
+		]);
+		expect(secondSse.pings).toBeGreaterThanOrEqual(1);
+		expect(vm.served).toEqual(["turn-1", "turn-2"]);
+	});
+
+	it("duplicate client message id: no second Turn; a terminal Turn answers 410, an in-flight one attaches", async () => {
+		const store = new FakeTurnStore();
+		store.rows.set("turn-done", { status: "done", parts: [] });
+		store.rows.set("turn-live", { status: "processing", parts: [] });
+		const { app, relay, vm } = submitApp({ store });
+
+		const ended = await app.request(
+			MESSAGES_URL,
+			submitBody(userMessage("turn-done")),
+		);
+		expect(ended.status).toBe(410);
+		expect(await ended.json()).toEqual({
+			error: "Turn already ended",
+			recovery: "history",
+		});
+		expect(vm.nudges).toBe(0);
+
+		const attached = await app.request(
+			MESSAGES_URL,
+			submitBody(userMessage("turn-live")),
+		);
+		expect(attached.status).toBe(200);
+		// The In-VM server is mid-Turn; only what it publishes from now on
+		// arrives (no backlog), and the nudge was a harmless no-op.
+		const publisher = relay.openPublisher("turn-live");
+		await publisher.publish({ type: "text-delta", id: "t1", delta: "late" });
+		const row = store.rows.get("turn-live");
+		if (row) row.status = "done";
+		await publisher.publish({ type: "finish" });
+		await publisher.close();
+		const { data } = parseSse(await attached.text());
+		expect(chunksOf(data)).toEqual([
+			{ type: "text-delta", id: "t1", delta: "late" },
+			{ type: "finish" },
+		]);
+		expect(store.rows.size).toBe(2);
+		expect(vm.nudges).toBe(1);
+	});
+
+	it("client disconnect mid-stream leaves the Turn running to its Outcome", async () => {
+		const store = new FakeTurnStore();
+		const relay = createInMemoryTurnLiveStreamRelay();
+		const vm = fakeInVmServer(relay, store, { chunkDelayMs: 20 });
+		const { app } = submitApp({
+			store,
+			turnLiveStreamRelay: relay,
+			nudgeInVmServer: () => vm.nudge(),
+		});
+		const client = new AbortController();
+
+		const response = await app.request(MESSAGES_URL, {
+			...submitBody(userMessage("turn-1")),
+			signal: client.signal,
+		});
+		expect(response.status).toBe(200);
+		const reader = response.body?.getReader();
+		if (!reader) throw new Error("no body");
+		await reader.read();
+		client.abort();
+		await reader.cancel();
+
+		await vm.idle();
+		expect(store.rows.get("turn-1")?.status).toBe("done");
+		expect(vm.served).toEqual(["turn-1"]);
+	});
+
+	it("ends a stream whose publisher vanished once the Turn is durably terminal", async () => {
+		const store = new FakeTurnStore();
+		const { app } = submitApp({
+			store,
+			// A nudge that never publishes: the VM died after claiming.
+			nudgeInVmServer: async () => {
+				const row = store.rows.get("turn-1");
+				if (row) row.status = "processing";
+			},
+		});
+
+		const response = await app.request(
+			MESSAGES_URL,
+			submitBody(userMessage("turn-1")),
+		);
+		expect(response.status).toBe(200);
+		// The boot sweep of a restarted VM lands while the client waits.
+		const row = store.rows.get("turn-1");
+		if (row) row.status = "interrupted";
+
+		const { data, pings } = parseSse(await response.text());
+		expect(pings).toBeGreaterThanOrEqual(1);
+		expect(data).toEqual(["[DONE]"]);
+	});
+
+	it("archived Conversation refuses the message; missing or foreign is 404", async () => {
+		const archived = submitApp();
+		archived.store.archived = true;
+		const refused = await archived.app.request(
+			MESSAGES_URL,
+			submitBody(userMessage("turn-1")),
+		);
+		expect(refused.status).toBe(409);
+		expect(await refused.json()).toEqual({ error: "Conversation is archived" });
+		expect(archived.vm.nudges).toBe(0);
+
+		const missing = submitApp();
+		missing.store.exists = false;
+		const notFound = await missing.app.request(
+			MESSAGES_URL,
+			submitBody(userMessage("turn-1")),
+		);
+		expect(notFound.status).toBe(404);
+	});
+
+	it("enforces the exposure gate on submission before any write", async () => {
+		const { app, store, vm } = submitApp({
+			exposureGate: { isAgentEnabled: async () => false },
+		});
+
+		const response = await app.request(
+			MESSAGES_URL,
+			submitBody(userMessage("turn-1")),
+		);
+
+		expect(response.status).toBe(403);
+		expect(store.rows.size).toBe(0);
+		expect(vm.nudges).toBe(0);
+	});
+
+	it("answers 503 without writing while no In-VM server is configured", async () => {
+		const { app, store } = submitApp({ nudgeInVmServer: undefined });
+
+		const response = await app.request(
+			MESSAGES_URL,
+			submitBody(userMessage("turn-1")),
+		);
+
+		expect(response.status).toBe(503);
+		expect(store.rows.size).toBe(0);
+	});
+
+	it("rejects bodies that are not one submitted user text UIMessage for this Conversation", async () => {
+		const { app, store } = submitApp();
+		const bad = [
+			submitBody(userMessage("turn-1"), "conversation-2"),
+			{
+				...submitBody(userMessage("turn-1")),
+				body: JSON.stringify({
+					id: CONVERSATION_ID,
+					trigger: "regenerate-message",
+					messages: [userMessage("turn-1")],
+				}),
+			},
+			submitBody({ id: "turn-1", role: "assistant", parts: [] }),
+			submitBody({ id: "turn-1", role: "user", parts: [] }),
+			submitBody({
+				id: "turn-1",
+				role: "user",
+				parts: [{ type: "file", url: "x", mediaType: "text/plain" }],
+			}),
+			submitBody(userMessage("not path safe!")),
+			submitBody(userMessage("turn-1", "")),
+		];
+		for (const request of bad) {
+			const response = await app.request(MESSAGES_URL, request);
+			expect(response.status).toBe(400);
+		}
+		expect(store.rows.size).toBe(0);
 	});
 });

--- a/apps/chat-api/src/features/conversation-messages/conversation-messages.route.test.ts
+++ b/apps/chat-api/src/features/conversation-messages/conversation-messages.route.test.ts
@@ -237,7 +237,10 @@ function fakeInVmServer(
 	const drain = async () => {
 		let turnId = store.claimNext();
 		while (turnId) {
-			const publisher = relay.openPublisher(turnId);
+			const publisher = relay.openPublisher({
+				conversationId: CONVERSATION_ID,
+				messageId: turnId,
+			});
 			for (const chunk of scriptedChunks(turnId)) {
 				await publisher.publish(chunk);
 				if (options.chunkDelayMs) await delay(options.chunkDelayMs);
@@ -449,7 +452,10 @@ describe("POST /v2/conversations/:conversationId/messages", () => {
 		expect(attached.status).toBe(200);
 		// The In-VM server is mid-Turn; only what it publishes from now on
 		// arrives (no backlog), and the nudge was a harmless no-op.
-		const publisher = relay.openPublisher("turn-live");
+		const publisher = relay.openPublisher({
+			conversationId: CONVERSATION_ID,
+			messageId: "turn-live",
+		});
 		await publisher.publish({ type: "text-delta", id: "t1", delta: "late" });
 		const row = store.rows.get("turn-live");
 		if (row) row.status = "done";

--- a/apps/chat-api/src/features/conversation-messages/conversation-messages.route.test.ts
+++ b/apps/chat-api/src/features/conversation-messages/conversation-messages.route.test.ts
@@ -18,7 +18,6 @@ import type {
 	ConversationMessagesStore,
 	EnqueueTurnResult,
 	TurnRef,
-	TurnSubmissionStore,
 } from "./conversation-messages-store";
 
 const { createApp } = await import("@/app");
@@ -28,7 +27,7 @@ const identityHeaders = {
 	"x-partner-code": "partner-1",
 };
 
-function appWith(store: ConversationMessagesStore) {
+function appWith(store: Pick<ConversationMessagesStore, "getPage">) {
 	const deps = {
 		conversationMessagesStore: store,
 		exposureGate: {
@@ -171,7 +170,7 @@ const CONVERSATION_ID = "conversation-1";
 const MESSAGES_URL = `/v2/conversations/${CONVERSATION_ID}/messages`;
 
 /** The queue as chat-api sees it: rows keyed by message id, insertion-ordered. */
-class FakeTurnStore implements ConversationMessagesStore, TurnSubmissionStore {
+class FakeTurnStore implements ConversationMessagesStore {
 	readonly rows = new Map<string, { status: TurnStatus; parts: unknown }>();
 	archived = false;
 	exists = true;

--- a/apps/chat-api/src/features/conversation-messages/conversation-messages.route.test.ts
+++ b/apps/chat-api/src/features/conversation-messages/conversation-messages.route.test.ts
@@ -233,7 +233,6 @@ function fakeInVmServer(
 	options: { chunkDelayMs?: number; sync?: boolean } = {},
 ) {
 	const served: string[] = [];
-	let nudges = 0;
 	let draining: Promise<void> | null = null;
 	const drain = async () => {
 		let turnId = store.claimNext();
@@ -253,11 +252,9 @@ function fakeInVmServer(
 	};
 	return {
 		served,
-		get nudges() {
-			return nudges;
-		},
+		nudges: 0,
 		async nudge() {
-			nudges += 1;
+			this.nudges += 1;
 			if (options.sync) {
 				await drain();
 				return;
@@ -275,11 +272,14 @@ function fakeInVmServer(
 }
 
 function submitApp(
-	overrides: Partial<AppDeps> & { store?: FakeTurnStore } = {},
+	overrides: Partial<AppDeps> & {
+		store?: FakeTurnStore;
+		vm?: Parameters<typeof fakeInVmServer>[2];
+	} = {},
 ) {
 	const store = overrides.store ?? new FakeTurnStore();
 	const relay = createInMemoryTurnLiveStreamRelay();
-	const vm = fakeInVmServer(relay, store);
+	const vm = fakeInVmServer(relay, store, overrides.vm);
 	const deps = {
 		conversationMessagesStore: store,
 		turnLiveStreamRelay: relay,
@@ -379,14 +379,7 @@ describe("POST /v2/conversations/:conversationId/messages", () => {
 	});
 
 	it("subscribes before nudging, so chunks published during the nudge itself are not lost", async () => {
-		const store = new FakeTurnStore();
-		const relay = createInMemoryTurnLiveStreamRelay();
-		const vm = fakeInVmServer(relay, store, { sync: true });
-		const { app } = submitApp({
-			store,
-			turnLiveStreamRelay: relay,
-			nudgeInVmServer: () => vm.nudge(),
-		});
+		const { app } = submitApp({ vm: { sync: true } });
 
 		const response = await app.request(
 			MESSAGES_URL,
@@ -402,15 +395,8 @@ describe("POST /v2/conversations/:conversationId/messages", () => {
 	});
 
 	it("two rapid POSTs: no 409; the second holds with silent keepalives, then streams only its own Turn", async () => {
-		const store = new FakeTurnStore();
-		const relay = createInMemoryTurnLiveStreamRelay();
 		// The first Turn outlasts one keepalive interval.
-		const vm = fakeInVmServer(relay, store, { chunkDelayMs: 900 });
-		const { app } = submitApp({
-			store,
-			turnLiveStreamRelay: relay,
-			nudgeInVmServer: () => vm.nudge(),
-		});
+		const { app, vm } = submitApp({ vm: { chunkDelayMs: 900 } });
 
 		const first = await app.request(
 			MESSAGES_URL,
@@ -479,14 +465,7 @@ describe("POST /v2/conversations/:conversationId/messages", () => {
 	});
 
 	it("client disconnect mid-stream leaves the Turn running to its Outcome", async () => {
-		const store = new FakeTurnStore();
-		const relay = createInMemoryTurnLiveStreamRelay();
-		const vm = fakeInVmServer(relay, store, { chunkDelayMs: 20 });
-		const { app } = submitApp({
-			store,
-			turnLiveStreamRelay: relay,
-			nudgeInVmServer: () => vm.nudge(),
-		});
+		const { app, store, vm } = submitApp({ vm: { chunkDelayMs: 20 } });
 		const client = new AbortController();
 
 		const response = await app.request(MESSAGES_URL, {

--- a/apps/chat-api/src/features/conversation-messages/conversation-messages.route.test.ts
+++ b/apps/chat-api/src/features/conversation-messages/conversation-messages.route.test.ts
@@ -353,7 +353,8 @@ describe("POST /v2/conversations/:conversationId/messages", () => {
 		const transport = new DefaultChatTransport({
 			api: MESSAGES_URL,
 			headers: identityHeaders,
-			fetch: (input, init) => app.request(input, init),
+			// Bun's `fetch` type also carries `preconnect`; the transport only calls.
+			fetch: ((input, init) => app.request(input, init)) as typeof fetch,
 		});
 
 		const stream = await transport.sendMessages({

--- a/apps/chat-api/src/features/conversation-messages/conversation-messages.route.ts
+++ b/apps/chat-api/src/features/conversation-messages/conversation-messages.route.ts
@@ -1,12 +1,54 @@
 import { sValidator as zValidator } from "@hono/standard-validator";
+import type { TurnStatus } from "@mymemo/agent-db/turn-store";
+import { classifyLiveStreamFailure } from "@mymemo/live-text";
+import { UI_MESSAGE_STREAM_HEADERS } from "ai";
 import { Hono } from "hono";
+import { streamSSE } from "hono/streaming";
 import { z } from "zod";
 import type { AppEnv } from "@/deps";
-import { ConversationIdParam } from "@/features/conversations/conversations.schema";
+import {
+	ConversationIdParam,
+	conversationBodyLimit,
+	MAX_MESSAGE_LENGTH,
+} from "@/features/conversations/conversations.schema";
 import { requireInternalIdentity } from "@/features/conversations/internal-identity";
 
 const DEFAULT_MESSAGES_LIMIT = 50;
 const MAX_MESSAGES_LIMIT = 100;
+const LIVE_STREAM_KEEPALIVE_MS = 5_000;
+
+const UserTextPart = z
+	.object({
+		type: z.literal("text"),
+		text: z.string().min(1).max(MAX_MESSAGE_LENGTH),
+	})
+	.strict();
+
+// The submitted UIMessage. Its client id becomes the Turn id, which names the
+// Turn's Live Stream channel, so it is held to the same path-safe shape as a
+// Conversation id.
+const UserUiMessage = z
+	.object({
+		id: ConversationIdParam,
+		role: z.literal("user"),
+		parts: z.array(UserTextPart).min(1),
+	})
+	.strict();
+
+// The stock `useChat`/`DefaultChatTransport` request body. Only the final
+// message is submitted; the earlier ones are the client's own history and
+// validation input, never new durable history (the v1 stance).
+const SubmitMessageBody = z
+	.object({
+		id: ConversationIdParam,
+		trigger: z.literal("submit-message"),
+		messages: z.array(z.unknown()).min(1),
+	})
+	.strict();
+
+function isTerminalTurnStatus(status: TurnStatus): boolean {
+	return status === "done" || status === "error" || status === "interrupted";
+}
 
 // An over-large limit clamps to the cap instead of erroring (the #663 read
 // contract); everything non-numeric, negative, zero, or fractional is a 400.
@@ -65,6 +107,171 @@ app.get(
 		});
 		if (!page) return c.json({ error: "Conversation not found" }, 404);
 		return c.json(page);
+	},
+);
+
+/**
+ * `POST /:conversationId/messages` (mounted at `/v2/conversations`) — submit a
+ * UIMessage (spec #654, ticket #667). Persist it `queued`, subscribe to the
+ * Turn's Live Stream BEFORE nudging the In-VM server, then relay the stock AI
+ * SDK v7 UI Message Stream scoped to this Turn: silent keepalives while queued
+ * predecessors drain, then only this Turn's chunks, ending at its terminal
+ * chunk. There is no 409 for concurrency — a second POST is the next queued
+ * row — and chat-api never cancels anything: a client disconnect leaves the
+ * Turn running to its Outcome.
+ */
+app.post(
+	"/:conversationId/messages",
+	conversationBodyLimit,
+	zValidator(
+		"param",
+		z.object({ conversationId: ConversationIdParam }),
+		(result, c) => {
+			if (!result.success) {
+				return c.json({ error: "Invalid conversation id" }, 400);
+			}
+		},
+	),
+	zValidator("json", SubmitMessageBody, (result, c) => {
+		if (!result.success) {
+			return c.json(
+				{ error: "Invalid message submission", issues: result.error },
+				400,
+			);
+		}
+	}),
+	requireInternalIdentity,
+	async (c) => {
+		const { conversationId } = c.req.valid("param");
+		const body = c.req.valid("json");
+		if (body.id !== conversationId) {
+			return c.json({ error: "id must match the Conversation id" }, 400);
+		}
+		const message = UserUiMessage.safeParse(body.messages.at(-1));
+		if (!message.success) {
+			return c.json(
+				{ error: "Final message must be one user UIMessage with text parts" },
+				400,
+			);
+		}
+		const { deps, logger } = c.var;
+		const nudge = deps.nudgeInVmServer;
+		if (!nudge) return c.json({ error: "v2 messaging is not configured" }, 503);
+		if (!(await deps.exposureGate.isAgentEnabled(c.var.identity))) {
+			return c.json({ error: "Agent is not enabled" }, 403);
+		}
+
+		const ref = {
+			userId: c.var.identity.memberCode,
+			conversationId,
+			messageId: message.data.id,
+		};
+		const admitted = await deps.conversationMessagesStore.enqueueTurn({
+			...ref,
+			parts: message.data.parts,
+		});
+		if (admitted.outcome === "not_found") {
+			return c.json({ error: "Conversation not found" }, 404);
+		}
+		if (admitted.outcome === "archived") {
+			return c.json({ error: "Conversation is archived" }, 409);
+		}
+		if (
+			admitted.outcome === "duplicate" &&
+			isTerminalTurnStatus(admitted.status)
+		) {
+			// The Live Stream died with the Turn; durable history has it.
+			return c.json({ error: "Turn already ended", recovery: "history" }, 410);
+		}
+
+		// Subscribe before nudging: the lane keeps no backlog, so this ordering
+		// is what makes early chunks unlosable.
+		const readAbort = new AbortController();
+		const readSignal = AbortSignal.any([c.req.raw.signal, readAbort.signal]);
+		let chunks: AsyncIterable<string>;
+		try {
+			chunks = await deps.turnLiveStreamRelay.subscribe(
+				ref.messageId,
+				readSignal,
+			);
+		} catch (error) {
+			logger.error(
+				{ ...ref, reason: classifyLiveStreamFailure(error) },
+				"v2 Live Stream subscribe failed",
+			);
+			// The Turn is durably queued; let it run so history has it.
+			await nudge(ref).catch(() => {});
+			return c.json({ error: "Live stream temporarily unavailable" }, 503);
+		}
+		try {
+			await nudge(ref);
+		} catch (error) {
+			// The row is durable and the In-VM server's interval self-heal
+			// consults Postgres on its own; stream on rather than fail the Turn.
+			logger.warn(
+				{
+					...ref,
+					error: error instanceof Error ? error.message : String(error),
+				},
+				"nudge failed; the queued Turn waits for the In-VM server",
+			);
+		}
+
+		for (const [name, value] of Object.entries(UI_MESSAGE_STREAM_HEADERS)) {
+			c.header(name, value);
+		}
+		return streamSSE(c, async (stream) => {
+			let clientGone = false;
+			const disconnect = () => {
+				clientGone = true;
+				readAbort.abort();
+			};
+			stream.onAbort(disconnect);
+			const gone = () => clientGone || c.req.raw.signal.aborted;
+			// One tick does both: the SSE comment keepalive, and the terminal
+			// watch that ends a stream whose publisher died without a terminal
+			// chunk (the In-VM server restarts, sweeping the Turn `interrupted`).
+			// Ticks chain rather than overlap.
+			let timer: ReturnType<typeof setTimeout> | undefined;
+			const tick = () => {
+				timer = setTimeout(async () => {
+					try {
+						await stream.write(": ping\n\n");
+						const status =
+							await deps.conversationMessagesStore.getTurnStatus(ref);
+						if (status === null || isTerminalTurnStatus(status)) {
+							readAbort.abort();
+							return;
+						}
+					} catch {
+						disconnect();
+						return;
+					}
+					tick();
+				}, LIVE_STREAM_KEEPALIVE_MS);
+			};
+			tick();
+			try {
+				for await (const chunk of chunks) {
+					await stream.write(`data: ${chunk}\n\n`);
+				}
+				// A clean end: the terminal chunk arrived, or the terminal watch
+				// found the Turn ended. A disconnected client gets nothing more.
+				if (!gone()) await stream.write("data: [DONE]\n\n");
+			} catch (error) {
+				if (!gone()) {
+					// Close the incomplete stream without synthesizing a chunk; the
+					// client Recovers from durable history.
+					logger.error(
+						{ ...ref, reason: classifyLiveStreamFailure(error) },
+						"v2 Live Stream read failed",
+					);
+				}
+			} finally {
+				clearTimeout(timer);
+				readAbort.abort();
+			}
+		});
 	},
 );
 

--- a/apps/chat-api/src/features/conversation-messages/conversation-messages.route.ts
+++ b/apps/chat-api/src/features/conversation-messages/conversation-messages.route.ts
@@ -219,13 +219,8 @@ app.post(
 			c.header(name, value);
 		}
 		return streamSSE(c, async (stream) => {
-			let clientGone = false;
-			const disconnect = () => {
-				clientGone = true;
-				readAbort.abort();
-			};
-			stream.onAbort(disconnect);
-			const gone = () => clientGone || c.req.raw.signal.aborted;
+			stream.onAbort(() => readAbort.abort());
+			const gone = () => stream.aborted || c.req.raw.signal.aborted;
 			// One tick does both: the SSE comment keepalive, and the terminal
 			// watch that ends a stream whose publisher died without a terminal
 			// chunk (the In-VM server restarts, sweeping the Turn `interrupted`).
@@ -242,7 +237,7 @@ app.post(
 							return;
 						}
 					} catch {
-						disconnect();
+						stream.abort();
 						return;
 					}
 					tick();

--- a/apps/chat-api/src/features/conversation-messages/conversation-messages.route.ts
+++ b/apps/chat-api/src/features/conversation-messages/conversation-messages.route.ts
@@ -1,4 +1,5 @@
 import { sValidator as zValidator } from "@hono/standard-validator";
+import { TERMINAL_TURN_STATUSES } from "@mymemo/agent-db/schema";
 import type { TurnStatus } from "@mymemo/agent-db/turn-store";
 import { classifyLiveStreamFailure } from "@mymemo/live-text";
 import { UI_MESSAGE_STREAM_HEADERS } from "ai";
@@ -8,6 +9,7 @@ import { z } from "zod";
 import type { AppEnv } from "@/deps";
 import {
 	ConversationIdParam,
+	ConversationPath,
 	conversationBodyLimit,
 	MAX_MESSAGE_LENGTH,
 } from "@/features/conversations/conversations.schema";
@@ -47,7 +49,7 @@ const SubmitMessageBody = z
 	.strict();
 
 function isTerminalTurnStatus(status: TurnStatus): boolean {
-	return status === "done" || status === "error" || status === "interrupted";
+	return (TERMINAL_TURN_STATUSES as readonly TurnStatus[]).includes(status);
 }
 
 // An over-large limit clamps to the cap instead of erroring (the #663 read
@@ -123,15 +125,11 @@ app.get(
 app.post(
 	"/:conversationId/messages",
 	conversationBodyLimit,
-	zValidator(
-		"param",
-		z.object({ conversationId: ConversationIdParam }),
-		(result, c) => {
-			if (!result.success) {
-				return c.json({ error: "Invalid conversation id" }, 400);
-			}
-		},
-	),
+	zValidator("param", ConversationPath, (result, c) => {
+		if (!result.success) {
+			return c.json({ error: "Invalid conversation id" }, 400);
+		}
+	}),
 	zValidator("json", SubmitMessageBody, (result, c) => {
 		if (!result.success) {
 			return c.json(
@@ -200,11 +198,11 @@ app.post(
 				"v2 Live Stream subscribe failed",
 			);
 			// The Turn is durably queued; let it run so history has it.
-			await nudge(ref).catch(() => {});
+			await nudge().catch(() => {});
 			return c.json({ error: "Live stream temporarily unavailable" }, 503);
 		}
 		try {
-			await nudge(ref);
+			await nudge();
 		} catch (error) {
 			// The row is durable and the In-VM server's interval self-heal
 			// consults Postgres on its own; stream on rather than fail the Turn.

--- a/apps/chat-api/src/features/conversation-messages/conversation-messages.route.ts
+++ b/apps/chat-api/src/features/conversation-messages/conversation-messages.route.ts
@@ -1,3 +1,4 @@
+import { setTimeout as delay } from "node:timers/promises";
 import { sValidator as zValidator } from "@hono/standard-validator";
 import { TERMINAL_TURN_STATUSES } from "@mymemo/agent-db/schema";
 import type { TurnStatus } from "@mymemo/agent-db/turn-store";
@@ -207,10 +208,7 @@ app.post(
 			// The row is durable and the In-VM server's interval self-heal
 			// consults Postgres on its own; stream on rather than fail the Turn.
 			logger.warn(
-				{
-					...ref,
-					error: error instanceof Error ? error.message : String(error),
-				},
+				{ ...ref, err: error },
 				"nudge failed; the queued Turn waits for the In-VM server",
 			);
 		}
@@ -224,19 +222,21 @@ app.post(
 			// One tick does both: the SSE comment keepalive, and the terminal
 			// watch that ends a stream whose publisher died without a terminal
 			// chunk (the In-VM server restarts, sweeping the Turn `interrupted`).
-			// Ticks chain rather than overlap. The In-VM server commits the
+			// Ticks chain rather than overlap, and the abortable delay ends the
+			// loop the moment the read signal fires. The In-VM server commits the
 			// Outcome BEFORE publishing the terminal chunk, so one terminal read
 			// may be that window; two consecutive reads mean the chunk is not
 			// coming.
-			let timer: ReturnType<typeof setTimeout> | undefined;
-			let terminalReads = 0;
-			const tick = () => {
-				timer = setTimeout(async () => {
-					if (readSignal.aborted) return;
+			void (async () => {
+				let terminalReads = 0;
+				for (;;) {
 					try {
+						await delay(LIVE_STREAM_KEEPALIVE_MS, undefined, {
+							signal: readSignal,
+						});
 						await stream.write(": ping\n\n");
 					} catch {
-						stream.abort();
+						if (!readSignal.aborted) stream.abort();
 						return;
 					}
 					try {
@@ -254,17 +254,12 @@ app.post(
 						// A failed read is retried next tick; the Live Stream itself is
 						// unaffected, so the response stays open.
 						logger.warn(
-							{
-								...ref,
-								error: error instanceof Error ? error.message : String(error),
-							},
+							{ ...ref, err: error },
 							"v2 terminal watch read failed",
 						);
 					}
-					if (!readSignal.aborted) tick();
-				}, LIVE_STREAM_KEEPALIVE_MS);
-			};
-			tick();
+				}
+			})();
 			try {
 				for await (const chunk of chunks) {
 					await stream.write(`data: ${chunk}\n\n`);
@@ -282,7 +277,6 @@ app.post(
 					);
 				}
 			} finally {
-				clearTimeout(timer);
 				readAbort.abort();
 			}
 		});

--- a/apps/chat-api/src/features/conversation-messages/conversation-messages.route.ts
+++ b/apps/chat-api/src/features/conversation-messages/conversation-messages.route.ts
@@ -188,10 +188,7 @@ app.post(
 		const readSignal = AbortSignal.any([c.req.raw.signal, readAbort.signal]);
 		let chunks: AsyncIterable<string>;
 		try {
-			chunks = await deps.turnLiveStreamRelay.subscribe(
-				ref.messageId,
-				readSignal,
-			);
+			chunks = await deps.turnLiveStreamRelay.subscribe(ref, readSignal);
 		} catch (error) {
 			logger.error(
 				{ ...ref, reason: classifyLiveStreamFailure(error) },
@@ -224,8 +221,12 @@ app.post(
 			// One tick does both: the SSE comment keepalive, and the terminal
 			// watch that ends a stream whose publisher died without a terminal
 			// chunk (the In-VM server restarts, sweeping the Turn `interrupted`).
-			// Ticks chain rather than overlap.
+			// Ticks chain rather than overlap. The In-VM server commits the
+			// Outcome BEFORE publishing the terminal chunk, so one terminal read
+			// may be that window; two consecutive reads mean the chunk is not
+			// coming.
 			let timer: ReturnType<typeof setTimeout> | undefined;
+			let terminalReads = 0;
 			const tick = () => {
 				timer = setTimeout(async () => {
 					try {
@@ -233,6 +234,9 @@ app.post(
 						const status =
 							await deps.conversationMessagesStore.getTurnStatus(ref);
 						if (status === null || isTerminalTurnStatus(status)) {
+							terminalReads += 1;
+						}
+						if (terminalReads >= 2) {
 							readAbort.abort();
 							return;
 						}
@@ -240,7 +244,7 @@ app.post(
 						stream.abort();
 						return;
 					}
-					tick();
+					if (!readSignal.aborted) tick();
 				}, LIVE_STREAM_KEEPALIVE_MS);
 			};
 			tick();

--- a/apps/chat-api/src/features/conversation-messages/conversation-messages.route.ts
+++ b/apps/chat-api/src/features/conversation-messages/conversation-messages.route.ts
@@ -119,7 +119,7 @@ app.get(
  * SDK v7 UI Message Stream scoped to this Turn: silent keepalives while queued
  * predecessors drain, then only this Turn's chunks, ending at its terminal
  * chunk. There is no 409 for concurrency — a second POST is the next queued
- * row — and chat-api never cancels anything: a client disconnect leaves the
+ * row — and chat-api never interrupts anything: a client disconnect leaves the
  * Turn running to its Outcome.
  */
 app.post(
@@ -173,6 +173,9 @@ app.post(
 		}
 		if (admitted.outcome === "archived") {
 			return c.json({ error: "Conversation is archived" }, 409);
+		}
+		if (admitted.outcome === "not_a_turn") {
+			return c.json({ error: "Message id names an assistant message" }, 409);
 		}
 		if (
 			admitted.outcome === "duplicate" &&
@@ -229,20 +232,34 @@ app.post(
 			let terminalReads = 0;
 			const tick = () => {
 				timer = setTimeout(async () => {
+					if (readSignal.aborted) return;
 					try {
 						await stream.write(": ping\n\n");
+					} catch {
+						stream.abort();
+						return;
+					}
+					try {
 						const status =
 							await deps.conversationMessagesStore.getTurnStatus(ref);
-						if (status === null || isTerminalTurnStatus(status)) {
-							terminalReads += 1;
-						}
+						terminalReads =
+							status === null || isTerminalTurnStatus(status)
+								? terminalReads + 1
+								: 0;
 						if (terminalReads >= 2) {
 							readAbort.abort();
 							return;
 						}
-					} catch {
-						stream.abort();
-						return;
+					} catch (error) {
+						// A failed read is retried next tick; the Live Stream itself is
+						// unaffected, so the response stays open.
+						logger.warn(
+							{
+								...ref,
+								error: error instanceof Error ? error.message : String(error),
+							},
+							"v2 terminal watch read failed",
+						);
 					}
 					if (!readSignal.aborted) tick();
 				}, LIVE_STREAM_KEEPALIVE_MS);

--- a/apps/chat-api/src/features/conversation-messages/postgres-conversation-messages-store.test.ts
+++ b/apps/chat-api/src/features/conversation-messages/postgres-conversation-messages-store.test.ts
@@ -244,13 +244,4 @@ describe("PostgresConversationMessagesStore Turn submission", () => {
 			await store.enqueueTurn({ ...ref, userId: "member-2", parts }),
 		).toEqual({ outcome: "not_found" });
 	});
-
-	it("getTurnStatus ignores assistant rows", async () => {
-		await tdb.db
-			.insert(conversationMessages)
-			.values(assistantRow(1, "assistant-1", []));
-		expect(
-			await store.getTurnStatus({ ...ref, messageId: "assistant-1" }),
-		).toBeNull();
-	});
 });

--- a/apps/chat-api/src/features/conversation-messages/postgres-conversation-messages-store.test.ts
+++ b/apps/chat-api/src/features/conversation-messages/postgres-conversation-messages-store.test.ts
@@ -186,3 +186,71 @@ describe("PostgresConversationMessagesStore", () => {
 		);
 	});
 });
+
+describe("PostgresConversationMessagesStore Turn submission", () => {
+	const ref = {
+		userId: "member-1",
+		conversationId: "conversation-1",
+		messageId: "turn-1",
+	};
+	const parts = [{ type: "text", text: "hi" }];
+
+	it("queues a new Turn once; a re-POST is a duplicate that changes nothing", async () => {
+		expect(await store.enqueueTurn({ ...ref, parts })).toEqual({
+			outcome: "queued",
+		});
+		expect(await store.getTurnStatus(ref)).toBe("queued");
+
+		expect(
+			await store.enqueueTurn({
+				...ref,
+				parts: [{ type: "text", text: "changed" }],
+			}),
+		).toEqual({ outcome: "duplicate", status: "queued" });
+		const page = await getPage();
+		expect(page?.messages).toEqual([
+			{
+				id: "turn-1",
+				role: "user",
+				parts,
+				metadata: { status: "queued", startedAt: null, finishedAt: null },
+			},
+		]);
+
+		await tdb.db
+			.update(conversationMessages)
+			.set({ status: "done", finishedAt: new Date() });
+		expect(await store.enqueueTurn({ ...ref, parts })).toEqual({
+			outcome: "duplicate",
+			status: "done",
+		});
+	});
+
+	it("refuses an archived Conversation without writing", async () => {
+		await tdb.db
+			.update(conversations)
+			.set({ archivedAt: new Date("2026-08-30T00:00:00.000Z") });
+		expect(await store.enqueueTurn({ ...ref, parts })).toEqual({
+			outcome: "archived",
+		});
+		expect(await store.getTurnStatus(ref)).toBeNull();
+	});
+
+	it("reports missing and foreign Conversations identically", async () => {
+		expect(
+			await store.enqueueTurn({ ...ref, conversationId: "nope", parts }),
+		).toEqual({ outcome: "not_found" });
+		expect(
+			await store.enqueueTurn({ ...ref, userId: "member-2", parts }),
+		).toEqual({ outcome: "not_found" });
+	});
+
+	it("getTurnStatus ignores assistant rows", async () => {
+		await tdb.db
+			.insert(conversationMessages)
+			.values(assistantRow(1, "assistant-1", []));
+		expect(
+			await store.getTurnStatus({ ...ref, messageId: "assistant-1" }),
+		).toBeNull();
+	});
+});

--- a/apps/chat-api/src/features/conversation-messages/postgres-conversation-messages-store.test.ts
+++ b/apps/chat-api/src/features/conversation-messages/postgres-conversation-messages-store.test.ts
@@ -236,6 +236,15 @@ describe("PostgresConversationMessagesStore Turn submission", () => {
 		expect(await store.getTurnStatus(ref)).toBeNull();
 	});
 
+	it("refuses a message id that already names an assistant message", async () => {
+		await tdb.db
+			.insert(conversationMessages)
+			.values(assistantRow(1, "assistant-1", []));
+		expect(
+			await store.enqueueTurn({ ...ref, messageId: "assistant-1", parts }),
+		).toEqual({ outcome: "not_a_turn" });
+	});
+
 	it("reports missing and foreign Conversations identically", async () => {
 		expect(
 			await store.enqueueTurn({ ...ref, conversationId: "nope", parts }),

--- a/apps/chat-api/src/features/conversation-messages/postgres-conversation-messages-store.ts
+++ b/apps/chat-api/src/features/conversation-messages/postgres-conversation-messages-store.ts
@@ -102,11 +102,11 @@ async function selectTurnStatus(
 				eq(conversationMessages.userId, ref.userId),
 				eq(conversationMessages.conversationId, ref.conversationId),
 				eq(conversationMessages.messageId, ref.messageId),
-				eq(conversationMessages.role, "user"),
 			),
 		);
-	// The turn-status check makes a user row's status a non-null TurnStatus.
-	return row ? (row.status as TurnStatus) : null;
+	// The turn-status check pins an assistant row's status to NULL and a user
+	// row's to a TurnStatus, so the column alone says whether this is a Turn.
+	return (row?.status as TurnStatus | undefined) ?? null;
 }
 
 function toUiMessage(

--- a/apps/chat-api/src/features/conversation-messages/postgres-conversation-messages-store.ts
+++ b/apps/chat-api/src/features/conversation-messages/postgres-conversation-messages-store.ts
@@ -9,11 +9,10 @@ import type {
 	ConversationUiMessage,
 	EnqueueTurnResult,
 	TurnRef,
-	TurnSubmissionStore,
 } from "./conversation-messages-store";
 
 export class PostgresConversationMessagesStore
-	implements ConversationMessagesStore, TurnSubmissionStore
+	implements ConversationMessagesStore
 {
 	constructor(private readonly db: Database) {}
 

--- a/apps/chat-api/src/features/conversation-messages/postgres-conversation-messages-store.ts
+++ b/apps/chat-api/src/features/conversation-messages/postgres-conversation-messages-store.ts
@@ -1,16 +1,19 @@
-import type { Database } from "@mymemo/agent-db/client";
+import type { Database, DbTx } from "@mymemo/agent-db/client";
 import { conversationMessages, conversations } from "@mymemo/agent-db/schema";
-import type { TurnStatus } from "@mymemo/agent-db/turn-store";
+import { enqueueTurnTx, type TurnStatus } from "@mymemo/agent-db/turn-store";
 import { and, desc, eq, lt } from "drizzle-orm";
 import type {
 	ConversationMessagesPage,
 	ConversationMessagesPageInput,
 	ConversationMessagesStore,
 	ConversationUiMessage,
+	EnqueueTurnResult,
+	TurnRef,
+	TurnSubmissionStore,
 } from "./conversation-messages-store";
 
 export class PostgresConversationMessagesStore
-	implements ConversationMessagesStore
+	implements ConversationMessagesStore, TurnSubmissionStore
 {
 	constructor(private readonly db: Database) {}
 
@@ -57,6 +60,54 @@ export class PostgresConversationMessagesStore
 			nextCursor: hasOlder ? (page[0]?.sequence ?? null) : null,
 		};
 	}
+
+	async enqueueTurn(
+		input: TurnRef & { parts: unknown },
+	): Promise<EnqueueTurnResult> {
+		return await this.db.transaction(async (tx) => {
+			const [conversation] = await tx
+				.select({ archivedAt: conversations.archivedAt })
+				.from(conversations)
+				.where(
+					and(
+						eq(conversations.userId, input.userId),
+						eq(conversations.conversationId, input.conversationId),
+					),
+				)
+				.for("update");
+			if (!conversation) return { outcome: "not_found" };
+			if (conversation.archivedAt !== null) return { outcome: "archived" };
+			if (await enqueueTurnTx(tx, input)) return { outcome: "queued" };
+			const status = await selectTurnStatus(tx, input);
+			if (status === null) {
+				throw new Error(`duplicate message ${input.messageId} is not a Turn`);
+			}
+			return { outcome: "duplicate", status };
+		});
+	}
+
+	getTurnStatus(ref: TurnRef): Promise<TurnStatus | null> {
+		return selectTurnStatus(this.db, ref);
+	}
+}
+
+async function selectTurnStatus(
+	db: Database | DbTx,
+	ref: TurnRef,
+): Promise<TurnStatus | null> {
+	const [row] = await db
+		.select({ status: conversationMessages.status })
+		.from(conversationMessages)
+		.where(
+			and(
+				eq(conversationMessages.userId, ref.userId),
+				eq(conversationMessages.conversationId, ref.conversationId),
+				eq(conversationMessages.messageId, ref.messageId),
+				eq(conversationMessages.role, "user"),
+			),
+		);
+	// The turn-status check makes a user row's status a non-null TurnStatus.
+	return row ? (row.status as TurnStatus) : null;
 }
 
 function toUiMessage(

--- a/apps/chat-api/src/features/conversation-messages/postgres-conversation-messages-store.ts
+++ b/apps/chat-api/src/features/conversation-messages/postgres-conversation-messages-store.ts
@@ -78,10 +78,9 @@ export class PostgresConversationMessagesStore
 			if (conversation.archivedAt !== null) return { outcome: "archived" };
 			if (await enqueueTurnTx(tx, input)) return { outcome: "queued" };
 			const status = await selectTurnStatus(tx, input);
-			if (status === null) {
-				throw new Error(`duplicate message ${input.messageId} is not a Turn`);
-			}
-			return { outcome: "duplicate", status };
+			return status === null
+				? { outcome: "not_a_turn" }
+				: { outcome: "duplicate", status };
 		});
 	}
 

--- a/apps/chat-api/src/features/conversations/conversations.schema.ts
+++ b/apps/chat-api/src/features/conversations/conversations.schema.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import type { ConversationListPosition } from "@/features/conversation-store/conversation-store";
 
 const MAX_IDENTIFIER_LENGTH = 256;
-const MAX_MESSAGE_LENGTH = 50_000;
+export const MAX_MESSAGE_LENGTH = 50_000;
 const MAX_LIST_CURSOR_LENGTH = 2_048;
 
 export const MAX_REQUEST_BODY_BYTES = 10 * 1024 * 1024;

--- a/apps/in-vm-server/src/turn-serving.test.ts
+++ b/apps/in-vm-server/src/turn-serving.test.ts
@@ -120,7 +120,10 @@ function collectLiveChunks(
 	relay: TurnLiveStreamRelay,
 ): Promise<UIMessageChunk[]> & { ready: Promise<void> } {
 	const controller = new AbortController();
-	const subscribed = relay.subscribe(TURN_ID, controller.signal);
+	const subscribed = relay.subscribe(
+		{ conversationId: CONVERSATION_ID, messageId: TURN_ID },
+		controller.signal,
+	);
 	const collected = (async () => {
 		const chunks: UIMessageChunk[] = [];
 		for await (const serialized of await subscribed) {

--- a/apps/in-vm-server/src/turn-serving.ts
+++ b/apps/in-vm-server/src/turn-serving.ts
@@ -85,7 +85,10 @@ export async function serveOneTurn(
 	deps.currentTurn.turnId = claimed.messageId;
 	const turnKey = { userId, conversationId, messageId: claimed.messageId };
 	const assistantMessageId = randomUUID();
-	const publisher = deps.relay.openPublisher(claimed.messageId);
+	const publisher = deps.relay.openPublisher({
+		conversationId,
+		messageId: claimed.messageId,
+	});
 	const publish = async (chunk: UIMessageChunk): Promise<void> => {
 		try {
 			await publisher.publish(chunk);

--- a/bun.lock
+++ b/bun.lock
@@ -118,6 +118,7 @@
         "@mymemo/document-tools": "workspace:*",
         "@mymemo/live-text": "workspace:*",
         "@statsig/statsig-node-core": "^0.19.8",
+        "ai": "7.0.83",
         "drizzle-orm": "^0.45.2",
         "hono": "^4.10.1",
         "hono-pino": "^0.10.3",

--- a/docs/agents/chat-api.md
+++ b/docs/agents/chat-api.md
@@ -163,6 +163,70 @@ The four lifecycle routes above (create, list, rename/Archive, permanent delete)
 
 `GET /v2/conversations/:conversationId/messages` returns the durable UIMessage history over `conversation_messages` in ascending `sequence`, paged backwards from the newest page as `{ messages, nextCursor }` (`?limit` defaults to 50 and clamps to 100; `?before=<sequence>` is the cursor `nextCursor` hands back). A user message carries its Turn `status`/`startedAt`/`finishedAt` as UIMessage `metadata`; a Turn's single assistant message returns its stored parts verbatim (step and tool parts included) — an interrupted or error Turn shows exactly its completed Steps by the In-VM writer's commit-before-publish invariant. chat-api only reads here. Owner-scoped: missing and foreign Conversations return `404`; an empty history — every pre-v2 Conversation included — is an empty page; archived Conversations stay readable; the read bypasses the new-work exposure gate (v1 precedent).
 
+### Submit a v2 message
+
+`POST /v2/conversations/:conversationId/messages` submits one UIMessage and
+answers with the stock AI SDK v7 UI Message Stream scoped to that message's
+own Turn (spec #654, #667). The body is the stock `useChat` /
+`DefaultChatTransport` request, `.strict()`: `id` (must equal the path
+Conversation id), `trigger: "submit-message"`, and `messages`, of which only
+the final one is submitted — it must be a user UIMessage with only text parts
+(each ≤ 50,000 characters), and its client `id` becomes the Turn id, so it is
+held to the path-safe Conversation-id shape (it names the Live Stream
+channel). Earlier messages are the client's history and validation input, not
+new durable history. `regenerate-message`, files, and message metadata are
+rejected with `400`.
+
+Order of operations: identity → `503` while no In-VM server is configured
+(`IN_VM_SERVER_URL`, the dev-mode Ensure-VM stub) → exposure gate (`403`,
+before any write, on every submission) → the `queued` INSERT under the
+Conversation row lock (`404` for missing or foreign, `409` for an archived
+Conversation — the lock is the one `PATCH` archive takes, so no message slips
+in beside an Archive) → subscribe to the Turn's Live Stream lane → nudge →
+relay. Subscribing before nudging is what makes early chunks unlosable: the
+v2 lane keeps no backlog. That INSERT is chat-api's only write to
+`conversation_messages`; the In-VM server owns every status transition. There
+is no `409` for concurrency: a second POST is simply the next queued row, and
+its response holds with silent SSE comment keepalives (`: ping`, every 5 s)
+while queued predecessors drain, then carries only its own Turn's chunks.
+
+The response is `200 text/event-stream` with the `x-vercel-ai-ui-message-stream: v1`
+header, each chunk as one `data:` frame exactly as the In-VM server published
+it (stock `UIMessageChunk` grammar, one assistant UIMessage per Turn), and a
+`data: [DONE]` terminator after the Turn's terminal chunk (`finish` | `abort`
+| `error` — the Outcome). A stock `useChat` needs no custom transport.
+The keepalive tick doubles as a terminal watch: if the Turn is durably
+terminal but no terminal chunk arrived (the publisher died; a restarted VM
+sweeps it `interrupted`), the stream ends with `[DONE]` and no synthesized
+chunk. A relay failure mid-stream closes the response without `[DONE]` and
+without synthesizing anything; a subscribe failure answers `503` after a
+best-effort nudge so the queued Turn still runs. A nudge failure is logged
+and the response streams on — the row is durable and the In-VM server's
+interval self-heal consults Postgres on its own. In every case the client
+Recovers from durable history.
+
+A re-POST of the same client message id creates no second Turn (the primary
+key is the idempotency authority; the row's parts and status stay as they
+were). If that Turn is still `queued` or `processing` the response attaches
+to its Live Stream and nudges — chunks published before the re-POST are
+missed, there being no backlog. If the Turn already reached its Outcome the
+Live Stream is gone and the response is `410 { error: "Turn already ended",
+recovery: "history" }`, the v1 history-recovery signal.
+
+Client disconnect never interrupts a Turn: chat-api drops its subscription
+and nothing else; the Turn runs to its Outcome and the durable history has
+it.
+
+Local check (a locally running In-VM server on `IN_VM_SERVER_URL`, the
+Compose Postgres + Redis, and chat-api with the same identity):
+
+```sh
+H='-H content-type:application/json -H x-member-code:m1 -H x-partner-code:p1'
+ID=$(curl -s -X POST localhost:3000/v2/conversations $H -d '{}' | jq -r .conversationId)   # the In-VM server's MYMEMO_CONVERSATION_ID
+curl -sN -X POST localhost:3000/v2/conversations/$ID/messages $H -d "{\"id\":\"$ID\",\"trigger\":\"submit-message\",\"messages\":[{\"id\":\"m1\",\"role\":\"user\",\"parts\":[{\"type\":\"text\",\"text\":\"Say pelican.\"}]}]}"
+curl -s localhost:3000/v2/conversations/$ID/messages $H | jq '.messages[-1]'   # the streamed assistant message, durably
+```
+
 ### Admit and stream a Run
 
 `POST /v1/conversations/:conversationId/runs` strictly validates one standard `RunAgentInput` and requires `threadId` to equal the owned Conversation id. Reject client Tools, state, and forwarded authority.

--- a/docs/agents/chat-api.md
+++ b/docs/agents/chat-api.md
@@ -213,7 +213,9 @@ were). If that Turn is still `queued` or `processing` the response attaches
 to its Live Stream and nudges — chunks published before the re-POST are
 missed, there being no backlog. If the Turn already reached its Outcome the
 Live Stream is gone and the response is `410 { error: "Turn already ended",
-recovery: "history" }`, the v1 history-recovery signal.
+recovery: "history" }`, the v1 history-recovery signal. A client id that
+names an assistant message instead (those ids are visible in history) is
+`409`; nothing is written.
 
 Client disconnect never interrupts a Turn: chat-api drops its subscription
 and nothing else; the Turn runs to its Outcome and the durable history has

--- a/docs/agents/chat-api.md
+++ b/docs/agents/chat-api.md
@@ -182,9 +182,10 @@ Order of operations: identity → `503` while no In-VM server is configured
 before any write, on every submission) → the `queued` INSERT under the
 Conversation row lock (`404` for missing or foreign, `409` for an archived
 Conversation — the lock is the one `PATCH` archive takes, so no message slips
-in beside an Archive) → subscribe to the Turn's Live Stream lane → nudge →
-relay. Subscribing before nudging is what makes early chunks unlosable: the
-v2 lane keeps no backlog. That INSERT is chat-api's only write to
+in beside an Archive) → subscribe to the Turn's Live Stream lane (keyed on
+Conversation id + message id: the message id is client-chosen and unique only
+within its Conversation) → nudge → relay. Subscribing before nudging is what
+makes early chunks unlosable: the v2 lane keeps no backlog. That INSERT is chat-api's only write to
 `conversation_messages`; the In-VM server owns every status transition. There
 is no `409` for concurrency: a second POST is simply the next queued row, and
 its response holds with silent SSE comment keepalives (`: ping`, every 5 s)
@@ -195,10 +196,11 @@ header, each chunk as one `data:` frame exactly as the In-VM server published
 it (stock `UIMessageChunk` grammar, one assistant UIMessage per Turn), and a
 `data: [DONE]` terminator after the Turn's terminal chunk (`finish` | `abort`
 | `error` — the Outcome). A stock `useChat` needs no custom transport.
-The keepalive tick doubles as a terminal watch: if the Turn is durably
-terminal but no terminal chunk arrived (the publisher died; a restarted VM
-sweeps it `interrupted`), the stream ends with `[DONE]` and no synthesized
-chunk. A relay failure mid-stream closes the response without `[DONE]` and
+The keepalive tick doubles as a terminal watch: if two consecutive ticks find
+the Turn durably terminal with no terminal chunk arrived (the publisher died;
+a restarted VM sweeps it `interrupted` — one such read may only be the window
+between the In-VM server's Outcome commit and its terminal publish), the
+stream ends with `[DONE]` and no synthesized chunk. A relay failure mid-stream closes the response without `[DONE]` and
 without synthesizing anything; a subscribe failure answers `503` after a
 best-effort nudge so the queued Turn still runs. A nudge failure is logged
 and the response streams on — the row is durable and the In-VM server's

--- a/docs/agents/configuration.md
+++ b/docs/agents/configuration.md
@@ -84,6 +84,7 @@ Optional:
 - `OPENROUTER_API_KEY`: secret; the real model credential the `/v2/gateway` route injects on forwarded requests (ADR-0034). Never delivered to a VM, image, or Checkpoint. While unset the gateway route answers 503.
 - `GATEWAY_TOKEN_SECRET`: secret; HMAC key for per-Conversation gateway tokens (minted at VM launch, verified on every gateway request — both in chat-api). While unset the gateway route answers 503.
 - `OPENROUTER_BASE_URL` (default `https://openrouter.ai/api`): upstream the gateway forwards to
+- `IN_VM_SERVER_URL`: dev-mode Ensure-VM stub (#667) — the base URL of one locally running In-VM server that `POST /v2/conversations/:id/messages` nudges. The orchestration ticket replaces it with per-Conversation MicroVM launch. While unset the v2 message POST answers 503.
 
 chat-api has no AgentCore dispatch queue or SSM parameter configuration. Admission ends after the transactional Postgres outbox write; publisher and consumer processes own queue delivery and the dispatch kill switch.
 

--- a/docs/agents/configuration.md
+++ b/docs/agents/configuration.md
@@ -85,6 +85,7 @@ Optional:
 - `GATEWAY_TOKEN_SECRET`: secret; HMAC key for per-Conversation gateway tokens (minted at VM launch, verified on every gateway request — both in chat-api). While unset the gateway route answers 503.
 - `OPENROUTER_BASE_URL` (default `https://openrouter.ai/api`): upstream the gateway forwards to
 - `IN_VM_SERVER_URL`: dev-mode Ensure-VM stub (#667) — the base URL of one locally running In-VM server that `POST /v2/conversations/:id/messages` nudges. The orchestration ticket replaces it with per-Conversation MicroVM launch. While unset the v2 message POST answers 503.
+- `IN_VM_SERVER_AUTH_TOKEN`: with `IN_VM_SERVER_URL` pointing at a real MicroVM endpoint, the platform's per-VM auth token (`CreateMicrovmAuthToken`), sent on the nudge as `X-aws-proxy-auth` with `X-aws-proxy-port: 8080`; unset for a plain local In-VM server
 
 chat-api has no AgentCore dispatch queue or SSM parameter configuration. Admission ends after the transactional Postgres outbox write; publisher and consumer processes own queue delivery and the dispatch kill switch.
 

--- a/packages/agent-db/src/turn-store.ts
+++ b/packages/agent-db/src/turn-store.ts
@@ -1,5 +1,5 @@
 import { and, asc, eq } from "drizzle-orm";
-import type { Database } from "./client";
+import type { Database, DbTx } from "./client";
 import {
 	type ALL_TURN_STATUSES,
 	conversationMessages,
@@ -57,7 +57,7 @@ function conversationTurns(input: { userId: string; conversationId: string }) {
  * alike) untouched.
  */
 export async function enqueueTurnTx(
-	db: Database,
+	db: Database | DbTx,
 	input: {
 		userId: string;
 		conversationId: string;

--- a/packages/live-text/src/live-stream-validation.ts
+++ b/packages/live-text/src/live-stream-validation.ts
@@ -24,11 +24,26 @@ export function validateLiveStreamRunId(value: string): void {
 	);
 }
 
-export function validateLiveStreamTurnId(value: string): void {
+/**
+ * A Turn's Live Stream identity. The message id is client-chosen and only
+ * unique within its Conversation (the table's primary key), so the
+ * Conversation id must be part of the channel — never the message id alone.
+ */
+export interface LiveStreamTurnKey {
+	conversationId: string;
+	messageId: string;
+}
+
+export function validateLiveStreamTurnKey(key: LiveStreamTurnKey): void {
 	validatePathSafeIdentifier(
-		value,
+		key.conversationId,
 		LIVE_STREAM_RUN_ID_MAX_LENGTH,
-		"turnId must be a path-safe Turn identifier",
+		"conversationId must be a path-safe Conversation identifier",
+	);
+	validatePathSafeIdentifier(
+		key.messageId,
+		LIVE_STREAM_RUN_ID_MAX_LENGTH,
+		"messageId must be a path-safe Turn identifier",
 	);
 }
 

--- a/packages/live-text/src/turn-live-stream-relay.contract.ts
+++ b/packages/live-text/src/turn-live-stream-relay.contract.ts
@@ -14,6 +14,7 @@ function textDelta(delta: string): unknown {
 }
 
 const FINISH = { type: "finish" } as const;
+const TURN = { conversationId: "conversation-1", messageId: "turn-1" };
 
 async function collect(events: AsyncIterable<string>): Promise<unknown[]> {
 	const collected: unknown[] = [];
@@ -28,12 +29,37 @@ export function turnLiveStreamRelayContract(
 	factory: TurnLiveStreamRelayContractFactory,
 ): void {
 	describe(`${name} Turn Live Stream relay`, () => {
+		it("keys the channel on Conversation id + message id, so a reused message id in another Conversation is a separate stream", async () => {
+			const relay = factory.create();
+			try {
+				const other = { ...TURN, conversationId: "conversation-2" };
+				const mine = collect(
+					await relay.subscribe(TURN, new AbortController().signal),
+				);
+				const theirs = collect(
+					await relay.subscribe(other, new AbortController().signal),
+				);
+				const publisher = relay.openPublisher(other);
+				await publisher.publish(textDelta("not yours"));
+				await publisher.publish(FINISH);
+				await publisher.close();
+				expect(await theirs).toEqual([textDelta("not yours"), FINISH]);
+
+				const ours = relay.openPublisher(TURN);
+				await ours.publish(FINISH);
+				await ours.close();
+				expect(await mine).toEqual([FINISH]);
+			} finally {
+				await relay.close();
+			}
+		});
+
 		it("delivers UIMessage chunks in order and ends after the terminal chunk", async () => {
 			const relay = factory.create();
 			try {
-				const publisher = relay.openPublisher("turn-1");
+				const publisher = relay.openPublisher(TURN);
 				const events = await relay.subscribe(
-					"turn-1",
+					TURN,
 					new AbortController().signal,
 				);
 				const collecting = collect(events);
@@ -63,9 +89,9 @@ export function turnLiveStreamRelayContract(
 			]) {
 				const relay = factory.create();
 				try {
-					const publisher = relay.openPublisher("turn-1");
+					const publisher = relay.openPublisher(TURN);
 					const events = await relay.subscribe(
-						"turn-1",
+						TURN,
 						new AbortController().signal,
 					);
 					const collecting = collect(events);
@@ -91,12 +117,12 @@ export function turnLiveStreamRelayContract(
 		it("has no backlog: a late subscriber misses earlier chunks", async () => {
 			const relay = factory.create();
 			try {
-				const publisher = relay.openPublisher("turn-1");
+				const publisher = relay.openPublisher(TURN);
 				await publisher.publish(textDelta("missed-1"));
 				await publisher.publish(textDelta("missed-2"));
 
 				const events = await relay.subscribe(
-					"turn-1",
+					TURN,
 					new AbortController().signal,
 				);
 				const collecting = collect(events);
@@ -113,13 +139,13 @@ export function turnLiveStreamRelayContract(
 		it("has no re-attach: after the Turn ends a subscriber sees nothing", async () => {
 			const relay = factory.create();
 			try {
-				const publisher = relay.openPublisher("turn-1");
+				const publisher = relay.openPublisher(TURN);
 				await publisher.publish(textDelta("gone"));
 				await publisher.publish(FINISH);
 				await publisher.close();
 
 				const subscriber = new AbortController();
-				const events = await relay.subscribe("turn-1", subscriber.signal);
+				const events = await relay.subscribe(TURN, subscriber.signal);
 				const collecting = collect(events);
 				setTimeout(() => subscriber.abort(), 50);
 				expect(await collecting).toEqual([]);
@@ -131,11 +157,11 @@ export function turnLiveStreamRelayContract(
 		it("ends an aborted subscriber without disturbing another", async () => {
 			const relay = factory.create();
 			try {
-				const publisher = relay.openPublisher("turn-1");
+				const publisher = relay.openPublisher(TURN);
 				const aborting = new AbortController();
 				const [abortedEvents, stayingEvents] = await Promise.all([
-					relay.subscribe("turn-1", aborting.signal),
-					relay.subscribe("turn-1", new AbortController().signal),
+					relay.subscribe(TURN, aborting.signal),
+					relay.subscribe(TURN, new AbortController().signal),
 				]);
 				const abortedCollecting = collect(abortedEvents);
 				const stayingCollecting = collect(stayingEvents);
@@ -158,9 +184,9 @@ export function turnLiveStreamRelayContract(
 		it("rejects chunks outside the stock v7 grammar and oversize chunks without failing the stream", async () => {
 			const relay = factory.create();
 			try {
-				const publisher = relay.openPublisher("turn-1");
+				const publisher = relay.openPublisher(TURN);
 				const events = await relay.subscribe(
-					"turn-1",
+					TURN,
 					new AbortController().signal,
 				);
 				const collecting = collect(events);
@@ -195,9 +221,9 @@ export function turnLiveStreamRelayContract(
 		it("accepts data-* chunks as payload", async () => {
 			const relay = factory.create();
 			try {
-				const publisher = relay.openPublisher("turn-1");
+				const publisher = relay.openPublisher(TURN);
 				const events = await relay.subscribe(
-					"turn-1",
+					TURN,
 					new AbortController().signal,
 				);
 				const collecting = collect(events);
@@ -214,7 +240,7 @@ export function turnLiveStreamRelayContract(
 		it("publishes exactly one terminal chunk as the publisher's final chunk", async () => {
 			const relay = factory.create();
 			try {
-				const publisher = relay.openPublisher("turn-1");
+				const publisher = relay.openPublisher(TURN);
 				await publisher.publish(textDelta("hello"));
 				await publisher.publish(FINISH);
 				await expect(
@@ -239,9 +265,9 @@ export function turnLiveStreamRelayContract(
 				},
 			});
 			try {
-				const publisher = relay.openPublisher("turn-1");
+				const publisher = relay.openPublisher(TURN);
 				const events = await relay.subscribe(
-					"turn-1",
+					TURN,
 					new AbortController().signal,
 				);
 				const subscriberFailure = collect(events).then(
@@ -268,9 +294,9 @@ export function turnLiveStreamRelayContract(
 		it("fails subscribers when the publisher closes without a terminal chunk", async () => {
 			const relay = factory.create();
 			try {
-				const publisher = relay.openPublisher("turn-1");
+				const publisher = relay.openPublisher(TURN);
 				const events = await relay.subscribe(
-					"turn-1",
+					TURN,
 					new AbortController().signal,
 				);
 				const subscriberFailure = collect(events).then(
@@ -288,11 +314,11 @@ export function turnLiveStreamRelayContract(
 		it("refuses new publishers and subscribers after the relay closes", async () => {
 			const relay = factory.create();
 			await relay.close();
-			expect(() => relay.openPublisher("turn-1")).toThrow(
+			expect(() => relay.openPublisher(TURN)).toThrow(
 				expect.objectContaining({ code: "relay_closed" }),
 			);
 			await expect(
-				relay.subscribe("turn-1", new AbortController().signal),
+				relay.subscribe(TURN, new AbortController().signal),
 			).rejects.toMatchObject({ code: "relay_closed" });
 		});
 	});

--- a/packages/live-text/src/turn-live-stream-relay.ts
+++ b/packages/live-text/src/turn-live-stream-relay.ts
@@ -6,8 +6,9 @@ import {
 } from "./live-stream-events";
 import { AsyncQueue, type LiveStreamRelayTransport } from "./live-stream-relay";
 import {
+	type LiveStreamTurnKey,
 	validateLiveStreamDeployment,
-	validateLiveStreamTurnId,
+	validateLiveStreamTurnKey,
 } from "./live-stream-validation";
 import {
 	createRedisRelayTransport,
@@ -17,7 +18,9 @@ import {
 /**
  * The v2 Live Stream lane (spec #654, chunk contract amended on #658): a
  * Turn's UIMessage chunks published over the payload-agnostic relay transport
- * on a per-Turn channel. The payload grammar is the stock AI SDK v7
+ * on a per-Turn channel keyed on Conversation id + message id (the message id
+ * is client-chosen and unique only within its Conversation — #694 review).
+ * The payload grammar is the stock AI SDK v7
  * `UIMessageChunk` vocabulary (`ai@7.0.83`) — no custom chunk types; one
  * assistant UIMessage per Turn, so the stock terminal chunks ARE the Turn's
  * Outcome: `finish` (done), `abort` (interrupted), `error` (error). The lane
@@ -50,14 +53,14 @@ export interface TurnLiveStreamPublisher {
 }
 
 export interface TurnLiveStreamRelay {
-	openPublisher(turnId: string): TurnLiveStreamPublisher;
+	openPublisher(turn: LiveStreamTurnKey): TurnLiveStreamPublisher;
 	/** Subscribe to a Turn's live chunks, each a serialized UIMessage chunk
 	 * ready for SSE framing. Delivery starts at subscription time — there is
 	 * no backlog; earlier chunks are simply missed. The iteration ends after
 	 * the Turn's terminal chunk (`finish` | `abort` | `error`), or when
 	 * `signal` aborts. */
 	subscribe(
-		turnId: string,
+		turn: LiveStreamTurnKey,
 		signal: AbortSignal,
 	): Promise<AsyncIterable<string>>;
 	close(): Promise<void>;
@@ -86,12 +89,12 @@ class PubSubTurnLiveStreamRelay implements TurnLiveStreamRelay {
 		this.#testHooks = options.testHooks;
 	}
 
-	openPublisher(turnId: string): TurnLiveStreamPublisher {
+	openPublisher(turn: LiveStreamTurnKey): TurnLiveStreamPublisher {
 		this.#assertOpen();
-		validateLiveStreamTurnId(turnId);
+		validateLiveStreamTurnKey(turn);
 		const publisher = new TransportTurnLiveStreamPublisher(
 			this.#transport,
-			this.#channel(turnId),
+			this.#channel(turn),
 			this.#testHooks,
 			() => this.#publishers.delete(publisher),
 		);
@@ -100,18 +103,18 @@ class PubSubTurnLiveStreamRelay implements TurnLiveStreamRelay {
 	}
 
 	async subscribe(
-		turnId: string,
+		turn: LiveStreamTurnKey,
 		signal: AbortSignal,
 	): Promise<AsyncIterable<string>> {
 		this.#assertOpen();
-		validateLiveStreamTurnId(turnId);
+		validateLiveStreamTurnKey(turn);
 		const queue = new AsyncQueue<string>();
 		if (signal.aborted) {
 			queue.end();
 			return queue.iterate(async () => {});
 		}
 		const subscription = await this.#transport.subscribe(
-			this.#channel(turnId),
+			this.#channel(turn),
 			(message) => {
 				let type: unknown;
 				try {
@@ -149,8 +152,8 @@ class PubSubTurnLiveStreamRelay implements TurnLiveStreamRelay {
 		if (this.#closed) throw new LiveStreamRelayError("relay_closed");
 	}
 
-	#channel(turnId: string): string {
-		return `${this.#channelPrefix}:{${turnId}}:live`;
+	#channel(turn: LiveStreamTurnKey): string {
+		return `${this.#channelPrefix}:{${turn.conversationId}}:${turn.messageId}:live`;
 	}
 }
 


### PR DESCRIPTION
Closes #667. Parent: spec #654 (/v2 chat on Lambda MicroVMs).

## What this builds

**`POST /v2/conversations/:conversationId/messages`** — submit a UIMessage; the response is the stock AI SDK v7 UI Message Stream scoped to the submitted message's own Turn. This route owns the SSE envelope around the chunk payloads the #658 lane relays: `x-vercel-ai-ui-message-stream: v1` (and the rest of `UI_MESSAGE_STREAM_HEADERS`), `data:` framing, `: ping` keepalives, `data: [DONE]`.

Order of operations: identity → `503` while no In-VM server is configured → exposure gate (`403`, before any write) → the `queued` INSERT → **subscribe to the Turn's Live Stream lane** → **nudge** → relay.

- **Store** (`conversation-messages` feature, `enqueueTurn`/`getTurnStatus` added to the existing `ConversationMessagesStore`): `enqueueTurn` runs under the Conversation row lock (`SELECT … FOR UPDATE`, the same lock `PATCH` archive takes), so `404` (missing/foreign), `409` (archived), `queued`, and `duplicate` (with the existing Turn's status) come out of one atomic step and no message slips in beside an Archive. It calls agent-db's `enqueueTurnTx`, now typed to accept a `DbTx` too. This INSERT is chat-api's only write to `conversation_messages`; the In-VM server owns every status transition.
- **Route**: the body is the stock `useChat`/`DefaultChatTransport` request (`.strict()`: `id` = path Conversation id, `trigger: "submit-message"`, `messages`); only the final message is submitted and must be a user UIMessage with text parts, its client `id` becoming the Turn id (held to the path-safe id shape since it names the relay channel). Earlier messages are validation input only, never durable history (the v1 stance). No `409` for concurrency: a second POST is the next queued row; its stream holds with silent `: ping` keepalives while predecessors drain, then carries only its own Turn's chunks.
- **Live Stream lane re-keyed** (`packages/live-text`, from review): the Turn relay's channel was keyed on the client-chosen message id alone, which is unique only within its Conversation (the table's PK), so a reused id in another Conversation would have shared a channel. `openPublisher`/`subscribe` now take `{ conversationId, messageId }` (Conversation id as the Redis hash tag), pinned by a contract test on both transports; the In-VM publisher and this route pass the pair.
- **Terminal watch**: the 5 s keepalive tick also reads the Turn's status; two consecutive terminal reads with no terminal chunk received (publisher died, restarted VM swept it `interrupted` — a single read may only be the In-VM server's commit-before-publish window) end the stream with `[DONE]` and no synthesized chunk. A failed status read is logged and retried next tick (only a failed write ends the stream); a finished stream never re-arms its tick. A mid-stream relay failure closes the response without `[DONE]`; a subscribe failure answers `503` after a best-effort nudge; a nudge failure is logged and the response streams on (the row is durable, the In-VM server self-heals on its interval). In every case the client Recovers from durable history.
- **Duplicate client message id** (documented in `docs/agents/chat-api.md`): no second Turn — the PK is the idempotency authority and the existing row is untouched. Still `queued`/`processing` → the response attaches to its Live Stream and nudges (earlier chunks missed; no backlog). Already terminal → `410 { error: "Turn already ended", recovery: "history" }`, the v1 history-recovery signal. A client id that names an assistant message (ids are visible in history) → `409`, nothing written.
- **Client disconnect** drops chat-api's subscription and nothing else; the Turn runs to its Outcome.
- **Ensure-VM is the dev-mode stub**: `IN_VM_SERVER_URL` (new optional `ApiConfig.inVmServerUrl`) → `AppDeps.nudgeInVmServer` POSTs `new URL("/nudge", url)` with a 5 s timeout; unset → `503`. With `IN_VM_SERVER_AUTH_TOKEN` (the platform's per-VM token) the nudge also sends `X-aws-proxy-auth` + `X-aws-proxy-port: 8080`, so the route can be driven against a hand-launched MicroVM before orchestration mints tokens itself. The orchestration ticket replaces this seam with per-Conversation MicroVM launch. `AppDeps` also gains `turnLiveStreamRelay` (Redis Turn lane, closed with the v1 relay on shutdown).
- `ai@7.0.83` becomes a chat-api dependency (already in the lockfile via live-text) for `UI_MESSAGE_STREAM_HEADERS` and the client-side test parser.

## Acceptance criteria

- **Against a locally running In-VM server: POST streams the full Turn as UIMessage SSE, ends with the Outcome, and the durable history matches the streamed message — verified live** (Compose Postgres + Redis, `apps/in-vm-server` on OpenRouter, chat-api local composition with `IN_VM_SERVER_URL`): `200 text/event-stream` + `x-vercel-ai-ui-message-stream: v1`; frames `start` → `start-step` → `text-start` → `text-delta`×3 → `text-end` → `finish-step` → `finish {"messageMetadata":{"status":"done"}}` → `[DONE]`; `GET …/messages` then returned the user row `status: done` and the assistant row with the same `messageId` and `[{step-start},{text:"pelican",state:"done"}]`.
- **Consumable by a stock v7 `useChat`/`DefaultChatTransport` with no custom transport** — `conversation-messages.route.test.ts` drives the real `DefaultChatTransport` (`ai@7.0.83`) through the app and `readUIMessageStream`; the Turn renders as one assistant message with `[step-start, text]`.
- **Two rapid POSTs: no 409; the second holds with silent keepalives during its predecessor, then streams only its own Turn's events** — live (two parallel `curl`s: second stream = 2 × `: ping`, then only its own 8 frames, zero leakage from the predecessor's 41) and in a route test (fake drain loop, keepalive asserted).
- **Subscribe-before-nudge ordering tested — no lost early events** — route test whose fake In-VM server publishes the whole Turn *synchronously inside the nudge call*; every chunk arrives.
- **Duplicate client message id: no second Turn; behaviour documented and tested** — store test (pglite: second enqueue is `duplicate`, parts untouched), route test (`410` for a terminal Turn with no nudge; attach for an in-flight one), live (`410 {"error":"Turn already ended","recovery":"history"}`), docs section.
- **Client disconnect mid-stream leaves the Turn running to its Outcome (verified via durable history)** — live: `curl --max-time 2` gave up after 1 frame; history showed the Turn `done` ~8 s later with the full 21-line assistant message. Route test covers the same with an aborted request.
- **Archived Conversation refuses the message; the exposure gate is enforced on submission** — live `409 {"error":"Conversation is archived"}` on an archived Conversation and `404` for a foreign owner; route test for the gate (`403`, no write, no nudge). (The local composition's gate is always-open, so the gate is unit-tested only.)

## Notes for review

- **`409` for archived, none for concurrency.** The ticket's "no 409 anywhere" is about the second POST; "archived-blocks-new-messages" is carried from the v1 message path where it is `409`, so that one stays.
- **Body shape.** "Submit a UIMessage" is read as the stock `useChat` body, which is what "consumable by a stock `DefaultChatTransport`" needs without `prepareSendMessagesRequest`. `regenerate-message`, file parts, and message metadata are `400`.
- The exposure gate runs on every submission, duplicates included (simplest rule; v1 skipped it on exact retries).
- The keepalive interval stays the v1 constant (5 s); the two timing-dependent tests wait for one tick, as the v1 keepalive test does.
- Pre-existing, untouched: chat-api's `bunx tsc --noEmit` reports the known `s3-artifact-download-signer.ts` `@smithy/types` fork error present on `main`.

## Verification

- `apps/chat-api`: 190 pass (25 in the conversation-messages feature: 15 route, 10 store); `bunx tsc --noEmit` clean apart from the pre-existing signer error.
- `packages/agent-db`: 254 pass, 17 skip; `bunx tsc --noEmit` clean.
- `packages/live-text`: 53 pass (new contract test: same message id, two Conversations, two streams); `bunx tsc --noEmit` clean.
- `apps/in-vm-server`: 93 pass; `bunx tsc --noEmit` clean.
- `biome check` clean on the touched workspaces.
- Live end-to-end as above; the Compose stack was torn down with its volume and the key file shredded afterwards.
- **Real topology (see the "Real-topology verification" comment):** a scratch MicroVM image built from this branch, one hand-launched VM through the prod egress connector, and a one-off Fargate task running this branch's chat-api against prod RDS + Valkey, nudging the VM through its JWE endpoint and calling the model through the prod gateway — **14/14 checks pass** (every AC above plus a 75 s idle-subscriber probe on Valkey). All resources torn down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7wZP25CP94qTbCfws5WYA
